### PR TITLE
feat(bdtl): 修改了本地模型和日志侧边栏的交互

### DIFF
--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -697,7 +697,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
           <LocalInferenceToastView toast={toast} onClose={dismissToast} />
         </div>
       )}
-        <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
         <div className="min-w-0 flex-1 overflow-y-auto scrollbar-gutter-stable [overflow-anchor:none]">
           <div className="w-full space-y-4 px-6 py-4">
             {activeTab === 'models' ? (
@@ -753,6 +753,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                   onOpenLaunchLog={launchLogs.openPanelForModel}
                   showRegisteredModelsTitle={false}
                   logPanelVisible={launchLogs.state.visible}
+                  logPanelModelName={launchLogs.state.modelName}
                 />
             </LayeredTabsContent>
             <LayeredTabsContent

--- a/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
+++ b/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
@@ -4,7 +4,7 @@ import { LocalInferenceLogViewer } from './LocalInferenceLogViewer';
 import { cn } from '@shared/lib/utils';
 import { Download, X } from 'lucide-react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { LlamaCppModelLaunchLogEvent } from '../../../../shared/llamacpp';
 import {
@@ -17,8 +17,9 @@ import type { ModelLaunchLogPanelState } from '../hooks/useModelLaunchLogs';
 import { ModelLaunchLogPanelStatus } from '../hooks/useModelLaunchLogs';
 
 const MODEL_LAUNCH_LOG_SIDEBAR_MIN_WIDTH = 300;
-const MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH = 720;
+const MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH = 560;
 const MODEL_LAUNCH_LOG_MAIN_CONTENT_MIN_WIDTH = 520;
+const MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT = 900;
 const MODEL_LAUNCH_LOG_DETAIL_SEPARATOR = ' ';
 
 const LlamaCppProcessLogMessage = {
@@ -42,11 +43,33 @@ export function ModelLaunchLogSidebar({
   const [isPresent, setIsPresent] = useState(state.visible);
   const [isEntered, setIsEntered] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
-  const [sidebarWidth, setSidebarWidth] = useState(getMaxSidebarWidth);
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [sidebarWidth, setSidebarWidth] = useState(() => getMaxSidebarWidth());
+
+  useEffect(() => {
+    const container = sidebarRef.current?.parentElement;
+    if (!container) return;
+
+    const updateContainerWidth = () => {
+      setContainerWidth(container.getBoundingClientRect().width);
+    };
+    updateContainerWidth();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const resizeObserver = new ResizeObserver(updateContainerWidth);
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (containerWidth <= 0) return;
+    setSidebarWidth(current => Math.min(current, getMaxSidebarWidth(containerWidth)));
+  }, [containerWidth]);
 
   useEffect(() => {
     if (state.visible) {
-      setSidebarWidth(getMaxSidebarWidth());
+      setSidebarWidth(getMaxSidebarWidth(containerWidth));
       setIsPresent(true);
       const frame = window.requestAnimationFrame(() => {
         setIsEntered(true);
@@ -61,10 +84,11 @@ export function ModelLaunchLogSidebar({
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS);
 
     return () => window.clearTimeout(timeout);
-  }, [state.visible]);
+  }, [containerWidth, state.visible]);
 
   const isPanelEntered = state.visible && isEntered;
   const isPanelPresent = state.visible || isPresent;
+  const isCompact = containerWidth > 0 && containerWidth < MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT;
   const handleDownloadLogs = () => {
     if (state.logs.length === 0) return;
 
@@ -96,7 +120,7 @@ export function ModelLaunchLogSidebar({
 
     const handlePointerMove = (moveEvent: PointerEvent) => {
       const nextWidth = startWidth + startX - moveEvent.clientX;
-      setSidebarWidth(clampSidebarWidth(nextWidth));
+      setSidebarWidth(clampSidebarWidth(nextWidth, getMaxSidebarWidth(containerWidth)));
     };
 
     const handlePointerEnd = () => {
@@ -116,9 +140,11 @@ export function ModelLaunchLogSidebar({
   return (
     <aside
       aria-hidden={!state.visible}
+      ref={sidebarRef}
       className={cn(
-        'relative flex h-full shrink-0 border-l bg-background ease-in-out',
+        'flex h-full border-l bg-background ease-in-out',
         'overflow-hidden transition-[width,border-color]',
+        isCompact ? 'absolute inset-y-0 right-0 z-20 shadow-xl' : 'relative shrink-0',
         isPanelPresent ? 'border-border' : 'border-transparent',
       )}
       style={{
@@ -219,18 +245,30 @@ function ModelLaunchLogSidebarToolbar({
     </header>
   );
 }
-function clampSidebarWidth(width: number): number {
-  return Math.min(Math.max(width, MODEL_LAUNCH_LOG_SIDEBAR_MIN_WIDTH), getMaxSidebarWidth());
+function clampSidebarWidth(width: number, maxWidth = getMaxSidebarWidth()): number {
+  return Math.min(
+    Math.max(width, MODEL_LAUNCH_LOG_SIDEBAR_MIN_WIDTH),
+    Math.max(MODEL_LAUNCH_LOG_SIDEBAR_MIN_WIDTH, maxWidth),
+  );
 }
 
-function getMaxSidebarWidth(): number {
-  if (typeof window === 'undefined') return MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH;
+function getMaxSidebarWidth(containerWidth = 0): number {
+  const availableWidth =
+    containerWidth > 0
+      ? containerWidth
+      : typeof window === 'undefined'
+        ? MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH
+        : window.innerWidth;
+
+  if (availableWidth < MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT) {
+    return Math.min(MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH, availableWidth);
+  }
 
   return Math.max(
     MODEL_LAUNCH_LOG_SIDEBAR_MIN_WIDTH,
     Math.min(
       MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH,
-      window.innerWidth - MODEL_LAUNCH_LOG_MAIN_CONTENT_MIN_WIDTH,
+      availableWidth - MODEL_LAUNCH_LOG_MAIN_CONTENT_MIN_WIDTH,
     ),
   );
 }

--- a/src/renderer/components/localInference/panels/ModelsPanel.tsx
+++ b/src/renderer/components/localInference/panels/ModelsPanel.tsx
@@ -82,7 +82,9 @@ const modelProviderIconMap = {
 const MODEL_CARD_MAX_VISIBLE_TAGS = 6;
 const MODEL_PAGE_SIZE_WITHOUT_LOG = 16;
 const MODEL_PAGE_SIZE_WITH_LOG = 8;
+const MODEL_PAGE_SIZE_WITH_SINGLE_COLUMN_LOG = 4;
 const MODEL_PAGE_GRID_COLUMNS_WITH_LOG = 2;
+const MODEL_PAGE_GRID_COLUMNS_WITH_SINGLE_COLUMN_LOG = 1;
 const MODEL_PAGE_GRID_COLUMNS_WIDE = 4;
 const MODEL_CARD_LAYOUT_TRANSITION_SECONDS =
   LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS / 1000;
@@ -113,6 +115,7 @@ type ModelsPanelProps = {
   ) => React.ReactNode;
   showRegisteredModelsTitle?: boolean;
   logPanelVisible?: boolean;
+  logPanelModelName?: string | null;
 };
 
 type ModelCardProps = {
@@ -171,15 +174,18 @@ export function ModelsPanel({
   renderLoadButton,
   showRegisteredModelsTitle = true,
   logPanelVisible = false,
+  logPanelModelName = null,
 }: ModelsPanelProps) {
   const [pendingDeleteModel, setPendingDeleteModel] = useState<LlamaCppModel | null>(null);
   const [modelOrder, setModelOrder] = useState<string[]>(readLocalModelOrder);
   const [draggedModelName, setDraggedModelName] = useState<string | null>(null);
   const [modelPage, setModelPage] = useState(1);
   const [logPanelLayoutVisible, setLogPanelLayoutVisible] = useState(logPanelVisible);
+  const [logPanelGridColumns, setLogPanelGridColumns] = useState(MODEL_PAGE_GRID_COLUMNS_WITH_LOG);
   const [frozenLayout, setFrozenLayout] = useState<FrozenModelCardLayout | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
   const previousLogPanelVisibleRef = useRef(logPanelVisible);
+  const previousModelsPerPageRef = useRef<number | null>(null);
   const modelCardTransitionIdRef = useRef(0);
   const latestGridLayoutRef = useRef<Pick<
     FrozenModelCardLayout,
@@ -205,12 +211,16 @@ export function ModelsPanel({
     });
   }, [availableModels, orderedModelNames, runningModels]);
   const modelsPerPage = logPanelLayoutVisible
-    ? MODEL_PAGE_SIZE_WITH_LOG
+    ? logPanelGridColumns === MODEL_PAGE_GRID_COLUMNS_WITH_SINGLE_COLUMN_LOG
+      ? MODEL_PAGE_SIZE_WITH_SINGLE_COLUMN_LOG
+      : MODEL_PAGE_SIZE_WITH_LOG
     : MODEL_PAGE_SIZE_WITHOUT_LOG;
   const totalModelPages = Math.max(1, Math.ceil(modelCards.length / modelsPerPage));
   const currentModelPage = Math.min(modelPage, totalModelPages);
   const modelGridClassName = logPanelLayoutVisible
-    ? 'grid-cols-2'
+    ? logPanelGridColumns === MODEL_PAGE_GRID_COLUMNS_WITH_SINGLE_COLUMN_LOG
+      ? 'grid-cols-1'
+      : 'grid-cols-2'
     : 'grid-cols-2 2xl:grid-cols-4';
   const visibleModelCards = modelCards.slice(
     (currentModelPage - 1) * modelsPerPage,
@@ -225,11 +235,16 @@ export function ModelsPanel({
 
     if (measuredLayout) {
       modelCardTransitionIdRef.current += 1;
+      const targetColumns = getTargetModelGridColumns(
+        logPanelVisible,
+        measuredLayout.sourceColumns,
+      );
       setFrozenLayout({
         id: modelCardTransitionIdRef.current,
         ...measuredLayout,
-        targetColumns: getTargetModelGridColumns(logPanelVisible),
+        targetColumns,
       });
+      setLogPanelGridColumns(targetColumns);
     }
     setLogPanelLayoutVisible(logPanelVisible);
 
@@ -250,8 +265,18 @@ export function ModelsPanel({
   });
 
   useEffect(() => {
-    setModelPage(1);
-  }, [modelsPerPage]);
+    const previousModelsPerPage = previousModelsPerPageRef.current;
+    if (previousModelsPerPage === modelsPerPage) return;
+    previousModelsPerPageRef.current = modelsPerPage;
+    const anchorIndex = logPanelModelName
+      ? modelCards.findIndex(({ model }) => model.name === logPanelModelName)
+      : -1;
+    if (anchorIndex >= 0) {
+      setModelPage(Math.floor(anchorIndex / modelsPerPage) + 1);
+      return;
+    }
+    setModelPage(currentPage => Math.min(currentPage, totalModelPages));
+  }, [logPanelModelName, modelCards, modelsPerPage, totalModelPages]);
 
   useEffect(() => {
     if (modelPage > totalModelPages) setModelPage(totalModelPages);
@@ -426,8 +451,13 @@ function getModelCardGridPosition(index: number, columns: number): { column: num
   };
 }
 
-function getTargetModelGridColumns(logPanelVisible: boolean): number {
-  if (logPanelVisible) return MODEL_PAGE_GRID_COLUMNS_WITH_LOG;
+function getTargetModelGridColumns(logPanelVisible: boolean, sourceColumns?: number): number {
+  if (logPanelVisible) {
+    return Math.max(
+      MODEL_PAGE_GRID_COLUMNS_WITH_SINGLE_COLUMN_LOG,
+      Math.floor((sourceColumns ?? MODEL_PAGE_GRID_COLUMNS_WITH_LOG) / 2),
+    );
+  }
   return window.matchMedia('(min-width: 1536px)').matches
     ? MODEL_PAGE_GRID_COLUMNS_WIDE
     : MODEL_PAGE_GRID_COLUMNS_WITH_LOG;
@@ -447,7 +477,6 @@ function measureModelGridLayout(
     .split(' ')
     .filter(Boolean)
     .length;
-
   return {
     width: cardRect.width,
     height: cardRect.height,


### PR DESCRIPTION
## 修改概述

  优化本地推理页面打开日志侧栏后的响应式布局，避免模型卡片被过度压缩或变形。

  ## 关联问题

  暂无关联问题。

  ## 修改内容

  - 将日志侧栏最大宽度限制为 560px。
  - 为模型区域保留至少 520px 的显示空间。
  - 根据实际内容区域宽度动态调整日志侧栏尺寸。
  - 内容区域小于 900px 时，日志侧栏改为覆盖显示。
  - 保留模型列数自适应逻辑：4 列变为 2 列，2 列变为 1 列。
  - 单列模式下每页显示 4 张模型卡片。
  - 根据打开日志的模型自动定位对应分页。

  ## 修改类型

  - [x] 问题修复
  - [ ] 新增功能
  - [ ] 不兼容的变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试情况

  - [x] 已完成本地验证
  - [ ] 已新增测试
  - [ ] 已更新现有测试
  - [ ] 已完成手动页面验证

  已通过以下检查：

  - npm run lint
  - npm run build
  - git diff --check

  ## 页面截图

  暂未添加。

  ## 检查清单

  - [x] 代码符合项目规范
  - [x] 已完成代码自查
  - [ ] 已为复杂逻辑补充代码注释
  - [ ] 已同步更新相关文档
  - [ ] 未产生新的警告
  - [ ] 已添加验证修改效果的测试
  - [ ] 新旧单元测试均已通过

  ## 桌面应用相关变更

  - [ ] 修改主进程代码
  - [ ] 修改预加载脚本
  - [ ] 修改进程间通信
  - [ ] 修改窗口管理逻辑
  - [x] 无相关变更

  ## 补充说明

  本次修改仅涉及本地推理页面的前端布局，不涉及主进程、进程间通信和窗口管理逻辑。