### PR TITLE
fix(shortcuts): skip unset values in duplicate shortcut detection

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1824,9 +1824,9 @@ const Settings: React.FC<SettingsProps> = ({ onClose, initialTab, notice, notice
 
   // 快捷键更新处理
   const handleShortcutChange = (key: keyof typeof shortcuts, value: string) => {
-    // Check for conflicts with other shortcuts
-    const conflictKey = Object.keys(shortcuts).find(
-      k => k !== key && shortcuts[k as keyof typeof shortcuts] === value
+    // Check for conflicts with other shortcuts (skip unset values)
+    const conflictKey = value && Object.keys(shortcuts).find(
+      k => k !== key && shortcuts[k as keyof typeof shortcuts] && shortcuts[k as keyof typeof shortcuts] === value
     );
     if (conflictKey) {
       const conflictLabel = i18nService.t(shortcutLabelMap[conflictKey] ?? conflictKey);


### PR DESCRIPTION
## Summary

快捷键设置页面对「未设置」值也会进行查重，导致两个未配置的快捷键显示冲突警告。

## Fix

查重时跳过空值：`value && shortcuts[k] && shortcuts[k] === value`

## Test Plan

- [x] `npx tsc --noEmit` 零错误
- [ ] 两个快捷键都未设置 → 不显示冲突
- [ ] 设置相同快捷键 → 正常显示冲突警告
- [ ] 其中一个未设置 → 不显示冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)