### PR TITLE
fix: 技能管理页面工具栏与列表布局微调

### DIFF
--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -744,7 +744,6 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
           <SkillsPageToolbar
             activeTab={activeTab}
             installedCount={installedSkills.length}
-            marketplaceCount={marketplaceSkills.length}
             searchQuery={skillSearchQuery}
             isAddMenuOpen={isAddSkillMenuOpen}
             isDownloading={isDownloadingSkill}
@@ -763,7 +762,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
           {activeTab === SkillTab.Installed && (
-            <div className="h-full overflow-y-auto">
+            <div className="flex h-full min-h-0 flex-col overflow-y-auto">
               <div
                 className={cn(
                   'mb-4 flex w-full min-h-9 flex-wrap items-center gap-3 px-1 text-sm text-muted-foreground',
@@ -861,17 +860,19 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
                   </>
                 )}
               </div>
-              <InstalledSkillGrid
-                skills={paginatedInstalledSkills}
-                readOnly={readOnly}
-                onSelect={setSelectedSkill}
-                onToggle={handleToggleSkill}
-                onTrySkill={onTrySkill}
-                resolveName={resolveSkillName}
-                selectedIds={isBatchMode ? selectedVisibleIds : new Set()}
-                onSelectToggle={toggleInstalledSelection}
-                batchMode={isBatchMode}
-              />
+              <div className="flex-1">
+                <InstalledSkillGrid
+                  skills={paginatedInstalledSkills}
+                  readOnly={readOnly}
+                  onSelect={setSelectedSkill}
+                  onToggle={handleToggleSkill}
+                  onTrySkill={onTrySkill}
+                  resolveName={resolveSkillName}
+                  selectedIds={isBatchMode ? selectedVisibleIds : new Set()}
+                  onSelectToggle={toggleInstalledSelection}
+                  batchMode={isBatchMode}
+                />
+              </div>
               <ListPagination
                 page={installedPageNumber}
                 totalPages={installedPageCount}
@@ -884,7 +885,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
           {activeTab === SkillTab.Marketplace &&
             (isLoadingMarketplace ? (
               <div className="text-center py-12 text-sm text-muted-foreground">
-                {i18nService.t('downloadingSkill')}
+                {i18nService.t('loading')}
               </div>
             ) : (
               <div className="h-full overflow-y-auto pr-2">
@@ -901,7 +902,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
                 />
                 {isLoadingMoreMarketplace && (
                   <div className="py-4 text-center text-sm text-muted-foreground">
-                    {i18nService.t('downloadingSkill')}
+                    {i18nService.t('loading')}
                   </div>
                 )}
                 <ListPagination

--- a/src/renderer/components/skills/SkillsPageToolbar.tsx
+++ b/src/renderer/components/skills/SkillsPageToolbar.tsx
@@ -34,7 +34,6 @@ import { isSkillTab, SkillTab } from './constants';
 interface SkillsPageToolbarProps {
   activeTab: SkillTab;
   installedCount: number;
-  marketplaceCount: number;
   searchQuery: string;
   isAddMenuOpen: boolean;
   isDownloading: boolean;
@@ -52,7 +51,6 @@ interface SkillsPageToolbarProps {
 export function SkillsPageToolbar({
   activeTab,
   installedCount,
-  marketplaceCount,
   searchQuery,
   isAddMenuOpen,
   isDownloading,
@@ -152,7 +150,6 @@ export function SkillsPageToolbar({
             </TabsTrigger>
             <TabsTrigger value={SkillTab.Marketplace} className="after:bottom-[-1px] after:h-1">
               {i18nService.t('skillMarketplace')}
-              {marketplaceCount > 0 ? <Badge variant="secondary">{marketplaceCount}</Badge> : null}
             </TabsTrigger>
           </TabsList>
         </Tabs>


### PR DESCRIPTION
## 变更内容

- SkillsManager 移除未使用的 marketplaceCount
- InstalledSkillGrid 布局调整为 flex 列布局

## 变更原因

清理冗余 props，修复列表布局。