### PR TITLE
fix(agent): prevent lifecycle fallback from closing turn deferred for Gateway retry

### DIFF
--- a/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/openclawRuntimeAdapter.ts
@@ -3265,6 +3265,18 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         if (!currentTurn) return; // Already completed by handleChatFinal
         // If a new turn started for a different run, skip — the new run manages itself.
         if (endingRunId && !currentTurn.knownRunIds.has(endingRunId)) return;
+        // If handleChatFinal deferred the turn (session status 'idle') to wait
+        // for a Gateway retry, skip the fallback.  The retry will send its own
+        // lifecycle end + chat.final if it succeeds, or the turn timeout watchdog
+        // will clean up if it never completes.
+        const deferredSession = this.store.getSession(sessionId);
+        if (deferredSession?.status === 'idle') {
+          console.debug(
+            '[OpenClawRuntime] lifecycle end fallback: skipping — turn deferred for Gateway retry, sessionId:',
+            sessionId,
+          );
+          return;
+        }
         console.log(
           '[OpenClawRuntime] agent lifecycle end fallback: completing turn that missed chat final, sessionId:',
           sessionId,


### PR DESCRIPTION
## Summary

修复 `agent lifecycle end fallback` 与 PR #82 的 `deferring run close` 之间的竞争条件。

### Root Cause

PR #82 在 `handleChatFinal` 中正确地将空响应的 turn 延迟关闭（`status = idle`），等待 Gateway 的 reasoning-only retry。但 `handleAgentLifecycleEvent` 中的 lifecycle end fallback 是一个独立的 3 秒定时器——它不检查 `handleChatFinal` 是否已经 defer 了这个 turn，到时间就调用 `completeChannelTurnFallback` 强行关闭。

### The race

```
handleChatFinal → defer (status=idle) → 等待 Gateway retry
lifecycle end → 3s timer → fallback → completeChannelTurnFallback → cleanupSessionTurn
→ Gateway retry 完成 → events 全部 dropped → 用户无回复
```

### The fix

在 fallback 定时器中增加检查：如果 session 状态为 `idle`（说明 `handleChatFinal` 已 defer），跳过 fallback。Gateway retry 完成后会自己发送 `chat.final`；如果 retry 永不完成，现有的 turn timeout watchdog 会兜底清理。

### Safety

| 维度 | 分析 |
|------|------|
| **功能性** | 只影响 handleChatFinal 已 defer 的 turn。正常完成的 turn 不受影响 |
| **安全性** | 无新增风险。retry 失败有 timeout watchdog 兜底 |
| **性能** | 一次 `store.getSession()` 查找 + 一个字符串比较，开销可忽略 |

### Test plan

- [ ] MiniMax-M2.7 thinking-only 响应 → Gateway retry 不被 fallback 打断
- [ ] retry 返回文本 → 用户正常看到回复
- [ ] retry 也返回空 → Gateway "retries exhausted" 错误正确投递
- [ ] 正常（有文本）响应 → lifecycle fallback 逻辑不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)
