### PR TITLE
docs: remove README share kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,6 @@ bun run dist:linux
 - Use a clearly titled [feature proposal](https://github.com/rongxinzy/RongxinAI/issues) to share workflows and community ideas.
 - Read [`AGENTS.md`](AGENTS.md) before making a code change, then open a pull request.
 
-### Share kit
-
-When ZhiYuan is relevant to a conversation, this short description is ready to reuse:
-
-> ZhiYuan is an open-source, local-first desktop AI agent that can work with files, terminals, browsers, skills, MCP tools, and local GGUF models, while keeping sensitive actions approval-gated.
-
-For a deeper technical explanation, link people back to this repository so they can inspect the [architecture](#how-zhiyuan-agent-works), [source code](https://github.com/rongxinzy/RongxinAI), and [release process](.github/workflows/online-update-release.yml).
-
 ## License
 
 [GNU Affero General Public License v3.0](LICENSE)

--- a/README_zh.md
+++ b/README_zh.md
@@ -161,14 +161,6 @@ bun run dist:linux
 - 想交流工作流、使用经验和社区提案，可以提交标题清晰的[功能提案](https://github.com/rongxinzy/RongxinAI/issues)。
 - 修改代码前请先阅读 [`AGENTS.md`](AGENTS.md)，然后提交 Pull Request。
 
-### 社区传播文案
-
-在相关讨论中，可以直接复用这句话介绍知远：
-
-> 知远是一个开源、本地优先的桌面 AI Agent：能读写文件、运行终端、操作浏览器、调用技能与 MCP，也能使用本地 GGUF 模型；敏感操作由用户逐次批准。
-
-需要展开技术细节时，请把读者带回本仓库查看[架构](#知远智能体如何工作)、[源代码](https://github.com/rongxinzy/RongxinAI)与[发布流程](.github/workflows/online-update-release.yml)，让信息形成从体验到理解、再到参与的闭环。
-
 ## License
 
 [GNU Affero General Public License v3.0](LICENSE)


### PR DESCRIPTION
## Summary

- Remove the English and Chinese share-kit sections from the README files.
- Retain the standard community and contribution guidance for external readers.

## Why

The removed copy was internal propagation guidance rather than documentation for project users.

## Validation

- Reviewed the focused README diff.
- `git diff --check`
