### PR TITLE
fix(build): use PowerShell Expand-Archive for llama.cpp zip on Windows

### DIFF
--- a/scripts/download-llamacpp-runtime.cjs
+++ b/scripts/download-llamacpp-runtime.cjs
@@ -291,6 +291,28 @@ async function extractArchive(archivePath, extractDir) {
     });
     return;
   }
+  if (process.platform === 'win32') {
+    // extract-zip (yauzl) stalls mid-archive on some Windows zips; the pending
+    // promise then lets Node exit silently with code 0 before the runtime is
+    // installed. Use PowerShell's Expand-Archive on Windows instead.
+    const psCommand = [
+      'Expand-Archive',
+      '-LiteralPath',
+      JSON.stringify(archivePath),
+      '-DestinationPath',
+      JSON.stringify(extractDir),
+      '-Force',
+    ].join(' ');
+    const result = spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', psCommand],
+      { stdio: 'inherit' },
+    );
+    if (result.status !== 0) {
+      throw new Error(`Failed to extract runtime archive: ${path.basename(archivePath)}`);
+    }
+    return;
+  }
   await extractZip(archivePath, { dir: extractDir });
 }
 


### PR DESCRIPTION
extract-zip (yauzl) stalls mid-archive on some Windows zips; the pending promise lets Node exit silently with code 0 before the runtime is installed, so the download appears to succeed but vendor/llamacpp-runtime is never created. Use PowerShell's Expand-Archive on Windows instead.

## Summary

<!-- Provide a brief summary of the changes in this PR -->

## Related Issue

<!-- Link to the related issue(s) if applicable -->

Fixes #(issue number)

## Changes Made

<!-- Describe the changes you've made -->

-
-
-

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you've performed -->

- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Checklist

<!-- Mark the completed items with [x] -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

<!-- If your PR includes Electron-specific changes, describe them here -->

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

<!-- Any additional information that reviewers should know -->
