### PR TITLE
feat(llamacpp): local runtime import with OS-specific guidance

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -61,6 +61,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     llamacppUnloadVramRecoveryPending: '模型已从 llama.cpp 运行列表移除，但显存仍可能在继续回收，请稍等片刻再观察。',
     llamacppUnloadConfirmationPending: '卸载请求已发出，但应用暂时还没确认该模型已完全从运行列表移除。请稍等几秒后再观察。',
     llamacppLaunchContextExceedsTrainingLimit: '该模型请求加载上下文 {requested} 已超过训练上限 {trained}，请调低 ctx-size 后再启动。',
+    localInferenceImportRuntimeDialogTitle: '选择 llama.cpp 运行时目录',
+    localInferenceImportRuntimeDialogMessage: '请选择包含 {name} 可执行文件的目录。该目录中的所有文件将被复制到 RongxinAI 管理的运行时目录中。',
     coworkErrorUnknown: '任务执行出错，请重试。如果问题持续出现，请检查模型配置。',
     imErrorPrefix: '处理消息时出错',
     // IM error replies (differentiated by error kind)
@@ -326,6 +328,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     llamacppUnloadVramRecoveryPending: 'The model has been removed from the llama.cpp running list, but VRAM may still be reclaiming. Wait a moment before checking again.',
     llamacppUnloadConfirmationPending: 'The unload request was sent, but the app has not yet confirmed that the model fully disappeared from the running list. Wait a few seconds and check again.',
     llamacppLaunchContextExceedsTrainingLimit: 'The requested load context {requested} exceeds the model training limit {trained}. Lower ctx-size before loading the model.',
+    localInferenceImportRuntimeDialogTitle: 'Select llama.cpp Runtime Directory',
+    localInferenceImportRuntimeDialogMessage: 'Select the directory containing the {name} executable. All files in this directory will be copied into the RongxinAI-managed runtime directory.',
     coworkErrorUnknown:
       'Task failed due to an unexpected error. Please retry. If the issue persists, check your model configuration.',
     imErrorPrefix: 'Error processing message',

--- a/src/main/ipcHandlers/llamacpp.ts
+++ b/src/main/ipcHandlers/llamacpp.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, dialog, ipcMain } from 'electron';
 
 import type { NvidiaSmiSnapshot } from '../../shared/hardware';
 import type {
@@ -7,6 +7,7 @@ import type {
   LlamaCppInstallProgress,
   LlamaCppModelLaunchInput,
   LlamaCppModelUnloadResult,
+  LlamaCppRuntimeImportResult,
   LlamaCppServiceConfig,
   LlamaCppStatusSnapshot,
 } from '../../shared/llamacpp';
@@ -198,6 +199,25 @@ export function registerLlamaCppIpcHandlers(
     return await manager.installRuntime();
   });
   ipcMain.handle(LlamaCppIpcChannel.UninstallRuntime, async () => manager.uninstallRuntime());
+  ipcMain.handle(LlamaCppIpcChannel.ImportRuntime, async () => {
+    const win = BrowserWindow.getFocusedWindow();
+    if (!win) {
+      return { success: false, error: '没有活动窗口' };
+    }
+
+    const executableName = process.platform === 'win32' ? 'llama-server.exe' : 'llama-server';
+    const result = await dialog.showOpenDialog(win, {
+      title: t('localInferenceImportRuntimeDialogTitle'),
+      message: t('localInferenceImportRuntimeDialogMessage').replace('{name}', executableName),
+      properties: ['openDirectory'],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { success: false, error: '已取消' };
+    }
+
+    return await manager.importRuntime(result.filePaths[0]);
+  });
   ipcMain.handle(LlamaCppIpcChannel.Start, async () => manager.start());
   ipcMain.handle(LlamaCppIpcChannel.Stop, async () => manager.stop());
   ipcMain.handle(LlamaCppIpcChannel.Restart, async () => manager.restart());

--- a/src/main/libs/llamacppManager.ts
+++ b/src/main/libs/llamacppManager.ts
@@ -13,6 +13,7 @@ import type {
   LlamaCppModelLaunchInput,
   LlamaCppModelLaunchResult,
   LlamaCppRunningModel,
+  LlamaCppRuntimeImportResult,
   LlamaCppRuntimeInstallResult,
   LlamaCppRuntimeUninstallResult,
   LlamaCppServiceConfig,
@@ -20,10 +21,12 @@ import type {
 } from '../../shared/llamacpp';
 import { LlamaCppClient } from './llamacppClient';
 import {
+  copyDirectoryContents,
   createLlamaCppRuntimeInstallPlan,
   ensureLlamaCppRuntimeCurrent,
   executeLlamaCppRuntimeInstallPlan,
   getProjectRoot,
+  resolveLlamaCppExecutableName,
   resolveLlamaCppRuntimeTargetId,
 } from './llamacppRuntimeInstaller';
 
@@ -211,6 +214,91 @@ export class LlamaCppManager extends EventEmitter {
       });
     }
     return result;
