### PR TITLE
feat: log cron repeated failures to main process log

### DIFF
--- a/src/scheduledTask/cronJobService.ts
+++ b/src/scheduledTask/cronJobService.ts
@@ -725,6 +725,15 @@ export class CronJobService {
           if (previousHash !== undefined) {
             const task = mapGatewayJob(job);
             this.emitStatusUpdate(task.id, task.state);
+
+            // Log repeated cron failures to main process log for diagnostics.
+            const errors = task.state.consecutiveErrors;
+            if (errors >= 3 && task.state.lastStatus === TaskStatus.Error) {
+              console.warn(
+                `[CronJobService] Task "${task.name}" (${task.id}) has ${errors} consecutive errors. ` +
+                `Last error: ${task.state.lastError || '(none)'}`,
+              );
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
P1-A of im-channel-health-probe-testing optimization plan.

When a cron task accumulates >= 3 consecutive errors, log a warning to the main process log (console.warn). This makes silent cron failures visible in log exports for diagnostics.

Previously, tasks like "北京天气" could fail 7+ times in a row with no indication outside of OpenClaw's internal `cron/runs/*.jsonl` files.

## Test plan
- [ ] Create a cron task that will fail (e.g. invalid model config)
- [ ] Wait for 3+ consecutive failures
- [ ] Check main process log for `[CronJobService] Task "..." has 3 consecutive errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)