### PR TITLE
fix(ui): Gateway startup overlay always on top via portal + max z-index

### DIFF
--- a/src/renderer/components/cowork/EngineStartupOverlay.tsx
+++ b/src/renderer/components/cowork/EngineStartupOverlay.tsx
@@ -1,5 +1,6 @@
 import { ChatBubbleLeftRightIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
@@ -105,8 +106,8 @@ const EngineStartupOverlay: React.FC = () => {
         messageClass: 'text-foreground',
       };
 
-  return (
-    <div className="pointer-events-none absolute top-0 left-0 right-0 z-50 flex justify-center">
+  const element = (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-[9999] flex justify-center">
       <div className="pointer-events-auto mt-2 w-full max-w-sm animate-in fade-in slide-in-from-top-2 duration-200 overflow-hidden rounded-xl border border-border bg-background shadow-2xl">
         <div className="flex items-start gap-3 px-4 py-3">
           <span
@@ -152,6 +153,8 @@ const EngineStartupOverlay: React.FC = () => {
       </div>
     </div>
   );
+
+  return createPortal(element, document.body);
 };
 
 export default EngineStartupOverlay;


### PR DESCRIPTION
## Summary

Gateway 硬重启时，前端进度条通知栏（EngineStartupOverlay）改为通过 `createPortal` 渲染到 `document.body`，z-index 设为 9999，确保不被任何弹窗遮盖或模糊。

## Root Cause

组件原本渲染在 `contain:layout_style_paint` 的容器内，创建了独立的 stacking context。`z-50` 只能在该容器内竞争——Settings Modal、AppUpdateModal 等通过 portal 渲染到 body 时，它们在同一层级用 `z-50` + `backdrop-blur`，会把启动通知栏遮盖和模糊。

## Change

| 维度 | 修改前 | 修改后 |
|------|--------|--------|
| 渲染方式 | 组件内 `absolute` | `createPortal(document.body)` |
| 定位 | `absolute`（相对于 paint 容器） | `fixed`（相对于视口） |
| z-index | `z-50` | `z-[9999]`（Toast 10000 之下） |

## Z-index 层级（修改后）

| 元素 | z-index |
|------|---------|
| Toast | 10000 |
| **Gateway 启动通知** | **9999** |
| CodeFullscreenModal | 200 |
| Settings 浮层 | 30 |
| 所有 Modal（Settings/AppUpdate/Permission） | 50 |
| Sidebar 渐变 | 10 |

## Test plan

- [ ] Gateway 硬重启时，Settings 页面已打开 → 通知栏不被遮盖
- [ ] Gateway 硬重启时，AppUpdateModal 弹出 → 通知栏在最上
- [ ] 正常运行中，通知栏淡出行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)
