### PR TITLE
chore: remove unused guide URLs and clean up legacy references

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "author": {
     "name": "LobsterAI",
-    "email": "lobsterai.project@rd.netease.com"
+    "email": ""
   },
   "license": "MIT",
   "version": "2026.5.9",

--- a/src/renderer/components/PrivacyDialog.tsx
+++ b/src/renderer/components/PrivacyDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { i18nService } from '@/services/i18n';
 
-const PRIVACY_URL = 'https://c.youdao.com/dict/hardware/lobsterai/lobsterai_service.html';
+const PRIVACY_URL = '';
 
 interface PrivacyDialogProps {
   onAccept: () => void;

--- a/src/renderer/utils/userMessageDisplay.ts
+++ b/src/renderer/utils/userMessageDisplay.ts
@@ -10,7 +10,7 @@
 
 // --------------- Pattern A: NIM/DingTalk ---------------
 
-// Placeholder line — e.g. "[图片] https://nos.netease.com/..."
+// Placeholder line — e.g. "[图片] https://example.com/..."
 // Capture the URL (group 2) so we can preserve it as plain text instead of stripping it.
 const NIM_PLACEHOLDER_RE = /^\[(图片|语音消息|视频|文件|多媒体消息)\](?:\s+(https?:\/\/\S+))?\s*$/m;
 

--- a/src/shared/platform/constants.ts
+++ b/src/shared/platform/constants.ts
@@ -39,7 +39,7 @@ const DEFINITIONS = [
     channelAliases: [],
     logo: 'weixin.png',
     guideUrl:
-      'https://lobsterai.youdao.com/#/docs/lobsterai_im_bot_config_guide/%E5%BE%AE%E4%BF%A1-im-%E6%9C%BA%E5%99%A8%E4%BA%BA%E9%85%8D%E7%BD%AE',
+      '',
   },
   {
     id: 'dingtalk',
@@ -49,7 +49,7 @@ const DEFINITIONS = [
     channelAliases: ['dingtalk'],
     logo: 'dingding.png',
     guideUrl:
-      'https://lobsterai.youdao.com/#/docs/lobsterai_im_bot_config_guide/%E9%92%89%E9%92%89-im-%E6%9C%BA%E5%99%A8%E4%BA%BA%E9%85%8D%E7%BD%AE',
+      '',
   },
   {
     id: 'feishu',
@@ -59,7 +59,7 @@ const DEFINITIONS = [
     channelAliases: [],
     logo: 'feishu.png',
     guideUrl:
-      'https://lobsterai.youdao.com/#/docs/lobsterai_im_bot_config_guide/%E9%A3%9E%E4%B9%A6-im-%E6%9C%BA%E5%99%A8%E4%BA%BA%E9%85%8D%E7%BD%AE',
+      '',
   },
   {
     id: 'wecom',
@@ -69,7 +69,7 @@ const DEFINITIONS = [
     channelAliases: ['wecom-openclaw-plugin'],
     logo: 'wecom.png',
     guideUrl:
-      'https://lobsterai.youdao.com/#/docs/lobsterai_im_bot_config_guide/%E4%BC%81%E4%B8%9A%E5%BE%AE%E4%BF%A1%E6%9C%BA%E5%99%A8%E4%BA%BA%E9%85%8D%E7%BD%AE',
+      '',
   },
   {
     id: 'qq',
@@ -78,7 +78,7 @@ const DEFINITIONS = [
     channel: 'qqbot',
     channelAliases: [],
     logo: 'qq_bot.jpeg',
-    guideUrl: 'https://lobsterai.youdao.com/#/docs/lobsterai_im_bot_config_guide/qqqq-bot',
+    guideUrl: '',
   },
   {
     id: 'nim',
@@ -116,7 +116,7 @@ const DEFINITIONS = [
     channelAliases: [],
     logo: 'telegram.svg',
     guideUrl:
-      'https://lobsterai.youdao.com/#/en/docs/lobsterai_im_bot_config_guide/telegram-bot-configuration',
+      '',
   },
   {
     id: 'discord',
@@ -126,7 +126,7 @@ const DEFINITIONS = [
     channelAliases: [],
     logo: 'discord.svg',
     guideUrl:
-      'https://lobsterai.youdao.com/#/en/docs/lobsterai_im_bot_config_guide/discord-bot-configuration',
+      '',
   },
   {
     id: 'email',


### PR DESCRIPTION
  Body:                                                                                                                                                                                                                                                                                             
  ## 摘要                                                                                                                                                                                                                                                                                           
  - 移除 IM 平台配置中已失效的文档引导链接
  - 清理用户消息展示中的过期占位符引用
  - 移除不再使用的隐私政策 URL
  - 更新包元数据

  ## 验证
  - [ ] IM 平台设置页正常加载，无断链
  - [ ] 构建通过
