### PR TITLE
fix(windows): suppress console flashes via windowsHide on all child_process calls

### DIFF
--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -280,7 +280,7 @@ function normalizeWindowsPath(input: string | undefined): string | null {
 
 function listWindowsCommandPaths(command: string): string[] {
   try {
-    const output = execSync(command, { encoding: 'utf-8', timeout: 5000 });
+    const output = execSync(command, { encoding: 'utf-8', timeout: 5000, windowsHide: true });
     const parsed = output
       .split(/\r?\n/)
       .map((line) => normalizeWindowsPath(line))
@@ -302,7 +302,7 @@ function listGitInstallPathsFromRegistry(): string[] {
 
   for (const key of registryKeys) {
     try {
-      const output = execSync(`reg query "${key}" /v InstallPath`, { encoding: 'utf-8', timeout: 5000 });
+      const output = execSync(`reg query "${key}" /v InstallPath`, { encoding: 'utf-8', timeout: 5000, windowsHide: true });
       for (const line of output.split(/\r?\n/)) {
         const match = line.match(/InstallPath\s+REG_\w+\s+(.+)$/i);
         const root = normalizeWindowsPath(match?.[1]);

--- a/src/main/libs/pythonRuntime.ts
+++ b/src/main/libs/pythonRuntime.ts
@@ -325,6 +325,7 @@ function runPythonCommand(
     stdio: 'pipe',
     timeout: 60_000,
     env,
+    windowsHide: true,
   });
   if (result.status === 0) {
     return { ok: true };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -732,7 +732,7 @@ const checkCalendarPermission = async (): Promise<string> => {
           $Outlook.Version
         } catch { exit 1 }
       `;
-      await execAsync('powershell -Command "' + checkScript + '"', { timeout: 10000 });
+      await execAsync('powershell -Command "' + checkScript + '"', { timeout: 10000, windowsHide: true });
       console.log('[Permissions] Windows Outlook is available');
       return 'authorized';
     } catch {

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -50,6 +50,7 @@ function hasCommand(command: string, env: NodeJS.ProcessEnv): boolean {
     stdio: 'pipe',
     env,
     shell: isWin,
+    windowsHide: isWin,
     timeout: 5000,
   });
   if (result.status !== 0) {
@@ -102,11 +103,11 @@ function resolveWindowsRegistryPath(): string | null {
   try {
     const machinePath = execSync(
       'reg query "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" /v Path',
-      { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] }
+      { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }
     );
     const userPath = execSync(
       'reg query "HKCU\\Environment" /v Path',
-      { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] }
+      { encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true }
     );
 
     const extract = (output: string): string => {
@@ -2586,6 +2587,7 @@ export class SkillManager {
         timeout: 120000, // 2 minute timeout
         env,
         shell: isWin,
+        windowsHide: isWin,
       });
 
       console.log(`[skills] npm install exit code: ${result.status}`);

--- a/src/main/skillServices.ts
+++ b/src/main/skillServices.ts
@@ -247,7 +247,7 @@ export class SkillServiceManager {
         throw new Error('Web-search runtime is incomplete and npm is not available to repair it');
       }
       console.log('[SkillServices] Installing/reparing web-search dependencies...');
-      execSync('npm install', { cwd: skillPath, stdio: 'ignore', env });
+      execSync('npm install', { cwd: skillPath, stdio: 'ignore', env, windowsHide: true });
     }
 
     const shouldCompileDist = !fs.existsSync(distDir) || this.isWebSearchDistOutdated(skillPath);
@@ -256,7 +256,7 @@ export class SkillServiceManager {
         throw new Error('Web-search dist files are missing/outdated and npm is not available to rebuild them');
       }
       console.log('[SkillServices] Compiling web-search TypeScript...');
-      execSync('npm run build', { cwd: skillPath, stdio: 'ignore', env });
+      execSync('npm run build', { cwd: skillPath, stdio: 'ignore', env, windowsHide: true });
     }
 
     if (!this.isWebSearchRuntimeHealthy(skillPath)) {


### PR DESCRIPTION
## Summary

Windows 生产模式下，`child_process.exec` / `execSync` / `spawnSync` 默认会创建可见控制台窗口。审计发现 5 个文件、9 处调用缺失 `windowsHide: true`，导致运行时弹出极短黑色控制台窗口。

## Safety analysis

`windowsHide` 是 Node.js 标准选项（所有 `exec`/`execSync`/`spawnSync` 均支持）：
- **Windows**: 隐藏子进程控制台窗口，不影响命令执行、stdio、退出码、错误处理
- **macOS/Linux**: 完全忽略，无任何影响
- **零功能变更**：纯 UI/UX 修复

## Changes (5 files, 10 insertions)

| 文件 | 调用 | API | 触发场景 |
|------|------|-----|---------|
| `main.ts:735` | `powershell -Command` | `exec` | 启动时日历权限 |
| `skillManager.ts:49` | `where`/`which` | `spawnSync` | 技能操作检测命令 |
| `skillManager.ts:103,107` | `reg query` | `execSync` | 启动时 PATH 解析 |
| `skillManager.ts:2582` | `npm install` | `spawnSync` | 技能安装 |
| `skillServices.ts:250,259` | `npm install`/`build` | `execSync` | web-search 修复 |
| `coworkUtil.ts:283,305` | `where`/`reg query` | `execSync` | 命令/Git 路径检测 |
| `pythonRuntime.ts:322` | `pythonExe` | `spawnSync` | 首次 Python 调用 |

## Audit result

源代码中所有 `child_process` 调用现已审计完毕。以下调用之前已正确设置：

| 文件 | 调用 | 防护 |
|------|------|------|
| `openclawEngineManager.ts:434,895` | Gateway spawn | `windowsHide: true` |
| `skillManager.ts:185,431` | `cmd.exe attrib`/`where` | `windowsHide: true` |
| `skillServices.ts:187,362` | `where`/`which`, bridge spawn | `windowsHide: true` |
| `coworkUtil.ts:165` | `reg query` | `windowsHide: true` |

## Test plan

- [ ] Windows 生产模式启动 — 无控制台弹窗
- [ ] macOS/Linux — 行为完全不变
- [ ] 首次 Python 调用 — 无弹窗
- [ ] 技能安装/修复 — 无弹窗
- [ ] 后台运行 — 无弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)
