### PR TITLE
fix(branding): 将用户可见路径和ID中的 lobsterai 替换为 rongxinai

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,5 +1,5 @@
 {
-  "appId": "com.lobsterai.app",
+  "appId": "com.rongxinai.app",
   "productName": "RongxinAI",
   "executableName": "RongxinAI",
   "directories": {

--- a/src/main/appConstants.ts
+++ b/src/main/appConstants.ts
@@ -1,4 +1,4 @@
 export const APP_NAME = 'RongxinAI';
 export const LEGACY_APP_NAME = 'LobsterAI';
-export const APP_ID = 'lobsterai';
+export const APP_ID = 'rongxinai';
 export const DB_FILENAME = 'lobsterai.sqlite';

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5179,7 +5179,7 @@ if (!gotTheLock) {
 
   ipcMain.handle('shell:openHtmlInBrowser', async (_event, htmlContent: string) => {
     try {
-      const tmpDir = path.join(os.tmpdir(), 'lobsterai-preview');
+      const tmpDir = path.join(os.tmpdir(), 'rongxinai-preview');
       fs.mkdirSync(tmpDir, { recursive: true });
       const tmpFile = path.join(tmpDir, `preview-${Date.now()}.html`);
       fs.writeFileSync(tmpFile, htmlContent, 'utf-8');
@@ -5842,7 +5842,7 @@ if (!gotTheLock) {
     // We don't trigger permission dialogs at startup to avoid annoying users
 
     // Ensure default working directory exists
-    const defaultProjectDir = path.join(os.homedir(), 'lobsterai', 'project');
+    const defaultProjectDir = path.join(os.homedir(), 'rongxinai', 'project');
     if (!fs.existsSync(defaultProjectDir)) {
       fs.mkdirSync(defaultProjectDir, { recursive: true });
       console.log('Created default project directory:', defaultProjectDir);

--- a/src/renderer/constants/app.ts
+++ b/src/renderer/constants/app.ts
@@ -1,4 +1,4 @@
 export const APP_NAME = 'RongxinAI';
-export const APP_ID = 'lobsterai';
+export const APP_ID = 'rongxinai';
 export const EXPORT_FORMAT_TYPE = 'lobsterai.providers';
 export const EXPORT_PASSWORD = 'lobsterai-APP';


### PR DESCRIPTION
## 问题描述

设置 → 模型 → 导出的默认文件名仍为 `lobsterai-providers-xxx.json`，存在多处用户可见的旧名称遗留。

## 修改内容

| 变更 | 文件 | 改前 | 改后 |
|---|---|---|---|
| 导出默认文件名 | `src/renderer/constants/app.ts` | `lobsterai-providers-xxx.json` | `rongxinai-providers-xxx.json` |
| 临时预览目录 | `src/main/main.ts` | `lobsterai-preview` | `rongxinai-preview` |
| 默认项目目录 | `src/main/main.ts` | `~/lobsterai/project` | `~/rongxinai/project` |
| 应用 ID | `electron-builder.json` | `com.lobsterai.app` | `com.rongxinai.app` |

## 保留不变（向后兼容）

- `EXPORT_FORMAT_TYPE = 'lobsterai.providers'` — 旧导出文件格式校验
- `EXPORT_PASSWORD = 'lobsterai-APP'` — 旧文件加密密码
- `DB_FILENAME = 'lobsterai.sqlite'` — 用户已有数据库
- `LEGACY_APP_NAME = 'LobsterAI'` — 旧版数据目录迁移
- Provider ID（`lobsterai-server`/`lobsterai-copilot`/`lobster`）
- 会话 key 格式（`agent:main:lobsterai:*`）
- Deep link 协议（`lobsterai://`）

## 测试计划

- [ ] 导出文件名为 `rongxinai-providers-YYYY-MM-DD.json`
- [ ] 默认工作目录为 `~/rongxinai/project`
- [ ] 安装后系统应用列表显示为 com.rongxinai.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)