### PR TITLE
fix: Agent-Channel 绑定变更立即生效，含 Gateway 重启与会话迁移

### DIFF
--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -367,11 +367,22 @@ export class OpenClawChannelSessionSync {
 
     // 4. Check persistent mapping in im_session_mappings
     const existingMapping = this.imStore.getSessionMapping(parsed.conversationId, parsed.platform);
+    const imSettings = this.imStore.getIMSettings();
+    const accountId = extractAccountIdFromKey(sessionKey);
+    const currentAgentId = resolveAgentBinding(
+      imSettings.platformAgentBindings,
+      parsed.platform,
+      accountId,
+    );
     console.log(
       '[ChannelSessionSync] existing mapping:',
       existingMapping
         ? `coworkSessionId=${existingMapping.coworkSessionId} agentId=${existingMapping.agentId}`
         : 'none',
+      '| current binding:',
+      currentAgentId,
+      '| platformAgentBindings:',
+      JSON.stringify(imSettings.platformAgentBindings),
     );
     if (existingMapping) {
       // Verify the Cowork session still exists
@@ -380,13 +391,7 @@ export class OpenClawChannelSessionSync {
         // Check if the agent binding has changed since this mapping was created.
         // When platformAgentBindings changes, the mapping's agentId becomes stale.
         // Create a new session for the new agent and update the mapping.
-        const imSettings = this.imStore.getIMSettings();
-        const accountId = extractAccountIdFromKey(sessionKey);
-        const currentAgentId = resolveAgentBinding(
-          imSettings.platformAgentBindings,
-          parsed.platform,
-          accountId,
-        );
+        // (imSettings, accountId, currentAgentId already resolved above)
         if (existingMapping.agentId !== currentAgentId) {
           console.log(
             '[ChannelSessionSync] agent binding changed:',
@@ -453,8 +458,7 @@ export class OpenClawChannelSessionSync {
     const shortId = displayId.length > 12 ? displayId.slice(-12) : displayId;
     const title = `${titlePrefix} ${shortId}`;
     // Look up the per-platform agent binding so the session is filed under the correct agent.
-    const imSettings = this.imStore.getIMSettings();
-    const accountId = extractAccountIdFromKey(sessionKey);
+    // (imSettings, accountId already resolved above; re-resolve agentId for the new-session path)
     const agentId = resolveAgentBinding(imSettings.platformAgentBindings, parsed.platform, accountId);
     const cwd = this.getDefaultCwd(agentId);
     console.log(

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -393,8 +393,11 @@ export class OpenClawChannelSessionSync {
             existingMapping.agentId,
             '→',
             currentAgentId,
-            '— creating new session',
+            '— creating new session and removing old',
           );
+          // Delete the old Cowork session so it doesn't linger in the
+          // previous agent's sidebar list after the binding change.
+          this.coworkStore.deleteSession(existingMapping.coworkSessionId);
           const titlePrefix = getChannelTitlePrefix(parsed.platform);
           const displayId = parsed.conversationId.includes('@')
             ? parsed.conversationId.split('@')[0]

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -273,6 +273,12 @@ export interface ChannelSessionSyncDeps {
   getDefaultCwd: (agentId?: string) => string;
   /** Optional synchronous lookup: jobId → human-readable name (for cron session titles). */
   resolveJobName?: (jobId: string) => string | null;
+  /**
+   * Called when a channel session's agent binding changes, so the caller can
+   * patch the Gateway session to use the new agent's model for the NEXT turn.
+   * (The current turn already started with the old model — this fixes future messages.)
+   */
+  onBindingChanged?: (sessionKey: string, platform: Platform, newAgentId: string) => void;
 }
 
 export class OpenClawChannelSessionSync {
@@ -280,6 +286,7 @@ export class OpenClawChannelSessionSync {
   private readonly imStore: IMStore;
   private readonly getDefaultCwd: (agentId?: string) => string;
   private readonly resolveJobName: ((jobId: string) => string | null) | null;
+  private readonly onBindingChanged: ((sessionKey: string, platform: Platform, newAgentId: string) => void) | null;
 
   /** In-memory cache: openclawSessionKey → local sessionId. */
   private readonly syncedSessionKeys = new Map<string, string>();
@@ -299,6 +306,7 @@ export class OpenClawChannelSessionSync {
     this.imStore = deps.imStore;
     this.getDefaultCwd = deps.getDefaultCwd;
     this.resolveJobName = deps.resolveJobName ?? null;
+    this.onBindingChanged = deps.onBindingChanged ?? null;
   }
 
   /**
@@ -428,6 +436,10 @@ export class OpenClawChannelSessionSync {
             currentAgentId,
           );
           console.log('[ChannelSessionSync] created new session for agent change:', newSession.id);
+          // Notify the caller so it can patch the Gateway session's model.
+          // The current turn already started with the old model — this fixes
+          // the NEXT inbound message so it uses the new agent's model.
+          this.onBindingChanged?.(sessionKey, parsed.platform, currentAgentId);
           this.imStore.updateSessionMappingTarget(
             parsed.conversationId,
             parsed.platform,

--- a/src/main/libs/openclawChannelSessionSync.ts
+++ b/src/main/libs/openclawChannelSessionSync.ts
@@ -302,15 +302,19 @@ export class OpenClawChannelSessionSync {
   }
 
   /**
-   * Check if a gateway session key belongs to the agent currently bound to its platform.
-   * When users switch agent bindings, the gateway retains old sessions under the previous
-   * agentId. This method filters them out so only the current agent's sessions are processed.
+   * Check if a gateway session key belongs to a platform that has a current
+   * agent binding.  The Gateway may resume old sessions (via sync buf) after
+   * a restart, so the key's agentId can be stale even post-restart.
+   *
+   * resolveOrCreateSession() handles the transition (create new session for
+   * the current agent, isolate history).  We only filter out sessions whose
+   * platform has NO binding at all.
    */
   isCurrentBindingKey(sessionKey: string): boolean {
     const parsed = parseChannelSessionKey(sessionKey);
-    if (!parsed) return true; // Not a channel key — let other logic handle it
+    if (!parsed) return true;
     const keyAgentId = extractAgentIdFromKey(sessionKey);
-    if (!keyAgentId) return true; // Legacy key without agentId — allow
+    if (!keyAgentId) return true;
     const imSettings = this.imStore.getIMSettings();
     const accountId = extractAccountIdFromKey(sessionKey);
     const currentAgentId = resolveAgentBinding(
@@ -318,7 +322,12 @@ export class OpenClawChannelSessionSync {
       parsed.platform,
       accountId,
     );
-    return keyAgentId === currentAgentId;
+    // Platform has NO non-main binding — session is truly orphaned, skip it.
+    if (!currentAgentId || currentAgentId === 'main') {
+      return keyAgentId === (currentAgentId || 'main');
+    }
+    // Platform HAS a binding — let resolveOrCreateSession() handle routing.
+    return true;
   }
 
   /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1311,7 +1311,12 @@ const syncOpenClawConfig = async (
     };
   }
 
-  if (hasActiveGatewayWorkloads()) {
+  // Binding changes are explicit user actions (reassigning a channel to a
+  // different agent).  The old Gateway session keeps the channel producing
+  // messages under the old agent's model, so active workloads never drain
+  // and the restart would be deferred indefinitely.  Force immediate restart
+  // so new messages route to the correct agent.
+  if (hasActiveGatewayWorkloads() && !syncResult.bindingsChanged) {
     console.log(`${D()} ──── RESTART DEFERRED (active workloads). reason=${options.reason}`);
     scheduleDeferredGatewayRestart(options.reason);
     return {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1447,6 +1447,21 @@ const getCoworkEngineRouter = () => {
             imStore,
             getDefaultCwd: (agentId?: string) => resolveAgentDefaultWorkingDirectory(agentId) || os.homedir(),
             resolveJobName: (jobId) => getCronJobService().getJobNameSync(jobId),
+            onBindingChanged: (sessionKey, _platform, newAgentId) => {
+              // Patch the Gateway session to use the new agent's model for
+              // future inbound messages.  The current turn already started
+              // with the old agent's configuration.
+              const agent = getCoworkStore().getAgent(newAgentId);
+              const model = agent?.model || '';
+              if (model && openClawRuntimeAdapter) {
+                const client = openClawRuntimeAdapter.getGatewayClient();
+                if (client) {
+                  void client.request('sessions.patch', { key: sessionKey, model }).catch((err) => {
+                    console.warn('[ChannelSessionSync] failed to patch Gateway session model after binding change:', err);
+                  });
+                }
+              }
+            },
           });
           openClawRuntimeAdapter.setChannelSessionSync(channelSessionSync);
         }

--- a/src/renderer/components/agentSidebar/useAgentSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.ts
@@ -306,6 +306,20 @@ export const useAgentSidebarState = () => {
         }
       });
 
+      // Remove task previews for sessions that were deleted from the Redux
+      // store (e.g. via batch delete).  The Redux sessions array is the
+      // source of truth; anything in taskPreviews that isn't in sessions
+      // should be pruned.
+      const sessionIdSet = new Set(sessions.map((s) => s.id));
+      for (const agentId of Object.keys(next)) {
+        if (!loadedAgentIdsRef.current.has(agentId)) continue;
+        const filtered = next[agentId].filter((task) => sessionIdSet.has(task.id));
+        if (filtered.length !== next[agentId].length) {
+          next[agentId] = filtered;
+          changed = true;
+        }
+      }
+
       return changed ? next : previous;
     });
   }, [sessions]);


### PR DESCRIPTION
## 概述

修复通过侧边栏 Agent 编辑页切换频道绑定关系后，变更不能立即生效的问题。

包含四个独立修复：

### 1. 绑定变更强制立即重启 Gateway

`main.ts` — 当 `bindingsChanged` 时跳过延期重启路径，强制执行立即 Gateway 硬重启（~8s）。之前微信频道持续产生消息导致活跃工作负载永远无法排空，重启被无限期推迟。

### 2. 微信 session 恢复后正确路由

`openclawChannelSessionSync.ts`:
- `isCurrentBindingKey()` 放宽匹配 — Gateway 重启后微信 provider 从 sync buffer 恢复旧 session（key 仍含旧 agentId），现在只要平台有非 main 绑定就放行，交给 `resolveOrCreateSession()` 处理迁移
- 绑定变更时删除旧 Cowork session、创建新 session

### 3. Gateway session 模型实时切换

`main.ts` — 新增 `onBindingChanged` 回调，绑定变更时立即通过 `sessions.patch` RPC 将 Gateway session 的模型切换为新 agent 的模型，确保后续入站消息使用正确模型。

### 4. 批量删除会话后侧边栏同步

`useAgentSidebarState.ts` — Redux sessions 同步到本地 `taskPreviewsByAgentId` 时增加删除检测。

## 变更文件

- `src/main/main.ts`
- `src/main/libs/openclawChannelSessionSync.ts`
- `src/renderer/components/agentSidebar/useAgentSidebarState.ts`

## 测试

- [x] TypeScript 编译通过
- [x] 721 个现有测试零回归
- [ ] 侧边栏编辑 Agent → 切换微信绑定 → 确认 Gateway 立即重启
- [ ] 绑定迁移后手机微信发消息 → 确认使用新 agent 模型
- [ ] 会话从旧 agent 列表消失，在新 agent 列表出现

🤖 Generated with [Claude Code](https://claude.com/claude-code)