### PR TITLE
fix(cowork): connect streaming execution steps

### DIFF
--- a/src/renderer/components/cowork/components/AssistantBubble.tsx
+++ b/src/renderer/components/cowork/components/AssistantBubble.tsx
@@ -27,7 +27,7 @@ export const AssistantBubble: React.FC<{
 
   return (
     <div
-      className="py-1 px-4 focus:outline-none"
+      className="py-1 focus:outline-none"
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/src/renderer/components/cowork/components/ExecutionSummary.tsx
+++ b/src/renderer/components/cowork/components/ExecutionSummary.tsx
@@ -3,10 +3,9 @@ import {
   ChainOfThoughtContent,
   ChainOfThoughtHeader,
 } from '@shared/components/ai-elements/chain-of-thought';
-import { CheckCircle2, SparklesIcon, TriangleAlert } from 'lucide-react';
+import { SparklesIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 
-import { i18nService } from '../../../services/i18n';
 import {
   getCompletedExecutionSummaryText,
   type ExecutionSummary as ExecutionSummaryData,
@@ -24,32 +23,7 @@ export const ExecutionSummary = ({
       {getCompletedExecutionSummaryText(summary)}
     </ChainOfThoughtHeader>
     <ChainOfThoughtContent>
-      <div className="flex flex-col gap-3">
-        {summary && summary.toolCalls > 0 && (
-          <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
-            <span>{`${summary.toolCalls} ${i18nService.t('coworkExecutionSummaryTools')}`}</span>
-            {summary.completedTools > 0 && (
-              <span className="flex items-center gap-1">
-                <CheckCircle2 className="size-3.5" />
-                {`${summary.completedTools} ${i18nService.t('coworkExecutionSummaryCompleted')}`}
-              </span>
-            )}
-            {summary.failedTools > 0 && (
-              <span className="flex items-center gap-1 text-destructive">
-                <TriangleAlert className="size-3.5" />
-                {`${summary.failedTools} ${i18nService.t('coworkExecutionSummaryFailed')}`}
-              </span>
-            )}
-            {summary.incompleteTools > 0 && (
-              <span className="flex items-center gap-1 text-warning">
-                <TriangleAlert className="size-3.5" />
-                {`${summary.incompleteTools} ${i18nService.t('coworkExecutionSummaryIncomplete')}`}
-              </span>
-            )}
-          </div>
-        )}
-        {children}
-      </div>
+      <div className="flex flex-col gap-3">{children}</div>
     </ChainOfThoughtContent>
   </ChainOfThought>
 );

--- a/src/renderer/components/cowork/components/ToolCard.tsx
+++ b/src/renderer/components/cowork/components/ToolCard.tsx
@@ -14,6 +14,7 @@ import {
   ToolInput,
   ToolOutput,
 } from '@shared/components/ai-elements/tool';
+import { cn } from '@shared/lib/utils';
 import type { ToolUIPart } from 'ai';
 import { Check } from 'lucide-react';
 import React, { useMemo } from 'react';
@@ -100,11 +101,11 @@ export const ToolCard: React.FC<{
     : (toolInputDisplay ?? '');
 
   return (
-    <div className="relative py-1">
+    <div className="relative">
       {!isLastInSequence && (
-        <div className="absolute left-[3.5px] top-[14px] bottom-[-8px] w-px bg-border" />
+        <div className="absolute top-full -bottom-3 left-2 w-px bg-border" aria-hidden="true" />
       )}
-      <Tool className={muted ? 'text-muted-foreground' : undefined}>
+      <Tool className={cn('mb-0', muted && 'text-muted-foreground')}>
         <ToolHeader
           type={`tool-${rawToolName}` as ToolUIPart['type']}
           state={toolState}

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -134,6 +134,7 @@ export const TurnBlock: React.FC<{
     isFinalAnswer: boolean,
     forceComplete = false,
     mutedExecution = false,
+    isLastInSequence = true,
   ) => {
     // ── Thinking: collapsed Reasoning block with shimmer ──
     if (item.type === 'assistant' && item.message.metadata?.isThinking) {
@@ -151,6 +152,7 @@ export const TurnBlock: React.FC<{
           defaultOpen={true}
           autoClose={false}
           duration={durationSeconds}
+          showConnector
         >
           <ReasoningTrigger
             getThinkingMessage={(s, d) => {
@@ -170,7 +172,7 @@ export const TurnBlock: React.FC<{
         <ToolCard
           key={item.group.toolUse.id}
           group={item.group}
-          isLastInSequence
+          isLastInSequence={isLastInSequence}
           muted={mutedExecution}
           mapDisplayText={mapDisplayText}
         />
@@ -179,13 +181,27 @@ export const TurnBlock: React.FC<{
 
     // ── Orphan tool result ──
     if (item.type === 'tool_result') {
-      return <div key={item.message.id}>{renderOrphanToolResult(item.message)}</div>;
+      return (
+        <div key={item.message.id} className="relative">
+          {!isLastInSequence && (
+            <div aria-hidden="true" className="absolute top-full -bottom-3 left-2 w-px bg-border" />
+          )}
+          {renderOrphanToolResult(item.message)}
+        </div>
+      );
     }
 
     // ── System message ──
     if (item.type === 'system') {
       const sys = renderSystemMessage(item.message);
-      return sys ? <div key={item.message.id}>{sys}</div> : null;
+      return sys ? (
+        <div key={item.message.id} className="relative">
+          {!isLastInSequence && (
+            <div aria-hidden="true" className="absolute top-full -bottom-3 left-2 w-px bg-border" />
+          )}
+          {sys}
+        </div>
+      ) : null;
     }
 
     // ── Assistant answer ──
@@ -301,7 +317,9 @@ export const TurnBlock: React.FC<{
           )}
         </ChainOfThoughtHeader>
         <ChainOfThoughtContent>
-          {group.items.map((item, idx) => renderItem(item, idx, false, false, true))}
+          {group.items.map((item, idx) =>
+            renderItem(item, idx, false, false, true, idx === group.items.length - 1),
+          )}
         </ChainOfThoughtContent>
       </ChainOfThought>
     );
@@ -310,13 +328,23 @@ export const TurnBlock: React.FC<{
     <div className="px-4 py-2">
       <div className="max-w-5xl min-w-[320px] mx-auto">
         <div className="flex items-start gap-3">
-          <div className="flex-1 min-w-0 px-4 py-3 space-y-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-3 px-4 py-3">
             {finalAnswerStarted && previousItems.length > 0 && (
               <ExecutionSummary summary={executionSummary}>
-                {previousItems.map((item, index) => {
-                  const isAnswer = item.type === 'assistant' && !item.message.metadata?.isThinking;
-                  return renderItem(item, index, false, true, !isAnswer);
-                })}
+                {previousGroups.map(group =>
+                  group.items.map((item, index) => {
+                    const isAnswer =
+                      item.type === 'assistant' && !item.message.metadata?.isThinking;
+                    return renderItem(
+                      item,
+                      index,
+                      false,
+                      true,
+                      !isAnswer,
+                      isAnswer || index === group.items.length - 1,
+                    );
+                  }),
+                )}
               </ExecutionSummary>
             )}
             {finalAnswerStarted && finalAnswerGroup

--- a/src/shared/components/ai-elements/chain-of-thought.tsx
+++ b/src/shared/components/ai-elements/chain-of-thought.tsx
@@ -53,7 +53,7 @@ export const ChainOfThought = memo(
 
     return (
       <ChainOfThoughtContext.Provider value={chainOfThoughtContext}>
-        <div className={cn('not-prose w-full space-y-4', className)} {...props}>
+        <div className={cn('not-prose flex w-full flex-col gap-4', className)} {...props}>
           {children}
         </div>
       </ChainOfThoughtContext.Provider>
@@ -166,7 +166,7 @@ export const ChainOfThoughtContent = memo(
       <Collapsible open={isOpen}>
         <CollapsibleContent
           className={cn(
-            'mt-2 space-y-3',
+            'mt-2 flex flex-col gap-3',
             'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-popover-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
             className,
           )}

--- a/src/shared/components/ai-elements/reasoning.tsx
+++ b/src/shared/components/ai-elements/reasoning.tsx
@@ -33,6 +33,7 @@ interface ReasoningContextValue {
   isOpen: boolean;
   setIsOpen: (open: boolean) => void;
   duration: number | undefined;
+  showConnector: boolean;
 }
 
 const ReasoningContext = createContext<ReasoningContextValue | null>(null);
@@ -48,6 +49,7 @@ export const useReasoning = () => {
 export type ReasoningProps = ComponentProps<typeof Collapsible> & {
   isStreaming?: boolean;
   autoClose?: boolean;
+  showConnector?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -62,6 +64,7 @@ export const Reasoning = memo(
     className,
     isStreaming = false,
     autoClose = true,
+    showConnector = false,
     open,
     defaultOpen,
     onOpenChange,
@@ -127,18 +130,24 @@ export const Reasoning = memo(
     );
 
     const contextValue = useMemo(
-      () => ({ duration, isOpen, isStreaming, setIsOpen }),
-      [duration, isOpen, isStreaming, setIsOpen],
+      () => ({ duration, isOpen, isStreaming, setIsOpen, showConnector }),
+      [duration, isOpen, isStreaming, setIsOpen, showConnector],
     );
 
     return (
       <ReasoningContext.Provider value={contextValue}>
         <Collapsible
-          className={cn('not-prose mb-4', className)}
+          className={cn('not-prose', showConnector ? 'relative mb-0' : 'mb-4', className)}
           onOpenChange={handleOpenChange}
           open={isOpen}
           {...props}
         >
+          {showConnector && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute top-5 -bottom-3 left-2 w-px bg-border"
+            />
+          )}
           {children}
         </Collapsible>
       </ReasoningContext.Provider>
@@ -197,20 +206,25 @@ export type ReasoningContentProps = ComponentProps<typeof CollapsibleContent> & 
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
-export const ReasoningContent = memo(({ className, children, ...props }: ReasoningContentProps) => (
-  <CollapsibleContent
-    className={cn(
-      'mt-4 text-sm',
-      'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
-      className,
-    )}
-    {...props}
-  >
-    <Streamdown plugins={streamdownPlugins} components={{ pre: AiPre }}>
-      {children}
-    </Streamdown>
-  </CollapsibleContent>
-));
+export const ReasoningContent = memo(({ className, children, ...props }: ReasoningContentProps) => {
+  const { showConnector } = useReasoning();
+
+  return (
+    <CollapsibleContent
+      className={cn(
+        'mt-4 text-sm',
+        showConnector && 'pl-4',
+        'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
+        className,
+      )}
+      {...props}
+    >
+      <Streamdown plugins={streamdownPlugins} components={{ pre: AiPre }}>
+        {children}
+      </Streamdown>
+    </CollapsibleContent>
+  );
+});
 
 Reasoning.displayName = 'Reasoning';
 ReasoningTrigger.displayName = 'ReasoningTrigger';


### PR DESCRIPTION
## 变更说明

- 为流式执行步骤增加连续竖线，轨道与思考图标垂直中线对齐
- 思考内容布局在轨道右侧；工具卡、错误卡和孤立工具结果仅在卡片之间连接，避免竖线穿过卡片或图标
- 中间及最终 answer 与步骤内容左对齐，并保持 answer 不参与竖线连接
- 移除执行详情中的工具数、完成数和失败数统计行

## 验证

- `npm run lint`
- `npm run build`
- `node_modules/.bin/vitest.cmd run src/renderer/components/cowork`（5 个测试文件，26 项测试通过）

## 影响范围

- 仅影响 Cowork 渲染器中的流式执行步骤布局
- 不涉及 IPC、存储或 Agent 执行逻辑