### PR TITLE
perf: 加速启动 — 延迟频道历史同步，避免阻塞首次轮询

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -1330,9 +1330,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         }
         console.log('[ChannelSync] discovered', channelCount, 'channel sessions, notified', notified, 'windows');
       }
-      // Sync full history for newly discovered sessions
+      // Sync full history for newly discovered sessions in background.
+      // Fire-and-forget so the poll cycle doesn't block on sequential
+      // chat.history RPC calls (each up to 10s timeout) while the Gateway
+      // is still starting channels and sidecars during postAttachRuntime.
       for (const { sessionId, sessionKey } of newSessionsToSync) {
-        await this.syncFullChannelHistory(sessionId, sessionKey);
+        void this.syncFullChannelHistory(sessionId, sessionKey);
       }
 
       // Incremental sync for already-known sessions: check if the gateway has messages
@@ -1354,11 +1357,9 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
           syncedThisCycle.add(sessionId);
           // Skip sessions with an active turn (they handle their own sync)
           if (this.activeTurns.has(sessionId)) continue;
-          try {
-            await this.incrementalChannelSync(sessionId, key);
-          } catch (err) {
+          void this.incrementalChannelSync(sessionId, key).catch((err) => {
             console.warn('[ChannelSync] incremental sync failed for', key, err);
-          }
+          });
         }
       }
     } catch (error) {


### PR DESCRIPTION
## 概述

将首次轮询周期中的频道历史同步从阻塞改为后台执行，减少 Gateway 启动期间的 RPC 争用，降低启动总耗时。

## 启动性能分析

从本次启动日志中提取的 Gateway 启动画像：

```
loadConfigSnapshot       208ms    1.3%
authBootstrap           3198ms   19.4%
pluginBootstrap         2149ms   13.0%
runtimeConfigResolve      13ms    0.1%
createRuntimeState        11ms    0.1%
earlyRuntime              18ms    0.1%
requestContextAndWsHandlers 1ms    0.0%
postAttachRuntime      10868ms   66.0%   ← 主瓶颈：频道/边车初始化
──────────────────────────────────────
TOTAL                  16478ms
```

关键时间线：

```
 1.1s  launcher import ok（V8 编译缓存生效，从 42s 降至 1.1s）
 2.1s  load-config: 426ms（过期插件已清理，从 8.5s 降至 0.4s）
 7.8s  gateway "ready"（HTTP 服务就绪，用户可交互）
16.5s  postAttachRuntime 完成（频道全部启动）
```

之前的 `fix/fastGatewayLaunch` 已将 launcher 冷启动从 42s 降至 1.1s，将 config 加载从 8.5s 降至 0.4s。

本次发现在 Gateway 的 `postAttachRuntime` 阶段（频道/插件/边车初始化期间），LobsterAI 侧的首个轮询周期中 `chat.history` RPC 调用耗时 6.4s，因为 Gateway 此时正忙于启动频道和边车。这些调用是串行阻塞的，与 Gateway 内部初始化形成资源争用。

## 变更内容

在 `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` 的 `pollChannelSessions` 方法中：

- `syncFullChannelHistory` 调用从 `await` 改为 `void`（fire-and-forget）
- `incrementalChannelSync` 调用从 `await` + try/catch 改为 `void` + `.catch()`

两项改动均安全：
- `fullySyncedSessions` Set 防止重复全量同步
- 增量同步仅对已全量同步过的会话执行，不会与全量同步并发
- 首个轮询周期未同步的会话会在 10 秒后的下个周期中覆盖
- `syncChannelAfterTurn`（turn 完成后立即同步）已经是 fire-and-forget 模式

## 测试计划

- [x] TypeScript 编译通过
- [x] 现有测试通过
- [ ] 启动应用，确认频道历史仍正常加载（延迟 10-20 秒内出现）
- [ ] 确认 `chat.history` 调用不再阻塞首个 poll 周期
- [ ] 确认多个频道会话的历史同步不会相互阻塞

🤖 Generated with [Claude Code](https://claude.com/claude-code)