### PR TITLE
Thank AnySearch for sponsoring ZhiYuan Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,7 @@ Scheduled tasks can be created from natural language or through the GUI. When a 
 ## License
 
 [MIT License](LICENSE)
+
+## Sponsors
+
+Special thanks to [AnySearch](https://www.anysearch.com/) for sponsoring ZhiYuan Agent and supporting its built-in web search capabilities.

--- a/README_zh.md
+++ b/README_zh.md
@@ -162,3 +162,7 @@ Cowork 是核心会话系统。用户任务从 Renderer 通过 IPC 发送到 Mai
 ## License
 
 [MIT License](LICENSE)
+
+## 赞助
+
+感谢 [AnySearch](https://www.anysearch.com/) 对知远智能体的赞助与支持，为项目的内置联网搜索能力提供助力。


### PR DESCRIPTION
## Summary

- add an English `Sponsors` section to the end of `README.md`
- add the corresponding Chinese sponsorship acknowledgment to `README_zh.md`
- link the AnySearch name to its official website

## Why

AnySearch sponsors ZhiYuan Agent and supports the project's built-in web search capabilities. This change recognizes that support using a conventional, durable README sponsorship section.

## Validation

- reviewed the rendered Markdown structure
- `git diff --check`
