### PR TITLE
Integrate AnySearch across OpenClaw, Pi Agent, and Chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@ MODELSCOPE_API_TOKEN=
 # Optional token pool. Separate multiple tokens with commas.
 # MODELSCOPE_API_TOKENS=token_1,token_2,token_3
 
-# Internal deployment secret for the built-in Agent web-search capability.
-# Set this only in the Electron main-process/CI environment; never expose it
-# through renderer code, user settings, or a committed .env file.
+# Optional emergency override for the built-in Agent web-search credential.
+# Normal releases include an obfuscated main-process value; use this only for
+# token rotation before the next desktop build. Never expose it to renderer code
+# or user settings, and never commit a real value.
 ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN=
 ZHIYUAN_ANYSEARCH_GATEWAY_URL=https://search.rongxzyai.com

--- a/src/main/libs/anysearchGateway.test.ts
+++ b/src/main/libs/anysearchGateway.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { searchAnySearchGateway } from './anysearchGateway';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('parses results from the AnySearch data envelope', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        code: 200,
+        message: 'success',
+        data: {
+          results: [
+            {
+              title: 'AnySearch',
+              url: 'https://www.anysearch.com',
+              snippet: 'Search result',
+              content: 'Result content',
+            },
+          ],
+          metadata: { request_id: 'upstream-request' },
+        },
+        gateway_request_id: 'gateway-request',
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    ),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+
+  await expect(searchAnySearchGateway({ query: 'AnySearch docs', maxResults: 5 })).resolves.toEqual(
+    {
+      query: 'AnySearch docs',
+      results: [
+        {
+          title: 'AnySearch',
+          url: 'https://www.anysearch.com',
+          snippet: 'Search result',
+          content: 'Result content',
+        },
+      ],
+    },
+  );
+});
+
+test('accepts legacy top-level results as a compatibility fallback', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              url: 'https://example.com',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ),
+  );
+
+  await expect(searchAnySearchGateway({ query: 'legacy response' })).resolves.toEqual({
+    query: 'legacy response',
+    results: [
+      {
+        title: 'https://example.com',
+        url: 'https://example.com',
+        snippet: '',
+      },
+    ],
+  });
+});

