### PR TITLE
feat(bug): 修改了本地推理页面的模型块的呈现效果

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit "$1"
+node node_modules/@commitlint/cli/cli.js --edit "$1"

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -752,6 +752,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                   }}
                   onOpenLaunchLog={launchLogs.openPanelForModel}
                   showRegisteredModelsTitle={false}
+                  logPanelVisible={launchLogs.state.visible}
                 />
             </LayeredTabsContent>
             <LayeredTabsContent

--- a/src/renderer/components/localInference/panels/MarketplacePanel.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.tsx
@@ -6,7 +6,6 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from '@shared/components/ui/input-group';
-import { Label } from '@shared/components/ui/label';
 import { Eye, EyeOff, RefreshCw, Search, SlidersHorizontal, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -318,13 +317,7 @@ export function MarketplacePanel({
               <X />
             </Button>
           </div>
-          <p className={`text-sm leading-relaxed ${localInferenceMutedTextClass}`}>
-            {i18nService.t('marketplaceTokenSettingsDesc')}
-          </p>
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="marketplace-token">
-              {i18nService.t('marketplaceTokenSettingsTitle')}
-            </Label>
             <InputGroup>
               <InputGroupInput
                 id="marketplace-token"

--- a/src/renderer/components/localInference/panels/ModelsPanel.tsx
+++ b/src/renderer/components/localInference/panels/ModelsPanel.tsx
@@ -48,6 +48,7 @@ import {
   reorderLocalModelOrder,
   writeLocalModelOrder,
 } from '../utils/modelOrder';
+import { ListPagination } from '../../common/ListPagination';
 import { type LocalModelProvider, resolveLocalModelProvider } from '../utils/modelProvider';
 import { formatBytes, formatDate } from '../utils/progress';
 
@@ -67,6 +68,8 @@ const modelProviderIconMap = {
 } satisfies Record<LocalModelProvider, ComponentType<{ className?: string }>>;
 
 const MODEL_CARD_MAX_VISIBLE_TAGS = 6;
+const MODEL_PAGE_SIZE_WITHOUT_LOG = 16;
+const MODEL_PAGE_SIZE_WITH_LOG = 8;
 const modelCardActionClassName =
   'relative z-20 transition-[opacity,transform] duration-200 ease-out group-hover/card:translate-x-0 group-hover/card:opacity-100 group-hover/card:pointer-events-auto';
 const modelCardHiddenActionClassName = 'pointer-events-none translate-x-1 opacity-0';
@@ -93,6 +96,7 @@ type ModelsPanelProps = {
     props: { disabled: boolean; onClick: () => void },
   ) => React.ReactNode;
   showRegisteredModelsTitle?: boolean;
+  logPanelVisible?: boolean;
 };
 
 type ModelCardProps = {
@@ -133,10 +137,12 @@ export function ModelsPanel({
   onOpenLaunchLog,
   renderLoadButton,
   showRegisteredModelsTitle = true,
+  logPanelVisible = false,
 }: ModelsPanelProps) {
   const [pendingDeleteModel, setPendingDeleteModel] = useState<LlamaCppModel | null>(null);
   const [modelOrder, setModelOrder] = useState<string[]>(readLocalModelOrder);
   const [draggedModelName, setDraggedModelName] = useState<string | null>(null);
+  const [modelPage, setModelPage] = useState(1);
   const availableModels = useMemo(
     () => mergeVisibleModels(localModels, runningModels),
     [localModels, runningModels],
@@ -156,6 +162,24 @@ export function ModelsPanel({
       return model ? [{ model, runningModel: findRunningModel(runningModels, model.name) }] : [];
     });
   }, [availableModels, orderedModelNames, runningModels]);
+  const modelsPerPage = logPanelVisible ? MODEL_PAGE_SIZE_WITH_LOG : MODEL_PAGE_SIZE_WITHOUT_LOG;
+  const totalModelPages = Math.max(1, Math.ceil(modelCards.length / modelsPerPage));
+  const currentModelPage = Math.min(modelPage, totalModelPages);
+  const modelGridClassName = logPanelVisible
+    ? 'grid-cols-2'
+    : 'grid-cols-2 2xl:grid-cols-4';
+  const visibleModelCards = modelCards.slice(
+    (currentModelPage - 1) * modelsPerPage,
+    currentModelPage * modelsPerPage,
+  );
+
+  useEffect(() => {
+    setModelPage(1);
+  }, [modelsPerPage]);
+
+  useEffect(() => {
+    if (modelPage > totalModelPages) setModelPage(totalModelPages);
+  }, [modelPage, totalModelPages]);
 
   useEffect(() => {
     setModelOrder(currentOrder => {
@@ -208,31 +232,44 @@ export function ModelsPanel({
           </h2>
         ) : null}
         {modelCards.length > 0 ? (
-          <div className="grid auto-rows-min content-start gap-3 md:grid-cols-2 2xl:grid-cols-4">
-            {modelCards.map(({ model, runningModel }) => (
-              <ModelCard
-                key={model.name}
-                model={model}
-                runningModel={runningModel}
-                preference={modelPreferences[model.name]}
-                loading={loading}
-                loadingModel={loadingModelName === model.name}
-                unloading={unloadingModelName === model.name}
-                onLoadModel={() => onLoadModel(model)}
-                onConfigureContext={() => onConfigureContext(model)}
-                onUnload={() => onUnload(model.name)}
-                dragging={draggedModelName === model.name}
-                onDragStart={event => handleCardDragStart(event, model.name)}
-                onDragOver={event => event.preventDefault()}
-                onDrop={event => handleCardDrop(event, model.name)}
-                onDragEnd={() => setDraggedModelName(null)}
-                renderLoadButton={
-                  renderLoadButton ? props => renderLoadButton(model, props) : undefined
-                }
-                onOpenLaunchLog={onOpenLaunchLog ?? (() => undefined)}
-              />
-            ))}
-          </div>
+          <>
+            <div
+              className={cn(
+                'grid w-full auto-rows-min content-start gap-3',
+                modelGridClassName,
+              )}
+            >
+              {visibleModelCards.map(({ model, runningModel }) => (
+                <ModelCard
+                  key={model.name}
+                  model={model}
+                  runningModel={runningModel}
+                  preference={modelPreferences[model.name]}
+                  loading={loading}
+                  loadingModel={loadingModelName === model.name}
+                  unloading={unloadingModelName === model.name}
+                  onLoadModel={() => onLoadModel(model)}
+                  onConfigureContext={() => onConfigureContext(model)}
+                  onUnload={() => onUnload(model.name)}
+                  dragging={draggedModelName === model.name}
+                  onDragStart={event => handleCardDragStart(event, model.name)}
+                  onDragOver={event => event.preventDefault()}
+                  onDrop={event => handleCardDrop(event, model.name)}
+                  onDragEnd={() => setDraggedModelName(null)}
+                  renderLoadButton={
+                    renderLoadButton ? props => renderLoadButton(model, props) : undefined
+                  }
+                  onOpenLaunchLog={onOpenLaunchLog ?? (() => undefined)}
+                />
+              ))}
+            </div>
+            <ListPagination
+              page={currentModelPage}
+              totalPages={totalModelPages}
+              onPageChange={setModelPage}
+              className="pt-1"
+            />
+          </>
         ) : null}
       </section>
 
@@ -318,7 +355,8 @@ function ModelCard({
 
   return (
     <motion.div
-      className="relative w-full"
+
+      className="relative h-full w-full"
       whileHover={
         reduceMotion || loadingModel || unloading || dragging
           ? undefined
@@ -334,7 +372,7 @@ function ModelCard({
         onDrop={onDrop}
         onDragEnd={onDragEnd}
         className={cn(
-          'relative w-full cursor-grab select-none border border-border/70 bg-card p-0 shadow-sm ring-0 transition-all duration-200 active:cursor-grabbing',
+          'relative h-full w-full cursor-grab select-none border border-border/70 bg-card p-0 shadow-sm ring-0 transition-all duration-200 active:cursor-grabbing',
           'hover:border-border hover:bg-muted/20 hover:shadow-md',
           (loadingModel || unloading) && 'bg-muted/30',
           dragging && 'opacity-50',

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -310,7 +310,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     marketplaceInfer: '推理',
     marketplaceOpenModel: '打开模型',
     marketplaceOpenModelScope: 'ModelScope',
-    marketplaceModelScopeLink: '魔塔链接',
+    marketplaceModelScopeLink: '魔搭链接',
     marketplaceDownloads: '{count} 次下载',
     marketplaceCancel: '取消',
     marketplaceCancelling: '取消中...',
@@ -322,8 +322,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     marketplacePullCancelled: '拉取已取消',
     marketplaceTokenSettings: '设置魔搭 API Token',
     marketplaceTokenSettingsTitle: '配置魔搭社区 API Token',
-    marketplaceTokenSettingsDesc:
-      '填入 Token 后可使用 ModelScope OpenAPI 搜索，获得更准确的模型列表和更快的搜索速度。在 modelscope.cn 注册账号后，前往个人设置 → 访问令牌获取。',
     marketplaceTokenPlaceholder: '请输入魔搭社区 API Token',
     marketplaceTokenSave: '保存',
     marketplaceTokenClear: '清除',
@@ -2691,8 +2689,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     marketplacePullCancelled: 'Pull cancelled',
     marketplaceTokenSettings: 'ModelScope API Token',
     marketplaceTokenSettingsTitle: 'Configure ModelScope API Token',
-    marketplaceTokenSettingsDesc:
-      'Enter a token to enable ModelScope OpenAPI search for faster, more accurate model results. Register at modelscope.cn, then go to Settings → Access Tokens.',
     marketplaceTokenPlaceholder: 'Enter ModelScope API token',
     marketplaceTokenSave: 'Save',
     marketplaceTokenClear: 'Clear',


### PR DESCRIPTION
PR 标题： feat(local-inference): 优化模型卡片布局

  ## 摘要

  优化本地推理模型市场页面的模型卡片布局，并清理魔搭模型市场相关文案。

  ## 关联 Issue

  Fixes #<issue-number>

  ## 修改内容

  - 日志面板打开时，新增模型卡片分页和响应式网格布局。
  - 优化模型卡片尺寸与对齐方式。
  - 将“魔塔链接”修正为“魔搭链接”。
  - 删除中英文环境下重复的 ModelScope Token 说明文案。

  ## 修改类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] Breaking Change
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 本地测试
  - [ ] 新增测试
  - [ ] 更新已有测试
  - [ ] 手动测试

  已完成验证：

  - `npm run lint`
  - `npm run build:tsc`
  - `npm run compile:electron`

  ## 截图

  已更新本地推理模型网格和魔搭 Token 配置界面。

  ## 检查清单

  - [x] 代码符合项目规范
  - [x] 已完成代码自查
  - [ ] 已为复杂代码添加必要注释
  - [ ] 已同步更新相关文档
  - [ ] 未产生新的警告
  - [ ] 已添加验证修复效果的测试
  - [ ] 新旧单元测试均已通过

  ## Electron 相关变更

  - [ ] 修改主进程
  - [ ] 修改 preload 脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 无

  ## 补充说明

  未修改 Electron 主进程、preload、IPC 或窗口管理逻辑。