### PR TITLE
fix(gateway): Windows cold-start compile cache corruption + triage tab extraction

### DIFF
--- a/src/main/libs/openclawEngineManager.ts
+++ b/src/main/libs/openclawEngineManager.ts
@@ -326,10 +326,14 @@ export class OpenClawEngineManager extends EventEmitter {
     try {
       if (!fs.existsSync(cacheDir)) return false;
       const entries = fs.readdirSync(cacheDir);
-      return entries.some((entry) => {
+      const hasFiles = entries.some((entry) => {
         const full = path.join(cacheDir, entry);
         try { return fs.statSync(full).isFile(); } catch { return false; }
       });
+      if (!hasFiles) return false;
+      // v8-compat marker must exist — without it, the warmup was interrupted
+      // and the cache may be corrupt (e.g. killed mid-write by stopGateway).
+      return fs.existsSync(this.v8CompatMarkerPath());
     } catch {
       return false;
     }
@@ -956,10 +960,14 @@ export class OpenClawEngineManager extends EventEmitter {
     }
 
     // Kill in-progress cache warmup (if any).
+    // Also clear the compile cache to prevent corrupted/partial files
+    // from being treated as valid on the next start (see doStartGateway).
     if (this.warmupProcess) {
+      console.log('[OpenClaw] killing in-progress compile cache warmup, clearing cache to avoid corruption');
       try { this.warmupProcess.kill(); } catch { /* ignore */ }
       this.warmupProcess = null;
       this.cleanupWarmingLock();
+      this.clearCompileCache();
     }
 
     if (this.gatewayProcess) {
@@ -1875,6 +1883,8 @@ export class OpenClawEngineManager extends EventEmitter {
 
     if (this.gatewayRestartAttempt >= GATEWAY_MAX_RESTART_ATTEMPTS) {
       console.error(`${gwDiagTs()} gateway auto-restart limit reached (${GATEWAY_MAX_RESTART_ATTEMPTS} attempts), giving up`);
+      // Last resort: clear potentially corrupt compile cache so manual restart works
+      this.clearCompileCache();
       this.setStatus({
         phase: 'error',
         version: this.status.version,
@@ -1882,6 +1892,13 @@ export class OpenClawEngineManager extends EventEmitter {
         canRetry: true,
       });
       return;
+    }
+
+    // On the last retry attempt, clear the compile cache to recover from
+    // potential cache corruption (e.g. warmup killed mid-write)
+    if (this.gatewayRestartAttempt === GATEWAY_MAX_RESTART_ATTEMPTS - 1) {
+      console.log(`${gwDiagTs()} clearing compile cache before final restart attempt`);
+      this.clearCompileCache();
     }
 
     const delay = GATEWAY_RESTART_DELAYS[Math.min(this.gatewayRestartAttempt, GATEWAY_RESTART_DELAYS.length - 1)];


### PR DESCRIPTION
## Summary

两个修复：

### 1. 修复 Windows 冷启动时编译缓存损坏导致网关超时

**根因:** llama.cpp 模型变更触发 `forceGatewayRestartIfRunning`，此时若编译缓存预热仍在进行：
1. `stopGateway()` kill 预热子进程 → 缓存目录残留损坏/不完整文件
2. `isCompileCachePopulated()` 只检查文件存在，不管完整性 → 返回 true
3. 预热被跳过 → 使用 WARM 超时 (120s) 而非 COLD (600s)
4. Gateway 读到损坏缓存 → 崩溃 → 自动重试 5 次 → 全部失败
5. 用户看到 "OpenClaw gateway failed to become healthy in time"

**修复 (3 处):**

| 位置 | 改动 |
|---|---|
| `stopGateway()` | kill warmup 时同步 clear CompileCache，防止残留损坏文件 |
| `isCompileCachePopulated()` | 新增 v8-compat.json 标记检查 — 标记缺失视为缓存无效 |
| `scheduleGatewayRestart()` | 最后一次重试前清缓存，确保手动重启可恢复 |

### 2. 提取 Triage 设置到独立标签页

- 新增 `'triage'` TabType + `ArrowsRightLeftIcon` sidebar 标签「模型路由」
- 卡片布局：全局默认参数 + 本地模型分类
- 从 Model 标签移除 triage 区块
- 补充 `CreateAgentRequest.triageOverride` 缺失字段
- 修复 `agent` 变量名冲突

## 文件

| 文件 | 变更 |
|---|---|
| `src/main/libs/openclawEngineManager.ts` | +18/-1: 缓存损坏修复 ×3 |
| `src/renderer/components/Settings.tsx` | +95/-68: triage 独立标签 |
| `src/renderer/services/i18n.ts` | +2: triageTab 键 |
| `src/main/coworkStore.ts` | +1: CreateAgentRequest 字段 |
| `src/main/libs/agentEngine/openclawRuntimeAdapter.ts` | +2/-2: 变量重命名 |

## Test Plan

- [x] `npx tsc --noEmit` 零错误
- [ ] Windows 冷启动 → llama.cpp 加载模型 → 网关重启不超时
- [ ] Settings → 「模型路由」标签正常显示
- [ ] Agent 设置 → 路由 tab 不受影响
- [ ] 手动重启网关（error banner 右侧按钮）正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)