--- a/src/main/libs/anysearchGateway.ts
+++ b/src/main/libs/anysearchGateway.ts
@@ -1,0 +1,70 @@
+import {
+  resolveAnySearchGatewayToken,
+  resolveAnySearchGatewayUrl,
+} from "./anysearchGatewayCredentials";
+
+export interface AnySearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  content?: string;
+}
+
+export interface AnySearchResponse {
+  query: string;
+  results: AnySearchResult[];
+}
+
+/** Main-process-only bridge to the product search gateway. */
+export async function searchAnySearchGateway(input: {
+  query?: unknown;
+  maxResults?: unknown;
+}): Promise<AnySearchResponse> {
+  const query = typeof input.query === "string" ? input.query.trim() : "";
+  if (!query || query.length > 500)
+    throw new Error("Search query must be between 1 and 500 characters.");
+  const requested = typeof input.maxResults === "number" ? input.maxResults : 8;
+  const maxResults = Math.max(1, Math.min(10, Math.floor(requested)));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 25_000);
+  try {
+    const response = await fetch(
+      `${resolveAnySearchGatewayUrl().replace(/\/+$/, "")}/v1/search`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${resolveAnySearchGatewayToken()}`,
+        },
+        body: JSON.stringify({ query, max_results: maxResults }),
+        signal: controller.signal,
+      },
+    );
+    if (!response.ok)
+      throw new Error(`Search gateway request failed (${response.status}).`);
+    const payload = (await response.json()) as { results?: unknown[] };
+    const results = Array.isArray(payload.results)
+      ? payload.results
+          .slice(0, maxResults)
+          .flatMap((item): AnySearchResult[] => {
+            if (!item || typeof item !== "object") return [];
+            const value = item as Record<string, unknown>;
+            const url = typeof value.url === "string" ? value.url : "";
+            if (!url) return [];
+            return [
+              {
+                title: typeof value.title === "string" ? value.title : url,
+                url,
+                snippet: typeof value.snippet === "string" ? value.snippet : "",
+                ...(typeof value.content === "string"
+                  ? { content: value.content }
+                  : {}),
+              },
+            ];
+          })
+      : [];
+    return { query, results };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/main/libs/anysearchGateway.ts
+++ b/src/main/libs/anysearchGateway.ts
@@ -19,7 +19,7 @@ export interface AnySearchResponse {
 export async function searchAnySearchGateway(input: {
   query?: unknown;
   maxResults?: unknown;
-}): Promise<AnySearchResponse> {
+}, externalSignal?: AbortSignal): Promise<AnySearchResponse> {
   const query = typeof input.query === "string" ? input.query.trim() : "";
   if (!query || query.length > 500)
     throw new Error("Search query must be between 1 and 500 characters.");
@@ -37,7 +37,9 @@ export async function searchAnySearchGateway(input: {
           Authorization: `Bearer ${resolveAnySearchGatewayToken()}`,
         },
         body: JSON.stringify({ query, max_results: maxResults }),
-        signal: controller.signal,
+        signal: externalSignal
+          ? AbortSignal.any([controller.signal, externalSignal])
+          : controller.signal,
       },
     );
     if (!response.ok)

--- a/src/main/libs/anysearchGateway.ts
+++ b/src/main/libs/anysearchGateway.ts
@@ -1,7 +1,7 @@
 import {
   resolveAnySearchGatewayToken,
   resolveAnySearchGatewayUrl,
-} from "./anysearchGatewayCredentials";
+} from './anysearchGatewayCredentials';
 
 export interface AnySearchResult {
   title: string;
@@ -16,55 +16,59 @@ export interface AnySearchResponse {
 }
 
 /** Main-process-only bridge to the product search gateway. */
-export async function searchAnySearchGateway(input: {
-  query?: unknown;
-  maxResults?: unknown;
-}, externalSignal?: AbortSignal): Promise<AnySearchResponse> {
-  const query = typeof input.query === "string" ? input.query.trim() : "";
+export async function searchAnySearchGateway(
+  input: {
+    query?: unknown;
+    maxResults?: unknown;
+  },
+  externalSignal?: AbortSignal,
+): Promise<AnySearchResponse> {
+  const query = typeof input.query === 'string' ? input.query.trim() : '';
   if (!query || query.length > 500)
-    throw new Error("Search query must be between 1 and 500 characters.");
-  const requested = typeof input.maxResults === "number" ? input.maxResults : 8;
+    throw new Error('Search query must be between 1 and 500 characters.');
+  const requested = typeof input.maxResults === 'number' ? input.maxResults : 8;
   const maxResults = Math.max(1, Math.min(10, Math.floor(requested)));
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 25_000);
   try {
-    const response = await fetch(
-      `${resolveAnySearchGatewayUrl().replace(/\/+$/, "")}/v1/search`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${resolveAnySearchGatewayToken()}`,
-        },
-        body: JSON.stringify({ query, max_results: maxResults }),
-        signal: externalSignal
-          ? AbortSignal.any([controller.signal, externalSignal])
-          : controller.signal,
+    const response = await fetch(`${resolveAnySearchGatewayUrl().replace(/\/+$/, '')}/v1/search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${resolveAnySearchGatewayToken()}`,
       },
-    );
-    if (!response.ok)
-      throw new Error(`Search gateway request failed (${response.status}).`);
-    const payload = (await response.json()) as { results?: unknown[] };
-    const results = Array.isArray(payload.results)
-      ? payload.results
-          .slice(0, maxResults)
-          .flatMap((item): AnySearchResult[] => {
-            if (!item || typeof item !== "object") return [];
-            const value = item as Record<string, unknown>;
-            const url = typeof value.url === "string" ? value.url : "";
-            if (!url) return [];
-            return [
-              {
-                title: typeof value.title === "string" ? value.title : url,
-                url,
-                snippet: typeof value.snippet === "string" ? value.snippet : "",
-                ...(typeof value.content === "string"
-                  ? { content: value.content }
-                  : {}),
-              },
-            ];
-          })
-      : [];
+      body: JSON.stringify({ query, max_results: maxResults }),
+      signal: externalSignal
+        ? AbortSignal.any([controller.signal, externalSignal])
+        : controller.signal,
+    });
+    if (!response.ok) throw new Error(`Search gateway request failed (${response.status}).`);
+    const payload = (await response.json()) as unknown;
+    const envelope =
+      payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
+    const data =
+      envelope.data && typeof envelope.data === 'object'
+        ? (envelope.data as Record<string, unknown>)
+        : {};
+    const rawResults = Array.isArray(data.results)
+      ? data.results
+      : Array.isArray(envelope.results)
+        ? envelope.results
+        : [];
+    const results = rawResults.slice(0, maxResults).flatMap((item): AnySearchResult[] => {
+      if (!item || typeof item !== 'object') return [];
+      const value = item as Record<string, unknown>;
+      const url = typeof value.url === 'string' ? value.url : '';
+      if (!url) return [];
+      return [
+        {
+          title: typeof value.title === 'string' ? value.title : url,
+          url,
+          snippet: typeof value.snippet === 'string' ? value.snippet : '',
+          ...(typeof value.content === 'string' ? { content: value.content } : {}),
+        },
+      ];
+    });
     return { query, results };
   } finally {
     clearTimeout(timeout);

--- a/src/main/libs/anysearchGatewayCredentials.ts
+++ b/src/main/libs/anysearchGatewayCredentials.ts
@@ -1,0 +1,22 @@
+/**
+ * Product-scoped gateway credential for the built-in Agent search capability.
+ *
+ * This is deliberately lightweight obfuscation, not cryptographic protection:
+ * it prevents accidental copy/paste from source while keeping startup cost near
+ * zero. The gateway still enforces authentication and the token can be rotated
+ * by replacing this representation in a normal release.
+ */
+const mask = new Uint8Array([73, 31, 184, 44, 209, 7, 102, 158, 58, 241, 19, 84, 166, 12, 227, 91]);
+const encoded = new Uint8Array([64, 36, 44, 74, 108, 86, 53, 135, 61, 194, 194, 34, 238, 145, 94, 243, 67, 105, 87, 2, 48, 8, 83, 134, 54, 225, 146, 15, 243, 145, 100, 149, 68, 121, 121, 76, 104, 30, 79, 136, 12, 140, 134]);
+
+export function resolveAnySearchGatewayToken(): string {
+  const deploymentOverride = process.env.ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN?.trim();
+  if (deploymentOverride) return deploymentOverride;
+
+  const clear = encoded.map((value, index) => value ^ mask[(index * 7 + 3) % mask.length]);
+  return new TextDecoder().decode(clear);
+}
+
+export function resolveAnySearchGatewayUrl(): string {
+  return process.env.ZHIYUAN_ANYSEARCH_GATEWAY_URL?.trim() || 'https://search.rongxzyai.com';
+}

--- a/src/main/libs/openclawConfigSync.ts
+++ b/src/main/libs/openclawConfigSync.ts
@@ -32,6 +32,7 @@ import {
   getCoworkOpenAICompatProxyBaseURL,
   getCoworkOpenAICompatProxyToken,
 } from './coworkOpenAICompatProxy';
+import { resolveAnySearchGatewayToken, resolveAnySearchGatewayUrl } from './anysearchGatewayCredentials';
 import type { McpToolManifestEntry } from './mcpServerManager';
 import { readOpenAICodexAuthFile } from './openaiCodexAuth';
 import {
@@ -2004,15 +2005,12 @@ export class OpenClawConfigSync {
 
     env.ZHIYUAN_PROXY_TOKEN = getCoworkOpenAICompatProxyToken() || 'unconfigured';
 
-    // The AnySearch gateway credential is deployment-owned. It is read only
-    // from the Electron main-process environment and injected into the Agent
-    // runtime; it is never persisted in openclaw.json or exposed to renderer.
-    const anySearchGatewayToken = process.env.ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN?.trim();
-    if (anySearchGatewayToken) {
-      env.ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN = anySearchGatewayToken;
-      env.ZHIYUAN_ANYSEARCH_GATEWAY_URL =
-        process.env.ZHIYUAN_ANYSEARCH_GATEWAY_URL?.trim() || 'https://search.rongxzyai.com';
-    }
+    // The credential is decoded only inside Electron main process and injected
+    // into the Agent runtime. It is never persisted in openclaw.json or exposed
+    // to renderer code. A deployment environment variable can override it for
+    // emergency rotation before a new desktop build is distributed.
+    env.ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN = resolveAnySearchGatewayToken();
+    env.ZHIYUAN_ANYSEARCH_GATEWAY_URL = resolveAnySearchGatewayUrl();
 
     // MCP Bridge Secret — always set so stale openclaw.json with
     // ${ZHIYUAN_MCP_BRIDGE_SECRET} placeholder doesn't crash the gateway.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,7 +39,11 @@ import {
   CoworkSessionExpertSource,
 } from '../shared/cowork/sessionExperts';
 import { ApiIpc, CoworkStreamIpc, McpIpc, SkillsIpc } from '../shared/ipc/channels';
-import { ApiFetchSchema, ApiStreamSchema, CoworkSessionStartSchema } from '../shared/ipc/schemas';
+import {
+  ApiFetchSchema,
+  ApiStreamSchema,
+  CoworkSessionStartSchema,
+} from '../shared/ipc/schemas';
 import { PlatformRegistry } from '../shared/platform';
 import { ProviderName } from '../shared/providers';
 import { WorkspaceIpc } from '../shared/workspace';
@@ -6329,13 +6333,20 @@ if (!gotTheLock) {
 
   // API 代理处理程序 - 解决 CORS 问题
   ipcMain.handle(ApiIpc.WebSearch, async (_event, rawInput: unknown) => {
+    const input =
+      rawInput && typeof rawInput === 'object' ? (rawInput as Record<string, unknown>) : {};
+    const requestId = typeof input.requestId === 'string' ? input.requestId : null;
+    const controller = new AbortController();
+    if (requestId) activeStreamControllers.set(requestId, controller);
     try {
-      const data = await searchAnySearchGateway(
-        rawInput && typeof rawInput === 'object' ? (rawInput as Record<string, unknown>) : {},
-      );
+      const data = await searchAnySearchGateway(input, controller.signal);
       return { ok: true, data };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : 'Search unavailable.' };
+    } finally {
+      if (requestId && activeStreamControllers.get(requestId) === controller) {
+        activeStreamControllers.delete(requestId);
+      }
     }
   });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,12 +38,14 @@ import {
   type CoworkSessionExpertInput,
   CoworkSessionExpertSource,
 } from '../shared/cowork/sessionExperts';
-import { CoworkStreamIpc, McpIpc, SkillsIpc } from '../shared/ipc/channels';
+import { ApiIpc, CoworkStreamIpc, McpIpc, SkillsIpc } from '../shared/ipc/channels';
 import { ApiFetchSchema, ApiStreamSchema, CoworkSessionStartSchema } from '../shared/ipc/schemas';
 import { PlatformRegistry } from '../shared/platform';
 import { ProviderName } from '../shared/providers';
 import { WorkspaceIpc } from '../shared/workspace';
 import { AgentManager } from './agentManager';
+import { searchAnySearchGateway } from './libs/anysearchGateway';
+import { resolveAnySearchGatewayToken, resolveAnySearchGatewayUrl } from './libs/anysearchGatewayCredentials';
 import { APP_DATA_DIR_NAME, APP_NAME, DB_FILENAME } from './appConstants';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
 import { applyCoworkLanguagePrompt, type CoworkPromptLanguage } from './coworkLanguagePrompt';
@@ -930,6 +932,10 @@ let piRuntimeAdapter: PiRuntimeAdapter | null = null;
 
 const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
   if (!piRuntimeAdapter) {
+    // Pi shell tools inherit the main-process environment. Keep the gateway
+    // credential here so installed builds work without user configuration.
+    process.env.ZHIYUAN_ANYSEARCH_GATEWAY_TOKEN = resolveAnySearchGatewayToken();
+    process.env.ZHIYUAN_ANYSEARCH_GATEWAY_URL = resolveAnySearchGatewayUrl();
     // Pi SDK resolves API keys from environment variables (ANTHROPIC_API_KEY etc.).
     // Inject keys from ZhiYuanAgent's provider configuration before initializing Pi.
     const keys = resolveAllProviderApiKeys();
@@ -6322,6 +6328,17 @@ if (!gotTheLock) {
   };
 
   // API 代理处理程序 - 解决 CORS 问题
+  ipcMain.handle(ApiIpc.WebSearch, async (_event, rawInput: unknown) => {
+    try {
+      const data = await searchAnySearchGateway(
+        rawInput && typeof rawInput === 'object' ? (rawInput as Record<string, unknown>) : {},
+      );
+      return { ok: true, data };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : 'Search unavailable.' };
+    }
+  });
+
   ipcMain.handle('api:fetch', async (_event, rawOptions: unknown) => {
     const options = ApiFetchSchema.input.parse(rawOptions);
     console.log(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -235,7 +235,7 @@ contextBridge.exposeInMainWorld('electron', {
   },
 
   api: {
-    webSearch: (input: { query: string; maxResults?: number }) =>
+    webSearch: (input: { query: string; maxResults?: number; requestId?: string }) =>
       ipcRenderer.invoke(ApiIpc.WebSearch, input),
 
     fetch: (options: {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -235,6 +235,9 @@ contextBridge.exposeInMainWorld('electron', {
   },
 
   api: {
+    webSearch: (input: { query: string; maxResults?: number }) =>
+      ipcRenderer.invoke(ApiIpc.WebSearch, input),
+
     fetch: (options: {
       url: string;
       method: string;

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -509,6 +509,81 @@ class ApiService {
     }
   }
 
+  /** Native provider tool loop; the gateway credential stays in the main process. */
+  async chatWithWebSearch(message: string, onProgress?: (content: string, reasoning?: string) => void, history: ChatMessagePayload[] = [], options: DirectChatRequestOptions = {}): Promise<{ content: string; reasoning?: string }> {
+    if (!this.config) throw new ApiError('API configuration not set. Please configure your API settings in the settings menu.');
+    const modelState = store.getState().model;
+    const requestedModelId = options.modelId?.trim();
+    const selectedModel = requestedModelId ? (modelState.availableModels.find(model => model.id === requestedModelId || `${model.provider}/${model.id}` === requestedModelId) ?? modelState.defaultSelectedModel) : modelState.defaultSelectedModel;
+    const provider = this.detectProvider(selectedModel.id, selectedModel.providerKey ?? selectedModel.provider);
+    const config = this.getProviderConfig(provider) ?? this.config;
+    if (this.providerRequiresApiKey(provider) && !config.apiKey) throw new ApiError('API key is not configured. Please set your API key in the settings menu.');
+    const prompt = 'Use the web_search tool when current, factual, or external information would improve the answer. Cite result URLs when you use search.';
+    if (this.normalizeApiFormat(config.apiFormat) === 'anthropic') {
+      const messages = [...history.filter(item => item.role !== 'system'), { role: 'user' as const, content: message }].map(item => this.formatAnthropicMessage(item, !!selectedModel.supportsImage)).filter(Boolean) as any[];
+      return this.runAnthropicWebSearchLoop(messages, [prompt, ...history.filter(item => item.role === 'system').map(item => item.content)].filter(Boolean).join('\n'), selectedModel.id, config, onProgress);
+    }
+    if (this.normalizeApiFormat(config.apiFormat) === 'gemini') {
+      const contents = [...history.filter(item => item.role !== 'system'), { role: 'user' as const, content: message }].map(item => ({ role: item.role === 'assistant' ? 'model' : 'user', parts: [{ text: item.content }] }));
+      return this.runGeminiWebSearchLoop(contents, [prompt, ...history.filter(item => item.role === 'system').map(item => item.content)].filter(Boolean).join('\n'), selectedModel.id, config, onProgress);
+    }
+    const messages = [{ role: 'system', content: prompt }, ...history.map(item => this.formatOpenAIMessage(item, !!selectedModel.supportsImage)).filter(Boolean), { role: 'user', content: message }];
+    return this.runOpenAIWebSearchLoop(messages, selectedModel.id, config, onProgress);
+  }
+
+  private async callJson(url: string, headers: Record<string, string>, body: unknown): Promise<any> {
+    const response = await window.electron.api.fetch({ url, method: 'POST', headers, body: JSON.stringify(body) });
+    if (!response.ok) { const data = response.data as any; throw new ApiError(data?.error?.message || response.statusText || 'API request failed', response.status, data); }
+    return response.data;
+  }
+
+  private async executeWebSearch(call: { query?: unknown; max_results?: unknown }): Promise<unknown> {
+    const response = await window.electron.api.webSearch({ query: typeof call.query === 'string' ? call.query : '', ...(typeof call.max_results === 'number' ? { maxResults: call.max_results } : {}) });
+    return response.ok ? response.data : { error: response.error || 'Search is temporarily unavailable.' };
+  }
+
+  private webSearchTool() {
+    return { name: 'web_search', description: 'Search the public web for up-to-date information. Returns titles, URLs, and short extracts.', parameters: { type: 'object', properties: { query: { type: 'string', description: 'Precise search query.' }, max_results: { type: 'integer', minimum: 1, maximum: 10 } }, required: ['query'], additionalProperties: false } };
+  }
+
+  private async runOpenAIWebSearchLoop(messages: any[], model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
+    const headers = { 'Content-Type': 'application/json', ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}) };
+    for (let turn = 0; turn < 4; turn += 1) {
+      const data = await this.callJson(this.buildOpenAICompatibleChatCompletionsUrl(config.baseUrl), headers, { model, messages, tools: [{ type: 'function', function: this.webSearchTool() }], tool_choice: 'auto' });
+      const assistant = data?.choices?.[0]?.message;
+      if (!assistant) throw new ApiError('No content received from the API. Please try again.');
+      const calls = Array.isArray(assistant.tool_calls) ? assistant.tool_calls.filter((call: any) => call?.function?.name === 'web_search') : [];
+      messages.push(assistant);
+      if (!calls.length) { const content = typeof assistant.content === 'string' ? assistant.content : ''; onProgress?.(content); return { content }; }
+      for (const call of calls.slice(0, 3)) { let args: { query?: unknown; max_results?: unknown } = {}; try { args = JSON.parse(call.function.arguments || '{}'); } catch {} messages.push({ role: 'tool', tool_call_id: call.id, content: JSON.stringify(await this.executeWebSearch(args)) }); }
+    }
+    throw new ApiError('Search tool call limit reached.');
+  }
+
+  private async runAnthropicWebSearchLoop(messages: any[], system: string, model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
+    const headers = { 'Content-Type': 'application/json', 'x-api-key': config.apiKey, 'anthropic-version': '2023-06-01' };
+    for (let turn = 0; turn < 4; turn += 1) {
+      const tool = this.webSearchTool();
+      const data = await this.callJson(`${config.baseUrl.trim().replace(/\/+$/, '')}/v1/messages`, headers, { model, max_tokens: 8192, system, messages, tools: [{ name: tool.name, description: tool.description, input_schema: tool.parameters }] });
+      const content = Array.isArray(data?.content) ? data.content : []; const calls = content.filter((block: any) => block?.type === 'tool_use' && block.name === 'web_search');
+      if (!calls.length) { const text = content.filter((block: any) => block?.type === 'text').map((block: any) => block.text).join(''); onProgress?.(text); return { content: text }; }
+      messages.push({ role: 'assistant', content });
+      messages.push({ role: 'user', content: await Promise.all(calls.slice(0, 3).map(async (call: any) => ({ type: 'tool_result', tool_use_id: call.id, content: JSON.stringify(await this.executeWebSearch(call.input || {})) }))) });
+    }
+    throw new ApiError('Search tool call limit reached.');
+  }
+
+  private async runGeminiWebSearchLoop(contents: any[], system: string, model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
+    const baseUrl = config.baseUrl.trim().replace(/\/+$/, '') || 'https://generativelanguage.googleapis.com/v1beta'; const tool = this.webSearchTool();
+    for (let turn = 0; turn < 4; turn += 1) {
+      const data = await this.callJson(`${baseUrl}/models/${model}:generateContent`, { 'Content-Type': 'application/json', 'x-goog-api-key': config.apiKey }, { contents, systemInstruction: { parts: [{ text: system }] }, tools: [{ functionDeclarations: [{ name: tool.name, description: tool.description, parameters: tool.parameters }] }], generationConfig: { maxOutputTokens: 8192 } });
+      const content = data?.candidates?.[0]?.content; const calls = Array.isArray(content?.parts) ? content.parts.filter((part: any) => part.functionCall?.name === 'web_search') : [];
+      if (!calls.length) { const text = (content?.parts || []).filter((part: any) => typeof part.text === 'string').map((part: any) => part.text).join(''); onProgress?.(text); return { content: text }; }
+      contents.push(content); contents.push({ role: 'user', parts: await Promise.all(calls.slice(0, 3).map(async (part: any) => ({ functionResponse: { name: 'web_search', response: await this.executeWebSearch(part.functionCall.args || {}) } }))) });
+    }
+    throw new ApiError('Search tool call limit reached.');
+  }
+
   // Anthropic API 调用
   private async chatWithAnthropic(
     message: ChatUserMessageInput,

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -510,76 +510,746 @@ class ApiService {
   }
 
   /** Native provider tool loop; the gateway credential stays in the main process. */
-  async chatWithWebSearch(message: string, onProgress?: (content: string, reasoning?: string) => void, history: ChatMessagePayload[] = [], options: DirectChatRequestOptions = {}): Promise<{ content: string; reasoning?: string }> {
-    if (!this.config) throw new ApiError('API configuration not set. Please configure your API settings in the settings menu.');
+  async chatWithWebSearch(
+    message: string,
+    onProgress?: (content: string, reasoning?: string) => void,
+    history: ChatMessagePayload[] = [],
+    options: DirectChatRequestOptions = {},
+    requestId: string = generateRequestId(),
+    abortSignal?: AbortSignal,
+  ): Promise<{ content: string; reasoning?: string }> {
+    if (!this.config) {
+      throw new ApiError(
+        'API configuration not set. Please configure your API settings in the settings menu.',
+      );
+    }
     const modelState = store.getState().model;
     const requestedModelId = options.modelId?.trim();
-    const selectedModel = requestedModelId ? (modelState.availableModels.find(model => model.id === requestedModelId || `${model.provider}/${model.id}` === requestedModelId) ?? modelState.defaultSelectedModel) : modelState.defaultSelectedModel;
-    const provider = this.detectProvider(selectedModel.id, selectedModel.providerKey ?? selectedModel.provider);
+    const selectedModel = requestedModelId
+      ? (modelState.availableModels.find(
+          model =>
+            model.id === requestedModelId || `${model.provider}/${model.id}` === requestedModelId,
+        ) ?? modelState.defaultSelectedModel)
+      : modelState.defaultSelectedModel;
+    const provider = this.detectProvider(
+      selectedModel.id,
+      selectedModel.providerKey ?? selectedModel.provider,
+    );
     const config = this.getProviderConfig(provider) ?? this.config;
-    if (this.providerRequiresApiKey(provider) && !config.apiKey) throw new ApiError('API key is not configured. Please set your API key in the settings menu.');
-    const prompt = 'Use the web_search tool when current, factual, or external information would improve the answer. Cite result URLs when you use search.';
-    if (this.normalizeApiFormat(config.apiFormat) === 'anthropic') {
-      const messages = [...history.filter(item => item.role !== 'system'), { role: 'user' as const, content: message }].map(item => this.formatAnthropicMessage(item, !!selectedModel.supportsImage)).filter(Boolean) as any[];
-      return this.runAnthropicWebSearchLoop(messages, [prompt, ...history.filter(item => item.role === 'system').map(item => item.content)].filter(Boolean).join('\n'), selectedModel.id, config, onProgress);
+    if (this.providerRequiresApiKey(provider) && !config.apiKey) {
+      throw new ApiError(
+        'API key is not configured. Please set your API key in the settings menu.',
+      );
     }
-    if (this.normalizeApiFormat(config.apiFormat) === 'gemini') {
-      const contents = [...history.filter(item => item.role !== 'system'), { role: 'user' as const, content: message }].map(item => ({ role: item.role === 'assistant' ? 'model' : 'user', parts: [{ text: item.content }] }));
-      return this.runGeminiWebSearchLoop(contents, [prompt, ...history.filter(item => item.role === 'system').map(item => item.content)].filter(Boolean).join('\n'), selectedModel.id, config, onProgress);
+    const prompt =
+      'Use the web_search tool when current, factual, or external information would improve the answer. Cite result URLs when you use search.';
+    const system = [
+      prompt,
+      ...history.filter(item => item.role === 'system').map(item => item.content),
+    ]
+      .filter(Boolean)
+      .join('\n');
+    const apiFormat = this.normalizeApiFormat(config.apiFormat);
+    const userMessage: ChatMessagePayload = { role: 'user', content: message };
+
+    if (apiFormat === 'anthropic') {
+      const messages = [...history.filter(item => item.role !== 'system'), userMessage]
+        .map(item => this.formatAnthropicMessage(item, !!selectedModel.supportsImage))
+        .filter(Boolean) as any[];
+      return this.runAnthropicWebSearchLoop(
+        messages,
+        system,
+        selectedModel.id,
+        config,
+        onProgress,
+        requestId,
+        abortSignal,
+      );
     }
-    const messages = [{ role: 'system', content: prompt }, ...history.map(item => this.formatOpenAIMessage(item, !!selectedModel.supportsImage)).filter(Boolean), { role: 'user', content: message }];
-    return this.runOpenAIWebSearchLoop(messages, selectedModel.id, config, onProgress);
+    if (apiFormat === 'gemini') {
+      const contents = [...history.filter(item => item.role !== 'system'), userMessage].map(item => ({
+        role: item.role === 'assistant' ? 'model' : 'user',
+        parts: [{ text: item.content }],
+      }));
+      return this.runGeminiWebSearchLoop(
+        contents,
+        system,
+        selectedModel.id,
+        config,
+        onProgress,
+        requestId,
+        abortSignal,
+      );
+    }
+    if (this.shouldUseOpenAIResponsesApi(provider)) {
+      const input = [...history.filter(item => item.role !== 'system'), userMessage]
+        .map(item => this.formatOpenAIResponsesInputMessage(item, !!selectedModel.supportsImage))
+        .filter(Boolean) as any[];
+      return this.runOpenAIResponsesWebSearchLoop(
+        input,
+        system,
+        selectedModel.id,
+        config,
+        onProgress,
+        requestId,
+        abortSignal,
+      );
+    }
+    const messages = [
+      { role: 'system', content: system },
+      ...history
+        .filter(item => item.role !== 'system')
+        .map(item => this.formatOpenAIMessage(item, !!selectedModel.supportsImage))
+        .filter(Boolean),
+      { role: 'user', content: message },
+    ];
+    return this.runOpenAIWebSearchLoop(
+      messages,
+      selectedModel.id,
+      config,
+      provider,
+      onProgress,
+      requestId,
+      abortSignal,
+    );
   }
 
-  private async callJson(url: string, headers: Record<string, string>, body: unknown): Promise<any> {
-    const response = await window.electron.api.fetch({ url, method: 'POST', headers, body: JSON.stringify(body) });
-    if (!response.ok) { const data = response.data as any; throw new ApiError(data?.error?.message || response.statusText || 'API request failed', response.status, data); }
-    return response.data;
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (signal?.aborted) throw new DOMException('The request was aborted.', 'AbortError');
   }
 
-  private async executeWebSearch(call: { query?: unknown; max_results?: unknown }): Promise<unknown> {
-    const response = await window.electron.api.webSearch({ query: typeof call.query === 'string' ? call.query : '', ...(typeof call.max_results === 'number' ? { maxResults: call.max_results } : {}) });
-    return response.ok ? response.data : { error: response.error || 'Search is temporarily unavailable.' };
+  private async consumeSse(
+    url: string,
+    headers: Record<string, string>,
+    body: unknown,
+    requestId: string,
+    onEvent: (event: any) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    this.throwIfAborted(abortSignal);
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let buffer = '';
+
+      const settle = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        this.cleanup(requestId);
+        if (error) reject(error);
+        else resolve();
+      };
+      const parseBuffer = (flush = false) => {
+        const lines = buffer.split('\n');
+        buffer = flush ? '' : (lines.pop() ?? '');
+        for (const rawLine of lines) {
+          const line = rawLine.replace(/\r$/, '');
+          if (!line.startsWith('data:')) continue;
+          const data = line.slice(5).trim();
+          if (!data || data === '[DONE]') continue;
+          try {
+            onEvent(JSON.parse(data));
+          } catch {
+            // Ignore keepalives and provider-specific non-JSON SSE frames.
+          }
+        }
+      };
+
+      const removeData = window.electron.api.onStreamData(requestId, chunk => {
+        buffer += chunk;
+        parseBuffer();
+      });
+      const removeDone = window.electron.api.onStreamDone(requestId, () => {
+        parseBuffer(true);
+        settle();
+      });
+      const removeError = window.electron.api.onStreamError(requestId, error => {
+        settle(new ApiError(typeof error === 'string' ? error : error.message));
+      });
+      const removeAbort = window.electron.api.onStreamAbort(requestId, () => {
+        settle(new DOMException('The request was aborted.', 'AbortError'));
+      });
+      const handleSignalAbort = () => {
+        void window.electron.api.cancelStream(requestId);
+        settle(new DOMException('The request was aborted.', 'AbortError'));
+      };
+      abortSignal?.addEventListener('abort', handleSignalAbort, { once: true });
+      const removeSignalAbort = () =>
+        abortSignal?.removeEventListener('abort', handleSignalAbort);
+      this.streamRequests.register(requestId, [
+        removeData,
+        removeDone,
+        removeError,
+        removeAbort,
+        removeSignalAbort,
+      ]);
+
+      if (abortSignal?.aborted) {
+        handleSignalAbort();
+        return;
+      }
+      window.electron.api
+        .stream({
+          url,
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+          requestId,
+        })
+        .then(response => {
+          if (!response.ok) {
+            settle(new ApiError(response.error || response.statusText, response.status));
+          }
+        })
+        .catch(error => {
+          settle(error instanceof Error ? error : new Error(String(error)));
+        });
+    });
+  }
+
+  private async streamOpenAIChatResponse(
+    url: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown>,
+    requestId: string,
+    onProgress?: (content: string, reasoning?: string) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<any> {
+    let content = '';
+    let reasoning = '';
+    const calls = new Map<number, { id: string; name: string; arguments: string }>();
+    await this.consumeSse(
+      url,
+      headers,
+      { ...body, stream: true },
+      requestId,
+      event => {
+        const delta = event?.choices?.[0]?.delta;
+        if (!delta) return;
+        if (typeof delta.content === 'string') content += delta.content;
+        const reasoningDelta =
+          typeof delta.reasoning_content === 'string'
+            ? delta.reasoning_content
+            : typeof delta.reasoning === 'string'
+              ? delta.reasoning
+              : '';
+        reasoning += reasoningDelta;
+        if (delta.content || reasoningDelta) onProgress?.(content, reasoning || undefined);
+        if (Array.isArray(delta.tool_calls)) {
+          delta.tool_calls.forEach((toolCall: any) => {
+            const index = typeof toolCall.index === 'number' ? toolCall.index : calls.size;
+            const current = calls.get(index) || { id: '', name: '', arguments: '' };
+            if (toolCall.id) current.id = toolCall.id;
+            if (toolCall.function?.name) current.name = toolCall.function.name;
+            if (toolCall.function?.arguments) {
+              current.arguments += toolCall.function.arguments;
+            }
+            calls.set(index, current);
+          });
+        }
+      },
+      abortSignal,
+    );
+    return {
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: content || null,
+            ...(calls.size
+              ? {
+                  tool_calls: [...calls.values()].map(call => ({
+                    id: call.id,
+                    type: 'function',
+                    function: { name: call.name, arguments: call.arguments },
+                  })),
+                }
+              : {}),
+          },
+        },
+      ],
+    };
+  }
+
+  private async streamOpenAIResponsesResponse(
+    url: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown>,
+    requestId: string,
+    onProgress?: (content: string, reasoning?: string) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<any> {
+    let content = '';
+    let reasoning = '';
+    let completedOutput: any[] | null = null;
+    const output = new Map<number, any>();
+    await this.consumeSse(
+      url,
+      headers,
+      { ...body, stream: true },
+      requestId,
+      event => {
+        const type = event?.type;
+        if (type === 'response.output_text.delta' && typeof event.delta === 'string') {
+          content += event.delta;
+          onProgress?.(content, reasoning || undefined);
+        } else if (
+          type === 'response.reasoning_summary_text.delta' &&
+          typeof event.delta === 'string'
+        ) {
+          reasoning += event.delta;
+          onProgress?.(content, reasoning);
+        } else if (type === 'response.output_item.added' && event.item) {
+          output.set(event.output_index ?? output.size, { ...event.item });
+        } else if (
+          type === 'response.function_call_arguments.delta' &&
+          typeof event.delta === 'string'
+        ) {
+          const index = event.output_index ?? 0;
+          const item = output.get(index) || {
+            type: 'function_call',
+            arguments: '',
+          };
+          item.arguments = `${item.arguments || ''}${event.delta}`;
+          output.set(index, item);
+        } else if (type === 'response.output_item.done' && event.item) {
+          output.set(event.output_index ?? output.size, event.item);
+        } else if (type === 'response.completed' && Array.isArray(event.response?.output)) {
+          completedOutput = event.response.output;
+        }
+      },
+      abortSignal,
+    );
+    return {
+      output_text: content,
+      output: completedOutput || [...output.entries()].sort(([a], [b]) => a - b).map(([, item]) => item),
+    };
+  }
+
+  private async streamAnthropicResponse(
+    url: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown>,
+    requestId: string,
+    onProgress?: (content: string, reasoning?: string) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<any> {
+    const blocks = new Map<number, any>();
+    let text = '';
+    let reasoning = '';
+    await this.consumeSse(
+      url,
+      headers,
+      { ...body, stream: true },
+      requestId,
+      event => {
+        const index = typeof event?.index === 'number' ? event.index : 0;
+        if (event?.type === 'content_block_start' && event.content_block) {
+          blocks.set(index, { ...event.content_block });
+        } else if (event?.type === 'content_block_delta') {
+          const block = blocks.get(index) || {};
+          if (event.delta?.type === 'text_delta' && typeof event.delta.text === 'string') {
+            block.type = 'text';
+            block.text = `${block.text || ''}${event.delta.text}`;
+            text += event.delta.text;
+            onProgress?.(text, reasoning || undefined);
+          } else if (
+            event.delta?.type === 'thinking_delta' &&
+            typeof event.delta.thinking === 'string'
+          ) {
+            reasoning += event.delta.thinking;
+            onProgress?.(text, reasoning);
+          } else if (
+            event.delta?.type === 'input_json_delta' &&
+            typeof event.delta.partial_json === 'string'
+          ) {
+            block.inputJson = `${block.inputJson || ''}${event.delta.partial_json}`;
+          }
+          blocks.set(index, block);
+        }
+      },
+      abortSignal,
+    );
+    const content = [...blocks.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, block]) => {
+        if (block.type !== 'tool_use') return block;
+        let input = {};
+        try {
+          input = block.inputJson ? JSON.parse(block.inputJson) : block.input || {};
+        } catch {
+          input = {};
+        }
+        return { ...block, input };
+      });
+    return { content };
+  }
+
+  private async streamGeminiResponse(
+    url: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown>,
+    requestId: string,
+    onProgress?: (content: string) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<any> {
+    let text = '';
+    const functionCalls: any[] = [];
+    await this.consumeSse(
+      `${url}?alt=sse`,
+      headers,
+      body,
+      requestId,
+      event => {
+        const parts = event?.candidates?.[0]?.content?.parts;
+        if (!Array.isArray(parts)) return;
+        parts.forEach((part: any) => {
+          if (typeof part.text === 'string') {
+            text += part.text;
+            onProgress?.(text);
+          }
+          if (part.functionCall) functionCalls.push(part);
+        });
+      },
+      abortSignal,
+    );
+    return {
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: [...(text ? [{ text }] : []), ...functionCalls],
+          },
+        },
+      ],
+    };
+  }
+
+  private async executeWebSearch(
+    call: { query?: unknown; max_results?: unknown },
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<unknown> {
+    this.throwIfAborted(abortSignal);
+    const response = await window.electron.api.webSearch({
+      query: typeof call.query === 'string' ? call.query : '',
+      ...(typeof call.max_results === 'number' ? { maxResults: call.max_results } : {}),
+      requestId,
+    });
+    this.throwIfAborted(abortSignal);
+    return response.ok
+      ? response.data
+      : { error: response.error || 'Search is temporarily unavailable.' };
   }
 
   private webSearchTool() {
-    return { name: 'web_search', description: 'Search the public web for up-to-date information. Returns titles, URLs, and short extracts.', parameters: { type: 'object', properties: { query: { type: 'string', description: 'Precise search query.' }, max_results: { type: 'integer', minimum: 1, maximum: 10 } }, required: ['query'], additionalProperties: false } };
+    return {
+      name: 'web_search',
+      description:
+        'Search the public web for up-to-date information. Returns titles, URLs, and short extracts.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Precise search query.' },
+          max_results: { type: 'integer', minimum: 1, maximum: 10 },
+        },
+        required: ['query'],
+        additionalProperties: false,
+      },
+    };
   }
 
-  private async runOpenAIWebSearchLoop(messages: any[], model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
-    const headers = { 'Content-Type': 'application/json', ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}) };
+  private async executeSearchCalls(
+    calls: Array<{ args: { query?: unknown; max_results?: unknown } }>,
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<unknown[]> {
+    const results: unknown[] = [];
+    for (let index = 0; index < calls.length; index += 1) {
+      results.push(
+        index < 3
+          ? await this.executeWebSearch(calls[index].args, requestId, abortSignal)
+          : { error: 'Only three web_search calls are allowed per model turn.' },
+      );
+    }
+    return results;
+  }
+
+  private async runOpenAIResponsesWebSearchLoop(
+    input: any[],
+    instructions: string,
+    model: string,
+    config: ApiConfig,
+    onProgress: ((content: string) => void) | undefined,
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ content: string }> {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${config.apiKey}`,
+    };
+    const tool = this.webSearchTool();
     for (let turn = 0; turn < 4; turn += 1) {
-      const data = await this.callJson(this.buildOpenAICompatibleChatCompletionsUrl(config.baseUrl), headers, { model, messages, tools: [{ type: 'function', function: this.webSearchTool() }], tool_choice: 'auto' });
-      const assistant = data?.choices?.[0]?.message;
-      if (!assistant) throw new ApiError('No content received from the API. Please try again.');
-      const calls = Array.isArray(assistant.tool_calls) ? assistant.tool_calls.filter((call: any) => call?.function?.name === 'web_search') : [];
-      messages.push(assistant);
-      if (!calls.length) { const content = typeof assistant.content === 'string' ? assistant.content : ''; onProgress?.(content); return { content }; }
-      for (const call of calls.slice(0, 3)) { let args: { query?: unknown; max_results?: unknown } = {}; try { args = JSON.parse(call.function.arguments || '{}'); } catch {} messages.push({ role: 'tool', tool_call_id: call.id, content: JSON.stringify(await this.executeWebSearch(args)) }); }
+      const data = await this.streamOpenAIResponsesResponse(
+        this.buildOpenAIResponsesUrl(config.baseUrl),
+        headers,
+        {
+          model,
+          input,
+          instructions,
+          tools: [{ type: 'function', ...tool, strict: true }],
+        },
+        requestId,
+        onProgress,
+        abortSignal,
+      );
+      const output = Array.isArray(data?.output) ? data.output : [];
+      const functionCalls = output.filter(
+        (item: any) => item?.type === 'function_call' && item.name === 'web_search',
+      );
+      if (!functionCalls.length) {
+        const content = this.extractResponsesOutputText(data);
+        onProgress?.(content);
+        return { content };
+      }
+      input.push(...output);
+      const parsedCalls = functionCalls.map((call: any) => {
+        let args = {};
+        try {
+          args = JSON.parse(call.arguments || '{}');
+        } catch {
+          args = {};
+        }
+        return { args };
+      });
+      const results = await this.executeSearchCalls(parsedCalls, requestId, abortSignal);
+      functionCalls.forEach((call: any, index: number) => {
+        input.push({
+          type: 'function_call_output',
+          call_id: call.call_id,
+          output: JSON.stringify(results[index]),
+        });
+      });
     }
     throw new ApiError('Search tool call limit reached.');
   }
 
-  private async runAnthropicWebSearchLoop(messages: any[], system: string, model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
-    const headers = { 'Content-Type': 'application/json', 'x-api-key': config.apiKey, 'anthropic-version': '2023-06-01' };
+  private async runOpenAIWebSearchLoop(
+    messages: any[],
+    model: string,
+    config: ApiConfig,
+    provider: string,
+    onProgress: ((content: string) => void) | undefined,
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ content: string }> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(config.apiKey ? { Authorization: `Bearer ${config.apiKey}` } : {}),
+    };
+    if (provider === ProviderName.Copilot) {
+      headers['Copilot-Integration-Id'] = 'vscode-chat';
+      headers['Editor-Version'] = 'vscode/1.96.2';
+      headers['Editor-Plugin-Version'] = 'copilot-chat/0.26.7';
+      headers['User-Agent'] = 'GitHubCopilotChat/0.26.7';
+      headers['Openai-Intent'] = 'conversation-panel';
+    }
+    for (let turn = 0; turn < 4; turn += 1) {
+      let data: any;
+      let attempt = 0;
+      while (true) {
+        try {
+          data = await this.streamOpenAIChatResponse(
+            this.buildOpenAICompatibleChatCompletionsUrl(config.baseUrl),
+            headers,
+            {
+              model,
+              messages,
+              tools: [{ type: 'function', function: this.webSearchTool() }],
+              tool_choice: 'auto',
+            },
+            requestId,
+            onProgress,
+            abortSignal,
+          );
+          break;
+        } catch (error) {
+          if (
+            provider !== ProviderName.LlamaCpp ||
+            !(error instanceof ApiError) ||
+            !shouldRetryLocalInferenceSlot(error) ||
+            attempt >= LOCAL_INFERENCE_SLOT_RETRY_DELAYS_MS.length
+          ) {
+            throw error;
+          }
+          await waitForLocalInferenceSlot(LOCAL_INFERENCE_SLOT_RETRY_DELAYS_MS[attempt]);
+          this.throwIfAborted(abortSignal);
+          attempt += 1;
+        }
+      }
+      const assistant = data?.choices?.[0]?.message;
+      if (!assistant) {
+        throw new ApiError('No content received from the API. Please try again.');
+      }
+      const calls = Array.isArray(assistant.tool_calls)
+        ? assistant.tool_calls.filter((call: any) => call?.function?.name === 'web_search')
+        : [];
+      messages.push(assistant);
+      if (!calls.length) {
+        const content = typeof assistant.content === 'string' ? assistant.content : '';
+        onProgress?.(content);
+        return { content };
+      }
+      const parsedCalls = calls.map((call: any) => {
+        let args = {};
+        try {
+          args = JSON.parse(call.function.arguments || '{}');
+        } catch {
+          args = {};
+        }
+        return { args };
+      });
+      const results = await this.executeSearchCalls(parsedCalls, requestId, abortSignal);
+      calls.forEach((call: any, index: number) => {
+        messages.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          content: JSON.stringify(results[index]),
+        });
+      });
+    }
+    throw new ApiError('Search tool call limit reached.');
+  }
+
+  private async runAnthropicWebSearchLoop(
+    messages: any[],
+    system: string,
+    model: string,
+    config: ApiConfig,
+    onProgress: ((content: string) => void) | undefined,
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ content: string }> {
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-api-key': config.apiKey,
+      'anthropic-version': '2023-06-01',
+    };
     for (let turn = 0; turn < 4; turn += 1) {
       const tool = this.webSearchTool();
-      const data = await this.callJson(`${config.baseUrl.trim().replace(/\/+$/, '')}/v1/messages`, headers, { model, max_tokens: 8192, system, messages, tools: [{ name: tool.name, description: tool.description, input_schema: tool.parameters }] });
-      const content = Array.isArray(data?.content) ? data.content : []; const calls = content.filter((block: any) => block?.type === 'tool_use' && block.name === 'web_search');
-      if (!calls.length) { const text = content.filter((block: any) => block?.type === 'text').map((block: any) => block.text).join(''); onProgress?.(text); return { content: text }; }
+      const data = await this.streamAnthropicResponse(
+        `${config.baseUrl.trim().replace(/\/+$/, '')}/v1/messages`,
+        headers,
+        {
+          model,
+          max_tokens: 8192,
+          system,
+          messages,
+          tools: [
+            {
+              name: tool.name,
+              description: tool.description,
+              input_schema: tool.parameters,
+            },
+          ],
+        },
+        requestId,
+        onProgress,
+        abortSignal,
+      );
+      const content = Array.isArray(data?.content) ? data.content : [];
+      const calls = content.filter(
+        (block: any) => block?.type === 'tool_use' && block.name === 'web_search',
+      );
+      if (!calls.length) {
+        const text = content
+          .filter((block: any) => block?.type === 'text')
+          .map((block: any) => block.text)
+          .join('');
+        onProgress?.(text);
+        return { content: text };
+      }
       messages.push({ role: 'assistant', content });
-      messages.push({ role: 'user', content: await Promise.all(calls.slice(0, 3).map(async (call: any) => ({ type: 'tool_result', tool_use_id: call.id, content: JSON.stringify(await this.executeWebSearch(call.input || {})) }))) });
+      const results = await this.executeSearchCalls(
+        calls.map((call: any) => ({ args: call.input || {} })),
+        requestId,
+        abortSignal,
+      );
+      messages.push({
+        role: 'user',
+        content: calls.map((call: any, index: number) => ({
+          type: 'tool_result',
+          tool_use_id: call.id,
+          content: JSON.stringify(results[index]),
+        })),
+      });
     }
     throw new ApiError('Search tool call limit reached.');
   }
 
-  private async runGeminiWebSearchLoop(contents: any[], system: string, model: string, config: ApiConfig, onProgress?: (content: string) => void): Promise<{ content: string }> {
-    const baseUrl = config.baseUrl.trim().replace(/\/+$/, '') || 'https://generativelanguage.googleapis.com/v1beta'; const tool = this.webSearchTool();
+  private async runGeminiWebSearchLoop(
+    contents: any[],
+    system: string,
+    model: string,
+    config: ApiConfig,
+    onProgress: ((content: string) => void) | undefined,
+    requestId: string,
+    abortSignal?: AbortSignal,
+  ): Promise<{ content: string }> {
+    const baseUrl =
+      config.baseUrl.trim().replace(/\/+$/, '') ||
+      'https://generativelanguage.googleapis.com/v1beta';
+    const tool = this.webSearchTool();
     for (let turn = 0; turn < 4; turn += 1) {
-      const data = await this.callJson(`${baseUrl}/models/${model}:generateContent`, { 'Content-Type': 'application/json', 'x-goog-api-key': config.apiKey }, { contents, systemInstruction: { parts: [{ text: system }] }, tools: [{ functionDeclarations: [{ name: tool.name, description: tool.description, parameters: tool.parameters }] }], generationConfig: { maxOutputTokens: 8192 } });
-      const content = data?.candidates?.[0]?.content; const calls = Array.isArray(content?.parts) ? content.parts.filter((part: any) => part.functionCall?.name === 'web_search') : [];
-      if (!calls.length) { const text = (content?.parts || []).filter((part: any) => typeof part.text === 'string').map((part: any) => part.text).join(''); onProgress?.(text); return { content: text }; }
-      contents.push(content); contents.push({ role: 'user', parts: await Promise.all(calls.slice(0, 3).map(async (part: any) => ({ functionResponse: { name: 'web_search', response: await this.executeWebSearch(part.functionCall.args || {}) } }))) });
+      const data = await this.streamGeminiResponse(
+        `${baseUrl}/models/${model}:streamGenerateContent`,
+        {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': config.apiKey,
+        },
+        {
+          contents,
+          systemInstruction: { parts: [{ text: system }] },
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: tool.name,
+                  description: tool.description,
+                  parameters: tool.parameters,
+                },
+              ],
+            },
+          ],
+          generationConfig: { maxOutputTokens: 8192 },
+        },
+        requestId,
+        onProgress,
+        abortSignal,
+      );
+      const content = data?.candidates?.[0]?.content;
+      const calls = Array.isArray(content?.parts)
+        ? content.parts.filter((part: any) => part.functionCall?.name === 'web_search')
+        : [];
+      if (!calls.length) {
+        const text = (content?.parts || [])
+          .filter((part: any) => typeof part.text === 'string')
+          .map((part: any) => part.text)
+          .join('');
+        onProgress?.(text);
+        return { content: text };
+      }
+      contents.push(content);
+      const results = await this.executeSearchCalls(
+        calls.map((part: any) => ({ args: part.functionCall.args || {} })),
+        requestId,
+        abortSignal,
+      );
+      contents.push({
+        role: 'user',
+        parts: calls.map((_part: any, index: number) => ({
+          functionResponse: { name: 'web_search', response: results[index] },
+        })),
+      });
     }
     throw new ApiError('Search tool call limit reached.');
   }

--- a/src/renderer/services/api.webSearch.test.ts
+++ b/src/renderer/services/api.webSearch.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { apiService } from './api';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('OpenAI Responses returns an output for every parallel tool call', async () => {
+  const streamResponse = vi
+    .spyOn(apiService as any, 'streamOpenAIResponsesResponse')
+    .mockResolvedValueOnce(
+      {
+        output: Array.from({ length: 4 }, (_, index) => ({
+          type: 'function_call',
+          call_id: `call-${index}`,
+          name: 'web_search',
+          arguments: JSON.stringify({ query: `query ${index}` }),
+        })),
+      },
+    )
+    .mockResolvedValueOnce({ output_text: 'final answer' });
+  const webSearch = vi.fn().mockResolvedValue({
+    ok: true,
+    data: { query: 'test', results: [] },
+  });
+  vi.stubGlobal('window', { electron: { api: { webSearch } } });
+
+  const result = await (apiService as any).runOpenAIResponsesWebSearchLoop(
+    [],
+    'system',
+    'gpt-test',
+    { apiKey: 'model-key', baseUrl: 'https://api.openai.com/v1' },
+    undefined,
+    'request-1',
+  );
+
+  expect(result.content).toBe('final answer');
+  expect(webSearch).toHaveBeenCalledTimes(3);
+  const secondBody = streamResponse.mock.calls[1][2] as { input: any[] };
+  const outputs = secondBody.input.filter(
+    (item: { type?: string }) => item.type === 'function_call_output',
+  );
+  expect(outputs).toHaveLength(4);
+  expect(JSON.parse(outputs[3].output)).toEqual({
+    error: 'Only three web_search calls are allowed per model turn.',
+  });
+  expect(streamResponse.mock.calls[0][0]).toBe('https://api.openai.com/v1/responses');
+});
+
+test('OpenAI-compatible Copilot requests retain required headers', async () => {
+  const streamResponse = vi
+    .spyOn(apiService as any, 'streamOpenAIChatResponse')
+    .mockResolvedValue(
+      {
+      choices: [{ message: { role: 'assistant', content: 'answer' } }],
+      },
+    );
+  vi.stubGlobal('window', {
+    electron: { api: { webSearch: vi.fn() } },
+  });
+
+  await (apiService as any).runOpenAIWebSearchLoop(
+    [],
+    'copilot-model',
+    { apiKey: 'copilot-token', baseUrl: 'https://api.githubcopilot.com' },
+    'github-copilot',
+    undefined,
+    'request-2',
+  );
+
+  expect(streamResponse.mock.calls[0][1]).toMatchObject({
+    'Copilot-Integration-Id': 'vscode-chat',
+    'Openai-Intent': 'conversation-panel',
+  });
+});
+
+test('native OpenAI tool calls are assembled from the cancellable SSE channel', async () => {
+  let onData: ((chunk: string) => void) | undefined;
+  let onDone: (() => void) | undefined;
+  const progress = vi.fn();
+  const api = {
+    onStreamData: vi.fn((_requestId: string, callback: (chunk: string) => void) => {
+      onData = callback;
+      return vi.fn();
+    }),
+    onStreamDone: vi.fn((_requestId: string, callback: () => void) => {
+      onDone = callback;
+      return vi.fn();
+    }),
+    onStreamError: vi.fn(() => vi.fn()),
+    onStreamAbort: vi.fn(() => vi.fn()),
+    stream: vi.fn(async () => {
+      queueMicrotask(() => {
+        onData?.(
+          `data: ${JSON.stringify({
+            choices: [
+              {
+                delta: {
+                  content: 'Checking ',
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call-1',
+                      function: { name: 'web_search', arguments: '{"query":' },
+                    },
+                  ],
+                },
+              },
+            ],
+          })}\n\n`,
+        );
+        onData?.(
+          `data: ${JSON.stringify({
+            choices: [
+              {
+                delta: {
+                  content: 'now',
+                  tool_calls: [{ index: 0, function: { arguments: '"latest"}' } }],
+                },
+              },
+            ],
+          })}\n\n`,
+        );
+        onDone?.();
+      });
+      return { ok: true, status: 200, statusText: 'OK' };
+    }),
+  };
+  vi.stubGlobal('window', { electron: { api } });
+
+  const response = await (apiService as any).streamOpenAIChatResponse(
+    'https://example.com/v1/chat/completions',
+    {},
+    { model: 'test' },
+    'request-stream',
+    progress,
+  );
+
+  expect(progress).toHaveBeenLastCalledWith('Checking now', undefined);
+  expect(response.choices[0].message.tool_calls[0]).toMatchObject({
+    id: 'call-1',
+    function: { name: 'web_search', arguments: '{"query":"latest"}' },
+  });
+});
+
+test('an already-aborted signal never starts the provider stream', async () => {
+  const abortController = new AbortController();
+  abortController.abort();
+  const api = {
+    onStreamData: vi.fn(() => vi.fn()),
+    onStreamDone: vi.fn(() => vi.fn()),
+    onStreamError: vi.fn(() => vi.fn()),
+    onStreamAbort: vi.fn(() => vi.fn()),
+    cancelStream: vi.fn().mockResolvedValue(false),
+    stream: vi.fn(),
+  };
+  vi.stubGlobal('window', { electron: { api } });
+
+  await expect(
+    (apiService as any).streamOpenAIChatResponse(
+      'https://example.com/v1/chat/completions',
+      {},
+      { model: 'test' },
+      'request-aborted',
+      undefined,
+      abortController.signal,
+    ),
+  ).rejects.toMatchObject({ name: 'AbortError' });
+
+  expect(api.cancelStream).not.toHaveBeenCalled();
+  expect(api.stream).not.toHaveBeenCalled();
+});
+
+test('Anthropic receives a tool_result for every parallel call', async () => {
+  const streamResponse = vi
+    .spyOn(apiService as any, 'streamAnthropicResponse')
+    .mockResolvedValueOnce({
+      content: Array.from({ length: 4 }, (_, index) => ({
+        type: 'tool_use',
+        id: `tool-${index}`,
+        name: 'web_search',
+        input: { query: `query ${index}` },
+      })),
+    })
+    .mockResolvedValueOnce({ content: [{ type: 'text', text: 'done' }] });
+  const webSearch = vi.fn().mockResolvedValue({
+    ok: true,
+    data: { query: 'test', results: [] },
+  });
+  vi.stubGlobal('window', { electron: { api: { webSearch } } });
+
+  await (apiService as any).runAnthropicWebSearchLoop(
+    [],
+    'system',
+    'claude-test',
+    { apiKey: 'key', baseUrl: 'https://api.anthropic.com' },
+    undefined,
+    'request-anthropic',
+  );
+
+  const secondBody = streamResponse.mock.calls[1][2] as { messages: any[] };
+  expect(secondBody.messages.at(-1).content).toHaveLength(4);
+  expect(JSON.parse(secondBody.messages.at(-1).content[3].content)).toEqual({
+    error: 'Only three web_search calls are allowed per model turn.',
+  });
+});
+
+test('Gemini uses streamGenerateContent and answers every parallel function call', async () => {
+  const streamResponse = vi
+    .spyOn(apiService as any, 'streamGeminiResponse')
+    .mockResolvedValueOnce({
+      candidates: [
+        {
+          content: {
+            role: 'model',
+            parts: Array.from({ length: 4 }, (_, index) => ({
+              functionCall: { name: 'web_search', args: { query: `query ${index}` } },
+            })),
+          },
+        },
+      ],
+    })
+    .mockResolvedValueOnce({
+      candidates: [{ content: { role: 'model', parts: [{ text: 'done' }] } }],
+    });
+  const webSearch = vi.fn().mockResolvedValue({
+    ok: true,
+    data: { query: 'test', results: [] },
+  });
+  vi.stubGlobal('window', { electron: { api: { webSearch } } });
+
+  await (apiService as any).runGeminiWebSearchLoop(
+    [],
+    'system',
+    'gemini-test',
+    { apiKey: 'key', baseUrl: 'https://generativelanguage.googleapis.com/v1beta' },
+    undefined,
+    'request-gemini',
+  );
+
+  expect(streamResponse.mock.calls[0][0]).toContain(':streamGenerateContent');
+  const secondBody = streamResponse.mock.calls[1][2] as { contents: any[] };
+  expect(secondBody.contents.at(-1).parts).toHaveLength(4);
+  expect(secondBody.contents.at(-1).parts[3].functionResponse.response).toEqual({
+    error: 'Only three web_search calls are allowed per model turn.',
+  });
+});

--- a/src/renderer/services/chatChatTransport.test.ts
+++ b/src/renderer/services/chatChatTransport.test.ts
@@ -6,7 +6,7 @@ import { ChatChatTransport } from './chatChatTransport';
 
 vi.mock('./api', () => ({
   apiService: {
-    chat: vi.fn(),
+    chatWithWebSearch: vi.fn(),
     cancelOngoingRequest: vi.fn(),
   },
 }));
@@ -27,7 +27,7 @@ async function collectChunks(stream: ReadableStream<Record<string, unknown>>): P
 test('emits reasoning-end when reasoning stream finishes before content', async () => {
   let onProgress: ((content: string, reasoning?: string) => void) | undefined;
   let resolveChat: (() => void) | undefined;
-  vi.mocked(apiService.chat).mockImplementation(
+  vi.mocked(apiService.chatWithWebSearch).mockImplementation(
     async (_message: string | unknown, progress?: (content: string, reasoning?: string) => void) => {
       onProgress = progress;
       return new Promise<{ content: string; reasoning?: string }>(resolve => {
@@ -69,7 +69,7 @@ test('emits reasoning-end when reasoning stream finishes before content', async 
 
 test('only uses messages before the latest user turn as history', async () => {
   let capturedHistory: Array<{ role: 'user' | 'assistant'; content: string }> | undefined;
-  vi.mocked(apiService.chat).mockImplementation(
+  vi.mocked(apiService.chatWithWebSearch).mockImplementation(
     async (
       _message: string | unknown,
       _progress?: (content: string, reasoning?: string) => void,

--- a/src/renderer/services/chatChatTransport.test.ts
+++ b/src/renderer/services/chatChatTransport.test.ts
@@ -99,3 +99,28 @@ test('only uses messages before the latest user turn as history', async () => {
   expect(capturedHistory).toHaveLength(3);
   expect(capturedHistory?.map(m => m.content)).toEqual(['hi', 'thinking...', 'hello']);
 });
+
+test('passes the request id and abort signal through the native tool loop', async () => {
+  vi.mocked(apiService.chatWithWebSearch).mockImplementation(
+    () => new Promise<{ content: string }>(() => {}),
+  );
+  const abortController = new AbortController();
+  const transport = new ChatChatTransport({});
+  const stream = await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'chat-1',
+    messageId: undefined,
+    messages: [{ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] }],
+    abortSignal: abortController.signal,
+  });
+
+  const calls = vi.mocked(apiService.chatWithWebSearch).mock.calls;
+  const call = calls[calls.length - 1];
+  const requestId = call[4];
+  expect(typeof requestId).toBe('string');
+  expect(call[5]).toBe(abortController.signal);
+
+  abortController.abort();
+  await collectChunks(stream);
+  expect(apiService.cancelOngoingRequest).toHaveBeenCalledWith(requestId);
+});

--- a/src/renderer/services/chatChatTransport.ts
+++ b/src/renderer/services/chatChatTransport.ts
@@ -156,6 +156,8 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
             },
             history,
             directChatOptions,
+            requestId,
+            abortSignal,
           )
           .then(() => {
             close();

--- a/src/renderer/services/chatChatTransport.ts
+++ b/src/renderer/services/chatChatTransport.ts
@@ -18,11 +18,8 @@ function extractText(message: UIMessage): string {
 }
 
 /**
- * A `ChatTransport` that bridges the `apiService.chat()` call (direct LLM,
- * no agent engine) into the AI SDK v6 `useChat` hook.
- *
- * Much simpler than CoworkChatTransport — no tool use, no permissions,
- * just text + reasoning streaming.
+ * A `ChatTransport` for direct LLM chat with provider-native web-search tool
+ * calling. Search execution remains in Electron's main process.
  */
 export class ChatChatTransport implements ChatTransport<UIMessage> {
   constructor(private readonly options: DirectChatRequestOptions = {}) {}
@@ -107,7 +104,7 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
         }
 
         void apiService
-          .chat(
+          .chatWithWebSearch(
             prompt,
             (content, reasoning) => {
               if (abortSignal?.aborted) {
@@ -159,7 +156,6 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
             },
             history,
             directChatOptions,
-            requestId,
           )
           .then(() => {
             close();

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -565,6 +565,11 @@ interface IElectronAPI {
     }>;
   };
   api: {
+    webSearch: (input: { query: string; maxResults?: number }) => Promise<{
+      ok: boolean;
+      data?: { query: string; results: Array<{ title: string; url: string; snippet: string; content?: string }> };
+      error?: string;
+    }>;
     fetch: (options: {
       url: string;
       method: string;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -565,7 +565,7 @@ interface IElectronAPI {
     }>;
   };
   api: {
-    webSearch: (input: { query: string; maxResults?: number }) => Promise<{
+    webSearch: (input: { query: string; maxResults?: number; requestId?: string }) => Promise<{
       ok: boolean;
       data?: { query: string; results: Array<{ title: string; url: string; snippet: string; content?: string }> };
       error?: string;

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -71,6 +71,7 @@ export type EnterpriseIpc = (typeof EnterpriseIpc)[keyof typeof EnterpriseIpc];
 // ─── API (HTTP proxy) ───────────────────────────────────────────────────────
 export const ApiIpc = {
   Fetch: 'api:fetch',
+  WebSearch: 'api:web-search',
   Stream: 'api:stream',
   CancelStream: 'api:stream:cancel',
   /** Dynamic: `api:stream:${requestId}:data` */


### PR DESCRIPTION
## What changed

- Bundles the product-scoped AnySearch gateway credential as an explicitly approved, lightweight obfuscated main-process value with an emergency environment override.
- Injects the gateway configuration into OpenClaw and Pi Agent execution environments without end-user setup.
- Adds direct Chat web search through provider-native tool calling for OpenAI Responses, OpenAI-compatible APIs, Anthropic, and Gemini.
- Keeps model responses on the existing cancellable SSE path and executes gateway searches through a main-process-only IPC boundary.
- Preserves provider-specific behavior including OpenAI Responses, GitHub Copilot headers/token refresh, and LlamaCpp busy-slot retries.
- Returns a result or explicit rate-limit error for every parallel tool call.

## Security note

The bundled shared credential uses deliberate low-strength obfuscation. Repository members and package reverse engineers can recover it; this risk has been explicitly approved. The credential is not sent to the renderer or model provider.

## Validation

- Renderer TypeScript build: passed
- Electron TypeScript build: passed
- Oxlint: passed
- Vite and Electron production build: passed
- Native web-search and Chat transport tests: 9/9 passed
- Deployed AnySearch gateway smoke test: passed
- git diff --check: passed