### PR TITLE
ci: scope reusable workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- remove the unused pull-requests read permission from the reusable CI workflow
- allow tag-triggered online releases to call the shared Bun lint/test workflow

## Validation
- actionlint

This fixes the startup failure on v2026.7.28-build.7. A fresh immutable tag will be created after merge.