### PR TITLE
feat: auto-run IM channel connectivity tests on settings page open

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -131,6 +131,32 @@ const IMSettings: React.FC = () => {
     return () => { isMountedRef.current = false; };
   }, []);
 
+  // Auto-run connectivity tests for all enabled platforms on mount
+  useEffect(() => {
+    const enabledPlatforms = PlatformRegistry.listIM()
+      .map(p => p.id as Platform)
+      .filter(platform => isPlatformEnabled(platform));
+    if (enabledPlatforms.length === 0) return;
+
+    let cancelled = false;
+    const runTests = async () => {
+      for (const platform of enabledPlatforms) {
+        if (cancelled) return;
+        try {
+          const result = await runConnectivityTest(platform, config);
+          if (!cancelled && result) {
+            setConnectivityResults(prev => ({ ...prev, [platform]: result }));
+          }
+        } catch {
+          // Ignore individual probe failures during auto-test.
+        }
+      }
+    };
+    runTests();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Cleanup feishu QR timers on unmount
   useEffect(() => {
     return () => {

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -133,7 +133,7 @@ const IMSettings: React.FC = () => {
 
   // Auto-run connectivity tests for all enabled platforms on mount
   useEffect(() => {
-    const imPlatforms: Platform[] = ['weixin', 'dingtalk', 'qq', 'feishu', 'email', 'wecom', 'telegram', 'discord', 'nim'];
+    const imPlatforms: Platform[] = ['weixin', 'dingtalk', 'qq', 'feishu', 'email', 'wecom', 'telegram', 'discord'];
     const enabledPlatforms = imPlatforms.filter(platform => isPlatformEnabled(platform));
     if (enabledPlatforms.length === 0) return;
 

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -133,9 +133,8 @@ const IMSettings: React.FC = () => {
 
   // Auto-run connectivity tests for all enabled platforms on mount
   useEffect(() => {
-    const enabledPlatforms = PlatformRegistry.listIM()
-      .map(p => p.id as Platform)
-      .filter(platform => isPlatformEnabled(platform));
+    const imPlatforms: Platform[] = ['weixin', 'dingtalk', 'qq', 'feishu', 'email', 'wecom', 'telegram', 'discord', 'nim'];
+    const enabledPlatforms = imPlatforms.filter(platform => isPlatformEnabled(platform));
     if (enabledPlatforms.length === 0) return;
 
     let cancelled = false;


### PR DESCRIPTION
## Summary
P2 of im-channel-health-probe-testing optimization plan.

When the IM settings page opens, automatically run connectivity tests for all enabled channels and display pass/warn/fail indicators. Previously, users had to manually click "测试连接" for each channel.

## Changes
- Add `useEffect` that auto-tests all enabled IM channels on component mount
- Results displayed via existing `connectivityResults` verdict badges (pass/warn/fail)

## Test plan
- [ ] Open Settings > IM Channels page with some enabled channels
- [ ] Wait a few seconds for auto-tests to complete
- [ ] Verify status indicators (green/red/yellow) appear next to each channel
- [ ] Verify "测试连接" manual button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)