### PR TITLE
fix(agent): cascade delete cowork sessions and IM mappings when agent is deleted

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -784,6 +784,17 @@ export class CoworkStore {
     this.markOrphanImplicitMemoriesStale();
   }
 
+  deleteSessionsByAgentId(agentId: string): string[] {
+    const rows = this.db
+      .prepare('SELECT id FROM cowork_sessions WHERE agent_id = ?')
+      .all(agentId) as { id: string }[];
+    const ids = rows.map(r => r.id);
+    if (ids.length > 0) {
+      this.deleteSessions(ids);
+    }
+    return ids;
+  }
+
   setSessionPinned(id: string, pinned: boolean): number | null {
     if (!pinned) {
       this.db.prepare('UPDATE cowork_sessions SET pinned = 0, pin_order = NULL WHERE id = ?').run(id);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -17,6 +17,7 @@ import { AgentManager } from './agentManager';
 import { APP_NAME, LEGACY_APP_NAME } from './appConstants';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
 import { CoworkStore } from './coworkStore';
+import { CoworkStreamIpc } from '../shared/ipc/channels';
 import { ApiFetchSchema, ApiStreamSchema, CoworkSessionStartSchema } from '../shared/ipc/schemas';
 import { generateCorrelationId, runWithCorrelationId } from './libs/logCorrelation';
 import { createLogger } from './libs/structuredLog';
@@ -3506,6 +3507,31 @@ if (!gotTheLock) {
   ipcMain.handle(AgentIpcChannel.Delete, async (_event, id: string) => {
     try {
       const result = getAgentManager().deleteAgent(id);
+
+      // Cascade delete all Cowork sessions belonging to the deleted agent
+      const coworkStore = getCoworkStore();
+      const deletedSessionIds = coworkStore.deleteSessionsByAgentId(id);
+
+      // Clean up IM session mappings for deleted sessions
+      if (deletedSessionIds.length > 0) {
+        try {
+          const imStore = getIMGatewayManager()?.getIMStore();
+          if (imStore) {
+            for (const sessionId of deletedSessionIds) {
+              imStore.deleteSessionMappingByCoworkSessionId(sessionId);
+            }
+          }
+        } catch {
+          // IM store may not be initialised yet; safe to ignore.
+        }
+
+        // Notify renderer to refresh session lists
+        const windows = BrowserWindow.getAllWindows();
+        for (const win of windows) {
+          if (win.isDestroyed()) continue;
+          win.webContents.send(CoworkStreamIpc.SessionsChanged, { agentId: id, deletedSessionIds });
+        }
+      }
 
       // Clean up IM platform bindings that reference the deleted agent
       // so that channels fall back to the default 'main' agent.


### PR DESCRIPTION
  ## Problem
  When an agent was deleted, its cowork sessions remained in the database as orphan records,
  causing them to still appear in Ctrl+K search.

  ## Root Cause
  `AgentIpcChannel.Delete` handler only deleted the agent row and cleaned up IM platform bind
  ings, but did not delete associated `cowork_sessions` or `im_session_mappings`.

  ## Changes
  - Add `deleteSessionsByAgentId()` to `CoworkStore` to batch-delete sessions by agent_id
  - Extend `AgentIpcChannel.Delete` handler to:
    1. Cascade delete all sessions belonging to the deleted agent
    2. Clean up IM session mappings for those deleted sessions
    3. Notify renderer via `cowork:sessions:changed` to refresh UI

  ## Verification
  - [ √] Delete agent with sessions → sessions no longer appear in search
  - [ √] Delete agent with sessions → sidebar refreshes automatically