### PR TITLE
fix(im): prevent silent reply drops from broken background accumulator

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -548,10 +548,18 @@ export class IMCoworkHandler extends EventEmitter {
     console.log('[IMCoworkHandler:handleMessage] sessionId:', sessionId, 'tracked:', tracked, 'messageType:', message.type);
     if (!tracked) return;
 
-    const accumulator = this.messageAccumulators.get(sessionId) ?? this.ensureBackgroundAccumulator(sessionId);
+    // Only use an existing accumulator — do NOT create a background accumulator here.
+    // ensureBackgroundAccumulator creates one without a resolve callback, so replies would
+    // be silently dropped. The proper accumulator (with resolve) is created synchronously
+    // by createAccumulatorPromise inside processMessageInternal before the session starts.
+    // When channel sync fires message events before processMessageInternal runs, we must
+    // skip accumulation rather than creating a broken background accumulator.
+    const accumulator = this.messageAccumulators.get(sessionId);
     console.log('[IMCoworkHandler:handleMessage] accumulator exists:', !!accumulator, 'backgroundDelivery:', !!accumulator?.backgroundDelivery);
     if (accumulator) {
       accumulator.messages.push(message);
+    } else {
+      console.warn('[IMCoworkHandler:handleMessage] no accumulator found for session, skipping message accumulation (possible race with processMessageInternal)');
     }
   }
 


### PR DESCRIPTION
## Summary

- **Fix**: `IMCoworkHandler.handleMessage` 中移除 `ensureBackgroundAccumulator` 回退逻辑，防止创建缺少 `resolve`/`reject` 回调的错误累加器导致 IM 回复被静默丢弃。
- **平台**: 直接影响依赖路径 B（IMCoworkHandler → sendConversationReply）的平台（钉钉、飞书等）。微信走路径 C（插件直发），不受此修复直接影响。

## Root Cause

`handleMessage` 中原来的 `?? ensureBackgroundAccumulator()` 在通道同步先于 `processMessageInternal` 触发 `message` 事件时会创建一种特殊的累加器：

- 该累加器设置了 `backgroundDelivery` 标记但**没有 `resolve` 或 `reject` 回调**
- `handleComplete` 因此进入 `backgroundDelivery` 分支，但不满足 `isReminderSystemTurn()` 条件，日志显示 "not a reminder system turn, skipping async reply" 后直接 return
- 即使到达 `resolve` 路径，`accumulator.resolve?.(replyText)` 的可选链调用也是空操作

## Message Send/Receive Architecture (3 Paths)

```
IM消息 → OpenClaw Gateway → AI 处理
                  │
    ┌─────────────┼─────────────┐
    ▼             ▼             ▼
 路径 A         路径 B         路径 C
 桌面 UI        IMCoworkHandler  插件直发
 (纯展示)       (sendConversationReply)  (唯一发送通道)
                weixin: no-op       weixin: sendMessageWeixin()
                dingtalk: 正常       dingtalk: -
                feishu: 正常         feishu: -
```

- **路径 A** (`adapter.emit → IPC → 渲染进程`): 纯展示，不参与消息发送，始终正常工作
- **路径 B** (`IMCoworkHandler → sendConversationReply → sendNotificationWithMedia`): 对微信是空操作（设计如此，微信回复由路径 C 发送），对钉钉/飞书等有实际发送逻辑
- **路径 C** (`openclaw-weixin 插件 → sendMessageWeixin → ilink/bot/sendmessage`): 微信唯一实际发送通道

## Analysis Details

本次对话中还对以下问题进行了深入分析（详见 `docs/wechat-reply-delivery-analysis-2026-05-26.md`）：

1. **微信回复未送达的另一独立问题**: `openclaw-weixin` 插件日志显示 `weixin getUpdates error: TypeError: fetch failed` 和 `weixin reply final: TypeError: fetch failed`。联网检索确认为 Node.js 24 + 插件旧版的 Content-Length 头冲突 Bug，与本次修复的累加器竞态问题是两个独立问题。

2. **Gateway 冷启动性能**: `authBootstrap` 阶段占 44s (52.5%)，`pluginBootstrap` 占 27s (32.3%)，瓶颈在 Gateway 内部各 provider 的认证解析。

3. **AI 推理延迟**: 桌面端对话延时主要由模型首 token 时间决定（~7.6s, 占 68%），受 systemPrompt 大小（50KB）和 context token 数（~30K）影响。

4. **Reasoning-only 响应丢弃 Bug**: 当 AI 模型（xiaomi/mimo-v2-pro）返回纯 thinking block 无可见文本时，Gateway 自动重试但 LobsterAI 侧已将 runId 标记为 closed，导致重试的流式响应全部被 `isRecentlyClosedRunId` 拦截丢弃。修复方案已识别（`openclawRuntimeAdapter.ts:4253` 前增加空文本判断并延迟 cleanup），待独立 PR 实施。

## Test Plan

- [ ] 钉钉平台发送消息，确认 AI 正常回复且无丢失
- [ ] 飞书平台发送消息，确认 AI 正常回复且无丢失
- [ ] 微信平台发送消息，确认桌面端正常显示回复（微信回复投递走路径 C，不受此修复影响）
- [ ] 定时任务提醒（backgroundDelivery），确认正常触发和发送
- [ ] 快速连续发送多条 IM 消息，确认无竞态异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)