### PR TITLE
Fix Work mode authentication for custom Pi providers

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -23,7 +23,16 @@ const hoisted = vi.hoisted(() => {
     }),
     mockGetAgentDir: vi.fn(() => '/tmp/pi-agent'),
     mockCompleteSimple: vi.fn().mockResolvedValue({ content: [{ text: 'Hello from Pi' }] }),
-    mockGetModel: vi.fn((provider: string, modelId: string) => ({ provider, id: modelId })),
+    mockGetModel: vi.fn((provider: string, modelId: string) => ({
+      provider,
+      id: modelId,
+      baseUrl:
+        provider === 'openai'
+          ? 'https://api.openai.com/v1'
+          : provider === 'moonshotai-cn'
+            ? 'https://api.moonshot.cn/v1'
+            : undefined,
+    })),
     mockModelRuntime: {
       registerProvider: vi.fn(),
       setRuntimeApiKey: vi.fn().mockResolvedValue(undefined),
@@ -68,6 +77,26 @@ const hoisted = vi.hoisted(() => {
             contextWindow: 272000,
             contextTokens: 272000,
             maxTokens: 16384,
+          },
+        };
+      }
+
+      if (providerName === 'moonshot') {
+        return {
+          config: {
+            apiKey: 'sk-moonshot',
+            baseURL: 'http://172.18.5.179:3000/v1',
+            model: modelName,
+            apiType: 'openai' as const,
+          },
+          providerMetadata: {
+            providerName: 'moonshot',
+            codingPlanEnabled: false,
+            supportsImage: true,
+            modelName,
+            contextWindow: 262144,
+            contextTokens: 262144,
+            maxTokens: 32768,
           },
         };
       }
@@ -213,6 +242,60 @@ describe('PiRuntimeAdapter', () => {
       );
       expect(mockModelRuntimeCreate).not.toHaveBeenCalled();
       expect(mockCreateAgentSession.mock.calls[0]?.[0]).not.toHaveProperty('modelRuntime');
+    });
+
+    it('should register remote custom models with their configured endpoint and API key', async () => {
+      mockGetModel.mockImplementationOnce(() => undefined);
+
+      await adapter.startSession('test', 'Hello Pi', {
+        modelOverride: 'moonshot/kimi-for-coding',
+      });
+
+      expect(mockResolveRawApiConfigForModelRef).toHaveBeenCalledWith('moonshot/kimi-for-coding');
+      expect(mockModelRuntime.registerProvider).toHaveBeenCalledWith(
+        'moonshot',
+        expect.objectContaining({
+          baseUrl: 'http://172.18.5.179:3000/v1',
+          api: 'openai-completions',
+          models: [
+            expect.objectContaining({
+              provider: 'moonshot',
+              id: 'kimi-for-coding',
+              baseUrl: 'http://172.18.5.179:3000/v1',
+            }),
+          ],
+        }),
+      );
+      expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith('moonshot', 'sk-moonshot');
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({
+            provider: 'moonshot',
+            id: 'kimi-for-coding',
+            baseUrl: 'http://172.18.5.179:3000/v1',
+          }),
+          modelRuntime: mockModelRuntime,
+        }),
+      );
+    });
+
+    it('should not reuse a built-in model when the configured endpoint differs', async () => {
+      await adapter.startSession('test', 'Hello Pi', {
+        modelOverride: 'moonshot/kimi-k2.6',
+      });
+
+      expect(mockGetModel).toHaveBeenCalledWith('moonshotai-cn', 'kimi-k2.6');
+      expect(mockModelRuntime.registerProvider).toHaveBeenCalledWith(
+        'moonshot',
+        expect.objectContaining({
+          baseUrl: 'http://172.18.5.179:3000/v1',
+          models: [expect.objectContaining({ id: 'kimi-k2.6' })],
+        }),
+      );
+      expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith('moonshot', 'sk-moonshot');
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({ modelRuntime: mockModelRuntime }),
+      );
     });
 
     it('should make session active after start', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1581,16 +1581,30 @@ function buildPiCustomModel(resolution: ApiConfigResolution): Record<string, unk
   };
 }
 
