### PR TITLE
fix(llamacpp): 启动失败时展示stderr真实错误原因

### DIFF
--- a/src/main/libs/llamacppManager.ts
+++ b/src/main/libs/llamacppManager.ts
@@ -38,6 +38,7 @@ export class LlamaCppManager extends EventEmitter {
   private executablePath: string | null = null;
   private process: ChildProcessWithoutNullStreams | null = null;
   private runtimeContextLengthByModel = new Map<string, number>();
+  private startupStderr = '';
   private status: LlamaCppStatusSnapshot = {
     status: 'unknown',
     checkedAt: new Date().toISOString(),
@@ -123,14 +124,31 @@ export class LlamaCppManager extends EventEmitter {
       },
     );
 
+    this.startupStderr = '';
     this.process.stdout.on('data', chunk => console.debug(`[LlamaCpp] ${chunk.toString().trim()}`));
-    this.process.stderr.on('data', chunk => console.warn(`[LlamaCpp] ${chunk.toString().trim()}`));
+    this.process.stderr.on('data', chunk => {
+      const text = chunk.toString().trim();
+      console.warn(`[LlamaCpp] ${text}`);
+      this.startupStderr += (this.startupStderr ? '\n' : '') + text;
+    });
     this.process.on('exit', (code, signal) => {
       console.log(
         `[LlamaCpp] process exited with code ${code ?? 'null'} and signal ${signal ?? 'null'}`,
       );
       this.process = null;
-      if (this.status.status === 'running' || this.status.status === 'starting') {
+      if (this.status.status === 'starting') {
+        const stderrSnippet = this.startupStderr
+          ? `: ${this.startupStderr.slice(0, 300)}`
+          : ` (exit code ${code ?? 'null'})`;
+        this.setStatus({
+          status: 'error',
+          error: `llama.cpp exited unexpectedly during startup${stderrSnippet}`,
+          executablePath: this.executablePath ?? undefined,
+          managedByApp: false,
+        });
+        return;
+      }
+      if (this.status.status === 'running') {
         this.setStatus({
           status: 'stopped',
           executablePath: this.executablePath ?? undefined,
@@ -526,12 +544,18 @@ export class LlamaCppManager extends EventEmitter {
     const startedAt = Date.now();
     while (Date.now() - startedAt < timeoutMs) {
       if (await this.isHealthy()) return;
+      if (this.status.status === 'error' || this.status.status === 'stopped') {
+        return; // exit handler already set an error
+      }
       await new Promise(resolve => setTimeout(resolve, 250));
     }
+    const detail = this.startupStderr
+      ? ` (stderr: ${this.startupStderr.slice(0, 300)})`
+      : '';
     this.setStatus({
       status: 'error',
       executablePath: this.executablePath ?? undefined,
-      error: 'llama.cpp did not become ready before timeout',
+      error: `llama.cpp did not become ready before timeout${detail}`,
       managedByApp: Boolean(this.process),
     });
   }


### PR DESCRIPTION
## 问题描述

Windows 干净机器上 llama.cpp 启动失败时，用户只能看到 `llama.cpp did not become ready before timeout`，无法判断是缺 VC++ 运行时还是其他原因。真实的错误信息（如 `VCRUNTIME140.dll is missing`）只输出到 console log，用户看不到。

## 修改内容

`llamacppManager.ts` 中 3 处改动：

1. **stderr 累积** — `startupStderr` 变量收拢启动阶段的 stderr 输出
2. **exit handler** — 进程在 `starting` 阶段退出时，立即设置 `error` 状态并附带 stderr 内容，不再等 30 秒超时
3. **waitUntilHealthy** — 循环中检测到 exit handler 已设置 error 则立即返回；超时时附带 stderr 作为 fallback

## 效果对比

之前：
```
llama.cpp did not become ready before timeout
```

之后：
```
llama.cpp exited unexpectedly during startup: The program can't start because VCRUNTIME140.dll is missing from your computer.
```

## 测试计划

- [ ] 干净 Windows 机器上启动失败，应显示具体错误原因而非通用超时提示
- [ ] 正常启动流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)