### PR TITLE
fix(llamacpp): 修复启动失败后 error 状态被 detect() 覆盖，无错误提示

### DIFF
--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -888,7 +888,14 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
             : result?.error || i18nService.t('localInferenceRuntimeMissing'),
         );
       } else if (status?.status === 'installed' || status?.status === 'stopped') {
-        await window.electron.llamacpp.start();
+        const startStatus = await window.electron.llamacpp.start();
+        if (startStatus.status !== 'running') {
+          showToast(
+            startStatus.error || i18nService.t('localInferenceLaunchRestartFailed'),
+            LocalInferenceToastKind.Error,
+          );
+          return;
+        }
       } else {
         await refreshStatus();
       }

--- a/src/shared/llamacpp/launchValidation.ts
+++ b/src/shared/llamacpp/launchValidation.ts
@@ -18,6 +18,6 @@ export function getLlamaCppLaunchContextLimitViolation(input: {
 }
 
 function normalizePositiveInteger(value: number | undefined): number | undefined {
-  if (!Number.isInteger(value) || value <= 0) return undefined;
+  if (value === undefined || !Number.isInteger(value) || value <= 0) return undefined;
   return value;
 }


### PR DESCRIPTION
## 问题描述

在未安装 VC++ 运行时等依赖的干净 Windows 机器上，llama.cpp 启动失败后，UI 表现为：按钮短暂变灰（启动中），随后恢复为"已安装"，无任何错误提示。

## 根因

`handlePrepare` 在 `start()` 失败后立即调用了 `refreshStatus()` → `detect()`。`detect()` 是无状态快照函数，它只看当前状态：服务没在跑 + exe 存在 = `'installed'`，于是把 `start()` 设置的 `'error'` 状态覆盖了。

```
start() → status 'starting' → spawn 失败 → status 'error'
  → refreshStatus() → detect() → 找到 exe → status 'installed'  ← 覆盖了 error
```

## 修改内容

1. **LocalInferenceView.tsx** — `handlePrepare` 中检查 `start()` 返回值，如果 `status !== 'running'` 则通过 toast 展示 `error` 信息，并跳过 `refreshStatus()` 调用
2. **launchValidation.ts** — 修复 `normalizePositiveInteger` 中 `value` 可能为 `undefined` 的 TS18048 编译错误

## 测试计划

- [ ] 在干净 Windows 机器上安装后，点击启动 llama.cpp，应显示具体错误信息而非静默恢复
- [ ] 正常启动流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)