### PR TITLE
fix(sidebar): 批量删除新建agent会话后侧边栏未更新

### DIFF
--- a/src/renderer/components/agentSidebar/useAgentSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.ts
@@ -284,7 +284,6 @@ export const useAgentSidebarState = () => {
   }, [loadAgentTasks, sortedEnabledAgents]);
 
   useEffect(() => {
-    if (sessions.length === 0) return;
     setTaskPreviewsByAgentId((previous) => {
       let changed = false;
       const next = { ...previous };
@@ -311,18 +310,36 @@ export const useAgentSidebarState = () => {
         }
       });
 
-      // Remove task previews for sessions that were deleted from the
-      // backend (e.g. via batch delete).  Only prune the *current* agent:
-      // Redux sessions are scoped to the active agent after a switch, so
-      // pruning all agents would wipe cached previews of inactive agents
-      // and briefly show "no tasks" until the user switches back.
+      // Prune task previews for sessions that were deleted from the
+      // backend (e.g. via batch delete).  Redux sessions are scoped to
+      // the active agent after a switch, so we only prune agents whose
+      // task data has already been loaded via loadAgentTasks/loadMoreTasks.
+      // When sessions is empty (all sessions of the current agent were
+      // deleted), still prune the current agent so the sidebar reflects
+      // the empty state immediately.
       const sessionIdSet = new Set(sessions.map((s) => s.id));
-      const currentTasks = next[currentAgentId];
-      if (currentTasks && loadedAgentIdsRef.current.has(currentAgentId)) {
-        const filtered = currentTasks.filter((task) => sessionIdSet.has(task.id));
-        if (filtered.length !== currentTasks.length) {
-          next[currentAgentId] = filtered;
+      const pruneAgent = (agentId: string) => {
+        const tasks = next[agentId];
+        if (!tasks || !loadedAgentIdsRef.current.has(agentId)) return;
+        const filtered = tasks.filter((task) => sessionIdSet.has(task.id));
+        if (filtered.length !== tasks.length) {
+          next[agentId] = filtered;
           changed = true;
+        }
+      };
+
+      // Always prune the current agent (even when sessions is empty).
+      pruneAgent(currentAgentId);
+
+      // Prune the primary source agent of the Redux sessions.
+      // When sessions is non-empty, the first session's agent is the one
+      // that loadSessions(agentId) was called for.  Pruning this agent
+      // covers the common case where batch delete removes sessions from
+      // the currently filtered view.
+      if (sessions.length > 0) {
+        const primaryAgentId = normalizeAgentId(sessions[0].agentId);
+        if (primaryAgentId !== currentAgentId) {
+          pruneAgent(primaryAgentId);
         }
       }
 


### PR DESCRIPTION
## 问题

侧边栏中，主Agent、agent2、agent3 等老 agent 下的会话可以正常批量删除，而 bendi、tst、tst1 等今天新建的 agent 下的会话，批量删除后侧边栏仍显示已删除的会话。切换到其他会话再切换回来恢复正常。

## 根因

`useAgentSidebarState.ts` 第 287 行 `if (sessions.length === 0) return` 早期返回守卫阻断了修剪逻辑。

新建 agent 通常只有 1-3 个测试会话。批量删除全部会话后：

1. `coworkService.deleteSessions(ids)` → Redux `state.cowork.sessions` 变为 `[]`
2. sideber 的 `sessions` useEffect 触发 → `sessions.length === 0` → 直接 return
3. 侧边栏的 `taskPreviewsByAgentId[agentId]` 从未被修剪
4. 侧边栏继续显示已删除的会话

老 agent 会话多，极少会全部删除，因此 `sessions.length` 始终 > 0，修剪正常执行。

## 修复

1. 移除 `sessions.length === 0` 早期返回，使修剪在 Redux sessions 为空时仍然执行
2. 始终修剪当前 agent 的任务预览
3. 当 sessions 非空时，同时修剪 Redux 数据来源的 agent（覆盖跨 agent 批量删除场景）

## 文件变更

| 文件 | 说明 |
|------|------|
| `src/renderer/components/agentSidebar/useAgentSidebarState.ts` | 移除早期返回 + 扩展修剪范围 |

[skip ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)