### PR TITLE
清理关于页面与提示文案中的品牌引用

### DIFF
--- a/src/main/libs/openclawMemoryFile.ts
+++ b/src/main/libs/openclawMemoryFile.ts
@@ -429,8 +429,8 @@ export function migrateSqliteToMemoryMd(
 // Bootstrap file management (IDENTITY.md, USER.md, SOUL.md)
 // ---------------------------------------------------------------------------
 
-const DEFAULT_IDENTITY_ZH = '你的名字是 LobsterAI，一个由网易有道开发的全场景个人助理 Agent。你 7×24 小时在线，能够自主处理日常生产力任务，包括数据分析、PPT 制作、视频生成、文档撰写、信息搜索、邮件工作流、定时任务等。你和用户共享同一个工作空间，协同完成用户的目标。';
-const DEFAULT_IDENTITY_EN = 'Your name is LobsterAI, a full-scenario personal assistant agent developed by NetEase Youdao. You are available 24/7 and can autonomously handle everyday productivity tasks, including data analysis, PPT creation, video generation, document writing, information search, email workflows, scheduled jobs, and more. You and the user share the same workspace, collaborating to achieve the user\'s goals.';
+const DEFAULT_IDENTITY_ZH = '你的名字是 LobsterAI，一个全场景个人助理 Agent。你 7×24 小时在线，能够自主处理日常生产力任务，包括数据分析、PPT 制作、视频生成、文档撰写、信息搜索、邮件工作流、定时任务等。你和用户共享同一个工作空间，协同完成用户的目标。';
+const DEFAULT_IDENTITY_EN = 'Your name is LobsterAI, a full-scenario personal assistant agent. You are available 24/7 and can autonomously handle everyday productivity tasks, including data analysis, PPT creation, video generation, document writing, information search, email workflows, scheduled jobs, and more. You and the user share the same workspace, collaborating to achieve the user\'s goals.';
 
 function getDefaultIdentity(): string {
   try {

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -4628,12 +4628,6 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                 </button>
               </div>
 
-              <p className="mt-5 text-xs text-secondary">
-                {i18nService.t('copyrightHolder')}
-              </p>
-              <p className="mt-1 text-xs text-secondary">
-                Copyright &copy; {new Date().getFullYear()} NetEase Youdao. All Rights Reserved.
-              </p>
             </div>
           </div>
         );

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -281,7 +281,7 @@ const composeExportCanvas = async (
 
   ctx.fillStyle = subtitleColor;
   ctx.font = `400 ${taglineFontSize}px ${fontStack}`;
-  ctx.fillText('7×24 小时帮你干活的全场景个人助理，由网易有道开发', textX, footerCenterY + brandFontSize / 2 + 3);
+  ctx.fillText('7×24 小时帮你干活的全场景个人助理', textX, footerCenterY + brandFontSize / 2 + 3);
 
   ctx.restore(); // card clip
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -247,7 +247,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageVisionHint:
       '当前模型未启用图片输入，图片将以文件路径形式发送。若该模型本身支持图片理解，可在模型配置中开启图片输入选项。',
     copied: '已复制',
-    copyrightHolder: '网易有道 版权所有',
+    copyrightHolder: 'LobsterAI',
     noModelsAvailable: '暂无可用模型',
     addFirstModel: '添加第一个模型',
     testConnection: '测试连接',
@@ -1760,9 +1760,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
       '定时任务「{name}」存在异常数据，已自动修正显示，建议重新编辑该任务',
 
     // 隐私协议弹窗
-    privacyDialogTitle: '网易有道LobsterAI服务协议',
-    privacyDialogDesc: '在使用网易有道LobsterAI之前，请您仔细阅读{link}内容，并进行确认。',
-    privacyDialogLinkText: '网易有道LobsterAI服务协议',
+    privacyDialogTitle: 'LobsterAI 服务协议',
+    privacyDialogDesc: '在使用 LobsterAI 之前，请您仔细阅读{link}内容，并进行确认。',
+    privacyDialogLinkText: 'LobsterAI 服务协议',
     privacyDialogAccept: '我已阅读并同意',
     privacyDialogReject: '拒绝',
     welcomeTitle: '欢迎使用LobsterAI',
@@ -2104,7 +2104,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imageVisionHint:
       'Image input is not enabled for the current model. Images will be sent as file paths. If the model supports vision, you can enable image input in the model configuration.',
     copied: 'Copied',
-    copyrightHolder: 'NetEase Youdao. All rights reserved.',
+    copyrightHolder: 'LobsterAI. All rights reserved.',
     noModelsAvailable: 'No models available',
     addFirstModel: 'Add First Model',
     testConnection: 'Test Connection',
@@ -3709,10 +3709,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
       'Scheduled task "{name}" has abnormal data. Display has been auto-corrected. Consider re-editing this task',
 
     // Privacy dialog
-    privacyDialogTitle: 'NetEase Youdao LobsterAI Terms of Service',
+    privacyDialogTitle: 'LobsterAI Terms of Service',
     privacyDialogDesc:
-      'Before using NetEase Youdao LobsterAI, please carefully read the {link} and confirm.',
-    privacyDialogLinkText: 'NetEase Youdao LobsterAI Terms of Service',
+      'Before using LobsterAI, please carefully read the {link} and confirm.',
+    privacyDialogLinkText: 'LobsterAI Terms of Service',
     privacyDialogAccept: 'I have read and agree',
     privacyDialogReject: 'Decline',
     welcomeTitle: 'Welcome to LobsterAI',


### PR DESCRIPTION
移除关于页面底部版权行、更新 i18n 及隐私弹窗文案、更新默认身份描述与欢迎页水印文案。

4 文件变更，TypeScript 编译通过，ESLint 无错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)