### PR TITLE
feat(cowork): 重绘「+」菜单会话专家图标

### DIFF
--- a/src/renderer/components/cowork/plusMenuIcons.tsx
+++ b/src/renderer/components/cowork/plusMenuIcons.tsx
@@ -40,16 +40,13 @@ export const PlusMenuSkillsIcon: React.FC<PlusMenuIconProps> = ({ className }) =
   </svg>
 );
 
-/** 会话专家：人物与肩部星标。 */
+/** 会话专家：学位帽人物（学者意象）。 */
 export const PlusMenuExpertsIcon: React.FC<PlusMenuIconProps> = ({ className }) => (
   <svg {...baseProps} className={className}>
-    <circle cx="7" cy="5.6" r="2.3" />
-    <path d="M2.8 13.4c.7-2.4 2.3-3.6 4.2-3.6s3.5 1.2 4.2 3.6" />
-    <path
-      d="M12.4 2.2l.65 1.3 1.45.2-1.05 1 .25 1.45-1.3-.7-1.3.7.25-1.45-1.05-1 1.45-.2z"
-      fill="currentColor"
-      stroke="none"
-    />
+    <path d="M8 2.4l6 2.5-6 2.5-6-2.5z" />
+    <path d="M5.3 6.3v2.2c0 1 1.2 1.7 2.7 1.7s2.7-.7 2.7-1.7V6.3" />
+    <path d="M14 5v2.8" />
+    <path d="M3.7 13.8c.7-1.9 2.3-2.9 4.3-2.9s3.6 1 4.3 2.9" />
   </svg>
 );
 


### PR DESCRIPTION
## 概述

重绘 Work 模式「+」菜单中「会话专家」子菜单的触发图标：原「人物 + 肩部星标」在 16px 下星标粘连、辨识差。

## 方案

从三个渲染候选中评选（均有明暗两色、16/32/48px 三档截图）：

- A 学位帽人物 ✅ —— 学者意象最贴合「专家」语义，16px 仍可辨
- B 奖章人物 —— 奖章与人形在小尺寸下糊在一起，淘汰
- C 纯奖章 —— 最干净但语义偏「成就」而非「专家」，备选

专家列表行继续用简洁的人形图标（子项代表具体的人，语义正确）。

## 验证

tsc + oxlint 全绿；图标经 Playwright 实际渲染自检。