-async function resolvePiLocalModelRuntime(
+function normalizePiBaseUrl(baseUrl: unknown): string {
+  return typeof baseUrl === 'string' ? baseUrl.trim().replace(/\/+$/, '') : '';
+}
+
+function canUsePiBuiltinModel(
+  builtinModel: Record<string, unknown> | null,
+  resolution: ApiConfigResolution,
+): boolean {
+  if (!builtinModel || !resolution.config) return false;
+  return normalizePiBaseUrl(builtinModel.baseUrl) === normalizePiBaseUrl(resolution.config.baseURL);
+}
+
+async function resolvePiCustomModelRuntime(
   pi: PiModules,
   resolution: ApiConfigResolution,
+  builtinModel: Record<string, unknown> | null,
   existingModelRuntime?: PiModelRuntime | null,
 ): Promise<PiModelRuntime | null> {
   const config = resolution.config;
   const providerMetadata = resolution.providerMetadata;
-  if (!config || !providerMetadata || !isLocalProviderName(providerMetadata.providerName)) {
+  if (!config || !providerMetadata) {
     return null;
   }
+  if (canUsePiBuiltinModel(builtinModel, resolution)) return existingModelRuntime ?? null;
 
   const modelRuntime = existingModelRuntime ?? (await pi.ModelRuntime.create());
   const model = buildPiCustomModel(resolution);
@@ -1601,7 +1615,10 @@ async function resolvePiLocalModelRuntime(
     api: model.api,
     models: [model],
   });
-  await modelRuntime.setRuntimeApiKey(providerId, config.apiKey?.trim() || PI_LOCAL_API_KEY);
+  const apiKey =
+    config.apiKey?.trim() ||
+    (isLocalProviderName(providerMetadata.providerName) ? PI_LOCAL_API_KEY : '');
+  if (apiKey) await modelRuntime.setRuntimeApiKey(providerId, apiKey);
   return modelRuntime;
 }
 
@@ -1645,18 +1662,24 @@ async function resolvePiModel(
   }
 
   const builtinModel = buildPiBuiltinModel(pi, resolution);
-  const modelRuntime = await resolvePiLocalModelRuntime(pi, resolution, existingModelRuntime);
+  const modelRuntime = await resolvePiCustomModelRuntime(
+    pi,
+    resolution,
+    builtinModel,
+    existingModelRuntime,
+  );
   const customModel = buildPiCustomModel(resolution);
-  const localModel = modelRuntime?.getModel(
+  const registeredModel = modelRuntime?.getModel(
     resolution.providerMetadata.providerName,
     resolution.config.model,
   );
+  const useBuiltinModel = canUsePiBuiltinModel(builtinModel, resolution);
 
   return {
     model:
-      builtinModel ??
-      (localModel && typeof localModel === 'object'
-        ? (localModel as Record<string, unknown>)
+      (useBuiltinModel ? builtinModel : null) ??
+      (registeredModel && typeof registeredModel === 'object'
+        ? (registeredModel as Record<string, unknown>)
         : customModel),
     modelRuntime,
     requestOptions: resolution.config.apiKey ? { apiKey: resolution.config.apiKey } : undefined,


### PR DESCRIPTION
## Summary

- register remote custom models and custom provider endpoints in a session-scoped Pi `ModelRuntime`
- inject the configured provider API key with `setRuntimeApiKey()`
- keep Pi built-in models only when their built-in endpoint matches the configured endpoint
- add regressions for Moonshot `kimi-for-coding` and built-in model IDs routed through a custom proxy

## Root cause

Work mode resolved the configured Moonshot model and API key correctly, but `kimi-for-coding` is not present in Pi's built-in Moonshot catalog. The fallback model used provider ID `moonshot`, while the code only registered custom runtimes for local providers. The resolved `requestOptions.apiKey` was not used by `createAgentSession()`, so Pi rejected every prompt with `No API key found for moonshot`.

Chat remained functional because it uses the application's direct provider transport and passes the configured API key independently.

## Impact

Work mode now honors the application's configured model, custom Base URL, and API key for remote providers whose model or endpoint cannot safely use Pi's built-in definition. Existing built-in provider behavior remains unchanged when the configured endpoint matches.

## Validation

- `npm test -- piRuntimeAdapter` — 40 tests passed
- `npm run lint -- --deny-warnings`
- `npm run compile:electron`
