### PR TITLE
feat(im): 启用频道健康自动监控

### DIFF
--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -1215,6 +1215,9 @@ export class OpenClawConfigSync {
         // "config change requires gateway restart (gateway.auth.token)".
         auth: { mode: 'token', token: '${OPENCLAW_GATEWAY_TOKEN}' },
         tailscale: { mode: 'off' },
+        channelHealthCheckMinutes: 5,
+        channelStaleEventThresholdMinutes: 30,
+        channelMaxRestartsPerHour: 10,
         ...(hasAnyChannel
           ? {
               http: {


### PR DESCRIPTION
## 概述

在 OpenClaw Gateway 配置同步中启用频道健康自动监控，将手动"测试连接"升级为每 5 分钟自动探测 + 断连自动重启，MTTR 从天级降到分钟级。

## 背景

根据频道可靠性建设路线图（P0），OpenClaw Gateway 已有内置的频道健康监控能力，但 LobsterAI 侧尚未在配置同步中写入相关字段。当前频道健康探测完全依赖用户在设置页手动点击"测试连接"按钮。

本次变更在 `openclawConfigSync.ts` 中新增 3 个 Gateway 配置项，利用 OpenClaw 内置能力实现零代码自动监控。

## 变更内容

在 `src/main/libs/openclawConfigSync.ts` 的 `gateway` 配置块中新增：

- `gateway.channelHealthCheckMinutes: 5` — 每 5 分钟周期性探测所有频道连接状态
- `gateway.channelStaleEventThresholdMinutes: 30` — 连续 30 分钟无入站事件的频道标记为 stale 并自动重启
- `gateway.channelMaxRestartsPerHour: 10` — 每小时每频道最多重启 10 次，防止 crash loop

这些字段写入 `~/.openclaw/openclaw.json` 后，由 OpenClaw Gateway 进程内部执行，无需 LobsterAI 侧任何运行时逻辑变更。

## 与现有功能的关系

- 与 `imGatewayManager.probeOpenClawChannel()` 手动探测**互补不冲突**
  - Gateway 自动监控：周期性执行、自动重启、对用户透明
  - LobsterAI 手动探测：用户主动触发、返回详细检查结果、在设置页展示
- Gateway 通过 `sessions.list` JSON-RPC 方法探测频道状态，与 LobsterAI 手动探测使用相同的底层机制

## 测试计划

- [x] TypeScript 编译通过
- [x] openclawConfigSync 单测 11/11 通过
- [ ] 启动应用后等待 5 分钟，确认 Gateway 日志中出现周期性 channel health check
- [ ] 停掉一个频道凭据 → 确认探测失败 → 恢复凭据 → 确认自动重连
- [ ] 验证重启频率限制生效（同频道 1 小时内不会超过 10 次重启）

🤖 Generated with [Claude Code](https://claude.com/claude-code)