### PR TITLE
feat(cowork): Pi 接入 AskUserQuestion 问答卡片

### DIFF
--- a/src/main/libs/agentEngine/piAskUserQuestion.test.ts
+++ b/src/main/libs/agentEngine/piAskUserQuestion.test.ts
@@ -1,0 +1,50 @@
+import { expect, test, vi } from 'vitest';
+
+import {
+  createPiAskUserQuestionTool,
+  PiAskUserQuestionSystemPrompt,
+  PiAskUserQuestionTimeoutMs,
+} from './piAskUserQuestion';
+
+const input = {
+  questions: [
+    {
+      question: 'Continue?',
+      options: [{ label: 'Yes' }, { label: 'No' }],
+    },
+  ],
+};
+
+test('returns the selected answers as a Pi tool result', async () => {
+  const request = vi.fn().mockResolvedValue({
+    behavior: 'allow',
+    updatedInput: { answers: { 'Continue?': 'Yes' } },
+  });
+  const tool = createPiAskUserQuestionTool(request) as {
+    execute: (id: string, value: typeof input) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  const result = await tool.execute('tool-1', input);
+
+  expect(request).toHaveBeenCalledWith('tool-1', input, undefined);
+  expect(result.content[0]?.text).toBe('Continue?: Yes');
+});
+
+test('returns a denial as a Pi tool result', async () => {
+  const tool = createPiAskUserQuestionTool(async () => ({
+    behavior: 'deny' as const,
+    message: 'The user denied the operation.',
+  })) as {
+    execute: (id: string, value: typeof input) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  const result = await tool.execute('tool-1', input);
+
+  expect(result.content[0]?.text).toBe('The user denied the operation.');
+});
+
+test('defines a ten-minute timeout and a system-level AskUserQuestion policy', () => {
+  expect(PiAskUserQuestionTimeoutMs).toBe(600_000);
+  expect(PiAskUserQuestionSystemPrompt).toContain('AskUserQuestion');
+  expect(PiAskUserQuestionSystemPrompt).toContain('Before deleting files or directories');
+});

--- a/src/main/libs/agentEngine/piAskUserQuestion.ts
+++ b/src/main/libs/agentEngine/piAskUserQuestion.ts
@@ -1,0 +1,87 @@
+import { Type } from 'typebox';
+
+export const PiAskUserQuestionToolName = 'AskUserQuestion' as const;
+export const PiAskUserQuestionTimeoutMs = 600_000;
+export const PiAskUserQuestionSystemPrompt = [
+  '## User Interaction',
+  '',
+  '- Before deleting files or directories, call AskUserQuestion and wait for the user response.',
+  '- Use AskUserQuestion for user choices whenever it is available; do not replace it with a plain-text question.',
+].join('\n');
+
+const QuestionOptionSchema = Type.Object({
+  label: Type.String(),
+  description: Type.Optional(Type.String()),
+});
+
+const QuestionSchema = Type.Object({
+  question: Type.String(),
+  header: Type.Optional(Type.String()),
+  options: Type.Array(QuestionOptionSchema, { minItems: 2, maxItems: 4 }),
+  multiSelect: Type.Optional(Type.Boolean()),
+});
+
+export const PiAskUserQuestionParameters = Type.Object({
+  questions: Type.Array(QuestionSchema, { minItems: 1, maxItems: 4 }),
+});
+
+export type PiAskUserQuestionInput = {
+  questions: Array<{
+    question: string;
+    header?: string;
+    options: Array<{ label: string; description?: string }>;
+    multiSelect?: boolean;
+  }>;
+};
+
+export type PiAskUserQuestionResponse = {
+  behavior: 'allow' | 'deny';
+  updatedInput?: Record<string, unknown>;
+  message?: string;
+};
+
+export type PiAskUserQuestionRequester = (
+  toolCallId: string,
+  input: PiAskUserQuestionInput,
+  signal?: AbortSignal,
+) => Promise<PiAskUserQuestionResponse>;
+
+export const createPiAskUserQuestionTool = (
+  request: PiAskUserQuestionRequester,
+): Record<string, unknown> => ({
+  name: PiAskUserQuestionToolName,
+  label: 'Ask User Question',
+  description:
+    'Ask the user a structured question and wait for a choice. ' +
+    'You MUST use this before any delete operation, including rm, del, rmdir, unlink, trash, or git clean.',
+  promptSnippet: 'Ask the user a structured question before destructive actions',
+  parameters: PiAskUserQuestionParameters,
+  executionMode: 'sequential',
+  execute: async (
+    toolCallId: string,
+    params: PiAskUserQuestionInput,
+    signal?: AbortSignal,
+  ) => {
+    const response = await request(toolCallId, params, signal);
+    if (response.behavior === 'deny') {
+      return {
+        content: [{ type: 'text', text: response.message || 'The user denied the operation.' }],
+        details: { behavior: 'deny' },
+      };
+    }
+
+    const answers = response.updatedInput?.answers;
+    const answerText =
+      answers && typeof answers === 'object'
+        ? Object.entries(answers)
+            .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+            .map(([question, answer]) => `${question}: ${answer}`)
+            .join('\n')
+        : '';
+
+    return {
+      content: [{ type: 'text', text: answerText || 'The user approved the operation.' }],
+      details: { behavior: 'allow', answers },
+    };
+  },
+});

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -123,6 +123,7 @@ vi.mock('../claudeSettings', () => ({
 }));
 
 import { PiRuntimeAdapter } from './piRuntimeAdapter';
+import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
 
 describe('PiRuntimeAdapter', () => {
   let adapter: PiRuntimeAdapter;
@@ -350,6 +351,116 @@ describe('PiRuntimeAdapter', () => {
       expect(() =>
         adapter.respondToPermission('unknown', { behavior: 'deny', message: 'no' }),
       ).not.toThrow();
+    });
+
+    it('appends the AskUserQuestion policy when a custom system prompt is configured', async () => {
+      await adapter.startSession('test', 'Hello Pi', { systemPrompt: 'Custom instructions' });
+
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      expect(loaderOptions.appendSystemPromptOverride()).toEqual([PiAskUserQuestionSystemPrompt]);
+    });
+
+    it('resolves a Pi AskUserQuestion tool call with the renderer response', async () => {
+      const permissionRequests: Array<{ requestId: string; toolInput: Record<string, unknown> }> =
+        [];
+      const dismissals: string[] = [];
+      adapter.on('permissionRequest', (_sessionId, request) => {
+        permissionRequests.push({ requestId: request.requestId, toolInput: request.toolInput });
+      });
+      adapter.on('permissionDismiss', requestId => dismissals.push(requestId));
+
+      await adapter.startSession('test', 'Ask me something');
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools?: Array<{
+          name: string;
+          execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{
+            content: Array<{ text: string }>;
+          }>;
+        }>;
+      };
+      const askUserTool = sessionOptions.customTools?.find(tool => tool.name === 'AskUserQuestion');
+      expect(askUserTool).toBeDefined();
+
+      const toolResult = askUserTool!.execute('tool-call-1', {
+        questions: [
+          {
+            question: 'Continue?',
+            options: [{ label: 'Yes' }, { label: 'No' }],
+          },
+        ],
+      });
+      await vi.waitFor(() => expect(permissionRequests).toHaveLength(1));
+
+      adapter.respondToPermission(permissionRequests[0].requestId, {
+        behavior: 'allow',
+        updatedInput: { answers: { 'Continue?': 'Yes' } },
+      });
+
+      await expect(toolResult).resolves.toMatchObject({
+        content: [{ text: 'Continue?: Yes' }],
+      });
+      expect(dismissals).toEqual([permissionRequests[0].requestId]);
+    });
+
+    it('keeps AskUserQuestion waits isolated to their owning Pi session', async () => {
+      const permissionRequests: Array<{ sessionId: string; requestId: string }> = [];
+      adapter.on('permissionRequest', (sessionId, request) => {
+        permissionRequests.push({ sessionId, requestId: request.requestId });
+      });
+
+      await adapter.startSession('session-a', 'Ask A');
+      await adapter.startSession('session-b', 'Ask B');
+
+      const getAskUserTool = (callIndex: number) => {
+        const sessionOptions = mockCreateAgentSession.mock.calls[callIndex]?.[0] as {
+          customTools?: Array<{
+            name: string;
+            execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+          }>;
+        };
+        const tool = sessionOptions.customTools?.find(item => item.name === 'AskUserQuestion');
+        expect(tool).toBeDefined();
+        return tool!;
+      };
+
+      const question = {
+        questions: [
+          {
+            question: 'Continue?',
+            options: [{ label: 'Yes' }, { label: 'No' }],
+          },
+        ],
+      };
+      let sessionAResolved = false;
+      const sessionAResult = getAskUserTool(0)
+        .execute('tool-call-a', question)
+        .then(result => {
+          sessionAResolved = true;
+          return result;
+        });
+      const sessionBResult = getAskUserTool(1).execute('tool-call-b', question);
+      await vi.waitFor(() => expect(permissionRequests).toHaveLength(2));
+
+      const sessionBRequest = permissionRequests.find(request => request.sessionId === 'session-b');
+      expect(sessionBRequest).toBeDefined();
+      adapter.respondToPermission(sessionBRequest!.requestId, {
+        behavior: 'allow',
+        updatedInput: { answers: { 'Continue?': 'Yes' } },
+      });
+
+      await expect(sessionBResult).resolves.toMatchObject({
+        content: [{ text: 'Continue?: Yes' }],
+      });
+      expect(sessionAResolved).toBe(false);
+
+      const sessionARequest = permissionRequests.find(request => request.sessionId === 'session-a');
+      expect(sessionARequest).toBeDefined();
+      adapter.respondToPermission(sessionARequest!.requestId, { behavior: 'deny' });
+      await expect(sessionAResult).resolves.toMatchObject({
+        content: [{ text: 'The user denied the operation.' }],
+      });
     });
   });
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -34,6 +34,14 @@ import {
 } from '../claudeSettings';
 import { getSkillsRoot } from '../coworkUtil';
 import type { McpServerManager } from '../mcpServerManager';
+import {
+  createPiAskUserQuestionTool,
+  PiAskUserQuestionToolName,
+  PiAskUserQuestionSystemPrompt,
+  PiAskUserQuestionTimeoutMs,
+  type PiAskUserQuestionInput,
+  type PiAskUserQuestionResponse,
+} from './piAskUserQuestion';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import type {
   CoworkContinueOptions,
@@ -206,6 +214,15 @@ if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '1';
 export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   private readonly activeSessions = new Map<string, ActivePiSession>();
   private readonly approvalSessionMap = new Map<string, string>();
+  private readonly pendingAskUserQuestions = new Map<
+    string,
+    {
+      sessionId: string;
+      resolve: (response: PiAskUserQuestionResponse) => void;
+      timer: ReturnType<typeof setTimeout>;
+      removeAbortListener?: () => void;
+    }
+  >();
   private store: CoworkStore | null = null;
   private mcpServerManager: McpServerManager | null = null;
 
@@ -327,8 +344,16 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         sessionOptions.modelRuntime = resolvedModel.modelRuntime;
       }
 
-      // Build custom tools: MCP proxy + optional subagent for Team Leads
+      // Build custom tools: MCP proxy + optional subagent for Team Leads.
+      // Each call creates a distinct tool instance for this Pi session, so its
+      // sequential execution mode cannot block another session.
       const customTools: Record<string, unknown>[] = [];
+
+      customTools.push(
+        createPiAskUserQuestionTool((toolCallId, input, signal) =>
+          this.requestAskUserQuestion(sessionId, toolCallId, input, signal),
+        ),
+      );
 
       // MCP tools: register a single proxy tool (pi-mcp-adapter pattern)
       const mcpProxyTool = this.buildMcpProxyTool();
@@ -522,6 +547,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   }
 
   stopSession(sessionId: string): void {
+    this.dismissAskUserQuestionsBySession(sessionId);
     const active = this.activeSessions.get(sessionId);
     if (!active) return;
 
@@ -548,6 +574,17 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   }
 
   respondToPermission(requestId: string, result: PermissionResult): void {
+    const pendingQuestion = this.pendingAskUserQuestions.get(requestId);
+    if (pendingQuestion) {
+      this.finishAskUserQuestion(requestId, {
+        behavior: result.behavior,
+        ...(result.behavior === 'allow'
+          ? { updatedInput: result.updatedInput }
+          : { message: result.message }),
+      });
+      return;
+    }
+
     const sessionId = this.approvalSessionMap.get(requestId);
     if (!sessionId) return;
     this.approvalSessionMap.delete(requestId);
@@ -601,7 +638,9 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
               ),
             }),
       systemPromptOverride: () => systemPrompt || '',
