### PR TITLE
fix(theme): 统一亮色模式 primary/foreground 为 rgb(60,63,67)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,7 @@ RongxinAI 前端设计标准。本文件是**项目级约束**：所有新增和
 
 1. **`shadcn`** — shadcn/ui 组件用法、样式规则、表单、组合、图标。项目中 shadcn 组件安装于 `@shared/components/ui/*`。
 2. **`ai-elements`** — Vercel AI Elements 的 AI 原生组件（`Message`、`PromptInput`、`ModelSelector`、`Conversation`、`Suggestion`、`Reasoning`、`Sources` 等）。安装于 `@shared/components/ai-elements/*`。
-3. **`rongxinai-ui-adapter`** — 本项目适配层：文件位置约定、i18n（`t()` 包裹所有用户可见文本）、常量（`as const` 对象定义判别值）、lobster theme 映射表、页面级组件选择矩阵、以及 `--zy-*` ↔ shadcn 语义 token 的对应关系。
+3. **`rongxinai-ui-adapter`** — 本项目适配层：文件位置约定、i18n（`t()` 包裹所有用户可见文本）、常量（`as const` 对象定义判别值）、`--zy-*` 主题映射表、页面级组件选择矩阵、以及 `--zy-*` ↔ shadcn 语义 token 的对应关系。
 
 **使用规则：**
 
@@ -60,6 +60,19 @@ Tailwind 工具类经 `index.css` 中 `@theme` 块桥接：`--color-background: 
 | 边框     | `border` / `border-subtle`                    | 分隔线、控件描边                                       |
 | 强调     | `primary` / `primary-hover` / `primary-muted` | 唯一的品牌强调色，用于主按钮、激活态、链接、focus ring |
 | 状态     | `destructive` / `success` / `warning`         | 仅用于语义状态，不作装饰                               |
+
+### 当前色值参考（Light）
+
+| Token | oklch | 等效 RGB |
+|-------|-------|----------|
+| `--zy-primary` / `--zy-foreground` / `--zy-text-primary` | `oklch(0.366 0.008 253)` | `rgb(60, 63, 67)` |
+| `--zy-text-secondary` / `--zy-text-muted` | `oklch(0.553 0.013 58.071)` | ≈ `rgb(128, 125, 119)` |
+| `--zy-background` | `oklch(1 0 0)` | `#ffffff` |
+| `--zy-surface-raised` | `oklch(0.97 0.001 106.424)` | ≈ `#f5f5f4` |
+| `--zy-border` | `oklch(0.923 0.003 48.717)` | ≈ `#e7e5e4` |
+| `--zy-destructive` | `oklch(0.577 0.245 27.325)` | ≈ `#ef4444` |
+
+> `primary`、`foreground`、`text-primary` 三者同值（`rgb(60,63,67)`，冷灰偏蓝），是 2026-07-28 验收后确定的统一主色。
 
 规则：
 

--- a/src/renderer/theme/css/shadcn-token-bridge.css
+++ b/src/renderer/theme/css/shadcn-token-bridge.css
@@ -2,12 +2,12 @@
 :root,
 [data-theme='classic-light'] {
   --background: oklch(1 0 0);
-  --foreground: oklch(0.147 0.004 49.25);
+  --foreground: oklch(0.366 0.008 253);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.147 0.004 49.25);
+  --card-foreground: oklch(0.366 0.008 253);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.147 0.004 49.25);
-  --primary: oklch(0.216 0.006 56.043);
+  --popover-foreground: oklch(0.366 0.008 253);
+  --primary: oklch(0.366 0.008 253);
   --primary-foreground: oklch(0.985 0.001 106.423);
   --secondary: oklch(0.97 0.001 106.424);
   --secondary-foreground: oklch(0.216 0.006 56.043);

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -4,20 +4,20 @@
 [data-theme='classic-light'] {
   color-scheme: light;
   /* ── Mapped to shadcn bridge ── */
-  --zy-primary: oklch(0.216 0.006 56.043);
+  --zy-primary: oklch(0.366 0.008 253);
   --zy-primary-foreground: oklch(0.985 0.001 106.423);
   --zy-primary-hover: oklch(0.147 0.004 49.25);
   --zy-primary-muted: oklch(0.97 0.001 106.424);
   --zy-accent: oklch(0.97 0.001 106.424);
   --zy-accent-foreground: oklch(0.216 0.006 56.043);
   --zy-background: oklch(1 0 0);
-  --zy-foreground: oklch(0.147 0.004 49.25);
+  --zy-foreground: oklch(0.366 0.008 253);
   --zy-surface: oklch(1 0 0);
-  --zy-surface-foreground: oklch(0.147 0.004 49.25);
+  --zy-surface-foreground: oklch(0.366 0.008 253);
   --zy-surface-raised: oklch(0.97 0.001 106.424);
   --zy-surface-tertiary: rgb(237 237 236);
   --zy-surface-overlay: oklch(1 0 0);
-  --zy-text-primary: oklch(0.147 0.004 49.25);
+  --zy-text-primary: oklch(0.366 0.008 253);
   --zy-text-secondary: oklch(0.553 0.013 58.071);
   --zy-text-muted: oklch(0.553 0.013 58.071);
   --zy-border: oklch(0.923 0.003 48.717);


### PR DESCRIPTION
## 变更内容

将亮色模式下的主色和正文色统一为 rgb(60, 63, 67)（oklch(0.366 0.008 253)）。

### 改动文件

- themes.css：--zy-primary、--zy-foreground、--zy-surface-foreground、--zy-text-primary
- shadcn-token-bridge.css：--foreground、--card-foreground、--popover-foreground、--primary
- DESIGN.md：新增当前色值参考表，移除旧称 lobster theme

### 验收说明

- 亮色模式下按钮和正文文本均为 rgb(60,63,67)
- 暗色模式不受影响

Generated with Claude Code