### PR TITLE
feat(logger): separate dev and prod log filenames to avoid conflicts

### DIFF
--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -1,6 +1,6 @@
 /**
  * Unit tests for logger.ts logic:
- *   - Log filename pattern (daily rotation naming)
+ *   - Log filename pattern (daily rotation naming, dev vs prod)
  *   - pruneOldLogs: which files get deleted
  *   - getRecentMainLogEntries: which files are included and ordering
  *
@@ -15,7 +15,7 @@ import { test, expect } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const LOG_RETENTION_DAYS = 7;
-const LOG_FILE_RE = /^main-\d{4}-\d{2}-\d{2}(\.old)?\.log$/;
+const LOG_FILE_RE = /^main(-dev)?-\d{4}-\d{2}-\d{2}(\.old)?\.log$/;
 
 type FileEntry = { name: string; mtimeMs: number };
 
@@ -91,6 +91,14 @@ test('pattern: rejects non-log extension', () => {
 
 test('pattern: rejects extra prefix', () => {
   expect(LOG_FILE_RE.test('renderer-2026-03-20.log')).toBeFalsy();
+});
+
+test('pattern: matches dev-mode daily log', () => {
+  expect(LOG_FILE_RE.test('main-dev-2026-03-20.log')).toBeTruthy();
+});
+
+test('pattern: matches dev-mode .old variant', () => {
+  expect(LOG_FILE_RE.test('main-dev-2026-03-19.old.log')).toBeTruthy();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -3,9 +3,12 @@
  * Intercepts console.* methods and writes to file + console simultaneously.
  *
  * Log file locations:
- *   macOS:   ~/Library/Logs/RongxinAI/main-YYYY-MM-DD.log
- *   Windows: %USERPROFILE%\AppData\Roaming\RongxinAI\logs\main-YYYY-MM-DD.log
- *   Linux:   ~/.config/RongxinAI/logs/main-YYYY-MM-DD.log
+ *   macOS:   ~/Library/Logs/RongxinAI/main[-dev]-YYYY-MM-DD.log
+ *   Windows: %USERPROFILE%\AppData\Roaming\RongxinAI\logs\main[-dev]-YYYY-MM-DD.log
+ *   Linux:   ~/.config/RongxinAI/logs/main[-dev]-YYYY-MM-DD.log
+ *
+ * Production uses  "main-YYYY-MM-DD.log"
+ * Development uses "main-dev-YYYY-MM-DD.log"  (app.isPackaged === false)
  *
  * Rotation policy:
  *   - Daily log files (one file per calendar day)
@@ -13,12 +16,15 @@
  *   - Files older than 7 days are pruned on startup
  */
 
+import { app } from 'electron';
 import log from 'electron-log/main';
 import fs from 'fs';
 import path from 'path';
 
 const LOG_RETENTION_DAYS = 7;
 const LOG_MAX_SIZE = 80 * 1024 * 1024; // 80 MB
+const LOG_BASENAME = app.isPackaged ? 'main' : 'main-dev';
+const LOG_FILE_RE = /^main(-dev)?-\d{4}-\d{2}-\d{2}(\.old)?\.log$/;
 
 /** Captured on first resolvePathFn call; used for pruning and export. */
 let _logDir: string | undefined;
@@ -39,7 +45,7 @@ export function initLogger(): void {
   // Daily rotation: one file per calendar day
   log.transports.file.resolvePathFn = (vars) => {
     _logDir = vars.libraryDefaultDir;
-    return path.join(vars.libraryDefaultDir, `main-${todayStr()}.log`);
+    return path.join(vars.libraryDefaultDir, `${LOG_BASENAME}-${todayStr()}.log`);
   };
 
   // File transport config
@@ -90,8 +96,9 @@ export function initLogger(): void {
   pruneOldLogs();
 
   // Log startup marker
+  const mode = app.isPackaged ? 'production' : 'development';
   log.info('='.repeat(60));
-  log.info(`RongxinAI started (${process.platform} ${process.arch})`);
+  log.info(`RongxinAI started (${process.platform} ${process.arch}, ${mode})`);
   log.info('='.repeat(60));
 }
 
@@ -103,7 +110,7 @@ function pruneOldLogs(): void {
   const cutoffMs = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
   for (const file of fs.readdirSync(dir)) {
-    if (!/^main-\d{4}-\d{2}-\d{2}(\.old)?\.log$/.test(file)) continue;
+    if (!LOG_FILE_RE.test(file)) continue;
     const filePath = path.join(dir, file);
     try {
       if (fs.statSync(filePath).mtimeMs < cutoffMs) {
@@ -133,7 +140,7 @@ export function getRecentMainLogEntries(): Array<{ archiveName: string; filePath
   const cutoffMs = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
   return fs.readdirSync(dir)
-    .filter((f) => /^main-\d{4}-\d{2}-\d{2}(\.old)?\.log$/.test(f))
+    .filter((f) => LOG_FILE_RE.test(f))
     .map((f) => ({ archiveName: f, filePath: path.join(dir, f) }))
     .filter(({ filePath }) => {
       try {


### PR DESCRIPTION
## Summary
- Production log: `main-YYYY-MM-DD.log`
- Development log: `main-dev-YYYY-MM-DD.log`
- Auto-switch via `app.isPackaged`, no manual config needed
- Log cleanup and export regexes match both prefixes

## Test plan
- [x] 26/26 unit tests pass (including 2 new dev-pattern cases)
- [ ] Local dev mode: verify log filename is correct
- [ ] Production build: verify log filename is correct