### PR TITLE
ci: restrict pull request checks and protect builds

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -29,10 +29,11 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ========== macOS 构建 ==========
+  # ========== macOS ?? ==========
   build-macos:
     if: ${{ github.event_name == 'push' || inputs.build_macos }}
     runs-on: macos-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -62,10 +63,11 @@ jobs:
           path: release/*.dmg
           retention-days: 7
 
-  # ========== Windows 构建 ==========
+  # ========== Windows ?? ==========
   build-windows:
     if: ${{ github.event_name == 'push' || inputs.build_windows }}
     runs-on: windows-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -82,7 +84,7 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
 
-      # Windows 需要 Python 运行时
+      # Windows ?? Python ???
       - name: Setup Python Runtime
         run: npm run setup:python-runtime
         env:
@@ -101,10 +103,11 @@ jobs:
           path: release/*.exe
           retention-days: 7
 
-  # ========== Linux 构建 ==========
+  # ========== Linux ?? ==========
   build-linux:
     if: ${{ github.event_name == 'push' || inputs.build_linux }}
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -140,7 +143,7 @@ jobs:
             release/*.deb
           retention-days: 7
 
-  # ========== 创建 Release ==========
+  # ========== ?? Release ==========
   create-release:
     needs: [build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, release-1.0, dev]
   pull_request:
 
 permissions:
@@ -17,148 +15,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ========== Stage 1: 变更检测 ==========
-  changed-files:
-    runs-on: ubuntu-latest
-    outputs:
-      renderer: ${{ steps.changes.outputs.renderer }}
-      main: ${{ steps.changes.outputs.main }}
-      skills: ${{ steps.changes.outputs.skills }}
-      scripts: ${{ steps.changes.outputs.scripts }}
-      docs: ${{ steps.changes.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            renderer:
-              - 'src/renderer/**'
-              - 'vite.config.ts'
-              - 'tsconfig.json'
-              - 'tailwind.config.js'
-              - 'postcss.config.js'
-            main:
-              - 'src/main/**'
-              - 'src/common/**'
-              - 'electron-tsconfig.json'
-              - 'src/main/preload.ts'
-            skills:
-              - 'SKILLs/**'
-            scripts:
-              - 'scripts/**'
-              - 'electron-builder.json'
-            docs:
-              - 'docs/**'
-              - '**/*.md'
-
-  # ========== Stage 2: 代码质量 (快速) ==========
   lint:
