### PR TITLE
feat: show Gateway session ID in cowork title bar when NODE_ENV=devel…

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3224,6 +3224,20 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle('cowork:session:gatewaySessionId', async (_event, lobsterSessionId: string) => {
+    try {
+      const stateDir = getOpenClawEngineManager().getStateDir();
+      const sessionsPath = path.join(stateDir, 'agents', 'main', 'sessions', 'sessions.json');
+      const raw = await fs.promises.readFile(sessionsPath, 'utf-8');
+      const sessions = JSON.parse(raw);
+      const sessionKey = `agent:main:lobsterai:${lobsterSessionId}`;
+      const entry = sessions[sessionKey];
+      return { success: true, gatewaySessionId: entry?.sessionId ?? null };
+    } catch {
+      return { success: false, gatewaySessionId: null };
+    }
+  });
+
   ipcMain.handle('cowork:session:remoteManaged', async (_event, sessionId: string) => {
     try {
       const mapping = getIMGatewayManager()?.getIMStore()?.getSessionMappingByCoworkSessionId(sessionId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -298,6 +298,8 @@ contextBridge.exposeInMainWorld('electron', {
     renameSession: (options: { sessionId: string; title: string }) =>
       ipcRenderer.invoke('cowork:session:rename', options),
     getSession: (sessionId: string) => ipcRenderer.invoke('cowork:session:get', sessionId),
+    getGatewaySessionId: (sessionId: string) =>
+      ipcRenderer.invoke('cowork:session:gatewaySessionId', sessionId),
     remoteManaged: (sessionId: string) =>
       ipcRenderer.invoke('cowork:session:remoteManaged', sessionId),
     listSessions: (options?: { limit?: number; offset?: number; agentId?: string }) =>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1677,8 +1677,19 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
   // Clear lazy-render height cache when session changes
   const sessionId = currentSession?.id;
+  const [gatewaySessionId, setGatewaySessionId] = useState<string | null>(null);
   useEffect(() => {
     clearHeightCache();
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (sessionId) {
+      window.electron.cowork.getGatewaySessionId(sessionId).then((res) => {
+        if (res.success) setGatewaySessionId(res.gatewaySessionId);
+      });
+    } else {
+      setGatewaySessionId(null);
+    }
   }, [sessionId]);
 
   // Rail navigation states
@@ -2667,8 +2678,16 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               {updateBadge}
             </div>
           )}
-          <h1 className="text-sm leading-none font-medium text-foreground truncate max-w-[360px]">
+          <h1 className="text-sm leading-none font-medium text-foreground truncate max-w-[400px]">
             {currentSession.title || i18nService.t('coworkNewSession')}
+            {process.env.NODE_ENV === 'development' && gatewaySessionId && (
+              <span
+                className="non-draggable text-[10px] text-muted-foreground ml-1.5 font-mono select-text cursor-text"
+                onPointerDown={(e) => e.stopPropagation()}
+              >
+                {gatewaySessionId.slice(0, 8)}
+              </span>
+            )}
           </h1>
         </div>
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -502,6 +502,9 @@ interface IElectronAPI {
     getSession: (
       sessionId: string,
     ) => Promise<{ success: boolean; session?: CoworkSession; error?: string }>;
+    getGatewaySessionId: (
+      sessionId: string,
+    ) => Promise<{ success: boolean; gatewaySessionId: string | null }>;
     remoteManaged: (
       sessionId: string,
     ) => Promise<{ success: boolean; remoteManaged: boolean; error?: string }>;


### PR DESCRIPTION
…opment

Add IPC handler cowork:session:gatewaySessionId that resolves the LobsterAI session ID to the OpenClaw Gateway internal session ID via sessions.json. Display the first 8 chars of the Gateway session ID next to the session title in dev mode, so developers can quickly locate the corresponding .jsonl session file.

## Summary
<!-- Provide a brief summary of the changes in this PR -->

## Related Issue
<!-- Link to the related issue(s) if applicable -->
Fixes #(issue number)

## Changes Made
<!-- Describe the changes you've made -->
- 
- 
- 

## Type of Change
<!-- Mark the relevant option with an [x] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you've performed -->
- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
<!-- Mark the completed items with [x] -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes
<!-- If your PR includes Electron-specific changes, describe them here -->
- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes
<!-- Any additional information that reviewers should know -->