-      appendSystemPromptOverride: (): string[] => [],
+      // Pi bypasses tool promptGuidelines when systemPromptOverride is non-empty.
+      // Append this policy so it remains present for both default and custom prompts.
+      appendSystemPromptOverride: (): string[] => [PiAskUserQuestionSystemPrompt],
     });
     await resourceLoader.reload();
     return resourceLoader;
@@ -1087,6 +1126,78 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   private clearApprovalsBySession(sessionId: string): void {
     for (const [requestId, sid] of this.approvalSessionMap.entries()) {
       if (sid === sessionId) this.approvalSessionMap.delete(requestId);
+    }
+  }
+
+  private requestAskUserQuestion(
+    sessionId: string,
+    toolCallId: string,
+    input: PiAskUserQuestionInput,
+    signal?: AbortSignal,
+  ): Promise<PiAskUserQuestionResponse> {
+    if (signal?.aborted) {
+      return Promise.resolve({ behavior: 'deny', message: 'The request was cancelled.' });
+    }
+
+    const requestId = randomUUID();
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        this.finishAskUserQuestion(requestId, {
+          behavior: 'deny',
+          message: 'The question timed out without a response.',
+        });
+      }, PiAskUserQuestionTimeoutMs);
+
+      const onAbort = () => {
+        this.finishAskUserQuestion(requestId, {
+          behavior: 'deny',
+          message: 'The request was cancelled.',
+        });
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+
+      this.pendingAskUserQuestions.set(requestId, {
+        sessionId,
+        resolve,
+        timer,
+        removeAbortListener: () => signal?.removeEventListener('abort', onAbort),
+      });
+
+      try {
+        this.emit('permissionRequest', sessionId, {
+          requestId,
+          toolName: PiAskUserQuestionToolName,
+          toolInput: input as unknown as Record<string, unknown>,
+          toolUseId: toolCallId,
+        });
+      } catch (error) {
+        console.error('[PiRuntime] failed to emit AskUserQuestion request:', error);
+        this.finishAskUserQuestion(requestId, {
+          behavior: 'deny',
+          message: 'Unable to show the question to the user.',
+        });
+      }
+    });
+  }
+
+  private finishAskUserQuestion(requestId: string, response: PiAskUserQuestionResponse): void {
+    const pending = this.pendingAskUserQuestions.get(requestId);
+    if (!pending) return;
+    this.pendingAskUserQuestions.delete(requestId);
+    clearTimeout(pending.timer);
+    pending.removeAbortListener?.();
+    pending.resolve(response);
+    this.emit('permissionDismiss', requestId);
+  }
+
+  private dismissAskUserQuestionsBySession(sessionId: string): void {
+    for (const [requestId, pending] of this.pendingAskUserQuestions.entries()) {
+      if (pending.sessionId === sessionId) {
+        this.finishAskUserQuestion(requestId, {
+          behavior: 'deny',
+          message: 'The session was stopped.',
+        });
+      }
     }
   }
 

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -36,6 +36,7 @@ export interface CoworkRuntimeEvents {
     metadata?: Record<string, unknown>,
   ) => void;
   permissionRequest: (sessionId: string, request: PermissionRequest) => void;
