### PR TITLE
feat(gateway): 网关硬重启不遮挡操作界面 — 通知栏方案

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -783,7 +783,16 @@ const CoworkPromptInput = React.forwardRef<CoworkPromptInputRef, CoworkPromptInp
     void handleIncomingFiles(files);
   }, [disabled, handleIncomingFiles, isStreaming]);
 
-  const canSubmit = !disabled && !isPatchingModel && !agentModelIsInvalid && !hasUnavailableLlamaCppModel && (!!value.trim() || attachments.length > 0);
+  const [isGatewayReady, setIsGatewayReady] = useState(true);
+  useEffect(() => {
+    coworkService.getOpenClawEngineStatus().then((s) => {
+      setIsGatewayReady(!s || s.phase === 'running');
+    });
+    return coworkService.onOpenClawEngineStatus((s) => {
+      setIsGatewayReady(s.phase === 'running');
+    });
+  }, []);
+  const canSubmit = isGatewayReady && !disabled && !isPatchingModel && !agentModelIsInvalid && !hasUnavailableLlamaCppModel && (!!value.trim() || attachments.length > 0);
   const invalidModelLabel = invalidExplicitModelRef?.split('/').pop() || invalidExplicitModelRef || '';
 
   const enhancedContainerClass = isDraggingFiles