-    needs: changed-files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - name: Lint changed files only
-        env:
-          BEFORE_SHA: ${{ github.event.before }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR origin/${BASE_REF}...HEAD -- '*.ts' '*.tsx')
-          elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR ${BEFORE_SHA}...HEAD -- '*.ts' '*.tsx')
-          else
-            echo "BEFORE_SHA unavailable, falling back to HEAD~1"
-            FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 -- '*.ts' '*.tsx')
-          fi
-          if [ -n "$FILES" ]; then
-            echo "Linting changed files:"
-            echo "$FILES"
-            echo "$FILES" | xargs -d '\n' npx eslint --ext ts,tsx --report-unused-disable-directives --no-warn-ignored --max-warnings 0
-          else
-            echo "No TypeScript files changed, skipping lint"
-          fi
-
-  # ========== Stage 3: Renderer 构建 ==========
-  build-renderer:
-    needs: [changed-files, lint]
-    if: ${{ needs.changed-files.outputs.renderer == 'true' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-      - uses: actions/cache@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run build
-        env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
+          bun-version: '1.3.14'
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Lint
+        run: bun run lint
 
-  # ========== Stage 4: Main 进程构建 ==========
-  build-main:
-    needs: [changed-files, lint]
-    if: ${{ needs.changed-files.outputs.main == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run compile:electron
-
-  # ========== Stage 5: Skill 构建 ==========
-  build-skills:
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.skills == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run build:skills
-
-  # ========== Stage 6: 测试 ==========
   test:
-    needs: [build-main]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-      - uses: actions/cache@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm test
+          bun-version: '1.3.14'
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Compile Electron sources used by integration tests
+        run: bun run compile:electron
+      - name: Run tests
+        run: bun run test

--- a/.github/workflows/electron-verify.yml
+++ b/.github/workflows/electron-verify.yml
@@ -3,12 +3,6 @@ name: Electron Verify
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'electron-builder.json'
-      - 'package.json'
-      - 'vite.config.ts'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -43,19 +37,19 @@ jobs:
           echo "=== Verifying dist/ structure ==="
           for f in dist/index.html; do
             if [ ! -f "$f" ]; then
-              echo "❌ $f not found"
+              echo "? $f not found"
               exit 1
             fi
           done
-          echo "✓ dist/ structure verified"
+          echo "? dist/ structure verified"
 
           echo "=== Verifying dist-electron/ structure ==="
           for f in dist-electron/main.js dist-electron/preload.js; do
             if [ ! -f "$f" ]; then
-              echo "❌ $f not found"
+              echo "? $f not found"
               exit 1
             fi
           done
-          echo "✓ dist-electron/ structure verified"
+          echo "? dist-electron/ structure verified"
 
           echo "=== Build verification complete ==="

--- a/.github/workflows/openclaw-check.yml
+++ b/.github/workflows/openclaw-check.yml
@@ -6,9 +6,6 @@ on:
       - 'package.json'
       - 'scripts/ensure-openclaw-version.cjs'
       - 'scripts/**openclaw*'
-  pull_request:
-    paths:
-      - 'package.json'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -26,20 +23,20 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').openclaw.version")
           if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Invalid OpenClaw version format: $VERSION"
+            echo "? Invalid OpenClaw version format: $VERSION"
             echo "Expected format: vX.Y.Z (e.g., v2026.3.2)"
             exit 1
           fi
-          echo "✓ OpenClaw version format valid: $VERSION"
+          echo "? OpenClaw version format valid: $VERSION"
 
       - name: Validate OpenClaw Repository
         run: |
           REPO=$(node -p "require('./package.json').openclaw.repo")
           if [[ ! $REPO =~ ^https://github\.com/.+/.+\.git$ ]]; then
-            echo "❌ Invalid OpenClaw repository URL: $REPO"
+            echo "? Invalid OpenClaw repository URL: $REPO"
             exit 1
           fi
-          echo "✓ OpenClaw repository URL valid: $REPO"
+          echo "? OpenClaw repository URL valid: $REPO"
 
       - name: Validate OpenClaw Plugins
         run: |
@@ -47,26 +44,26 @@ jobs:
             const pkg = require('./package.json');
             
             if (!pkg.openclaw.plugins || !Array.isArray(pkg.openclaw.plugins)) {
-              console.error('❌ Invalid openclaw.plugins configuration: must be an array');
+              console.error('? Invalid openclaw.plugins configuration: must be an array');
               process.exit(1);
             }
             
-            console.log('✓ OpenClaw plugins configuration valid');
+            console.log('? OpenClaw plugins configuration valid');
             console.log('  Total plugins:', pkg.openclaw.plugins.length);
             
             // Validate each plugin
             let hasError = false;
             pkg.openclaw.plugins.forEach((plugin, index) => {
               if (!plugin.id) {
-                console.error('❌ Plugin at index ' + index + ' missing \"id\" field');
+                console.error('? Plugin at index ' + index + ' missing \"id\" field');
                 hasError = true;
               }
               if (!plugin.npm) {
-                console.error('❌ Plugin at index ' + index + ' missing \"npm\" field');
+                console.error('? Plugin at index ' + index + ' missing \"npm\" field');
                 hasError = true;
               }
               if (!plugin.version) {
-                console.error('❌ Plugin at index ' + index + ' missing \"version\" field');
+                console.error('? Plugin at index ' + index + ' missing \"version\" field');
                 hasError = true;
               }
             });
@@ -75,7 +72,7 @@ jobs:
               process.exit(1);
             }
             
-            console.log('✓ All plugins have required fields');
+            console.log('? All plugins have required fields');
           "
 
       - name: Check OpenClaw Scripts Exist
@@ -95,13 +92,13 @@ jobs:
           MISSING=0
           for script in "${SCRIPTS[@]}"; do
             if [ -f "$script" ]; then
-              echo "✓ $script"
+              echo "? $script"
             else
-              echo "⚠ $script not found"
+              echo "? $script not found"
               MISSING=$((MISSING + 1))
             fi
           done
 
           if [ $MISSING -gt 0 ]; then
-            echo "⚠ $MISSING OpenClaw scripts missing (this may be expected for new projects)"
+            echo "? $MISSING OpenClaw scripts missing (this may be expected for new projects)"
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,15 +3,14 @@ name: Security Scan
 on:
   push:
     branches: [main, develop]
-  pull_request:
   schedule:
-    - cron: '0 0 * * 1' # 每周一
+    - cron: '0 0 * * 1' # ???
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ========== 密钥泄露检测 ==========
+  # ========== ?????? ==========
   secrets-scan:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +26,7 @@ jobs:
           head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --only-verified
 
-  # ========== 依赖漏洞扫描 ==========
+  # ========== ?????? ==========
   dependency-audit:
     runs-on: ubuntu-latest
     steps:
@@ -41,21 +40,21 @@ jobs:
           key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
           restore-keys: npm-${{ runner.os }}-
 
-      # npm install 会生成临时 package-lock.json 供 audit 使用
+      # npm install ????? package-lock.json ? audit ??
       - run: npm install
 
       # npm audit
       - name: Run npm audit
         run: |
           echo "Running npm audit..."
-          npm audit --audit-level=high || echo "⚠ npm audit found issues (non-blocking)"
+          npm audit --audit-level=high || echo "? npm audit found issues (non-blocking)"
 
-      # 使用 better-npm-audit 获得更好体验
+      # ?? better-npm-audit ??????
       - name: Run better-npm-audit
         run: |
-          npx better-npm-audit audit --level=high || echo "⚠ better-npm-audit found issues (non-blocking)"
+          npx better-npm-audit audit --level=high || echo "? better-npm-audit found issues (non-blocking)"
 
-  # ========== Skill 依赖扫描 ==========
+  # ========== Skill ???? ==========
   skills-audit:
     runs-on: ubuntu-latest
     steps:
@@ -72,14 +71,14 @@ jobs:
             if [ -f "$skill/package.json" ]; then
               echo ""
               echo "=== Auditing $skill ==="
-              (cd "$skill" && npm install --package-lock-only 2>/dev/null && npm audit --audit-level=moderate 2>/dev/null) || echo "⚠ Audit issues found in $skill (non-blocking)"
+              (cd "$skill" && npm install --package-lock-only 2>/dev/null && npm audit --audit-level=moderate 2>/dev/null) || echo "? Audit issues found in $skill (non-blocking)"
             fi
           done
 
           echo ""
           echo "=== Skill audit complete ==="
 
-  # ========== 代码扫描 (CodeQL) ==========
+  # ========== ???? (CodeQL) ==========
   codeql:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- keep pull request CI to lint and test jobs
- compile Electron sources inside the test job for integration tests
- bind platform build jobs to the `release` environment
- stop Electron Verify, security, and OpenClaw checks from running on pull requests

## Verification

- YAML parsing passed
- `bun run lint` passed
- Electron compilation passed locally
- Full tests were blocked locally by a Windows permission error while rebuilding `better-sqlite3`