### PR TITLE
feat(llamacpp): switch default runtime download source to Gitee with GitHub fallback

### DIFF
--- a/scripts/download-llamacpp-runtime.cjs
+++ b/scripts/download-llamacpp-runtime.cjs
@@ -9,6 +9,8 @@ const tar = require('tar');
 
 const DEFAULT_LLAMACPP_RUNTIME_GITHUB_REPO = 'ggml-org/llama.cpp';
 const DEFAULT_LLAMACPP_RUNTIME_RELEASE_TAG = 'b9244';
+const DEFAULT_LLAMACPP_RUNTIME_RELEASES_URL =
+  'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download';
 const OfficialAssetByTarget = {
   'mac-arm64': 'llama-{tag}-bin-macos-arm64.tar.gz',
   'mac-x64': 'llama-{tag}-bin-macos-x64.tar.gz',
@@ -104,25 +106,32 @@ function resolveArchiveExtension(archiveName) {
 }
 
 function resolveRuntimeDownloadSource(targetId, options = {}) {
+  return resolveRuntimeDownloadSources(targetId, options)[0];
+}
+
+function resolveRuntimeDownloadSources(targetId, options = {}) {
   const env = options.env ?? process.env;
   const rootDir = options.rootDir ?? path.resolve(__dirname, '..');
   const assetName = resolveOfficialRuntimeAssetName(targetId, env);
 
   const explicitUrl = env.LLAMACPP_RUNTIME_URL?.trim();
   if (explicitUrl) {
-    return explicitUrl
+    return [explicitUrl
       .replace(/\{target\}/g, targetId)
-      .replace(/\{asset\}/g, assetName);
+      .replace(/\{asset\}/g, assetName)];
   }
 
   const baseUrl = env.LLAMACPP_RUNTIME_BASE_URL?.trim();
   if (baseUrl) {
-    return `${baseUrl.replace(/\/$/, '')}/${assetName}`;
+    return [`${baseUrl.replace(/\/$/, '')}/${assetName}`];
   }
 
   const repo = resolveGitHubRepo(env);
   const releaseTag = resolveRuntimeReleaseTag(rootDir, env);
-  return `https://github.com/${repo}/releases/download/${releaseTag}/${assetName}`;
+  return [
+    `${DEFAULT_LLAMACPP_RUNTIME_RELEASES_URL}/${releaseTag}/${assetName}`,
+    `https://github.com/${repo}/releases/download/${releaseTag}/${assetName}`,
+  ];
 }
 
 function formatDownloadFailureMessage(status, statusText, url, targetId, rootDir) {
@@ -171,6 +180,19 @@ async function downloadFile(url, outputPath, rootDir, targetId) {
     file.end((error) => error ? reject(error) : resolve());
   });
   if (total > 0) process.stdout.write('\n');
+  return url;
+}
+
+async function downloadFileWithFallback(urls, outputPath, rootDir, targetId) {
+  const errors = [];
+  for (const url of urls) {
+    try {
+      return await downloadFile(url, outputPath, rootDir, targetId);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  throw new Error(errors.join('; '));
 }
 
 async function main() {
@@ -184,12 +206,13 @@ async function main() {
   if (fs.existsSync(targetExecutable)) {
     console.log(`[download-llamacpp-runtime] Runtime already exists: ${targetRuntimeDir}`);
   } else {
-    const url = resolveRuntimeDownloadSource(targetId, { rootDir });
+    const urls = resolveRuntimeDownloadSources(targetId, { rootDir });
+    const url = urls[0];
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llamacpp-runtime-'));
     const archiveName = path.basename(new URL(url).pathname) || resolveOfficialRuntimeAssetName(targetId);
     const archivePath = path.join(tempDir, archiveName);
     const extractDir = path.join(tempDir, 'extract');
-    await downloadFile(url, archivePath, rootDir, targetId);
+    const sourceUrl = await downloadFileWithFallback(urls, archivePath, rootDir, targetId);
     fs.mkdirSync(extractDir, { recursive: true });
     await extractArchive(archivePath, extractDir);
     fs.rmSync(targetRuntimeDir, { recursive: true, force: true });
@@ -199,7 +222,7 @@ async function main() {
       targetId,
       executableName,
       rootDir,
-      sourceUrl: url,
+      sourceUrl,
       assetName: archiveName,
     });
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -321,5 +344,6 @@ module.exports = {
   resolveHostTargetId,
   resolveOfficialRuntimeAssetName,
   resolveRuntimeDownloadSource,
+  resolveRuntimeDownloadSources,
   resolveRuntimeReleaseTag,
 };

--- a/src/main/libs/llamacppRuntimeDownload.test.ts
+++ b/src/main/libs/llamacppRuntimeDownload.test.ts
@@ -5,6 +5,7 @@ const scriptPath = path.resolve(process.cwd(), 'scripts', 'download-llamacpp-run
 const {
   formatDownloadFailureMessage,
   resolveRuntimeDownloadSource,
+  resolveRuntimeDownloadSources,
   resolveRuntimeReleaseTag,
 } = require(scriptPath) as {
   formatDownloadFailureMessage: (
@@ -18,17 +19,25 @@ const {
     targetId: string,
     options?: { env?: NodeJS.ProcessEnv; rootDir?: string },
   ) => string;
+  resolveRuntimeDownloadSources: (
+    targetId: string,
+    options?: { env?: NodeJS.ProcessEnv; rootDir?: string },
+  ) => string[];
   resolveRuntimeReleaseTag: (rootDir: string, env?: NodeJS.ProcessEnv) => string;
 };
 
 describe('llamacpp runtime download script', () => {
-  test('defaults to the configured upstream llama.cpp release asset', () => {
+  test('defaults to the configured Gitee asset with GitHub fallback', () => {
     const rootDir = process.cwd();
 
     expect(resolveRuntimeReleaseTag(rootDir, {})).toBe('b9244');
     expect(resolveRuntimeDownloadSource('win-x64', { rootDir, env: {} })).toBe(
-      'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+      'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
     );
+    expect(resolveRuntimeDownloadSources('win-x64', { rootDir, env: {} })).toEqual([
+      'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+      'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+    ]);
   });
 
   test('maps the official asset names per target', () => {
@@ -41,7 +50,7 @@ describe('llamacpp runtime download script', () => {
         env: { LLAMACPP_RUNTIME_RELEASE_TAG: 'b9243' },
       }),
     ).toBe(
-      'https://github.com/ggml-org/llama.cpp/releases/download/b9243/llama-b9243-bin-ubuntu-arm64.tar.gz',
+      'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9243/llama-b9243-bin-ubuntu-arm64.tar.gz',
     );
   });
 

--- a/src/main/libs/llamacppRuntimeInstaller.test.ts
+++ b/src/main/libs/llamacppRuntimeInstaller.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test } from 'vitest';
 
 import {
   createLlamaCppRuntimeInstallPlan,
+  resolveLlamaCppRuntimeDownloadUrls,
   ensureLlamaCppRuntimeCurrent,
   resolveLlamaCppRuntimeDownloadUrl,
   resolveLlamaCppRuntimeExecutablePath,
@@ -89,7 +90,10 @@ describe('llamacpp runtime installer planning', () => {
       targetId: 'win-x64',
       runtimeRoot,
       executablePath: path.join(runtimeRoot, 'current', 'bin', 'llama-server.exe'),
-      url: 'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+      url: 'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+      fallbackUrls: [
+        'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-win-cpu-x64.zip',
+      ],
     });
   });
 
@@ -102,8 +106,12 @@ describe('llamacpp runtime installer planning', () => {
 
   test('resolves official runtime download URLs for packaged installs', () => {
     expect(resolveLlamaCppRuntimeDownloadUrl('mac-arm64')).toBe(
-      'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-macos-arm64.tar.gz',
+      'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9244/llama-b9244-bin-macos-arm64.tar.gz',
     );
+    expect(resolveLlamaCppRuntimeDownloadUrls('mac-arm64')).toEqual([
+      'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download/b9244/llama-b9244-bin-macos-arm64.tar.gz',
+      'https://github.com/ggml-org/llama.cpp/releases/download/b9244/llama-b9244-bin-macos-arm64.tar.gz',
+    ]);
   });
 
   test('repairs current runtime when a target runtime already exists', async () => {

--- a/src/main/libs/llamacppRuntimeInstaller.ts
+++ b/src/main/libs/llamacppRuntimeInstaller.ts
@@ -11,6 +11,8 @@ import type {
 
 const LLAMACPP_RUNTIME_GITHUB_REPO = 'ggml-org/llama.cpp';
 const LLAMACPP_RUNTIME_RELEASE_TAG = 'b9244';
+const LLAMACPP_RUNTIME_DEFAULT_RELEASES_URL =
+  'https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download';
 const LLAMACPP_RUNTIME_ASSETS: Record<string, string> = {
   'mac-arm64': 'llama-{tag}-bin-macos-arm64.tar.gz',
   'mac-x64': 'llama-{tag}-bin-macos-x64.tar.gz',
@@ -50,16 +52,26 @@ export function resolveLlamaCppRuntimeDownloadUrl(
   targetId: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
+  return resolveLlamaCppRuntimeDownloadUrls(targetId, env)[0];
+}
+
+export function resolveLlamaCppRuntimeDownloadUrls(
+  targetId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
   const assetName = resolveLlamaCppRuntimeAssetName(targetId);
   const explicitUrl = env.LLAMACPP_RUNTIME_URL?.trim();
   if (explicitUrl) {
-    return explicitUrl.replace(/\{target\}/g, targetId).replace(/\{asset\}/g, assetName);
+    return [explicitUrl.replace(/\{target\}/g, targetId).replace(/\{asset\}/g, assetName)];
   }
   const baseUrl = env.LLAMACPP_RUNTIME_BASE_URL?.trim();
   if (baseUrl) {
-    return `${baseUrl.replace(/\/$/, '')}/${assetName}`;
+    return [`${baseUrl.replace(/\/$/, '')}/${assetName}`];
   }
-  return `https://github.com/${LLAMACPP_RUNTIME_GITHUB_REPO}/releases/download/${LLAMACPP_RUNTIME_RELEASE_TAG}/${assetName}`;
+  return [
+    `${LLAMACPP_RUNTIME_DEFAULT_RELEASES_URL}/${LLAMACPP_RUNTIME_RELEASE_TAG}/${assetName}`,
+    `https://github.com/${LLAMACPP_RUNTIME_GITHUB_REPO}/releases/download/${LLAMACPP_RUNTIME_RELEASE_TAG}/${assetName}`,
+  ];
 }
 
 export function createLlamaCppRuntimeInstallPlan(context: LlamaCppRuntimeInstallContext): LlamaCppRuntimeInstallPlan {
@@ -85,6 +97,7 @@ export function createLlamaCppRuntimeInstallPlan(context: LlamaCppRuntimeInstall
         message: 'The app could not resolve the local llama.cpp runtime install directory.',
       };
     }
+    const [url, ...fallbackUrls] = resolveLlamaCppRuntimeDownloadUrls(targetId);
     return {
       kind: 'download',
       targetId,
@@ -95,7 +108,8 @@ export function createLlamaCppRuntimeInstallPlan(context: LlamaCppRuntimeInstall
         'bin',
         resolveLlamaCppExecutableName(context.platform),
       ),
-      url: resolveLlamaCppRuntimeDownloadUrl(targetId),
+      url,
+      fallbackUrls,
     };
   }
 
@@ -201,7 +215,7 @@ async function installDownloadedRuntime(plan: Extract<LlamaCppRuntimeInstallPlan
   const executableName = path.basename(plan.executablePath);
 
   try {
-    await downloadFile(plan.url, archivePath);
+    const sourceUrl = await downloadFile(plan.url, archivePath, plan.fallbackUrls);
     fs.mkdirSync(extractDir, { recursive: true });
     await extractArchive(archivePath, extractDir);
 
@@ -215,7 +229,7 @@ async function installDownloadedRuntime(plan: Extract<LlamaCppRuntimeInstallPlan
     fs.rmSync(currentRuntimeRoot, { recursive: true, force: true });
     fs.mkdirSync(targetBinDir, { recursive: true });
     copyDirectoryContents(path.dirname(extractedExecutable), targetBinDir);
-    writeRuntimeBuildInfo(currentRuntimeRoot, plan, archiveName);
+    writeRuntimeBuildInfo(currentRuntimeRoot, { ...plan, url: sourceUrl }, archiveName);
 
     if (!fs.existsSync(plan.executablePath)) {
       throw new Error(`Installed llama.cpp runtime is missing ${path.join('bin', executableName)}.`);
@@ -228,17 +242,26 @@ async function installDownloadedRuntime(plan: Extract<LlamaCppRuntimeInstallPlan
   }
 }
 
-async function downloadFile(url: string, outputPath: string): Promise<void> {
-  const response = await fetch(url, {
-    headers: { 'User-Agent': 'RongxinAI/llamacpp-runtime-installer' },
-  });
-  if (!response.ok || !response.body) {
-    throw new Error(`Download failed: HTTP ${response.status} ${response.statusText} (${url})`);
+async function downloadFile(url: string, outputPath: string, fallbackUrls: string[] = []): Promise<string> {
+  const attempts = [url, ...fallbackUrls];
+  const errors: string[] = [];
+
+  for (const attemptUrl of attempts) {
+    const response = await fetch(attemptUrl, {
+      headers: { 'User-Agent': 'RongxinAI/llamacpp-runtime-installer' },
+    });
+    if (!response.ok || !response.body) {
+      errors.push(`HTTP ${response.status} ${response.statusText} (${attemptUrl})`);
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    const arrayBuffer = await response.arrayBuffer();
+    fs.writeFileSync(outputPath, Buffer.from(arrayBuffer));
+    return attemptUrl;
   }
 
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  const arrayBuffer = await response.arrayBuffer();
-  fs.writeFileSync(outputPath, Buffer.from(arrayBuffer));
+  throw new Error(`Download failed: ${errors.join('; ')}`);
 }
 
 async function extractArchive(archivePath: string, extractDir: string): Promise<void> {

--- a/src/shared/llamacpp/types.ts
+++ b/src/shared/llamacpp/types.ts
@@ -29,6 +29,7 @@ export type LlamaCppRuntimeInstallPlan =
     runtimeRoot: string;
     executablePath: string;
     url: string;
+    fallbackUrls?: string[];
   }
   | {
     kind: 'needs-manual';


### PR DESCRIPTION
将 llama.cpp runtime 的默认下载源从 GitHub 切换到 Gitee，GitHub 作为自动 fallback。

## 变更内容

### 默认源切换
- Gitee: `https://gitee.com/wanghaozhe1106/llama.cpp-runtime/releases/download`
- GitHub: 作为第一个 fallback 地址

### 下载链
Gitee（主）→ GitHub（备）。主源失败自动尝试备源。

### 兼容性
- `LLAMACPP_RUNTIME_URL` 和 `LLAMACPP_RUNTIME_BASE_URL` 环境变量覆盖仍然有效
- 现有用户不受影响，仅新下载/安装时使用新源