### PR TITLE
ci: restrict pull request checks and protect builds

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -33,6 +33,7 @@ jobs:
   build-macos:
     if: ${{ github.event_name == 'push' || inputs.build_macos }}
     runs-on: macos-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -66,6 +67,7 @@ jobs:
   build-windows:
     if: ${{ github.event_name == 'push' || inputs.build_windows }}
     runs-on: windows-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -105,6 +107,7 @@ jobs:
   build-linux:
     if: ${{ github.event_name == 'push' || inputs.build_linux }}
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, release-1.0, dev]
   pull_request:
 
 permissions:
@@ -17,148 +15,32 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ========== Stage 1: 变更检测 ==========
-  changed-files:
-    runs-on: ubuntu-latest
-    outputs:
-      renderer: ${{ steps.changes.outputs.renderer }}
-      main: ${{ steps.changes.outputs.main }}
-      skills: ${{ steps.changes.outputs.skills }}
-      scripts: ${{ steps.changes.outputs.scripts }}
-      docs: ${{ steps.changes.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            renderer:
-              - 'src/renderer/**'
-              - 'vite.config.ts'
-              - 'tsconfig.json'
-              - 'tailwind.config.js'
-              - 'postcss.config.js'
-            main:
-              - 'src/main/**'
-              - 'src/common/**'
-              - 'electron-tsconfig.json'
-              - 'src/main/preload.ts'
-            skills:
-              - 'SKILLs/**'
-            scripts:
-              - 'scripts/**'
-              - 'electron-builder.json'
-            docs:
-              - 'docs/**'
-              - '**/*.md'
-
-  # ========== Stage 2: 代码质量 (快速) ==========
   lint:
-    needs: changed-files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - name: Lint changed files only
-        env:
-          BEFORE_SHA: ${{ github.event.before }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR origin/${BASE_REF}...HEAD -- '*.ts' '*.tsx')
-          elif [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR ${BEFORE_SHA}...HEAD -- '*.ts' '*.tsx')
-          else
-            echo "BEFORE_SHA unavailable, falling back to HEAD~1"
-            FILES=$(git diff --name-only --diff-filter=ACMR HEAD~1 -- '*.ts' '*.tsx')
-          fi
-          if [ -n "$FILES" ]; then
-            echo "Linting changed files:"
-            echo "$FILES"
-            echo "$FILES" | xargs -d '\n' npx eslint --ext ts,tsx --report-unused-disable-directives --no-warn-ignored --max-warnings 0
-          else
-            echo "No TypeScript files changed, skipping lint"
-          fi
-
-  # ========== Stage 3: Renderer 构建 ==========
-  build-renderer:
-    needs: [changed-files, lint]
-    if: ${{ needs.changed-files.outputs.renderer == 'true' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-      - uses: actions/cache@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run build
-        env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
+          bun-version: '1.3.14'
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Lint
+        run: bun run lint
 
-  # ========== Stage 4: Main 进程构建 ==========
-  build-main:
-    needs: [changed-files, lint]
-    if: ${{ needs.changed-files.outputs.main == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run compile:electron
-
-  # ========== Stage 5: Skill 构建 ==========
-  build-skills:
-    needs: changed-files
-    if: ${{ needs.changed-files.outputs.skills == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm run build:skills
-
-  # ========== Stage 6: 测试 ==========
   test:
-    needs: [build-main]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '24.x'
-      - uses: actions/cache@v4
+      - uses: oven-sh/setup-bun@v2
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-${{ runner.os }}-
-      - run: npm install
-      - run: npm test
+          bun-version: '1.3.14'
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Compile Electron sources used by integration tests
+        run: bun run compile:electron
+      - name: Run tests
+        run: bun run test

--- a/.github/workflows/electron-verify.yml
+++ b/.github/workflows/electron-verify.yml
@@ -3,12 +3,6 @@ name: Electron Verify
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'electron-builder.json'
-      - 'package.json'
-      - 'vite.config.ts'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/openclaw-check.yml
+++ b/.github/workflows/openclaw-check.yml
@@ -6,9 +6,6 @@ on:
       - 'package.json'
       - 'scripts/ensure-openclaw-version.cjs'
       - 'scripts/**openclaw*'
-  pull_request:
-    paths:
-      - 'package.json'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,6 @@ name: Security Scan
 on:
   push:
     branches: [main, develop]
-  pull_request:
   schedule:
     - cron: '0 0 * * 1' # 每周一
 


### PR DESCRIPTION
## Summary

- Keep pull request CI limited to lint and test.
- Compile Electron sources in the test job because the tests consume the generated Electron output.
- Require the release environment for platform packaging jobs.
- Remove duplicate pull_request triggers from build and scan workflows.

## Verification

- bun run lint
- bun run compile:electron
- Full tests were attempted locally but blocked by a Windows permission error while rebuilding better-sqlite3.