+  }
+
+  /**
+   * Import a user-provided llama.cpp runtime from a local directory.
+   * Copies all files from the directory containing llama-server into
+   * <runtimeRoot>/current/bin/, matching the existing auto-download
+   * copy strategy. Platform differences (DLLs, dylibs, .so) are handled
+   * automatically by copying the full directory.
+   */
+  async importRuntime(sourceDir: string): Promise<LlamaCppRuntimeImportResult> {
+    const executableName = resolveLlamaCppExecutableName(process.platform);
+    const sourceExecutable = path.join(sourceDir, executableName);
+
+    if (!fs.existsSync(sourceExecutable)) {
+      return {
+        success: false,
+        error: `未在所选目录中找到 ${executableName}。请选择包含 ${executableName} 的目录。`,
+      };
+    }
+
+    // Verify the executable is actually runnable
+    try {
+      if (process.platform !== 'win32') {
+        fs.accessSync(sourceExecutable, fs.constants.X_OK);
+      }
+    } catch {
+      return {
+        success: false,
+        error: `${executableName} 没有执行权限，请先设置可执行权限（chmod +x）。`,
+      };
+    }
+
+    const runtimeRoot = getUserLlamaCppRuntimeRoot();
+    const currentRuntimeRoot = path.join(runtimeRoot, 'current');
+    const targetBinDir = path.join(currentRuntimeRoot, 'bin');
+    const targetExecutable = path.join(targetBinDir, executableName);
+
+    try {
+      // Stop the running process if it's managed by us
+      if (this.process && this.executablePath && isPathInside(this.executablePath, runtimeRoot)) {
+        await this.stop();
+      }
+
+      // Clear existing runtime and copy the user's files
+      fs.rmSync(currentRuntimeRoot, { recursive: true, force: true });
+      fs.mkdirSync(targetBinDir, { recursive: true });
+      copyDirectoryContents(sourceDir, targetBinDir);
+
+      if (!fs.existsSync(targetExecutable)) {
+        throw new Error(`复制后缺少 ${executableName}，请检查源目录内容。`);
+      }
+
+      if (process.platform !== 'win32') {
+        fs.chmodSync(targetExecutable, 0o755);
+      }
+
+      // Write build info
+      fs.writeFileSync(
+        path.join(currentRuntimeRoot, 'runtime-build-info.json'),
+        JSON.stringify({
+          target: resolveLlamaCppRuntimeTargetId(process.platform, process.arch),
+          source: 'user-import',
+          importedFrom: sourceDir,
+          importedAt: new Date().toISOString(),
+        }, null, 2) + '\n',
+        'utf8',
+      );
+
+      this.executablePath = targetExecutable;
+      this.setStatus({
+        status: 'installed',
+        executablePath: targetExecutable,
+        managedByApp: false,
+      });
+      return { success: true, executablePath: targetExecutable };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.setStatus({
+        status: 'not-installed',
+        executablePath: this.executablePath ?? undefined,
+        managedByApp: false,
+        error: message,
+      });
+      return { success: false, error: message };
+    }
   }
 
   async uninstallRuntime(): Promise<LlamaCppRuntimeUninstallResult> {

--- a/src/main/libs/llamacppRuntimeInstaller.ts
+++ b/src/main/libs/llamacppRuntimeInstaller.ts
@@ -276,7 +276,7 @@ async function extractArchive(archivePath: string, extractDir: string): Promise<
   throw new Error(`Unsupported llama.cpp runtime archive format: ${archivePath}`);
 }
 
