### PR TITLE
feat: cron channel preflight check

### DIFF
--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -289,6 +289,40 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
     }
   });
 
+  ipcMain.handle(ScheduledTaskIpc.Preflight, async (_event, taskId: string) => {
+    try {
+      const task = await getCronJobService().getJob(taskId);
+      if (!task) return { success: false, error: 'Task not found' };
+
+      // Only relevant for tasks with IM channel delivery.
+      const channel = task.delivery?.channel;
+      if (!channel || task.delivery?.mode === 'none') {
+        return { success: true, preflight: { hasChannel: false } };
+      }
+
+      // Check recent runs for delivery failures indicating channel issues.
+      const recentRuns = await getCronJobService().listRuns(taskId, 5, 0, { status: 'error' });
+      const deliveryErrors = recentRuns
+        .filter(r => r.error?.includes('channel') || r.error?.includes('delivery'))
+        .map(r => r.error!);
+
+      return {
+        success: true,
+        preflight: {
+          hasChannel: true,
+          channel,
+          lastDeliveryErrors: deliveryErrors.length > 0 ? deliveryErrors.slice(0, 3) : null,
+          consecutiveErrors: task.state.consecutiveErrors,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Preflight failed',
+      };
+    }
+  });
+
   ipcMain.handle(
     ScheduledTaskIpc.ListChannelConversations,
     async (_event, channel: string, accountId?: string, filterAccountId?: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -572,6 +572,7 @@ contextBridge.exposeInMainWorld('electron', {
     // Execution
     runManually: (id: string) => ipcRenderer.invoke(ScheduledTaskIpc.RunManually, id),
     stop: (id: string) => ipcRenderer.invoke(ScheduledTaskIpc.Stop, id),
+    preflight: (id: string) => ipcRenderer.invoke(ScheduledTaskIpc.Preflight, id),
 
     // Run history
     listRuns: (taskId: string, limit?: number, offset?: number, filter?: any) =>

--- a/src/renderer/components/scheduledTasks/TaskDetail.tsx
+++ b/src/renderer/components/scheduledTasks/TaskDetail.tsx
@@ -1,5 +1,5 @@
 import { PlayIcon } from '@heroicons/react/24/outline';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import type { ScheduledTask } from '../../../scheduledTask/types';
@@ -28,9 +28,19 @@ const TaskDetail: React.FC<TaskDetailProps> = ({ task, onRequestDelete }) => {
   const dispatch = useDispatch();
   const runs = useSelector((state: RootState) => state.scheduledTask.runs[task.id] ?? []);
   const availableModels = useSelector((state: RootState) => state.model.availableModels);
+  const [preflight, setPreflight] = useState<{
+    hasChannel: boolean;
+    channel?: string;
+    lastDeliveryErrors?: string[] | null;
+    consecutiveErrors?: number;
+  } | null>(null);
 
   useEffect(() => {
     void scheduledTaskService.loadRuns(task.id);
+  }, [task.id]);
+
+  useEffect(() => {
+    void scheduledTaskService.preflight(task.id).then(setPreflight);
   }, [task.id]);
 
   const statusLabel = i18nService.t(getStatusLabelKey(task.state.lastStatus));
@@ -123,6 +133,17 @@ const TaskDetail: React.FC<TaskDetailProps> = ({ task, onRequestDelete }) => {
           )}
         </div>
       </div>
+
+      {preflight?.hasChannel && preflight.lastDeliveryErrors && preflight.lastDeliveryErrors.length > 0 && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-red-600 dark:text-red-400">
+              Channel delivery issue detected
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-red-500/80">{preflight.lastDeliveryErrors[0]}</p>
+        </div>
+      )}
 
       <div className={sectionClass}>
         <h3 className={sectionTitleClass}>{i18nService.t('scheduledTasksStatus')}</h3>

--- a/src/renderer/services/scheduledTask.ts
+++ b/src/renderer/services/scheduledTask.ts
@@ -202,6 +202,23 @@ class ScheduledTaskService {
     }
   }
 
+  async preflight(id: string): Promise<{
+    hasChannel: boolean;
+    channel?: string;
+    lastDeliveryErrors?: string[] | null;
+    consecutiveErrors?: number;
+  } | null> {
+    const api = window.electron?.scheduledTasks;
+    if (!api) return null;
+
+    try {
+      const result = await api.preflight(id);
+      return result.success ? (result.preflight ?? null) : null;
+    } catch {
+      return null;
+    }
+  }
+
   async stopTask(id: string): Promise<void> {
     const api = window.electron?.scheduledTasks;
     if (!api) return;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -801,6 +801,16 @@ interface IElectronAPI {
     }>;
     runManually: (id: string) => Promise<{ success: boolean; error?: string }>;
     stop: (id: string) => Promise<{ success: boolean; error?: string }>;
+    preflight: (id: string) => Promise<{
+      success: boolean;
+      error?: string;
+      preflight?: {
+        hasChannel: boolean;
+        channel?: string;
+        lastDeliveryErrors?: string[] | null;
+        consecutiveErrors?: number;
+      };
+    }>;
     listRuns: (
       taskId: string,
       limit?: number,

--- a/src/scheduledTask/constants.ts
+++ b/src/scheduledTask/constants.ts
@@ -115,6 +115,7 @@ export const IpcChannel = {
   ResolveSession: 'scheduledTask:resolveSession',
   ListChannels: 'scheduledTask:listChannels',
   ListChannelConversations: 'scheduledTask:listChannelConversations',
+  Preflight: 'scheduledTask:preflight',
   StatusUpdate: 'scheduledTask:statusUpdate',
   RunUpdate: 'scheduledTask:runUpdate',
   Refresh: 'scheduledTask:refresh',


### PR DESCRIPTION
## Summary
P3 of im-channel-health-probe-testing optimization plan.

Adds a preflight check for cron tasks that analyzes recent delivery errors to detect channel-related issues. When viewing a task detail, a warning banner is shown if the task's delivery channel has recent failures.

## Changes
- New `Preflight` IPC channel constant
- IPC handler that checks delivery errors in recent runs for channel issues
- Preload bridge and TypeScript type definitions
- Frontend service method `preflight(id)`
- Warning banner in `TaskDetail` when channel delivery errors detected

## Test plan
- [ ] Open a cron task with `delivery.mode: "announce"` and a channel configured
- [ ] Verify preflight runs automatically when viewing task detail
- [ ] If the channel has recent delivery failures, verify warning banner appears
- [ ] If `delivery.mode: "none"`, verify no warning banner (hasChannel: false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)