### PR TITLE
fix(skills): ignore null-filename fs.watch events on Windows

### DIFF
--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -2216,7 +2216,14 @@ export class SkillManager {
 
     // Root-level watch: only react to directory additions/removals (new/deleted skills).
     const rootWatchHandler = (_event: string, filename: string | null) => {
-      if (!filename) { this.scheduleNotify(); return; }
+      // On Windows, fs.watch (ReadDirectoryChangesW) frequently reports null
+      // filenames for unrelated filesystem activity (AV scans, search indexing,
+      // timestamp updates).  Ignoring null filenames avoids false
+      // skills-changed → syncOpenClawConfig chains that can trigger unwanted
+      // Gateway restarts.  Legitimate skill changes always go through explicit
+      // code paths (installSkill, deleteSkill, etc.) that call
+      // notifySkillsChanged directly.
+      if (!filename) { if (process.platform !== 'win32') this.scheduleNotify(); return; }
       // Ignore hidden files/dirs and known non-skill files
       if (filename.startsWith('.')) return;
       // Accept directory changes (new skill added/removed) and config file
@@ -2228,7 +2235,7 @@ export class SkillManager {
 
     // Skill-directory-level watch: only react to skill definition file changes.
     const skillDirWatchHandler = (_event: string, filename: string | null) => {
-      if (!filename) { this.scheduleNotify(); return; }
+      if (!filename) { if (process.platform !== 'win32') this.scheduleNotify(); return; }
       if (filename === SKILL_FILE_NAME || filename === SKILLS_CONFIG_FILE) {
         this.scheduleNotify();
       }


### PR DESCRIPTION
## Summary

On Windows, `fs.watch` (backed by `ReadDirectoryChangesW`) frequently reports `filename=null` for unrelated filesystem activity — antivirus scans, search indexing, timestamp updates. The skill watcher handlers unconditionally triggered on null filename, causing a cascade of unnecessary work culminating in Gateway restarts.

**The fix**: On Windows, silently ignore `fs.watch` events with null filename. Legitimate skill changes (install/delete/enable/disable) go through explicit code paths that call `notifySkillsChanged()` directly. macOS/Linux behavior is unchanged.

## Root Cause Analysis

### The chain of events

```
Windows filesystem noise
  → fs.watch callback (filename = null)
    → scheduleNotify()           [unconditional on null]
      → 250ms debounce
        → startWatching()        [close all watchers, scan 27 skill dirs, recreate watchers]
        → notifySkillsChanged()  [IPC broadcast to all renderer windows]
          → onSkillsChanged callback [main.ts:6282]
            → syncOpenClawConfig("skills-changed")
              → openClawConfigSync.sync()
                → full openclaw.json rewrite
                → config.apply RPC to Gateway
                → Gateway detects gateway.auth.token "changed"
                → Gateway RESTART
```

### Evidence from production logs (2026-05-27)

Three `skills-changed` events observed, all with no corresponding `[skills]` log output (ruling out explicit operations):

| Time | Result | Details |
|------|--------|---------|
| 10:45:08 | hot-reload | During startup, `startWatching` setup |
| 11:45:08 | hot-reload | Idle — user just sent "吼吼吼" |
| 12:57:52 | **HARD RESTART** | Idle — picked up pending DingTalk env var |

The 12:57 event triggered a full Gateway hard restart because an unrelated DingTalk `clientSecret` configuration (added hours earlier but never synced) was detected as a new env var during the spurious sync.

### Why `scheduleNotify` is the only possible path

`notifySkillsChanged()` has 7 call sites. Code audit of each:

| Call site | Log signature | Production log count |
|-----------|--------------|---------------------|
| `setSkillEnabled` | `[SkillManager] setSkillEnabled` | 0 |
| `deleteSkill` | `[skills] deleteSkill` | 0 |
| `installSkill` | `[skills] install` | 0 |
| `upgradeSkill` | `[skills] upgrade` | 0 |
| `confirmPendingInstall` | `[SkillManager] confirmPendingInstall` | 0 |
| `handleWorkingDirectoryChange` | (only on working dir change) | 0 |
| **`scheduleNotify` debounce** | **(no log)** | **3 occurrences** |

## Code Change

Two lines changed in `src/main/skillManager.ts`:

```diff
-  if (!filename) { this.scheduleNotify(); return; }
+  if (!filename) { if (process.platform !== "win32") this.scheduleNotify(); return; }
```

Applied identically to both `rootWatchHandler` (line 2219) and `skillDirWatchHandler` (line 2231).

## Why this is safe

- **All** skill CRUD operations (`installSkill`, `deleteSkill`, `setSkillEnabled`, `upgradeSkill`, `confirmPendingInstall`) call `notifySkillsChanged()` directly in their success paths
- The `fs.watch` handlers are a backup for **external** changes (e.g., manually editing a SKILL.md file outside the app)
- On macOS/Linux, `FSEvents`/`inotify` reliably provide filenames, so the backup still works there
- On Windows, external skill edits are rare and will be picked up on next app restart or explicit skill operation

## Test plan

- [ ] Windows: verify `npm run electron:dev` starts without Gateway restart
- [ ] Windows: let app idle for 2+ hours, confirm no `skills-changed` in logs
- [ ] macOS: manually edit a SKILL.md file externally, confirm skill reload triggers
- [ ] All platforms: install/enable/disable/delete a skill, confirm UI updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
