### PR TITLE
fix(gateway): 消除双重错误横幅 + 显示崩溃自动重试进度

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -1638,11 +1638,14 @@ export class OpenClawEngineManager extends EventEmitter {
           progressPct = Math.min(90, 10 + Math.round((elapsedMs / timeoutMs) * 80));
           phaseLabel = `${t('gatewayStartupStarting')} (${Math.round(elapsedMs / 1000)}s)`;
         }
+        const retrySuffix = this.gatewayRestartAttempt > 0
+          ? ` (${t('gatewayStartupRetryAttempt') || 'auto-retry'} ${this.gatewayRestartAttempt}/${GATEWAY_MAX_RESTART_ATTEMPTS})`
+          : '';
         this.setStatus({
           phase: this.startupPhase === 'compiling' ? 'compiling' : 'starting',
           version: this.status.version,
           progressPercent: progressPct,
-          message: phaseLabel,
+          message: phaseLabel + retrySuffix,
           canRetry: false,
         });
 

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -515,7 +515,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({ onRequestAppSettings, onShowSki
   );
 
   // Engine status banner for error/non-running states (starting overlay is now global in App.tsx)
-  const engineStatusBanner = shouldShowEngineStatus && openClawStatus && openClawStatus.phase !== 'starting' ? (
+  const engineStatusBanner = shouldShowEngineStatus && openClawStatus && openClawStatus.phase !== 'starting' && openClawStatus.phase !== 'error' ? (
     <div className={`shrink-0 flex items-center justify-between px-4 py-2 text-xs ${isEngineError
       ? 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'
       : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'


### PR DESCRIPTION
## 概述

修复网关崩溃恢复场景（场景 3）中的两个 UI 问题：
1. EngineStartupOverlay 和 CoworkView 同时显示错误横幅（视觉重复）
2. 自动重试时用户看不到重试进度

## 改动（2 文件，+5/-2 行）

| 文件 | 改动 |
|---|---|
| `CoworkView.tsx` | `engineStatusBanner` 排除 `phase === 'error'`，EngineStartupOverlay 已覆盖 error 状态 |
| `openclawEngineManager.ts` | 健康检查轮询时追加重试次数到 message，如 `Compiling... (12s) (auto-retry 2/5)` |

## 效果对比

**改动前：**
```
┌──────────────────────────────────────┐
│ ⚠ 网关启动失败：xxx  [重试]           │  ← EngineStartupOverlay
├──────────────────────────────────────┤
│  ⚠ 网关启动失败：xxx  [重启]          │  ← CoworkView（重复）
└──────────────────────────────────────┘
```

**改动后：**
```
┌──────────────────────────────────────┐
│ ⚠ 网关崩溃，正在自动重启（第 2/5 次）...│  ← 仅 EngineStartupOverlay
│   编译中... (8s) (auto-retry 2/5)     │
├──────────────────────────────────────┤
│  聊天界面                             │
└──────────────────────────────────────┘
```

## 测试计划

- [ ] 网关崩溃后自动重试，横幅显示重试次数
- [ ] CoworkView 不再显示重复的错误横幅
- [ ] 5 次失败后显示"手动重试"按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)