--- a/src/renderer/components/cowork/EngineStartupOverlay.tsx
+++ b/src/renderer/components/cowork/EngineStartupOverlay.tsx
@@ -1,5 +1,5 @@
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
-import React, { useEffect,useState } from 'react';
+import { ChatBubbleLeftRightIcon, ChevronDownIcon, ChevronUpIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
@@ -17,7 +17,7 @@ const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
     case 'compiling':
       return status.message || i18nService.t('coworkOpenClawStarting');
     case 'error':
-      return i18nService.t('coworkOpenClawError');
+      return status.message || i18nService.t('coworkOpenClawError');
     case 'running':
     default:
       return i18nService.t('coworkOpenClawRunning');
@@ -25,11 +25,19 @@ const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
 };
 
 /**
- * Global overlay shown when the OpenClaw gateway is starting up.
- * Renders on top of all views (cowork, skills, scheduled tasks, mcp).
+ * Non-blocking top banner shown when the OpenClaw gateway is starting or in error.
+ *
+ * Unlike the previous full-screen overlay, this banner allows the user to:
+ * - Browse conversation history
+ * - Switch to other sessions/tabs
+ * - Open Settings
+ * - Use IM features
+ *
+ * Only the message send button is disabled during startup (handled in CoworkPromptInput).
  */
 const EngineStartupOverlay: React.FC = () => {
   const [status, setStatus] = useState<OpenClawEngineStatus | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     coworkService.getOpenClawEngineStatus().then((s) => {
@@ -38,12 +46,31 @@ const EngineStartupOverlay: React.FC = () => {
 
     const unsubscribe = coworkService.onOpenClawEngineStatus((s) => {
       setStatus(s);
+      // Auto-expand on error
+      if (s.phase === 'error') {
+        setCollapsed(false);
+      }
     });
 
     return unsubscribe;
   }, []);
 
-  if (!status || (status.phase !== 'starting' && status.phase !== 'compiling')) {
+  const dismiss = useCallback(() => {
+    setCollapsed(true);
+  }, []);
+
+  const expand = useCallback(() => {
+    setCollapsed(false);
+  }, []);
+
+  const retry = useCallback(() => {
+    coworkService.restartOpenClawGateway().catch(() => { /* handled by status event */ });
+  }, []);
+
+  const isStarting = status?.phase === 'starting' || status?.phase === 'compiling';
+  const isError = status?.phase === 'error';
+
+  if (!status || (!isStarting && !isError)) {
     return null;
   }
 
@@ -51,28 +78,88 @@ const EngineStartupOverlay: React.FC = () => {
     ? Math.max(0, Math.min(100, Math.round(status.progressPercent)))
     : null;
 
+  if (collapsed && isStarting) {
+    return (
+      <div className="absolute top-0 left-0 right-0 z-[50]">
+        <button
+          onClick={expand}
+          className="mx-auto mt-1 flex items-center gap-1.5 rounded-b-lg bg-primary-muted/80 px-3 py-1 text-xs text-primary hover:bg-primary-muted transition-colors"
+          aria-label={i18nService.t('coworkOpenClawStartingNoticeExpand') || '展开网关状态'}
+        >
+          <ChatBubbleLeftRightIcon className="h-3 w-3 animate-pulse" />
+          <span>{i18nService.t('coworkOpenClawStartingNoticeShort') || '网关启动中...'}</span>
+          <ChevronDownIcon className="h-3 w-3" />
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/90 backdrop-blur-sm">
-      <div className="w-full max-w-lg rounded-2xl border border-border bg-surface p-6 shadow-card">
-        <div className="flex flex-col items-center text-center gap-3">
-          <div className="h-10 w-10 rounded-full bg-primary/15 text-primary flex items-center justify-center animate-pulse">
-            <ChatBubbleLeftRightIcon className="h-5 w-5" />
-          </div>
-          <div className="text-sm text-foreground">
+    <div
+      className={`absolute top-0 left-0 right-0 z-[50] border-b transition-colors ${
+        isError
+          ? 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950'
+          : 'border-primary/20 bg-primary-muted'
+      }`}
+    >
+      <div className="flex items-center gap-3 px-4 py-2.5">
+        {/* Icon */}
+        <div
+          className={`h-7 w-7 rounded-full flex items-center justify-center shrink-0 ${
+            isError
+              ? 'bg-red-200 text-red-700 dark:bg-red-800 dark:text-red-300'
+              : 'bg-primary/15 text-primary animate-pulse'
+          }`}
+        >
+          {isError ? (
+            <ExclamationTriangleIcon className="h-4 w-4" />
+          ) : (
+            <ChatBubbleLeftRightIcon className="h-4 w-4" />
+          )}
+        </div>
+
+        {/* Message + Progress */}
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-foreground">
             {resolveEngineStatusText(status)}
           </div>
-          {progressPercent !== null && (
-            <div className="w-full space-y-1">
-              <div className="h-1.5 w-full rounded-full bg-primary/15 overflow-hidden">
+          {progressPercent !== null && isStarting && (
+            <div className="mt-1 flex items-center gap-2">
+              <div className="h-1 flex-1 max-w-[200px] rounded-full bg-primary/15 overflow-hidden">
                 <div
                   className="h-full rounded-full bg-primary transition-all"
                   style={{ width: `${progressPercent}%` }}
                 />
               </div>
-              <div className="text-xs text-secondary">
-                {progressPercent}%
-              </div>
+              <span className="text-xs text-secondary">{progressPercent}%</span>
             </div>
+          )}
+          {isError && (
+            <div className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+              {i18nService.t('coworkOpenClawErrorHint') || '请检查网络连接或重试'}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {isError && (
+            <button
+              onClick={retry}
+              className="text-xs font-medium px-2.5 py-1 rounded-lg bg-red-200 text-red-700 hover:bg-red-300 dark:bg-red-800 dark:text-red-300 dark:hover:bg-red-700 transition-colors"
+            >
+              {i18nService.t('retry') || '重试'}
+            </button>
+          )}
+          {isStarting && (
+            <button
+              onClick={dismiss}
+              className="text-xs text-secondary hover:text-foreground px-1.5 py-0.5 rounded transition-colors"
+              aria-label={i18nService.t('collapse') || '收起'}
+              title={i18nService.t('coworkOpenClawStartingNoticeDismiss') || '收起通知'}
+            >
+              <ChevronUpIcon className="h-3.5 w-3.5" />
+            </button>
           )}
         </div>
       </div>
@@ -81,3 +168,24 @@ const EngineStartupOverlay: React.FC = () => {
 };
 
 export default EngineStartupOverlay;
+
+/**
+ * Hook for other components to react to gateway readiness.
+ */
+export function useGatewayReady(): boolean {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    coworkService.getOpenClawEngineStatus().then((s) => {
+      setReady(s?.phase === 'running');
+    });
+
+    const unsubscribe = coworkService.onOpenClawEngineStatus((s) => {
+      setReady(s.phase === 'running');
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return ready;
+}


### PR DESCRIPTION
## 概述

将网关硬重启期间的**全屏阻塞覆盖层**替换为**顶部通知横幅**，用户可继续浏览历史、切换会话、操作 Settings，仅发送消息暂时不可用。

## 问题

网关因 bindingsChanged（切换 Agent/模型）等配置变更触发硬重启时，`EngineStartupOverlay` 以 `fixed inset-0 z-[100]` 全屏覆盖，阻断所有交互 5-15 秒。用户无法浏览消息、切换会话或进入设置。

## 改动内容

### EngineStartupOverlay.tsx（重写）

| 改动前 | 改动后 |
|---|---|
| `fixed inset-0 z-[100]` 全屏覆盖 | `absolute top-0` 顶部通知横幅 |
| 完全阻断交互 | 不阻断交互 |
| 无收起功能 | 可收起为最小化气泡 |
| 无错误恢复入口 | 错误时显示重试按钮 + 错误提示 |

**三种状态：**
- **启动中**：顶部蓝色横幅 + 进度条 + 收起按钮
- **已收起**：最小化气泡 "网关启动中..." + 展开按钮
- **错误**：红色横幅 + 错误信息 + 重试按钮（自动展开，不可收起）

### CoworkPromptInput.tsx（联动）

- 新增 `isGatewayReady` 状态，通过 `coworkService.onOpenClawEngineStatus` 监听
- 网关未就绪时 `canSubmit = false`，发送按钮置灰

## 效果对比

| 行为 | 改动前 | 改动后 |
|---|---|---|
| 浏览历史消息 | ✗ 被挡住 | ✓ 正常 |
| 切换会话 | ✗ 被挡住 | ✓ 正常 |
| 打开 Settings | ✗ 被挡住 | ✓ 正常 |
| 使用 IM 功能 | ✗ 被挡住 | ✓ 正常 |
| 发送新消息 | ✗ 被挡住 | ✗ 按钮置灰 + 提示 |
| 了解网关状态 | ✓ 全屏卡片 | ✓ 顶部横幅 + 进度条 |

## 安全性

- 发送按钮在网关未就绪时置灰，避免 ENGINE_NOT_READY 错误
- 错误状态醒目（红色 + 重试按钮）
- `phase === 'running'` 时自动恢复，无需手动操作

## 测试计划

- [ ] 切换 Agent → 顶部横幅显示，不遮挡 UI
- [ ] 启动期间可以浏览历史消息、切换会话、打开 Settings
- [ ] 发送按钮置灰，网关就绪后自动恢复
- [ ] 网关启动失败 → 红色错误横幅 + 重试按钮
- [ ] 收起/展开横幅正常工作
- [ ] 网关已运行时不显示横幅

🤖 Generated with [Claude Code](https://claude.com/claude-code)