### PR TITLE
fix(llamacpp): use official runtime release assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,18 @@
       }
     ]
   },
+  "llamacpp": {
+    "runtimeRepo": "https://github.com/ggml-org/llama.cpp.git",
+    "runtimeReleaseTag": "b9244",
+    "runtimeAssets": {
+      "mac-arm64": "llama-{tag}-bin-macos-arm64.tar.gz",
+      "mac-x64": "llama-{tag}-bin-macos-x64.tar.gz",
+      "win-x64": "llama-{tag}-bin-win-cpu-x64.zip",
+      "win-arm64": "llama-{tag}-bin-win-cpu-arm64.zip",
+      "linux-x64": "llama-{tag}-bin-ubuntu-x64.tar.gz",
+      "linux-arm64": "llama-{tag}-bin-ubuntu-arm64.tar.gz"
+    }
+  },
   "main": "dist-electron/main.js",
   "engines": {
     "node": ">=24 <25"

--- a/scripts/download-llamacpp-runtime.cjs
+++ b/scripts/download-llamacpp-runtime.cjs
@@ -4,7 +4,19 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const extractZip = require('extract-zip');
 const tar = require('tar');
+
+const DEFAULT_LLAMACPP_RUNTIME_GITHUB_REPO = 'ggml-org/llama.cpp';
+const DEFAULT_LLAMACPP_RUNTIME_RELEASE_TAG = 'b9244';
+const OfficialAssetByTarget = {
+  'mac-arm64': 'llama-{tag}-bin-macos-arm64.tar.gz',
+  'mac-x64': 'llama-{tag}-bin-macos-x64.tar.gz',
+  'win-x64': 'llama-{tag}-bin-win-cpu-x64.zip',
+  'win-arm64': 'llama-{tag}-bin-win-cpu-arm64.zip',
+  'linux-x64': 'llama-{tag}-bin-ubuntu-x64.tar.gz',
+  'linux-arm64': 'llama-{tag}-bin-ubuntu-arm64.tar.gz',
+};
 
 function resolveHostTargetId() {
   const platformMap = {
@@ -29,49 +41,113 @@ function resolveExecutableName(targetId) {
   return targetId.startsWith('win-') ? 'llama-server.exe' : 'llama-server';
 }
 
-function resolveGitHubRepo() {
-  const envRepo = process.env.LLAMACPP_RUNTIME_GITHUB_REPO?.trim();
+function readPackageJson(rootDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function resolveGitHubRepo(env = process.env) {
+  const envRepo = env.LLAMACPP_RUNTIME_GITHUB_REPO?.trim();
   if (envRepo) return envRepo.replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '');
 
-  const result = spawnSync('git', ['config', '--get', 'remote.origin.url'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-  });
-  const remote = result.stdout?.trim();
-  if (!remote) return null;
+  const packageJson = readPackageJson(path.resolve(__dirname, '..'));
+  const packageRepo = packageJson?.llamacpp?.runtimeRepo;
+  if (typeof packageRepo === 'string' && packageRepo.trim()) {
+    return packageRepo.trim().replace(/^https:\/\/github\.com\//, '').replace(/\.git$/, '');
+  }
 
-  const httpsMatch = remote.match(/^https:\/\/github\.com\/(.+?)(?:\.git)?$/);
-  if (httpsMatch) return httpsMatch[1];
-
-  const sshMatch = remote.match(/^git@github\.com:(.+?)(?:\.git)?$/);
-  if (sshMatch) return sshMatch[1];
-
-  return null;
+  return DEFAULT_LLAMACPP_RUNTIME_GITHUB_REPO;
 }
 
-function resolveRuntimeUrl(targetId) {
-  const explicitUrl = process.env.LLAMACPP_RUNTIME_URL?.trim();
-  if (explicitUrl) return explicitUrl.replace(/\{target\}/g, targetId);
+function resolveRuntimeReleaseTag(rootDir, env = process.env) {
+  const explicitTag = env.LLAMACPP_RUNTIME_RELEASE_TAG?.trim();
+  if (explicitTag) {
+    return explicitTag;
+  }
 
-  const baseUrl = process.env.LLAMACPP_RUNTIME_BASE_URL?.trim();
+  const packageJson = readPackageJson(rootDir);
+  const packageTag = packageJson?.llamacpp?.runtimeReleaseTag;
+  if (typeof packageTag === 'string' && packageTag.trim()) {
+    return packageTag.trim();
+  }
+
+  return DEFAULT_LLAMACPP_RUNTIME_RELEASE_TAG;
+}
+
+function resolveOfficialRuntimeAssetName(targetId, env = process.env) {
+  const rootDir = path.resolve(__dirname, '..');
+  const overridePrefix = env.LLAMACPP_RUNTIME_ASSET_PREFIX?.trim();
+  const releaseTag = resolveRuntimeReleaseTag(rootDir, env);
+  const packageJson = readPackageJson(rootDir);
+  const configuredAssetTemplate = packageJson?.llamacpp?.runtimeAssets?.[targetId];
+  if (typeof configuredAssetTemplate === 'string' && configuredAssetTemplate.trim()) {
+    return configuredAssetTemplate.trim().replace(/\{tag\}/g, releaseTag);
+  }
+
+  const assetTemplate = OfficialAssetByTarget[targetId];
+  if (!assetTemplate) {
+    throw new Error(`Unsupported prebuilt llama.cpp runtime target: ${targetId}`);
+  }
+  const assetName = assetTemplate.replace(/\{tag\}/g, releaseTag);
+
+  if (!overridePrefix) return assetName;
+  return assetName.replace(/^llama-[^-]+-bin/, overridePrefix);
+}
+
+function resolveArchiveExtension(archiveName) {
+  if (archiveName.endsWith('.tar.gz')) return '.tar.gz';
+  if (archiveName.endsWith('.zip')) return '.zip';
+  throw new Error(`Unsupported runtime archive format: ${archiveName}`);
+}
+
+function resolveRuntimeDownloadSource(targetId, options = {}) {
+  const env = options.env ?? process.env;
+  const rootDir = options.rootDir ?? path.resolve(__dirname, '..');
+  const assetName = resolveOfficialRuntimeAssetName(targetId, env);
+
+  const explicitUrl = env.LLAMACPP_RUNTIME_URL?.trim();
+  if (explicitUrl) {
+    return explicitUrl
+      .replace(/\{target\}/g, targetId)
+      .replace(/\{asset\}/g, assetName);
+  }
+
+  const baseUrl = env.LLAMACPP_RUNTIME_BASE_URL?.trim();
   if (baseUrl) {
-    return `${baseUrl.replace(/\/$/, '')}/llamacpp-runtime-${targetId}.tar.gz`;
+    return `${baseUrl.replace(/\/$/, '')}/${assetName}`;
   }
 
-  const repo = resolveGitHubRepo();
-  if (!repo) {
-    throw new Error('Set LLAMACPP_RUNTIME_URL, LLAMACPP_RUNTIME_BASE_URL, or LLAMACPP_RUNTIME_GITHUB_REPO to download a prebuilt runtime.');
-  }
-  return `https://github.com/${repo}/releases/latest/download/llamacpp-runtime-${targetId}.tar.gz`;
+  const repo = resolveGitHubRepo(env);
+  const releaseTag = resolveRuntimeReleaseTag(rootDir, env);
+  return `https://github.com/${repo}/releases/download/${releaseTag}/${assetName}`;
 }
 
-async function downloadFile(url, outputPath) {
+function formatDownloadFailureMessage(status, statusText, url, targetId, rootDir) {
+  if (status === 404 && url.includes('github.com/')) {
+    const repo = resolveGitHubRepo();
+    const releaseTag = resolveRuntimeReleaseTag(rootDir);
+    const assetName = resolveOfficialRuntimeAssetName(targetId);
+    return [
+      `Download failed: HTTP ${status} ${statusText}.`,
+      `${url} does not exist.`,
+      `The default downloader expects the published upstream llama.cpp asset ${assetName} from ${repo}@${releaseTag}.`,
+      `Set LLAMACPP_RUNTIME_URL / LLAMACPP_RUNTIME_BASE_URL if you want to use a mirror, or build locally with npm run llamacpp:runtime:${targetId}.`,
+    ].join(' ');
+  }
+
+  return `Download failed: HTTP ${status} ${statusText}`;
+}
+
+async function downloadFile(url, outputPath, rootDir, targetId) {
   console.log(`[download-llamacpp-runtime] Downloading ${url}`);
   const response = await fetch(url, {
     headers: { 'User-Agent': 'RongxinAI/llamacpp-runtime-downloader' },
   });
   if (!response.ok || !response.body) {
-    throw new Error(`Download failed: HTTP ${response.status} ${response.statusText}`);
+    throw new Error(formatDownloadFailureMessage(response.status, response.statusText, url, targetId, rootDir));
   }
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -108,20 +184,24 @@ async function main() {
   if (fs.existsSync(targetExecutable)) {
     console.log(`[download-llamacpp-runtime] Runtime already exists: ${targetRuntimeDir}`);
   } else {
-    const url = resolveRuntimeUrl(targetId);
+    const url = resolveRuntimeDownloadSource(targetId, { rootDir });
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llamacpp-runtime-'));
-    const archivePath = path.join(tempDir, `llamacpp-runtime-${targetId}.tar.gz`);
+    const archiveName = path.basename(new URL(url).pathname) || resolveOfficialRuntimeAssetName(targetId);
+    const archivePath = path.join(tempDir, archiveName);
     const extractDir = path.join(tempDir, 'extract');
-    await downloadFile(url, archivePath);
+    await downloadFile(url, archivePath, rootDir, targetId);
     fs.mkdirSync(extractDir, { recursive: true });
-    await tar.x({
-      file: archivePath,
-      cwd: extractDir,
-    });
-    const extractedSourceDir = resolveExtractedRuntimeRoot(extractDir, executableName, targetId);
+    await extractArchive(archivePath, extractDir);
     fs.rmSync(targetRuntimeDir, { recursive: true, force: true });
-    fs.mkdirSync(path.dirname(targetRuntimeDir), { recursive: true });
-    fs.cpSync(extractedSourceDir, targetRuntimeDir, { recursive: true });
+    installNormalizedRuntime({
+      extractDir,
+      targetRuntimeDir,
+      targetId,
+      executableName,
+      rootDir,
+      sourceUrl: url,
+      assetName: archiveName,
+    });
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 
@@ -139,23 +219,80 @@ async function main() {
   if (sync.status !== 0) process.exit(sync.status || 1);
 }
 
-function resolveExtractedRuntimeRoot(extractDir, executableName, targetId) {
-  const directExecutable = path.join(extractDir, 'bin', executableName);
-  if (fs.existsSync(directExecutable)) {
-    validateRuntimeTarget(extractDir, targetId);
-    return extractDir;
+async function extractArchive(archivePath, extractDir) {
+  const extension = resolveArchiveExtension(archivePath);
+  if (extension === '.tar.gz') {
+    await tar.x({
+      file: archivePath,
+      cwd: extractDir,
+    });
+    return;
+  }
+  await extractZip(archivePath, { dir: extractDir });
+}
+
+function installNormalizedRuntime(options) {
+  const { extractDir, targetRuntimeDir, targetId, executableName, rootDir, sourceUrl, assetName } = options;
+  const executablePath = findExecutablePath(extractDir, executableName);
+  if (!executablePath) {
+    throw new Error(`Downloaded runtime archive does not contain ${executableName}.`);
   }
 
-  const entries = fs.readdirSync(extractDir, { withFileTypes: true }).filter((entry) => entry.isDirectory());
-  if (entries.length === 1) {
-    const candidate = path.join(extractDir, entries[0].name);
-    if (fs.existsSync(path.join(candidate, 'bin', executableName))) {
-      validateRuntimeTarget(candidate, targetId);
-      return candidate;
+  const executableDir = path.dirname(executablePath);
+  const targetBinDir = path.join(targetRuntimeDir, 'bin');
+  fs.mkdirSync(targetBinDir, { recursive: true });
+  copyDirectoryContents(executableDir, targetBinDir);
+  writeRuntimeBuildInfo(targetRuntimeDir, {
+    target: targetId,
+    version: resolveRuntimeReleaseTag(rootDir),
+    sourceUrl,
+    assetName,
+  });
+}
+
+function copyDirectoryContents(sourceDir, targetDir) {
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(targetPath, { recursive: true });
+      copyDirectoryContents(sourcePath, targetPath);
+      continue;
+    }
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+function findExecutablePath(rootDir, executableName) {
+  const queue = [rootDir];
+  while (queue.length > 0) {
+    const currentDir = queue.shift();
+    if (!currentDir) continue;
+    const directExecutable = path.join(currentDir, executableName);
+    if (fs.existsSync(directExecutable)) return directExecutable;
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        queue.push(path.join(currentDir, entry.name));
+      }
     }
   }
+  return null;
+}
 
-  throw new Error(`Downloaded runtime archive does not contain bin/${executableName}.`);
+function writeRuntimeBuildInfo(runtimeDir, details) {
+  const buildInfo = {
+    target: details.target,
+    version: details.version,
+    source: 'official-release',
+    sourceUrl: details.sourceUrl,
+    assetName: details.assetName,
+    downloadedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(
+    path.join(runtimeDir, 'runtime-build-info.json'),
+    JSON.stringify(buildInfo, null, 2) + '\n',
+    'utf8',
+  );
 }
 
 function validateRuntimeTarget(runtimeDir, targetId) {
@@ -175,3 +312,14 @@ main().catch((error) => {
   console.error(`[download-llamacpp-runtime] ${error instanceof Error ? error.message : String(error)}`);
   process.exit(1);
 });
+
+module.exports = {
+  formatDownloadFailureMessage,
+  resolveArchiveExtension,
+  resolveExecutableName,
+  resolveGitHubRepo,
+  resolveHostTargetId,
+  resolveOfficialRuntimeAssetName,
+  resolveRuntimeDownloadSource,
+  resolveRuntimeReleaseTag,
+};

--- a/src/main/libs/llamacppRuntimeDownload.test.ts
+++ b/src/main/libs/llamacppRuntimeDownload.test.ts
@@ -1,0 +1,71 @@
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+const scriptPath = path.resolve(process.cwd(), 'scripts', 'download-llamacpp-runtime.cjs');
+const {
+  formatDownloadFailureMessage,
+  resolveRuntimeDownloadSource,
+  resolveRuntimeReleaseTag,
+} = require(scriptPath) as {
+  formatDownloadFailureMessage: (
+    status: number,
+    statusText: string,
+    url: string,
+    targetId: string,
+    rootDir: string,
+  ) => string;
+  resolveRuntimeDownloadSource: (
+    targetId: string,
+    options?: { env?: NodeJS.ProcessEnv; rootDir?: string },
+  ) => string;
+  resolveRuntimeReleaseTag: (rootDir: string, env?: NodeJS.ProcessEnv) => string;
+};
+
+describe('llamacpp runtime download script', () => {
+  test('defaults to the configured upstream llama.cpp release asset', () => {
+    const rootDir = process.cwd();
+
+    expect(resolveRuntimeReleaseTag(rootDir, {})).toBe('b9244');
+    expect(resolveRuntimeDownloadSource('win-x64', { rootDir, env: {} })).toBe(
+      'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+    );
+  });
+
+  test('maps the official asset names per target', () => {
+    const rootDir = process.cwd();
+
+    expect(resolveRuntimeReleaseTag(rootDir, { LLAMACPP_RUNTIME_RELEASE_TAG: 'b9243' })).toBe('b9243');
+    expect(
+      resolveRuntimeDownloadSource('linux-arm64', {
+        rootDir,
+        env: { LLAMACPP_RUNTIME_RELEASE_TAG: 'b9243' },
+      }),
+    ).toBe(
+      'https://github.com/ggml-org/llama.cpp/releases/download/b9243/llama-b9243-bin-ubuntu-arm64.tar.gz',
+    );
+  });
+
+  test('allows explicit mirrors to substitute both target and asset placeholders', () => {
+    const rootDir = process.cwd();
+    const url = resolveRuntimeDownloadSource('mac-arm64', {
+      rootDir,
+      env: {
+        LLAMACPP_RUNTIME_URL: 'https://mirror.example.com/{target}/{asset}',
+      },
+    });
+
+    expect(url).toBe('https://mirror.example.com/mac-arm64/llama-b9244-bin-macos-arm64.tar.gz');
+  });
+
+  test('formats GitHub 404 failures with actionable guidance', () => {
+    const rootDir = process.cwd();
+    const url = 'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip';
+
+    const message = formatDownloadFailureMessage(404, 'Not Found', url, 'win-x64', rootDir);
+
+    expect(message).toContain('does not exist');
+    expect(message).toContain('published upstream llama.cpp asset');
+    expect(message).toContain('llama-b9244-bin-win-cpu-x64.zip');
+    expect(message).toContain('npm run llamacpp:runtime:win-x64');
+  });
+});

--- a/src/main/libs/llamacppRuntimeInstaller.ts
+++ b/src/main/libs/llamacppRuntimeInstaller.ts
@@ -50,7 +50,7 @@ export function createLlamaCppRuntimeInstallPlan(context: LlamaCppRuntimeInstall
 
   return {
     kind: 'needs-manual',
-    message: `The prebuilt llama.cpp runtime is missing. Run npm run llamacpp:runtime:download -- ${targetId} before starting the app, or set LLAMACPP_BIN to a prebuilt llama-server executable.`,
+    message: `The prebuilt llama.cpp runtime is missing. Run npm run llamacpp:runtime:download -- ${targetId} before starting the app. If the download returns 404, the published release asset is missing and you must either set LLAMACPP_RUNTIME_URL / LLAMACPP_RUNTIME_BASE_URL, build locally with npm run llamacpp:runtime:${targetId}, or set LLAMACPP_BIN to a prebuilt llama-server executable.`,
   };
 }
 


### PR DESCRIPTION
## Summary
Use official llama.cpp runtime release assets instead of custom builds.

## Changes Made
- Update package.json with official release configuration
- Refactor download-llamacpp-runtime.cjs to use official GitHub releases
- Add unit tests for llama.cpp runtime download logic
- Fix version reference in llama.cpp runtime installer

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] Tested locally

## Electron-Specific Changes
- [x] Changes to main process (src/main/)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code