### PR TITLE
fix: 修复更新系统禁用后仍显示有新版本的问题

### DIFF
--- a/src/main/libs/appUpdateCoordinator.ts
+++ b/src/main/libs/appUpdateCoordinator.ts
@@ -493,6 +493,23 @@ export class AppUpdateCoordinator {
   }
 
   private restoreStoredReadyState(): void {
+    // When the update system is disabled, clear any stale persisted state
+    // left over from earlier versions.  Otherwise a stored ready-file
+    // record (version + installer path) keeps showing "有新版本" on every
+    // startup even though fetchUpdateInfo() is hardcoded to return null.
+    if (this.isUpdateDisabled()) {
+      console.log('[AppUpdate] update system is disabled, clearing any persisted ready state');
+      for (const source of [AppUpdateSource.Manual, AppUpdateSource.Auto] as AppUpdateSource[]) {
+        const stale = this.getStoredReadyFile(source);
+        if (stale) {
+          this.clearStoredReadyFile(source);
+          void this.cleanupReadyFile(stale.filePath);
+        }
+        void this.pruneCachedInstallerFiles(source);
+      }
+      return;
+    }
+
     const sources: AppUpdateSource[] = [AppUpdateSource.Manual, AppUpdateSource.Auto];
     let restored = false;
 


### PR DESCRIPTION
## 概述

修复应用左上角持续显示"有新版本"徽章的问题。根因不是从网易远端拉取了新版本，而是本地 SQLite 中残留的历史记录被反复恢复。

## 根因分析

应用的自动更新系统已被完全禁用：
- `fetchUpdateInfo()` 永远返回 null（不请求远端）
- `checkNow()` 立即返回（不执行检查）
- `isUpdateDisabled()` 永远返回 true

但遗漏了构造函数中的 `restoreStoredReadyState()`—— 这个方法在每次启动时从 SQLite 读取旧版本遗留的更新记录（key: `app_update_ready_file:auto`），并将运行时状态置为 `Ready`，导致 UI 显示"有新版本"徽章。

完整链路：
```
应用启动
  → AppUpdateCoordinator 构造
    → restoreStoredReadyState()
      → SQLite 读取 app_update_ready_file:auto
      → 版本 2026.5.12 > 当前版本 ✓
      → 安装包文件存在 ✓
      → 恢复状态为 Ready
        → UI: updateInfo.latestVersion = "2026.5.12"
        → shouldShowUpdateBadge = true
        → 左上角显示"有新版本"
```

之前多次代码和插件清理未解决此问题，因为清理范围仅限于 IM 集成和插件代码，从未触及 `restoreStoredReadyState()` 逻辑、SQLite 存储记录和磁盘上的安装包缓存。

## 变更内容

在 `src/main/libs/appUpdateCoordinator.ts` 的 `restoreStoredReadyState()` 方法开头增加 `isUpdateDisabled()` 检查：

当更新系统被禁用时，主动清理：
- SQLite 中的 `app_update_ready_file:auto` 和 `app_update_ready_file:manual` 记录
- 磁盘上的过期安装包缓存文件（`updates/` 目录）

清理后直接返回，不恢复任何状态，UI 中 `updateInfo` 始终为 null，徽章不再出现。

## 测试计划

- [x] TypeScript 编译通过
- [ ] 启动应用，确认左上角不再显示"有新版本"徽章
- [ ] 确认控制台日志出现 `[AppUpdate] update system is disabled, clearing any persisted ready state`
- [ ] 确认 `AppData\Roaming\LobsterAI\updates\` 目录下旧安装包被清理
- [ ] 确认设置页无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)