### PR TITLE
feat: 模型自动路由 (Phase 2.1) + 记忆来源追踪 (Phase 2.2a)

### DIFF
--- a/src/main/ipcHandlers/triage.ts
+++ b/src/main/ipcHandlers/triage.ts
@@ -1,0 +1,66 @@
+import { ipcMain } from 'electron';
+
+import type { TriageConfig } from '../../shared/triage';
+import { DEFAULT_TRIAGE_CONFIG, TriageIpcChannel } from '../../shared/triage';
+import type { SqliteStore } from '../sqliteStore';
+
+const TRIAGE_CONFIG_KEY = 'model_triage_config';
+
+export function registerTriageIpcHandlers(options: {
+  getStore: () => SqliteStore;
+}): void {
+  ipcMain.handle(TriageIpcChannel.GetConfig, async () => {
+    const stored = options.getStore().get<TriageConfig>(TRIAGE_CONFIG_KEY);
+    if (stored && typeof stored === 'object' && typeof stored.enabled === 'boolean') {
+      return stored;
+    }
+    options.getStore().set(TRIAGE_CONFIG_KEY, DEFAULT_TRIAGE_CONFIG);
+    return DEFAULT_TRIAGE_CONFIG;
+  });
+
+  ipcMain.handle(TriageIpcChannel.SetConfig, async (_event, config: unknown) => {
+    const sanitized = sanitizeTriageConfig(config);
+    options.getStore().set(TRIAGE_CONFIG_KEY, sanitized);
+    return sanitized;
+  });
+}
+
+export function getTriageConfig(store: SqliteStore): TriageConfig {
+  const stored = store.get<TriageConfig>(TRIAGE_CONFIG_KEY);
+  if (stored && typeof stored === 'object' && typeof stored.enabled === 'boolean') {
+    return sanitizeTriageConfig(stored);
+  }
+  store.set(TRIAGE_CONFIG_KEY, DEFAULT_TRIAGE_CONFIG);
+  return DEFAULT_TRIAGE_CONFIG;
+}
+
+function sanitizeTriageConfig(raw: unknown): TriageConfig {
+  if (!raw || typeof raw !== 'object') return DEFAULT_TRIAGE_CONFIG;
+  const input = raw as Record<string, unknown>;
+
+  return {
+    enabled: typeof input.enabled === 'boolean' ? input.enabled : DEFAULT_TRIAGE_CONFIG.enabled,
+    rules: {
+      lightModelRef:
+        typeof input.rules === 'object' && input.rules !== null
+          ? String((input.rules as Record<string, unknown>).lightModelRef || '')
+          : DEFAULT_TRIAGE_CONFIG.rules.lightModelRef,
+      heavyModelRef:
+        typeof input.rules === 'object' && input.rules !== null
+          ? String((input.rules as Record<string, unknown>).heavyModelRef || '')
+          : DEFAULT_TRIAGE_CONFIG.rules.heavyModelRef,
+      maxConversationRoundsForTriage:
+        typeof input.rules === 'object' && input.rules !== null
+          ? Math.max(1, Number((input.rules as Record<string, unknown>).maxConversationRoundsForTriage) || DEFAULT_TRIAGE_CONFIG.rules.maxConversationRoundsForTriage)
+          : DEFAULT_TRIAGE_CONFIG.rules.maxConversationRoundsForTriage,
+      allowCrossProviderSwitch:
+        typeof input.rules === 'object' && input.rules !== null
+          ? Boolean((input.rules as Record<string, unknown>).allowCrossProviderSwitch)
+          : DEFAULT_TRIAGE_CONFIG.rules.allowCrossProviderSwitch,
+      cooldownRounds:
+        typeof input.rules === 'object' && input.rules !== null
+          ? Math.max(1, Number((input.rules as Record<string, unknown>).cooldownRounds) || DEFAULT_TRIAGE_CONFIG.rules.cooldownRounds)
+          : DEFAULT_TRIAGE_CONFIG.rules.cooldownRounds,
+    },
+  };
+}

--- a/src/main/ipcHandlers/triage.ts
+++ b/src/main/ipcHandlers/triage.ts
@@ -61,6 +61,14 @@ function sanitizeTriageConfig(raw: unknown): TriageConfig {
         typeof input.rules === 'object' && input.rules !== null
           ? Math.max(1, Number((input.rules as Record<string, unknown>).cooldownRounds) || DEFAULT_TRIAGE_CONFIG.rules.cooldownRounds)
           : DEFAULT_TRIAGE_CONFIG.rules.cooldownRounds,
+      useLocalModelTriage:
+        typeof input.rules === 'object' && input.rules !== null
+          ? Boolean((input.rules as Record<string, unknown>).useLocalModelTriage)
+          : DEFAULT_TRIAGE_CONFIG.rules.useLocalModelTriage,
+      triageModelName:
+        typeof input.rules === 'object' && input.rules !== null
+          ? String((input.rules as Record<string, unknown>).triageModelName || '')
+          : DEFAULT_TRIAGE_CONFIG.rules.triageModelName,
     },
   };
 }

