### PR TITLE
fix: 批量删除会话后侧边栏树节点残留

### DIFF
--- a/src/renderer/components/agentSidebar/useAgentSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.ts
@@ -306,6 +306,20 @@ export const useAgentSidebarState = () => {
         }
       });
 
+      // Remove task previews for sessions that were deleted from the Redux
+      // store (e.g. via batch delete).  The Redux sessions array is the
+      // source of truth; anything in taskPreviews that isn't in sessions
+      // should be pruned.
+      const sessionIdSet = new Set(sessions.map((s) => s.id));
+      for (const agentId of Object.keys(next)) {
+        if (!loadedAgentIdsRef.current.has(agentId)) continue;
+        const filtered = next[agentId].filter((task) => sessionIdSet.has(task.id));
+        if (filtered.length !== next[agentId].length) {
+          next[agentId] = filtered;
+          changed = true;
+        }
+      }
+
       return changed ? next : previous;
     });
   }, [sessions]);


### PR DESCRIPTION
## 概述

批量删除会话后，Redux store 正确更新了，但 Agent 侧边栏的 `taskPreviewsByAgentId` React 本地状态未同步清理，导致已删除的会话仍显示在侧边栏树中（无内容）。

## 根因

`useAgentSidebarState` 中有一个 `useEffect` 负责将 Redux `sessions` 数组同步到 `taskPreviewsByAgentId` 本地状态，但它只处理了新增和更新，没有处理删除。

## 修复

在同步 effect 的末尾增加了清理逻辑：构建 Redux 中所有会话 ID 的 Set，遍历 `taskPreviewsByAgentId`，过滤掉不存在于 Redux 中的条目。

```typescript
const sessionIdSet = new Set(sessions.map((s) => s.id));
for (const agentId of Object.keys(next)) {
  if (!loadedAgentIdsRef.current.has(agentId)) continue;
  const filtered = next[agentId].filter((task) => sessionIdSet.has(task.id));
  if (filtered.length !== next[agentId].length) {
    next[agentId] = filtered;
    changed = true;
  }
}
```

## 测试

- [x] TypeScript 编译通过
- [ ] 批量删除多个会话 → 确认侧边栏立即更新，无残留节点
- [ ] 单个删除会话 → 确认侧边栏正常
- [ ] 新建会话 → 确认正常出现在侧边栏

🤖 Generated with [Claude Code](https://claude.com/claude-code)