### PR TITLE
feat(issue): 优化了本地模型卡片的启动按钮交互效果

### DIFF
--- a/src/renderer/components/localInference/panels/ModelsPanel.tsx
+++ b/src/renderer/components/localInference/panels/ModelsPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@shared/components/ui/hover-card';
 import { Spinner } from '@shared/components/ui/spinner';
 import { cn } from '@shared/lib/utils';
-import { Box, Clock3, Play, Settings2, Square } from 'lucide-react';
+import { Box, Clock3, Settings2 } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import {
   type ComponentType,
@@ -668,6 +668,7 @@ function ModelCard({
               type="button"
               variant="outline"
               size="sm"
+              className="cursor-pointer hover:bg-background hover:shadow-lg hover:shadow-foreground/10"
               disabled={buttonsDisabled}
               onClick={onConfigureContext}
             >
@@ -723,12 +724,12 @@ function ModelCard({
                 type="button"
                 variant="danger"
                 size="sm"
+                className="h-8 min-w-16 px-3"
                 isDisabled={buttonsDisabled}
                 data-local-inference-model-action-button="true"
                 data-local-inference-unload-button="true"
                 onClick={onUnload}
               >
-                <Square data-icon="inline-start" />
                 {i18nService.t('close')}
               </Button21st>
             ) : renderLoadButton ? (
@@ -737,11 +738,11 @@ function ModelCard({
               <Button21st
                 type="button"
                 size="sm"
+                className="h-8 min-w-16 px-3"
                 isDisabled={buttonsDisabled}
                 data-local-inference-model-action-button="true"
                 onClick={onLoadModel}
               >
-                <Play data-icon="inline-start" />
                 {i18nService.t('start')}
               </Button21st>
             )}

--- a/src/shared/components/ui/button-21st-variants.ts
+++ b/src/shared/components/ui/button-21st-variants.ts
@@ -1,14 +1,14 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 const button21stSurfaceClassName = [
-  'bg-surface shadow-sm',
-  'hover:bg-surface-tertiary hover:shadow-md',
+  'bg-background shadow-none',
+  'hover:shadow-lg hover:shadow-foreground/10',
   'active:shadow-inset',
 ].join(' ');
 
 const button21stVariants = cva(
   [
-    'group/button-21st relative isolate inline-flex shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-3xl border text-sm font-semibold whitespace-nowrap outline-none select-none',
+    'group/button-21st relative isolate inline-flex shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-md border text-sm leading-tight font-medium whitespace-nowrap outline-none select-none',
     'transition-[background-color,border-color,box-shadow,filter] duration-200 ease-out',
     'focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50',
     "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -41,7 +41,7 @@ const button21stVariants = cva(
       },
       size: {
         default: 'h-10 gap-1.5 px-5',
-        sm: 'h-9 gap-1.5 px-4 text-xs',
+        sm: 'h-9 gap-1.5 px-4 text-[0.8rem]',
         lg: 'h-12 gap-2 px-7',
         icon: 'size-10 p-0',
       },


### PR DESCRIPTION
## Summary

  统一本地推理模型卡片及设置界面的浅色/深色主题表现，优化按钮交互和视觉样式。

  ## Related Issue

  Fixes #<issue-number>

  ## Changes Made

  - 修复模型启动按钮在深色模式下的颜色、文字对比度和悬停阴影问题。
  - 修复启动日志图标不显示问题，统一时间信息与时钟图标，并移除模型卡片中的量化标签。
  - 移除启动/关闭按钮图标，调整按钮尺寸、字体、宽度和居中布局。
  - 统一配置上下文按钮与启动按钮的悬停阴影和鼠标手型。
  - 统一设置界面保存按钮与取消按钮的显色风格。
  - 复用通用设置开关组件，修复休眠开关点击时出现禁止光标的问题。

  ## Type of Change

  - [x] Bug fix（非破坏性问题修复）
  - [ ] New feature（非破坏性新功能）
  - [ ] Breaking change（破坏性变更）
  - [x] Code refactoring（代码重构）
  - [ ] Documentation update（文档更新）
  - [ ] Performance improvement（性能优化）
  - [ ] Other

  ## Testing

  - [x] Tested locally
  - [ ] Added new tests
  - [ ] Updated existing tests
  - [ ] Manual testing performed

  已通过：

  - `npm run lint`
  - `npm run build:tsc`
  - `git diff --check`

  ## Screenshots (if applicable)

  已附上模型卡片及设置界面浅色/深色模式相关截图。

  ## Checklist

  - [x] 代码符合项目样式规范
  - [x] 已完成代码自检
  - [x] 必要位置已添加代码注释
  - [ ] 已同步更新相关文档
  - [x] 未产生新的 lint 警告
  - [ ] 已添加自动化测试
  - [ ] 新增及现有单元测试均已通过

  ## Electron-Specific Changes

  - [ ] 修改主进程（`src/main/`）
  - [ ] 修改预加载脚本（`src/main/preload.ts`）
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] None（无 Electron 特定修改）

  ## Additional Notes

  完整生产构建暂未完成，原因是本地 Tailwind Oxide Windows 原生依赖无法加载。TypeScript 编译和 lint 验证已成功通过。
