### PR TITLE
fix(agent): prevent false positive unsaved changes dialog when closing unmodified agent edit panel

### DIFF
--- a/src/renderer/components/agent/AgentSettingsPanel.tsx
+++ b/src/renderer/components/agent/AgentSettingsPanel.tsx
@@ -177,11 +177,13 @@ const AgentSettingsPanel: React.FC<AgentSettingsPanelProps> = ({ agentId, onClos
     const currentTriage = triageCustom ? {
       ...triageOverride,
       ...(triageOverride.enabled === undefined ? {} : { enabled: triageOverride.enabled }),
-    } : null;
-    const prevTriage = initialTriageRef.current;
+    } : {};
+    const prevTriage = initialTriageRef.current && Object.keys(initialTriageRef.current).length > 0
+      ? initialTriageRef.current
+      : {};
     if (JSON.stringify(currentTriage) !== JSON.stringify(prevTriage)) return true;
     return false;
-  }, [name, description, systemPrompt, identity, userInfo, icon, model, workingDirectory, skillIds, boundKeys, initialBoundKeys]);
+  }, [name, description, systemPrompt, identity, userInfo, icon, model, workingDirectory, skillIds, boundKeys, initialBoundKeys, triageCustom, triageOverride]);
 
   if (!agentId) return null;
 


### PR DESCRIPTION
 ## Problem
  In the Agent edit panel, closing the window without making any modifications incorrectly tr
  iggers the "Unsaved Changes" confirmation dialog.

  ## Root Cause
  Two bugs in `AgentSettingsPanel.tsx` `isDirty()` caused it to always return `true`:

  1. **Triage dirty check compared `null` vs `{}`** (main cause). When `triageCustom === fals
  e`, `currentTriage` was `null` but `prevTriage` (loaded from `agent.triageOverride ?? {}`)
  was `{}`. `JSON.stringify(null) !== JSON.stringify({})` always evaluated to `true`.

  2. **`useCallback` missing dependencies** (`triageCustom`, `triageOverride`). This caused `
  isDirty` to use stale closure values for triage state.

  ## Changes
  - Normalize both `currentTriage` and `prevTriage` to `{}` when empty for consistent compari
  son
  - Add missing `triageCustom` and `triageOverride` to `useCallback` dependency array

  ## Verification
  - [x] `npm run lint` passes on modified file (no new issues introduced)
  - [x] Unmodified agent edit panel closes without dialog
  - [x] Modified agent edit panel still shows confirmation dialog correctly

  Closes #86