### PR TITLE
fix(agent): keep turn alive on empty response to allow Gateway reasoning-only retry

### DIFF
--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -548,10 +548,18 @@ export class IMCoworkHandler extends EventEmitter {
     console.log('[IMCoworkHandler:handleMessage] sessionId:', sessionId, 'tracked:', tracked, 'messageType:', message.type);
     if (!tracked) return;
 
-    const accumulator = this.messageAccumulators.get(sessionId) ?? this.ensureBackgroundAccumulator(sessionId);
+    // Only use an existing accumulator — do NOT create a background accumulator here.
+    // ensureBackgroundAccumulator creates one without a resolve callback, so replies would
+    // be silently dropped. The proper accumulator (with resolve) is created synchronously
+    // by createAccumulatorPromise inside processMessageInternal before the session starts.
+    // When channel sync fires message events before processMessageInternal runs, we must
+    // skip accumulation rather than creating a broken background accumulator.
+    const accumulator = this.messageAccumulators.get(sessionId);
     console.log('[IMCoworkHandler:handleMessage] accumulator exists:', !!accumulator, 'backgroundDelivery:', !!accumulator?.backgroundDelivery);
     if (accumulator) {
       accumulator.messages.push(message);
+    } else {
+      console.warn('[IMCoworkHandler:handleMessage] no accumulator found for session, skipping message accumulation (possible race with processMessageInternal)');
     }
   }
 

--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -4250,6 +4250,23 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
     }
 
+    // When the API returns an empty response (e.g. MiniMax/MiMo 400 due
+    // to missing reasoning_content on replayed thinking blocks —
+    // openclaw#81416), the Gateway retries automatically with a
+    // visible-answer continuation prompt using the same runId.  Keep the
+    // turn alive so streaming delta events from the retry are not dropped
+    // by isRecentlyClosedRunId / sessionIdByRunId cleanup.
+    // The turn timeout watchdog handles cleanup if no retry ever arrives.
+    if (!turn.currentText.trim() && !turn.committedAssistantText.trim()) {
+      console.debug(
+        '[OpenClawRuntime] deferring run close — empty response, awaiting potential Gateway retry',
+        `sessionId=${sessionId}`,
+        `runId=${payload.runId ?? turn.runId}`,
+      );
+      this.store.updateSession(sessionId, { status: 'idle' });
+      return;
+    }
+
     this.store.updateSession(sessionId, { status: 'completed' });
     this.emit('complete', sessionId, payload.runId ?? turn.runId);
     this.cleanupSessionTurn(sessionId);


### PR DESCRIPTION
## Summary

AI 模型（MiniMax/MiMo）返回空/thinking-only 响应时，OpenClaw Gateway 自动用同一个 runId 重试。当前代码在 `handleChatFinal` 收到空文本后立即 `cleanupSessionTurn`，将 runId 加入 `recentlyClosedRunIds`，导致 Gateway 重试的所有 streaming 事件被丢弃，用户看不到任何回复。

## Root Cause

```
handleChatFinal (finalText="")
  → cleanupSessionTurn
    → rememberRecentlyClosedRunId(runId)   // 封禁 120s
    → sessionIdByRunId.delete(runId)        // 映射被清除

Gateway retry (same runId)
  → agent lifecycle start → isRecentlyClosedRunId → ✗ DROPPED
  → stream=assistant text → isRecentlyClosedRunId → ✗ DROPPED
  → 用户: 什么都看不到
```

**上游根因**: MiniMax/MiMo 模型在 `thinking=off` 时仍返回 thinking blocks，跨轮重放时缺少 `reasoning_content` 字段，导致 API 返回 400。Gateway 检测后自动以 visible-answer continuation 重试。

参考: [openclaw/openclaw#81416](https://github.com/openclaw/openclaw/issues/81416)

## Fix

`src/main/libs/agentEngine/openclawRuntimeAdapter.ts` — `handleChatFinal` 方法。

当 `turn.currentText` 和 `turn.committedAssistantText` 均为空时，不关闭 run：

```
if (!turn.currentText.trim() && !turn.committedAssistantText.trim()) {
    this.store.updateSession(sessionId, { status: 'idle' });
    return;  // 不调用 cleanupSessionTurn / emit('complete') / resolveTurn
}
```

- status 设为 `idle` 避免 UI 显示 spinner
- turn 保持活跃 → retry 的 streaming delta 事件正常进入 `handleChatEvent` → 用户实时看到文本
- retry 的 `chat.final` 正常触发 complete/cleanup
- 现有 turn timeout watchdog 兜底（极端无 retry 时自动清理）

## Verification

**修复前** (23:14 日志):
```
handleChatFinal: finalText=""
→ cleanupSessionTurn → runId 封禁
→ agent lifecycle start → "dropped late agent event for a closed run"
→ assistant "你好！快十一点半了..." → 全部 dropped
→ 用户: 什么都看不到
```

**修复后预期**:
```
handleChatFinal: finalText=""
→ defer: status=idle, return
→ agent lifecycle start → 正常处理
→ assistant "你好！..." → handleChatEvent → UI 实时显示
→ chat.final → handleChatFinal(有文本) → 正常 complete
→ 用户: 看到完整回复
```

## Test Plan

- [ ] 正常对话：回复正常显示，无回归
- [ ] thinking-only 场景触发 Gateway 重试：验证 streaming 文本正常显示
- [ ] 连续多轮对话：状态转换正确
- [ ] 工具调用完成后正常 cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)