--- a/src/main/libs/agentEngine/modelTriage.ts
+++ b/src/main/libs/agentEngine/modelTriage.ts
@@ -1,0 +1,118 @@
+import type { TriageConfig, TriageResult, TriageState, TriageTier } from '../../../shared/triage';
+import { TRIAGE_TIER_ORDER } from '../../../shared/triage';
+
+/**
+ * Classify a user message using rule-based heuristics.
+ *
+ * Returns a TriageResult with the recommended tier and optional model override.
+ * If modelRef is null, the current model should be kept unchanged.
+ */
+export function classifyByRules(
+  prompt: string,
+  conversationDepth: number,
+  config: TriageConfig,
+): TriageResult {
+  if (conversationDepth > config.rules.maxConversationRoundsForTriage) {
+    return { tier: 'standard', modelRef: null, reason: 'deep-conversation' };
+  }
+
+  const trimmed = prompt.trim();
+  const len = trimmed.length;
+  const hasCode = /```[\s\S]*?```/.test(prompt);
+  const hasInlineCode = /`[^`]+`/.test(prompt);
+  const isGreeting =
+    /^(你好|hi\b|hello\b|hey\b|早上好|晚上好|下午好|再见|bye\b|谢谢|thank)/i.test(trimmed);
+  const isSimpleFact =
+    /^(什么是|who is|when did|where is|how many|what is|几点|天气|日期|今天.*几)/i.test(trimmed);
+  const isComplex =
+    /(为什么|怎么实现|如何设计|分析|架构|重构|review|解释.*原理|compare|区别|源码|底层|原理|设计模式)/.test(prompt) ||
+    /(write|implement|refactor|explain|analyze|design|optimize|debug|fix.*bug)/i.test(prompt);
+  const hasFilePath =
+    /(?:^|\s)([\w./-]*\/[\w./-]+\.[\w]{1,6})(?:\s|$)/.test(prompt) ||
+    /(?:^|\s)([A-Za-z]:\\[\w\\./-]+\.\w{1,6})(?:\s|$)/.test(prompt);
+  const isTranslation =
+    /(翻译|translate|译成|翻成|用.*怎么说)/i.test(prompt) && len < 200;
+  const isSummaryRequest =
+    /(总结|概括|摘要|summarize|summarize|tl;dr)/i.test(prompt) && len > 500;
+
+  // light tier: short greetings, simple facts, translations
+  if (len < 60 && (isGreeting || isSimpleFact) && !hasCode) {
+    if (config.rules.lightModelRef) {
+      return { tier: 'light', modelRef: config.rules.lightModelRef, reason: `light: ${isGreeting ? 'greeting' : 'simple-fact'}` };
+    }
+    return { tier: 'light', modelRef: null, reason: 'light-rule-match-no-model' };
+  }
+
+  if (isTranslation && config.rules.lightModelRef) {
+    return { tier: 'light', modelRef: config.rules.lightModelRef, reason: 'light: translation' };
+  }
+
+  // heavy tier: code generation, architecture analysis, complex reasoning, summarization
+  if (
+    (hasCode && len > 200) ||
+    (isComplex && len > 80) ||
+    hasFilePath ||
+    isSummaryRequest
+  ) {
+    if (config.rules.heavyModelRef) {
+      return { tier: 'heavy', modelRef: config.rules.heavyModelRef, reason: `heavy: ${[
+        hasCode ? 'code' : '',
+        isComplex ? 'complex' : '',
+        hasFilePath ? 'file' : '',
+        isSummaryRequest ? 'summary' : '',
+      ].filter(Boolean).join('+')}` };
+    }
+    return { tier: 'heavy', modelRef: null, reason: 'heavy-rule-match-no-model' };
+  }
+
+  // medium-length code snippets: standard
+  if ((hasCode || hasInlineCode) && len <= 200) {
+    return { tier: 'standard', modelRef: null, reason: 'standard: small-code' };
+  }
+
+  return { tier: 'standard', modelRef: null, reason: 'default' };
+}
+
+/**
+ * Check whether a tier switch should be allowed given hysteresis control.
+ *
+ * Switching up (light→standard, standard→heavy) is always allowed.
+ * Switching down must respect the cooldown period.
+ */
+export function shouldAllowSwitch(
+  newTier: TriageTier,
+  currentRound: number,
+  state: TriageState,
+  cooldownRounds: number,
+): boolean {
+  if (newTier === state.activeTier) return true;
+
+  const newOrder = TRIAGE_TIER_ORDER[newTier];
+  const activeOrder = TRIAGE_TIER_ORDER[state.activeTier];
+
+  // Always allow switching up
+  if (newOrder > activeOrder) return true;
+
+  // Switching down: respect cooldown
+  return currentRound - state.lastSwitchRound >= cooldownRounds;
+}
+
+/**
+ * Extract the provider prefix from a model ref.
+ * e.g. "openai/gpt-5.4" → "openai", "ollama/qwen2.5:0.5b" → "ollama"
+ */
+export function extractProviderId(modelRef: string): string | null {
+  const idx = modelRef.indexOf('/');
+  if (idx <= 0) return null;
+  return modelRef.slice(0, idx);
+}
+
+/**
+ * Create a fresh triage state for a new session.
+ */
+export function createTriageState(): TriageState {
+  return {
+    lastSwitchRound: 0,
+    activeTier: 'standard',
+  };
+}

--- a/src/main/libs/agentEngine/modelTriage.ts
+++ b/src/main/libs/agentEngine/modelTriage.ts
@@ -130,6 +130,42 @@ export function createTriageState(): TriageState {
   };
 }
 
+/**
+ * Full triage classification pipeline:
+ * 1. Try rule-based classification first (<1ms)
+ * 2. If result is ambiguous and local model triage is enabled,
+ *    try LLM-based classification (100-500ms, 3s timeout)
+ * 3. If all else fails, return standard tier
+ */
+export async function classifyMessage(
+  prompt: string,
+  conversationDepth: number,
+  config: TriageConfig,
+): Promise<TriageResult> {
+  const ruleResult = classifyByRules(prompt, conversationDepth, config);
+
+  // Definitive rule matches — return immediately
+  if (ruleResult.reason.startsWith('light:') || ruleResult.reason.startsWith('heavy:')) {
+    return ruleResult;
+  }
+  if (ruleResult.reason === 'deep-conversation') {
+    return ruleResult;
+  }
+
+  // Ambiguous cases — try local model if configured
+  if (
+    config.rules.useLocalModelTriage &&
+    config.rules.triageModelName
+  ) {
+    const llmResult = await classifyByLocalModel(prompt, config.rules.triageModelName, config);
+    if (llmResult) {
+      return llmResult;
+    }
+  }
+
+  return ruleResult;
+}
+
 // ─── Phase 2.1b: Local model classification ──────────────────────────────
 
 /**

--- a/src/main/libs/agentEngine/modelTriage.ts
+++ b/src/main/libs/agentEngine/modelTriage.ts
@@ -1,6 +1,19 @@
 import type { TriageConfig, TriageResult, TriageState, TriageTier } from '../../../shared/triage';
 import { TRIAGE_TIER_ORDER } from '../../../shared/triage';
 
+const LLAMACPP_BASE_URL = 'http://127.0.0.1:8080';
+const TRIAGE_LOCAL_MODEL_TIMEOUT_MS = 3_000;
+
+/**
+ * Build a classifier-friendly snippet from user input.
+ * Truncate to 200 chars to keep the classification fast and prevent prompt injection.
+ */
+function truncateForClassification(prompt: string): string {
+  const singleLine = prompt.replace(/\n/g, ' ').trim();
+  if (singleLine.length <= 200) return singleLine;
+  return singleLine.slice(0, 197) + '...';
+}
+
 /**
  * Classify a user message using rule-based heuristics.
  *
@@ -115,4 +128,103 @@ export function createTriageState(): TriageState {
     lastSwitchRound: 0,
     activeTier: 'standard',
   };
+}
+
+// ─── Phase 2.1b: Local model classification ──────────────────────────────
+
+/**
+ * Classification prompt sent to the local model.
+ * The user message is appended after this system prompt.
+ *
+ * Design goals:
+ * - Isolate classification from user content (separate system prompt)
+ * - Request structured output (single word)
+ * - Keep the prompt small for fast inference on small models
+ */
+const TRIAGE_CLASSIFIER_PROMPT = `Classify the following user message into exactly one category:
+- light: simple greeting, thanks, goodbye, small talk, simple factual question, short translation
+- standard: normal conversation, general question, moderate instruction
+- heavy: complex coding task, architecture design, debugging, long analysis, refactoring
+
+Reply with only one word: light, standard, or heavy.`;
+
+interface LocalClassificationResponse {
+  category: 'light' | 'standard' | 'heavy' | null;
+  error?: string;
+}
+
+/**
+ * Classify a user message using a local llama.cpp model.
+ *
+ * Sends the classification prompt + truncated user message to the
+ * llama.cpp server's /v1/chat/completions endpoint.
+ *
+ * Returns null on any failure — caller should fall back to standard tier.
+ */
+export async function classifyByLocalModel(
+  prompt: string,
+  triageModelName: string,
+  config: TriageConfig,
+): Promise<TriageResult | null> {
+  const truncated = truncateForClassification(prompt);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TRIAGE_LOCAL_MODEL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${LLAMACPP_BASE_URL}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: triageModelName,
+        messages: [
+          { role: 'system', content: TRIAGE_CLASSIFIER_PROMPT },
+          { role: 'user', content: truncated },
+        ],
+        max_tokens: 5,
+        temperature: 0,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = await response.json() as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const rawText = body?.choices?.[0]?.message?.content?.trim().toLowerCase() || '';
+
+    const category = parseClassificationResponse(rawText);
+    if (!category) {
+      return null;
+    }
+
+    return tierToResult(category, config);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function parseClassificationResponse(text: string): 'light' | 'standard' | 'heavy' | null {
+  if (/\blight\b/.test(text)) return 'light';
+  if (/\bheavy\b/.test(text)) return 'heavy';
+  if (/\bstandard\b/.test(text)) return 'standard';
+  return null;
+}
+
+function tierToResult(
+  tier: 'light' | 'standard' | 'heavy',
+  config: TriageConfig,
+): TriageResult {
+  if (tier === 'light' && config.rules.lightModelRef) {
+    return { tier: 'light', modelRef: config.rules.lightModelRef, reason: 'llm: light' };
+  }
+  if (tier === 'heavy' && config.rules.heavyModelRef) {
+    return { tier: 'heavy', modelRef: config.rules.heavyModelRef, reason: 'llm: heavy' };
+  }
+  return { tier, modelRef: null, reason: `llm: ${tier}` };
 }

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -33,7 +33,7 @@ import {
 } from '../openclawEngineManager';
 import { parsePrimaryModelRef } from '../openclawAgentModels';
 import type { TriageConfig, TriageResult, TriageState } from '../../../shared/triage';
-import { classifyByRules, createTriageState, extractProviderId, shouldAllowSwitch } from './modelTriage';
+import { classifyMessage, createTriageState, extractProviderId, shouldAllowSwitch } from './modelTriage';
 import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
@@ -1883,13 +1883,12 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (
       triageConfig?.enabled &&
       !session.modelOverride &&
-      currentModel &&
-      triageConfig.rules.lightModelRef
+      currentModel
     ) {
       const conversationDepth = (session.messages?.length ?? 0);
-      const ruleResult = classifyByRules(prompt, conversationDepth, triageConfig);
+      const classification = await classifyMessage(prompt, conversationDepth, triageConfig);
 
-      if (ruleResult.modelRef) {
+      if (classification.modelRef) {
         let triageState = this.triageStateBySession.get(sessionId);
         if (!triageState) {
           triageState = createTriageState();
@@ -1898,7 +1897,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
 
         // Cross-provider safety check
         const currentProvider = extractProviderId(currentModel);
-        const targetProvider = extractProviderId(ruleResult.modelRef);
+        const targetProvider = extractProviderId(classification.modelRef);
         const isCrossProvider =
           currentProvider && targetProvider && currentProvider !== targetProvider;
         if (isCrossProvider && !triageConfig.rules.allowCrossProviderSwitch) {
@@ -1906,18 +1905,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
             '[ModelTriage] skipped: cross-provider switch blocked',
             `sessionId=${sessionId}`,
             `from=${currentModel}`,
-            `to=${ruleResult.modelRef}`,
+            `to=${classification.modelRef}`,
             `reason=allowCrossProviderSwitch is false`,
           );
         } else if (
           shouldAllowSwitch(
-            ruleResult.tier,
+            classification.tier,
             conversationDepth,
             triageState,
             triageConfig.rules.cooldownRounds,
           )
         ) {
-          triageResult = ruleResult;
+          triageResult = classification;
           triageState.lastSwitchRound = conversationDepth;
           triageState.activeTier = triageResult.tier;
           console.log(

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -32,6 +32,8 @@ import {
   type OpenClawGatewayConnectionInfo,
 } from '../openclawEngineManager';
 import { parsePrimaryModelRef } from '../openclawAgentModels';
+import type { TriageConfig, TriageResult, TriageState } from '../../../shared/triage';
+import { classifyByRules, createTriageState, extractProviderId, shouldAllowSwitch } from './modelTriage';
 import {
   extractGatewayHistoryEntries,
   extractGatewayMessageText,
@@ -127,6 +129,7 @@ type OpenClawRuntimeAdapterOptions = {
   normalizeModelRef?: (modelRef: string) => string;
   isModelAvailableForSession?: (modelRef: string) => { available: boolean; message?: string };
   getModelContextWindow?: (modelRef: string) => number | undefined;
+  getTriageConfig?: () => TriageConfig;
 };
 
 type ChatEventState = 'delta' | 'final' | 'aborted' | 'error';
@@ -901,6 +904,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private readonly sessionModelPatchQueue = new Map<string, Promise<void>>();
   private readonly gatewayHistoryCountBySession = new Map<string, number>();
   private readonly latestTurnTokenBySession = new Map<string, number>();
+  private readonly triageStateBySession = new Map<string, TriageState>();
 
   /**
    * Sessions that were manually stopped by the user via stopSession().
@@ -1760,7 +1764,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     sessionId: string;
     sessionKey: string;
     model: string;
-    source: 'sessionOverride' | 'agentModel';
+    source: 'sessionOverride' | 'agentModel' | 'triage';
   }): Promise<void> {
     const { sessionId, sessionKey, model, source } = options;
     if (!model) {
@@ -1872,15 +1876,80 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     if (!session.modelOverride && currentModel && currentModel !== rawCurrentModel && agent?.id) {
       this.store.updateAgent(agent.id, { model: currentModel });
     }
+
+    // ── Model Triage ────────────────────────────────────────────────────
+    let triageResult: TriageResult | null = null;
+    const triageConfig = this.options.getTriageConfig?.();
+    if (
+      triageConfig?.enabled &&
+      !session.modelOverride &&
+      currentModel &&
+      triageConfig.rules.lightModelRef
+    ) {
+      const conversationDepth = (session.messages?.length ?? 0);
+      const ruleResult = classifyByRules(prompt, conversationDepth, triageConfig);
+
+      if (ruleResult.modelRef) {
+        let triageState = this.triageStateBySession.get(sessionId);
+        if (!triageState) {
+          triageState = createTriageState();
+          this.triageStateBySession.set(sessionId, triageState);
+        }
+
+        // Cross-provider safety check
+        const currentProvider = extractProviderId(currentModel);
+        const targetProvider = extractProviderId(ruleResult.modelRef);
+        const isCrossProvider =
+          currentProvider && targetProvider && currentProvider !== targetProvider;
+        if (isCrossProvider && !triageConfig.rules.allowCrossProviderSwitch) {
+          console.debug(
+            '[ModelTriage] skipped: cross-provider switch blocked',
+            `sessionId=${sessionId}`,
+            `from=${currentModel}`,
+            `to=${ruleResult.modelRef}`,
+            `reason=allowCrossProviderSwitch is false`,
+          );
+        } else if (
+          shouldAllowSwitch(
+            ruleResult.tier,
+            conversationDepth,
+            triageState,
+            triageConfig.rules.cooldownRounds,
+          )
+        ) {
+          triageResult = ruleResult;
+          triageState.lastSwitchRound = conversationDepth;
+          triageState.activeTier = triageResult.tier;
+          console.log(
+            '[ModelTriage]',
+            `sessionId=${sessionId}`,
+            `tier=${triageResult.tier}`,
+            `reason=${triageResult.reason}`,
+            `from=${currentModel}`,
+            `to=${triageResult.modelRef}`,
+            `crossProvider=${isCrossProvider}`,
+          );
+        }
+      }
+    }
+
+    const effectiveModel = triageResult?.modelRef || currentModel;
+    const effectiveSource = triageResult?.modelRef
+      ? 'triage'
+      : session.modelOverride
+        ? 'sessionOverride'
+        : 'agentModel';
+    // ── End Model Triage ────────────────────────────────────────────────
+
     try {
       await this.ensureSessionModelForTurn({
         sessionId,
         sessionKey,
-        model: currentModel,
-        source: session.modelOverride ? 'sessionOverride' : 'agentModel',
+        model: effectiveModel,
+        source: effectiveSource,
       });
       await this.assertLlamaCppContextBudget({
-        modelRef: currentModel,
+        modelRef: effectiveModel,
         sessionKey,
       });
     } catch (error) {

--- a/src/main/libs/openclawMemoryFile.ts
+++ b/src/main/libs/openclawMemoryFile.ts
@@ -594,6 +594,32 @@ export function ensureDefaultIdentity(workingDirectory: string | undefined): voi
 }
 
 // ---------------------------------------------------------------------------
+// Source provenance helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a MemorySource from session context.
+ *
+ * @param sessionId - Full Cowork session ID; we shorten to first 8 hex chars
+ * @param role - Who said it (user/assistant/tool/system/im)
+ * @param date - Optional ISO date string; defaults to today
+ */
+export function buildMemorySource(
+  sessionId: string | null,
+  role: MemorySource['role'],
+  date?: string,
+): MemorySource {
+  const shortId = sessionId
+    ? sessionId.replace(/-/g, '').slice(0, 8)
+    : null;
+  return {
+    sessionId: shortId,
+    role,
+    date: date || new Date().toISOString().slice(0, 10),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Workspace change sync
 // ---------------------------------------------------------------------------
 

--- a/src/main/libs/openclawMemoryFile.ts
+++ b/src/main/libs/openclawMemoryFile.ts
@@ -21,11 +21,22 @@ const TAG = '[OpenClaw Memory]';
 // Types
 // ---------------------------------------------------------------------------
 
+export interface MemorySource {
+  /** Short session ID (first 8 hex chars of SHA) or null for manually-added entries. */
+  sessionId: string | null;
+  /** Who produced the information. */
+  role: 'user' | 'assistant' | 'tool' | 'system' | 'im';
+  /** ISO date (YYYY-MM-DD) when the memory was created. */
+  date: string;
+}
+
 export interface OpenClawMemoryEntry {
   /** SHA-1 of the normalised text – stable across reads. */
   id: string;
   /** Raw text without the leading "- ". */
   text: string;
+  /** Source provenance metadata (null for legacy entries or manual additions). */
+  source: MemorySource | null;
 }
 
 export interface OpenClawMemoryStats {
@@ -87,6 +98,48 @@ function isBulletLine(line: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Source provenance (Phase 2.2a)
+// ---------------------------------------------------------------------------
+
+/**
+ * Inline source comment at the end of a memory bullet line.
+ *
+ * Format: <!-- source:s=<sessionId_8chars>:r=<role>:t=<YYYY-MM-DD> -->
+ *
+ * This is a standard Markdown comment that OpenClaw's parsers ignore.
+ * Legacy entries without this comment will have `source: null`.
+ */
+const SOURCE_RE = /<!--\s*source:s=([a-f0-9]{1,8}):r=([a-z]+):t=(\d{4}-\d{2}-\d{2})\s*-->$/;
+
+function parseSourceFromLine(line: string): MemorySource | null {
+  const match = line.match(SOURCE_RE);
+  if (!match) return null;
+  const role = match[2] as MemorySource['role'];
+  const validRoles = new Set<string>(['user', 'assistant', 'tool', 'system', 'im']);
+  return {
+    sessionId: match[1] || null,
+    role: validRoles.has(role) ? (role as MemorySource['role']) : 'system',
+    date: match[3],
+  };
+}
+
+function stripSourceComment(line: string): string {
+  return line.replace(SOURCE_RE, '').trimEnd();
+}
+
+function formatSourceComment(source: MemorySource): string {
+  return `<!-- source:s=${source.sessionId || 'manual'}:r=${source.role}:t=${source.date} -->`;
+}
+
+function formatMemoryLine(entry: OpenClawMemoryEntry): string {
+  const line = `- ${entry.text}`;
+  if (entry.source) {
+    return `${line} ${formatSourceComment(entry.source)}`;
+  }
+  return line;
+}
+
+// ---------------------------------------------------------------------------
 // Parsing & serialisation
 // ---------------------------------------------------------------------------
 
@@ -105,15 +158,22 @@ export function parseMemoryMd(content: string): OpenClawMemoryEntry[] {
   const seen = new Set<string>();
 
   for (const line of lines) {
-    const match = line.trim().match(BULLET_RE);
+    const trimmed = line.trim();
+    const match = trimmed.match(BULLET_RE);
     if (!match?.[1]) continue;
-    const text = match[1].replace(/\s+/g, ' ').trim();
+
+    // Strip source comment before fingerprinting so metadata changes
+    // don't change the entry ID.
+    const rawText = match[1];
+    const cleanText = stripSourceComment(rawText);
+    const text = cleanText.replace(/\s+/g, ' ').trim();
     if (!text) continue;
 
+    const source = parseSourceFromLine(trimmed);
     const fp = fingerprint(text);
     if (seen.has(fp)) continue;
     seen.add(fp);
-    entries.push({ id: fp, text });
+    entries.push({ id: fp, text, source });
   }
 
   return entries;
@@ -124,7 +184,7 @@ export function parseMemoryMd(content: string): OpenClawMemoryEntry[] {
  */
 export function serializeMemoryMd(entries: OpenClawMemoryEntry[]): string {
   if (entries.length === 0) return `${HEADER}\n`;
-  const lines = entries.map((e) => `- ${e.text}`);
+  const lines = entries.map((e) => formatMemoryLine(e));
   return `${HEADER}\n\n${lines.join('\n')}\n`;
 }
 
@@ -195,11 +255,17 @@ function rebuildMemoryMd(
 
           if (desiredById.has(fp)) {
             // Entry still exists (possibly with updated text via id change)
-            // Keep it at its original position
+            // Keep it at its original position, preserving source if available
             const desiredText = desiredById.get(fp)!;
+            // Look up the full entry to preserve source metadata
+            const desiredEntry = entries.find((e) => e.text === desiredText);
+            const source = desiredEntry?.source || parseSourceFromLine(line.trim());
             // Preserve original indentation
             const indent = line.match(/^(\s*)/)?.[1] ?? '';
-            result.push(`${indent}- ${desiredText}`);
+            const formatted = source
+              ? `${indent}- ${desiredText} ${formatSourceComment(source)}`
+              : `${indent}- ${desiredText}`;
+            result.push(formatted.trimEnd());
             desiredById.delete(fp); // mark as handled
             continue;
           }
@@ -227,7 +293,7 @@ function rebuildMemoryMd(
       result.push('');
     }
     for (const e of newEntries) {
-      result.push(`- ${e.text}`);
+      result.push(formatMemoryLine(e));
     }
   }
 
@@ -235,17 +301,16 @@ function rebuildMemoryMd(
   // matched to an original bullet (e.g. entries whose text was updated,
   // producing a new id). These are effectively "updated" entries that
   // lost their positional anchor.
-  const remaining = [...desiredById.values()].filter((text) => {
-    // Exclude entries that were already appended as newEntries
-    return !newEntries.some((ne) => ne.text === text);
+  const remaining = entries.filter((e) => {
+    return !newEntries.some((ne) => ne.id === e.id) && desiredById.has(e.id);
   });
   if (remaining.length > 0) {
     const lastLine = result[result.length - 1];
     if (lastLine !== undefined && lastLine.trim() !== '') {
       result.push('');
     }
-    for (const text of remaining) {
-      result.push(`- ${text}`);
+    for (const e of remaining) {
+      result.push(formatMemoryLine(e));
     }
   }
 
@@ -289,12 +354,20 @@ export function writeMemoryEntries(filePath: string, entries: OpenClawMemoryEntr
   console.log(`${TAG} writeMemoryEntries: wrote ${entries.length} entries to ${filePath}`);
 }
 
-export function addMemoryEntry(filePath: string, text: string): OpenClawMemoryEntry {
+export function addMemoryEntry(
+  filePath: string,
+  text: string,
+  source?: MemorySource | null,
+): OpenClawMemoryEntry {
   const trimmed = text.replace(/\s+/g, ' ').trim();
   if (!trimmed) throw new Error('Memory text is required');
 
   const entries = readMemoryEntries(filePath);
-  const entry: OpenClawMemoryEntry = { id: fingerprint(trimmed), text: trimmed };
+  const entry: OpenClawMemoryEntry = {
+    id: fingerprint(trimmed),
+    text: trimmed,
+    source: source || null,
+  };
 
   if (entries.some((e) => e.id === entry.id)) {
     console.log(`${TAG} addMemoryEntry: duplicate skipped (id=${entry.id.slice(0, 8)}…)`);
@@ -303,7 +376,10 @@ export function addMemoryEntry(filePath: string, text: string): OpenClawMemoryEn
 
   entries.push(entry);
   writeMemoryEntries(filePath, entries);
-  console.log(`${TAG} addMemoryEntry: added "${trimmed.slice(0, 40)}…" (id=${entry.id.slice(0, 8)}…)`);
+  const sourceInfo = entry.source
+    ? ` [source:s=${entry.source.sessionId}:r=${entry.source.role}:t=${entry.source.date}]`
+    : '';
+  console.log(`${TAG} addMemoryEntry: added "${trimmed.slice(0, 40)}…" (id=${entry.id.slice(0, 8)}…)${sourceInfo}`);
   return entry;
 }
 
@@ -323,7 +399,11 @@ export function updateMemoryEntry(
   }
 
   // Note: ID changes because it's content-based (fingerprint of text)
-  const updated: OpenClawMemoryEntry = { id: fingerprint(trimmed), text: trimmed };
+  const updated: OpenClawMemoryEntry = {
+    id: fingerprint(trimmed),
+    text: trimmed,
+    source: entries[idx].source, // preserve source metadata on update
+  };
   const oldText = entries[idx].text;
   entries[idx] = updated;
   writeMemoryEntries(filePath, entries);
@@ -406,7 +486,7 @@ export function migrateSqliteToMemoryMd(
         skipped++;
         continue;
       }
-      existing.push({ id, text });
+      existing.push({ id, text, source: null });
       existingIds.add(id);
       added++;
     }
@@ -557,7 +637,8 @@ export function syncMemoryFileOnWorkspaceChange(
     let added = 0;
     for (const entry of oldEntries) {
       if (newIds.has(entry.id)) continue;
-      newEntries.push(entry);
+      // Preserve source metadata from old file
+      newEntries.push({ ...entry, source: entry.source || null });
       newIds.add(entry.id);
       added++;
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,7 +31,7 @@ import {
 import type { DingTalkInstanceConfig, DiscordInstanceConfig, EmailMultiInstanceConfig, FeishuInstanceConfig, Platform, QQInstanceConfig, TelegramInstanceConfig, WecomInstanceConfig } from './im/types';
 import { getLlamaCppServiceConfig, registerLlamaCppIpcHandlers } from './ipcHandlers/llamacpp';
 import { registerMarketplaceIpcHandlers } from './ipcHandlers/marketplace';
-import { registerTriageIpcHandlers } from './ipcHandlers/triage';
+import { getTriageConfig, registerTriageIpcHandlers } from './ipcHandlers/triage';
 import { getOllamaServiceConfig, registerOllamaIpcHandlers } from './ipcHandlers/ollama';
 import {
   getCronJobService,
@@ -1514,6 +1514,7 @@ const getCoworkEngineRouter = () => {
           if (!parsed || parsed.providerId !== ProviderName.LlamaCpp) return undefined;
           return getLlamaCppModelContextWindow(parsed.modelId);
         },
+        getTriageConfig: () => getTriageConfig(getStore()),
       });
       // Wire up channel session sync for IM conversations via OpenClaw
       try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -96,6 +96,7 @@ import {
   readBootstrapFile,
   readMemoryEntries,
   resolveMemoryFilePath,
+  type MemorySource,
   searchMemoryEntries,
   updateMemoryEntry,
   writeBootstrapFile,
@@ -3790,10 +3791,18 @@ if (!gotTheLock) {
     text: string;
     confidence?: number;
     isExplicit?: boolean;
+    source?: MemorySource;
   }) => {
     try {
       const filePath = resolveMemoryFilePath(getMainAgentWorkspacePath(getOpenClawEngineManager().getStateDir()));
-      const entry = addMemoryEntry(filePath, input.text);
+      const source = input.source && typeof input.source === 'object'
+        ? {
+            sessionId: typeof input.source.sessionId === 'string' ? input.source.sessionId : null,
+            role: (['user', 'assistant', 'tool', 'system', 'im'] as const).includes(input.source.role as MemorySource['role']) ? input.source.role : 'system',
+            date: typeof input.source.date === 'string' ? input.source.date : new Date().toISOString().slice(0, 10),
+          } as MemorySource
+        : undefined;
+      const entry = addMemoryEntry(filePath, input.text, source);
       return { success: true, entry };
     } catch (error) {
       return {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,6 +31,7 @@ import {
 import type { DingTalkInstanceConfig, DiscordInstanceConfig, EmailMultiInstanceConfig, FeishuInstanceConfig, Platform, QQInstanceConfig, TelegramInstanceConfig, WecomInstanceConfig } from './im/types';
 import { getLlamaCppServiceConfig, registerLlamaCppIpcHandlers } from './ipcHandlers/llamacpp';
 import { registerMarketplaceIpcHandlers } from './ipcHandlers/marketplace';
+import { registerTriageIpcHandlers } from './ipcHandlers/triage';
 import { getOllamaServiceConfig, registerOllamaIpcHandlers } from './ipcHandlers/ollama';
 import {
   getCronJobService,
@@ -5893,6 +5894,7 @@ if (!gotTheLock) {
       syncOpenClawConfig,
       getAgentManager,
     });
+    registerTriageIpcHandlers({ getStore });
     registerOllamaIpcHandlers(getOllamaManager(), {
       getStore,
       syncOpenClawConfig,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -36,6 +36,7 @@ import {
 } from '../shared/ipc/channels';
 import { LlamaCppIpcChannel } from '../shared/llamacpp/constants';
 import { MarketplaceIpcChannel } from '../shared/marketplace/constants';
+import { TriageIpcChannel } from '../shared/triage';
 import { OllamaIpcChannel } from '../shared/ollama/constants';
 import type { Platform } from '../shared/platform';
 import { OpenClawSessionIpc } from './openclawSession/constants';
@@ -193,6 +194,11 @@ contextBridge.exposeInMainWorld('electron', {
   },
   marketplace: {
     search: (params?: unknown) => ipcRenderer.invoke(MarketplaceIpcChannel.Search, params),
+  },
+
+  triage: {
+    getConfig: () => ipcRenderer.invoke(TriageIpcChannel.GetConfig),
+    setConfig: (config: unknown) => ipcRenderer.invoke(TriageIpcChannel.SetConfig, config),
   },
 
   hardware: {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -418,8 +418,10 @@ contextBridge.exposeInMainWorld('electron', {
       query?: string; status?: 'created' | 'stale' | 'deleted' | 'all';
       includeDeleted?: boolean; limit?: number; offset?: number;
     }) => ipcRenderer.invoke(CoworkMemoryIpc.ListEntries, input),
-    createMemoryEntry: (input: { text: string; confidence?: number; isExplicit?: boolean }) =>
-      ipcRenderer.invoke(CoworkMemoryIpc.CreateEntry, input),
+    createMemoryEntry: (input: {
+      text: string; confidence?: number; isExplicit?: boolean;
+      source?: { sessionId?: string | null; role?: string; date?: string };
+    }) => ipcRenderer.invoke(CoworkMemoryIpc.CreateEntry, input),
     updateMemoryEntry: (input: {
       id: string; text?: string; confidence?: number;
       status?: 'created' | 'stale' | 'deleted'; isExplicit?: boolean;

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -556,6 +556,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [triageLightModel, setTriageLightModel] = useState('');
   const [triageHeavyModel, setTriageHeavyModel] = useState('');
   const [triageAllowCrossProvider, setTriageAllowCrossProvider] = useState(false);
+  const [triageUseLocalModel, setTriageUseLocalModel] = useState(false);
+  const [triageModelName, setTriageModelName] = useState('');
   const initialThemeRef = useRef<'light' | 'dark' | 'system'>(themeService.getTheme());
   const initialThemeIdRef = useRef<string>(themeService.getThemeId());
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
@@ -973,6 +975,8 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       setTriageLightModel(config.rules.lightModelRef);
       setTriageHeavyModel(config.rules.heavyModelRef);
       setTriageAllowCrossProvider(config.rules.allowCrossProviderSwitch);
+      setTriageUseLocalModel(config.rules.useLocalModelTriage);
+      setTriageModelName(config.rules.triageModelName);
     }).catch(() => { /* triage not available */ });
   }, []);
 
@@ -4318,6 +4322,63 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       ⚠ {i18nService.t('modelTriageCrossProviderWarning') || '跨服务商切换可能导致对话数据发送到第三方服务器，请确认您信任目标服务商。'}
                     </p>
                   )}
+
+                  {/* ── Local Model Triage (Phase 2.1b) ────────────── */}
+                  <div className="mt-3 pt-3 border-t border-border-subtle">
+                    <div className="flex items-center justify-between mb-2">
+                      <div>
+                        <span className="text-xs font-medium text-secondary">
+                          {i18nService.t('modelTriageUseLocalModelLabel') || '使用本地小模型辅助分类'}
+                        </span>
+                        <p className="text-[11px] text-secondary mt-0.5">
+                          {i18nService.t('modelTriageUseLocalModelHint') || '规则无法确定时，调用本地 llama.cpp 小模型进行分类（需已启动）。'}
+                        </p>
+                      </div>
+                      <label className="relative inline-flex items-center cursor-pointer shrink-0 ml-2">
+                        <input
+                          type="checkbox"
+                          checked={triageUseLocalModel}
+                          onChange={async (e) => {
+                            const value = e.target.checked;
+                            setTriageUseLocalModel(value);
+                            const config = await window.electron.triage.getConfig();
+                            await window.electron.triage.setConfig({
+                              ...config,
+                              rules: { ...config.rules, useLocalModelTriage: value },
+                            });
+                          }}
+                          className="sr-only peer"
+                        />
+                        <div className="w-9 h-5 bg-surface-raised peer-checked:bg-primary rounded-full peer transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-[16px]"/>
+                      </label>
+                    </div>
+
+                    {triageUseLocalModel && (
+                      <div>
+                        <label className="text-xs font-medium text-secondary block mb-1">
+                          {i18nService.t('modelTriageModelNameLabel') || '分类模型名称'}
+                        </label>
+                        <input
+                          type="text"
+                          value={triageModelName}
+                          onChange={async (e) => {
+                            const value = e.target.value;
+                            setTriageModelName(value);
+                            const config = await window.electron.triage.getConfig();
+                            await window.electron.triage.setConfig({
+                              ...config,
+                              rules: { ...config.rules, triageModelName: value },
+                            });
+                          }}
+                          placeholder={i18nService.t('modelTriageModelNamePlaceholder') || '例如: qwen2.5-0.5b'}
+                          className="w-full text-sm rounded-lg border px-3 py-2 border-border bg-surface text-foreground"
+                        />
+                        <p className="text-[11px] text-secondary mt-1">
+                          {i18nService.t('modelTriageModelNameNote') || '需要先在本地推理中加载该模型。推荐使用 0.5B-1B 的轻量模型。'}
+                        </p>
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
             </div>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -552,6 +552,10 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
   const [pendingDeleteProvider, setPendingDeleteProvider] = useState<ProviderType | null>(null);
   const [isImportingProviders, setIsImportingProviders] = useState(false);
   const [isExportingProviders, setIsExportingProviders] = useState(false);
+  const [triageEnabled, setTriageEnabled] = useState(false);
+  const [triageLightModel, setTriageLightModel] = useState('');
+  const [triageHeavyModel, setTriageHeavyModel] = useState('');
+  const [triageAllowCrossProvider, setTriageAllowCrossProvider] = useState(false);
   const initialThemeRef = useRef<'light' | 'dark' | 'system'>(themeService.getTheme());
   const initialThemeIdRef = useRef<string>(themeService.getThemeId());
   const initialLanguageRef = useRef<LanguageType>(i18nService.getLanguage());
@@ -961,6 +965,15 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
       themeService.restoreTheme(initialThemeId, initialTheme);
       i18nService.setLanguage(initialLanguage, { persist: false });
     };
+  }, []);
+
+  useEffect(() => {
+    window.electron.triage.getConfig().then((config) => {
+      setTriageEnabled(config.enabled);
+      setTriageLightModel(config.rules.lightModelRef);
+      setTriageHeavyModel(config.rules.heavyModelRef);
+      setTriageAllowCrossProvider(config.rules.allowCrossProviderSwitch);
+    }).catch(() => { /* triage not available */ });
   }, []);
 
   // 监听标签页切换，确保内容区域滚动到顶部
@@ -4178,6 +4191,133 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
                       </div>
                     )}
                   </div>
+                </div>
+              )}
+            </div>
+
+            {/* ── Model Triage ────────────────────────────────────── */}
+            <div className="mt-4 pt-4 border-t border-border">
+              <div className="flex items-center justify-between mb-3">
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">
+                    {i18nService.t('modelTriageTitle') || '自动模型路由'}
+                  </h3>
+                  <p className="text-xs text-secondary mt-0.5">
+                    {i18nService.t('modelTriageDescription') || '开启后，简单消息自动使用轻量模型以降低延迟和成本，复杂任务保持使用默认模型。'}
+                  </p>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer shrink-0 ml-2">
+                  <input
+                    type="checkbox"
+                    checked={triageEnabled}
+                    onChange={async (e) => {
+                      const enabled = e.target.checked;
+                      setTriageEnabled(enabled);
+                      const config = await window.electron.triage.getConfig();
+                      await window.electron.triage.setConfig({ ...config, enabled });
+                    }}
+                    className="sr-only peer"
+                  />
+                  <div className="w-9 h-5 bg-surface-raised peer-checked:bg-primary rounded-full peer transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-[16px]"/>
+                </label>
+              </div>
+
+              {triageEnabled && (
+                <div className="space-y-3 ml-1 pl-3 border-l-2 border-primary-muted">
+                  <div>
+                    <label className="text-xs font-medium text-secondary block mb-1">
+                      {i18nService.t('modelTriageLightModelLabel') || '轻量模型'}
+                    </label>
+                    <select
+                      value={triageLightModel}
+                      onChange={async (e) => {
+                        const value = e.target.value;
+                        setTriageLightModel(value);
+                        const config = await window.electron.triage.getConfig();
+                        await window.electron.triage.setConfig({
+                          ...config,
+                          rules: { ...config.rules, lightModelRef: value },
+                        });
+                      }}
+                      className="w-full text-sm rounded-lg border px-3 py-2 border-border bg-surface text-foreground"
+                    >
+                      <option value="">{i18nService.t('modelTriageNoModel') || '不指定（使用当前模型）'}</option>
+                      {Object.entries(visibleProviders).flatMap(([provider, config]) => {
+                        const providerKey = provider as ProviderType;
+                        const models = config.models || [];
+                        return models.map((model: { id: string; name: string }) => {
+                          const ref = `${providerKey}/${model.id}`;
+                          return (
+                            <option key={ref} value={ref}>
+                              [{providerKey}] {model.name || model.id}
+                            </option>
+                          );
+                        });
+                      })}
+                    </select>
+                  </div>
+
+                  <div>
+                    <label className="text-xs font-medium text-secondary block mb-1">
+                      {i18nService.t('modelTriageHeavyModelLabel') || '强推理模型（可选）'}
+                    </label>
+                    <select
+                      value={triageHeavyModel}
+                      onChange={async (e) => {
+                        const value = e.target.value;
+                        setTriageHeavyModel(value);
+                        const config = await window.electron.triage.getConfig();
+                        await window.electron.triage.setConfig({
+                          ...config,
+                          rules: { ...config.rules, heavyModelRef: value },
+                        });
+                      }}
+                      className="w-full text-sm rounded-lg border px-3 py-2 border-border bg-surface text-foreground"
+                    >
+                      <option value="">{i18nService.t('modelTriageNoModel') || '不指定（使用当前模型）'}</option>
+                      {Object.entries(visibleProviders).flatMap(([provider, config]) => {
+                        const providerKey = provider as ProviderType;
+                        const models = config.models || [];
+                        return models.map((model: { id: string; name: string }) => {
+                          const ref = `${providerKey}/${model.id}`;
+                          return (
+                            <option key={ref} value={ref}>
+                              [{providerKey}] {model.name || model.id}
+                            </option>
+                          );
+                        });
+                      })}
+                    </select>
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-secondary">
+                      {i18nService.t('modelTriageAllowCrossProviderLabel') || '允许跨服务商切换'}
+                    </span>
+                    <label className="relative inline-flex items-center cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={triageAllowCrossProvider}
+                        onChange={async (e) => {
+                          const value = e.target.checked;
+                          setTriageAllowCrossProvider(value);
+                          const config = await window.electron.triage.getConfig();
+                          await window.electron.triage.setConfig({
+                            ...config,
+                            rules: { ...config.rules, allowCrossProviderSwitch: value },
+                          });
+                        }}
+                        className="sr-only peer"
+                      />
+                      <div className="w-9 h-5 bg-surface-raised peer-checked:bg-primary rounded-full peer transition-colors after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-[16px]"/>
+                    </label>
+                  </div>
+
+                  {triageAllowCrossProvider && (
+                    <p className="text-[11px] text-amber-500">
+                      ⚠ {i18nService.t('modelTriageCrossProviderWarning') || '跨服务商切换可能导致对话数据发送到第三方服务器，请确认您信任目标服务商。'}
+                    </p>
+                  )}
                 </div>
               )}
             </div>

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -690,6 +690,7 @@ class CoworkService {
 
   async createMemoryEntry(input: {
     text: string;
+    source?: { sessionId?: string | null; role?: string; date?: string };
   }): Promise<CoworkUserMemoryEntry | null> {
     const api = window.electron?.cowork?.createMemoryEntry;
     if (!api) return null;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -133,9 +133,16 @@ type CoworkConfigUpdate = Partial<
   >
 >;
 
+interface MemorySource {
+  sessionId: string | null;
+  role: 'user' | 'assistant' | 'tool' | 'system' | 'im';
+  date: string;
+}
+
 interface CoworkUserMemoryEntry {
   id: string;
   text: string;
+  source?: MemorySource | null;
 }
 
 interface CoworkMemoryStats {
@@ -626,6 +633,7 @@ interface IElectronAPI {
     }) => Promise<{ success: boolean; entries?: CoworkUserMemoryEntry[]; error?: string }>;
     createMemoryEntry: (input: {
       text: string;
+      source?: { sessionId?: string | null; role?: string; date?: string };
     }) => Promise<{ success: boolean; entry?: CoworkUserMemoryEntry; error?: string }>;
     updateMemoryEntry: (input: {
       id: string;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -19,6 +19,7 @@ import type {
   LlamaCppStatusSnapshot,
 } from '../../shared/llamacpp';
 import type { MarketplaceSearchParams, MarketplaceSearchResult } from '../../shared/marketplace';
+import type { TriageConfig } from '../../shared/triage';
 import type {
   OllamaCancelPullResult,
   OllamaChatChunk,
@@ -440,6 +441,10 @@ interface IElectronAPI {
   };
   marketplace: {
     search: (params?: MarketplaceSearchParams) => Promise<MarketplaceSearchResult>;
+  };
+  triage: {
+    getConfig: () => Promise<TriageConfig>;
+    setConfig: (config: TriageConfig) => Promise<TriageConfig>;
   };
   hardware: {
     nvidiaSmi: () => Promise<NvidiaSmiSnapshot>;

--- a/src/shared/triage.ts
+++ b/src/shared/triage.ts
@@ -1,0 +1,48 @@
+export const TRIAGE_TIERS = ['light', 'standard', 'heavy'] as const;
+export type TriageTier = (typeof TRIAGE_TIERS)[number];
+
+export const TRIAGE_TIER_ORDER: Record<TriageTier, number> = {
+  light: 0,
+  standard: 1,
+  heavy: 2,
+};
+
+export interface TriageConfig {
+  enabled: boolean;
+  rules: {
+    lightModelRef: string;
+    heavyModelRef: string;
+    maxConversationRoundsForTriage: number;
+    allowCrossProviderSwitch: boolean;
+    cooldownRounds: number;
+  };
+}
+
+export const DEFAULT_TRIAGE_CONFIG: TriageConfig = {
+  enabled: false,
+  rules: {
+    lightModelRef: '',
+    heavyModelRef: '',
+    maxConversationRoundsForTriage: 20,
+    allowCrossProviderSwitch: false,
+    cooldownRounds: 3,
+  },
+};
+
+export interface TriageResult {
+  tier: TriageTier;
+  modelRef: string | null;
+  reason: string;
+}
+
+export interface TriageState {
+  lastSwitchRound: number;
+  activeTier: TriageTier;
+}
+
+export const TriageIpcChannel = {
+  GetConfig: 'triage:config:get',
+  SetConfig: 'triage:config:set',
+} as const;
+
+export type TriageIpcChannel = (typeof TriageIpcChannel)[keyof typeof TriageIpcChannel];

--- a/src/shared/triage.ts
+++ b/src/shared/triage.ts
@@ -15,6 +15,8 @@ export interface TriageConfig {
     maxConversationRoundsForTriage: number;
     allowCrossProviderSwitch: boolean;
     cooldownRounds: number;
+    useLocalModelTriage: boolean;
+    triageModelName: string;
   };
 }
 
@@ -26,6 +28,8 @@ export const DEFAULT_TRIAGE_CONFIG: TriageConfig = {
     maxConversationRoundsForTriage: 20,
     allowCrossProviderSwitch: false,
     cooldownRounds: 3,
+    useLocalModelTriage: false,
+    triageModelName: '',
   },
 };
 


### PR DESCRIPTION
## 概述

本次 PR 包含两个 Phase 的改动：

1. **Phase 2.1a + 2.1b：模型 Triage 自动路由** — 根据用户消息内容自动选择合适的模型，降低 API 成本、提升简单消息响应速度
2. **Phase 2.2a：记忆来源追踪** — MEMORY.md 格式增强，每条记忆可追溯到来源会话、角色和日期

---

## Phase 2.1a：规则引擎（8 个文件，+459 行）

| 文件 | 内容 |
|---|---|
| `src/shared/triage.ts` | TriageTier / TriageConfig / TriageResult / TriageState 类型定义 |
| `src/main/libs/agentEngine/modelTriage.ts` | classifyByRules 规则分类器（问候/代码/复杂推理/翻译/总结 6 类）+ 滞回控制 + classifyMessage 编排器 |
| `src/main/ipcHandlers/triage.ts` | IPC handler（getConfig / setConfig）+ SqliteStore 持久化 + 输入 sanitize |
| `src/main/preload.ts` | triage IPC 桥接 |
| `src/main/main.ts` | 注册 triage handler + getTriageConfig 传入 adapter |
| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | runTurn 核心集成：triage 决策 → 跨 provider 安全检查 → 滞回控制 → session patch |
| `src/renderer/types/electron.d.ts` | triage API 类型声明 |
| `src/renderer/components/Settings.tsx` | 开关 + 轻量/重度模型选择器 + 跨 provider 警告 |

## Phase 2.1b：本地小模型回退（4 个提交，+280 行）

- `classifyByLocalModel`：调 llama.cpp `/v1/chat/completions`，3s 超时，隔离 system prompt
- `classifyMessage` 编排器：规则命中 → 直接返回；规则模糊 → 本地 LLM 分类
- UI：本地模型开关 + 分类模型名称输入框
- 用户消息截断 200 字符，分类 prompt 与用户输入完全隔离

## 安全策略（Phase 2.1）

- session.modelOverride 存在时自动跳过 triage（用户手动选择优先）
- 跨 Provider 切换默认禁止，需用户显式开启并看到隐私警告
- 滞回控制：切换后至少保持 3 轮，避免频繁抖动
- 长会话（>20 轮）自动禁用 triage
- Triage 失败静默回退到 agent model，不阻塞会话
- 分类 prompt 与用户输入隔离（system prompt 硬编码）
- 规则引擎纯本地、零网络调用、零延迟

---

## Phase 2.2a：记忆来源追踪（3 个文件，+148 行）

| 文件 | 内容 |
|---|---|
| `src/main/libs/openclawMemoryFile.ts` | MemorySource 类型 + `<!-- source:s=...:r=...:t=... -->` Markdown 注释格式 + 解析/序列化/重建全部支持 + buildMemorySource 辅助函数 |
| `src/main/main.ts` | IPC createEntry 接受 source 参数并校验 |
| `src/main/preload.ts` / `src/renderer/types/electron.d.ts` / `src/renderer/services/cowork.ts` | 渲染进程全链路传递 source |

### MEMORY.md 格式变化

```markdown
# User Memories