+  permissionDismiss: (requestId: string) => void;
   complete: (sessionId: string, claudeSessionId: string | null) => void;
   error: (sessionId: string, error: CoworkError) => void;
   sessionStopped: (sessionId: string) => void;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1742,6 +1742,18 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
     });
   });
 
+  runtime.on('permissionDismiss', (requestId: string) => {
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach(win => {
+      if (win.isDestroyed()) return;
+      try {
+        win.webContents.send('cowork:stream:permissionDismiss', { requestId });
+      } catch (error) {
+        console.error('Failed to forward cowork permission dismissal:', error);
+      }
+    });
+  });
+
   runtime.on('complete', (sessionId: string, claudeSessionId: string | null) => {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach(win => {


### PR DESCRIPTION
## 概述

- 为 Pi Work 会话接入原生 AskUserQuestion，结构化问答将显示问答卡片。
- 回答会恢复工具调用；完成、超时、取消、停止和删除会话时清理等待状态。
- 等待时限为 10 分钟；超时返回拒绝。
- 自定义系统提示词下仍注入删除确认与结构化选择规则。

## 验证

- `npx.cmd vitest run src/main/libs/agentEngine/piRuntimeAdapter.test.ts src/main/libs/agentEngine/piAskUserQuestion.test.ts`（44 通过）
- `npm.cmd run build:tsc -- --noEmit`
- `npm.cmd run lint`
- `git diff --check`

## 影响与回滚

- 仅影响 Pi Work 会话；现有 OpenClaw 问答桥接不变。
- 如需回滚，可回退本 PR 的单个提交，不涉及数据迁移或持久化格式变更。