-function copyDirectoryContents(sourceDir: string, targetDir: string): void {
+export function copyDirectoryContents(sourceDir: string, targetDir: string): void {
   for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
     const sourcePath = path.join(sourceDir, entry.name);
     const targetPath = path.join(targetDir, entry.name);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -150,6 +150,7 @@ contextBridge.exposeInMainWorld('electron', {
     status: () => ipcRenderer.invoke(LlamaCppIpcChannel.Status),
     install: () => ipcRenderer.invoke(LlamaCppIpcChannel.Install),
     uninstallRuntime: () => ipcRenderer.invoke(LlamaCppIpcChannel.UninstallRuntime),
+    importRuntime: () => ipcRenderer.invoke(LlamaCppIpcChannel.ImportRuntime),
     start: () => ipcRenderer.invoke(LlamaCppIpcChannel.Start),
     stop: () => ipcRenderer.invoke(LlamaCppIpcChannel.Stop),
     restart: () => ipcRenderer.invoke(LlamaCppIpcChannel.Restart),

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -13,6 +13,7 @@ import {
   InformationCircleIcon,
   PaperAirplaneIcon,
   PlayIcon,
+  QuestionMarkCircleIcon,
   ServerStackIcon,
   StopIcon,
   TrashIcon,
@@ -527,6 +528,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
   const [launchTarget, setLaunchTarget] = useState<OllamaModel | null>(null);
   const [servicePopoverOpen, setServicePopoverOpen] = useState(false);
   const [serviceConfigDialogOpen, setServiceConfigDialogOpen] = useState(false);
+  const [importGuideOpen, setImportGuideOpen] = useState(false);
   const [serviceConfig, setServiceConfig] = useState<OllamaServiceConfig>({});
   const marketplaceSearchRef = useRef<number>(0);
   const toastTimerRef = useRef<number | null>(null);
@@ -929,6 +931,25 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
     });
   };
 
+  const handleImportRuntime = () => {
+    void runAction(async () => {
+      const result = await window.electron.llamacpp.importRuntime();
+      if (!result.success) {
+        if (result.error === '已取消') return;
+        showToast(
+          result.error || i18nService.t('localInferenceImportRuntimeFailed'),
+          LocalInferenceToastKind.Error,
+        );
+        return;
+      }
+      showToast(
+        i18nService.t('localInferenceImportRuntimeSuccess'),
+        LocalInferenceToastKind.Success,
+      );
+      await refreshStatus();
+    });
+  };
+
   const handleUninstallRuntime = () => {
     void runAction(async () => {
       const result = await window.electron.llamacpp.uninstallRuntime();
@@ -940,12 +961,17 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
         return;
       }
 
-      showToast(
-        result.deleted
-          ? i18nService.t('localInferenceRuntimeUninstalled')
-          : i18nService.t('localInferenceRuntimeNotInstalled'),
-        LocalInferenceToastKind.Success,
-      );
+      if (result.deleted) {
+        showToast(
+          i18nService.t('localInferenceRuntimeUninstalled'),
+          LocalInferenceToastKind.Success,
+        );
+      } else {
+        showToast(
+          i18nService.t('localInferenceRuntimeNotInstalled'),
+          LocalInferenceToastKind.Info,
+        );
+      }
       if (result.status.status === 'running') {
         await refreshLocalModels();
         await refreshRunningModels();
@@ -1273,7 +1299,9 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
               onToggle={() => setServicePopoverOpen(current => !current)}
               onPrepare={handlePrepare}
               onStop={handleStop}
+              onImportRuntime={handleImportRuntime}
               onUninstallRuntime={handleUninstallRuntime}
+              onOpenImportGuide={() => setImportGuideOpen(true)}
               onOpenServiceConfig={() => {
                 setServicePopoverOpen(false);
                 setServiceConfigDialogOpen(true);
@@ -1389,9 +1417,127 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
           onSave={handleSaveServiceConfig}
         />
       )}
+      {importGuideOpen && (
+        <ImportGuideDialog onClose={() => setImportGuideOpen(false)} />
+      )}
     </div>
   );
 };
+
+function ImportGuideDialog({ onClose }: { onClose: () => void }) {
+  const platform = window.electron.platform as string;
+  const isWin = platform === 'win32';
+  const isMac = platform === 'darwin';
+
+  const executable = isWin ? 'llama-server.exe' : 'llama-server';
+
+  const filesKey = isWin
+    ? 'localInferenceImportGuideFilesWin'
+    : isMac
+      ? 'localInferenceImportGuideFilesMac'
+      : 'localInferenceImportGuideFilesLinux';
+
+  const noteKey = isWin
+    ? 'localInferenceImportGuideStep1WinNote'
+    : isMac
+      ? 'localInferenceImportGuideStep1MacNote'
+      : 'localInferenceImportGuideStep1LinuxNote';
+
+  const openUrl = useCallback(() => {
+    const url = i18nService.t('localInferenceImportGuideStep1Url');
+    window.electron.shell.openExternal(url).catch(() => undefined);
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 p-4"
+      onMouseDown={event => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="flex max-h-[88vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 border-b border-border bg-surface/40 px-4 py-3">
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-foreground">
+              {i18nService.t('localInferenceImportGuideTitle')}
+            </h3>
+            <p className="mt-1 text-sm text-secondary">
+              {i18nService.t('localInferenceImportGuideDescription')}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-secondary transition-colors hover:bg-surface-raised hover:text-foreground"
+            aria-label={i18nService.t('close')}
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="overflow-y-auto px-4 py-4">
+          {/* OS info */}
+          <div className="rounded-lg border border-border bg-surface/60 px-3 py-2.5 mb-4">
+            <p className="text-xs font-medium text-foreground">
+              {isWin ? 'Windows' : isMac ? 'macOS' : 'Linux'}
+            </p>
+            <p className="mt-1 text-xs text-secondary">
+              {i18nService.t(filesKey)} ({executable})
+            </p>
+          </div>
+
+          {/* Steps */}
+          <ol className="space-y-4 text-sm">
+            <li className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary">1</span>
+              <div className="min-w-0">
+                <p className="text-foreground">
+                  {i18nService.t('localInferenceImportGuideStep1')}
+                </p>
+                <button
+                  type="button"
+                  onClick={openUrl}
+                  className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                >
+                  {i18nService.t('localInferenceImportGuideStep1LinkLabel')}
+                  <ArrowTopRightOnSquareIcon className="h-3 w-3" />
+                </button>
+                <p className="mt-1 text-xs text-secondary">
+                  {i18nService.t(noteKey)}
+                </p>
+              </div>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary">2</span>
+              <p className="text-foreground pt-0.5">
+                {i18nService.t('localInferenceImportGuideStep2')}
+              </p>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-medium text-primary">3</span>
+              <p className="text-foreground pt-0.5">
+                {i18nService.t('localInferenceImportGuideStep3')}
+              </p>
+            </li>
+          </ol>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-9 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+          >
+            {i18nService.t('localInferenceImportGuideClose')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function ServicePopover({
   containerRef,
@@ -1403,7 +1549,9 @@ function ServicePopover({
   onToggle,
   onPrepare,
   onStop,
+  onImportRuntime,
   onUninstallRuntime,
+  onOpenImportGuide,
   onOpenServiceConfig,
   onRefresh,
 }: {
@@ -1416,7 +1564,9 @@ function ServicePopover({
   onToggle: () => void;
   onPrepare: () => void;
   onStop: () => void;
+  onImportRuntime: () => void;
   onUninstallRuntime: () => void;
+  onOpenImportGuide: () => void;
   onOpenServiceConfig: () => void;
   onRefresh: () => void;
 }) {
@@ -1524,6 +1674,29 @@ function ServicePopover({
                 <PlayIcon className="h-3.5 w-3.5" />
                 {actionLabel}
               </button>
+            )}
+            {!running && status?.status === 'not-installed' && (
+              <>
+                <button
+                  type="button"
+                  onClick={onImportRuntime}
+                  disabled={loading}
+                  className={smallOutlineButtonClass}
+                  title={i18nService.t('localInferenceImportRuntimeTooltip')}
+                >
+                  <ArrowDownTrayIcon className="h-3.5 w-3.5" />
+                  {i18nService.t('localInferenceImportRuntime')}
+                </button>
+                <button
+                  type="button"
+                  onClick={onOpenImportGuide}
+                  disabled={loading}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-md text-secondary transition-colors hover:bg-surface-raised hover:text-foreground"
+                  title={i18nService.t('localInferenceImportGuideTitle')}
+                >
+                  <QuestionMarkCircleIcon className="h-4 w-4" />
+                </button>
+              </>
             )}
             {running && managedByApp ? (
               <button

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -13,6 +13,7 @@ import type {
   LlamaCppModelLaunchResult,
   LlamaCppModelUnloadResult,
   LlamaCppRunningModel,
+  LlamaCppRuntimeImportResult,
   LlamaCppRuntimeInstallResult,
   LlamaCppRuntimeUninstallResult,
   LlamaCppServiceConfig,
@@ -414,6 +415,7 @@ interface IElectronAPI {
   llamacpp: {
     status: () => Promise<LlamaCppStatusSnapshot>;
     install: () => Promise<LlamaCppRuntimeInstallResult>;
+    importRuntime: () => Promise<LlamaCppRuntimeImportResult>;
     uninstallRuntime: () => Promise<LlamaCppRuntimeUninstallResult>;
     start: () => Promise<LlamaCppStatusSnapshot>;
     stop: () => Promise<LlamaCppStatusSnapshot>;

--- a/src/shared/llamacpp/constants.ts
+++ b/src/shared/llamacpp/constants.ts
@@ -20,6 +20,7 @@ export const LlamaCppIpcChannel = {
   ChatStream: 'llamacpp:chat-stream',
   CancelChatStream: 'llamacpp:cancel-chat-stream',
   SetOpenClawModel: 'llamacpp:set-openclaw-model',
+  ImportRuntime: 'llamacpp:import-runtime',
   StatusChanged: 'llamacpp:status-changed',
   InstallProgress: 'llamacpp:install-progress',
   ChatStreamChunk: 'llamacpp:chat-stream-chunk',

--- a/src/shared/llamacpp/types.ts
+++ b/src/shared/llamacpp/types.ts
@@ -51,6 +51,12 @@ export type LlamaCppRuntimeUninstallResult = {
   error?: string;
 };
 
+export type LlamaCppRuntimeImportResult = {
+  success: boolean;
+  executablePath?: string;
+  error?: string;
+};
+
 export type LlamaCppInstallProgressPhase =
   | 'starting'
   | 'detecting'


### PR DESCRIPTION
## Summary

允许用户从本地导入已编译/下载的 llama.cpp 运行时，替代自动下载。

### 功能

- 本地推理页 → 服务状态弹出框，status='not-installed' 时新增「从本地导入...」按钮
- 旁边 `?` 按钮弹出 OS 特定引导对话框（匹配配置弹窗样式）
- 主进程弹出文件夹选择器 → 验证 llama-server 可执行文件 → 复制全部文件到管理目录
- 自动处理平台差异（Windows DLL、macOS dylib、Linux .so）

### 文件

| 文件 | 变更 |
|---|---|
| `src/main/libs/llamacppManager.ts` | +88: importRuntime() |
| `src/main/ipcHandlers/llamacpp.ts` | +22: IPC handler + dialog |
| `src/renderer/components/localInference/LocalInferenceView.tsx` | +185: UI + ImportGuideDialog |
| `src/renderer/services/i18n.ts` | +36: 中/英文案 |
| Others | types, constants, preload 等基础 |

### Test Plan

- [x] `npx tsc --noEmit` 零错误
- [ ] 未安装时弹出框显示「从本地导入...」+ `?` 按钮
- [ ] `?` 弹出 OS 特定引导对话框
- [ ] 选择有效目录 → 导入成功 → 状态变为 installed
- [ ] 选择无效目录 → 错误提示
- [ ] 导入后可正常启动/停止

🤖 Generated with [Claude Code](https://claude.com/claude-code)