- 用户喜欢用 VS Code <!-- source:s=a3f2b1e5:r=user:t=2026-05-21 -->
- 项目 A 使用 PostgreSQL <!-- source:s=b4c3d2f6:r=assistant:t=2026-05-20 -->
- 手动添加的记忆（无来源注释）
```

### 设计要点

- source 注释在计算指纹前剥离，元数据变化不影响条目 ID
- sessionId 取前 8 位 SHA 短哈希保护隐私
- 旧条目向后兼容：无注释 → `source: null`
- update 操作保留原有 source 元数据

---

## 测试计划

### Phase 2.1
- [ ] Settings 中开启自动路由，选择轻量模型
- [ ] 发送"你好" → 路由到轻量模型
- [ ] 发送"帮我写 LRU cache" → 路由到默认/重度模型
- [ ] 用户手动选择模型 → triage 被跳过
- [ ] 关闭自动路由 → 模型选择恢复正常
- [ ] 开启本地模型分类 → 规则模糊时调 llama.cpp 分类

### Phase 2.2a
- [ ] 查看 MEMORY.md，新条目应有 source 注释
- [ ] 旧条目无 source 注释 → parse 后 source: null
- [ ] 修改记忆 → source 元数据保留
- [ ] 新旧格式混合的 MEMORY.md → parse 正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)