### PR TITLE
feat(skills): 已挂载技能胶囊改为蓝色功能色样式

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -69,6 +69,7 @@ Tailwind 工具类经 `index.css` 中 `@theme` 块桥接：`--color-background: 
 | 边框     | `border` / `border-subtle`                    | 分隔线、控件描边                                       |
 | 强调     | `primary` / `primary-hover` / `primary-muted` | 唯一的品牌强调色，用于主按钮、激活态、链接、focus ring |
 | 状态     | `destructive` / `success` / `warning`         | 仅用于语义状态，不作装饰                               |
+| 技能着色 | `skill-blue`（`--zy-skill-blue-foreground/background`） | 已挂载技能胶囊（ActiveSkillBadge）的文字与 hover 底色；唯一的功能性蓝色例外，不推广到其他元素 |
 
 ### 当前色值参考（Light）
 

--- a/src/renderer/components/skills/ActiveSkillBadge.tsx
+++ b/src/renderer/components/skills/ActiveSkillBadge.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@shared/components/ui/badge';
 import { Button } from '@shared/components/ui/button';
 import { Puzzle, X } from 'lucide-react';
 import React from 'react';
@@ -32,7 +31,7 @@ const SkillChip: React.FC<SkillChipProps> = ({ skillId, skill, onRemove }) => {
   const ShortcutIcon = shortcut?.icon;
 
   return (
-    <Badge variant="outline" className="gap-1.5 pl-1.5 pr-1 text-foreground">
+    <span className="inline-flex h-6 items-center gap-1.5 rounded-full pl-1.5 pr-1 text-xs font-medium text-(--zy-skill-blue-foreground) transition-colors hover:bg-(--zy-skill-blue-background)">
       {skill?.iconUrl ? (
         <img
           src={resolveSkillIconUrl(skill.iconUrl)}
@@ -40,20 +39,20 @@ const SkillChip: React.FC<SkillChipProps> = ({ skillId, skill, onRemove }) => {
           className="size-3.5 object-contain"
         />
       ) : ShortcutIcon ? (
-        <ShortcutIcon className="size-3.5 text-muted-foreground" />
+        <ShortcutIcon className="size-3.5" />
       ) : (
-        <Puzzle className="size-3.5 text-muted-foreground" />
+        <Puzzle className="size-3.5" />
       )}
       <span className="max-w-24 truncate">{label}</span>
       <button
         type="button"
         onClick={onRemove}
         title={i18nService.t('clearSkill')}
-        className="ml-0.5 rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-(--zy-skill-blue-foreground)/10"
       >
         <X className="size-3" />
       </button>
-    </Badge>
+    </span>
   );
 };
 

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -40,6 +40,8 @@
   --zy-model-tag-green-background: oklch(0.96 0.025 155);
   --zy-model-tag-green-foreground: oklch(0.45 0.1 155);
   --zy-model-tag-green-border: oklch(0.89 0.05 155);
+  --zy-skill-blue-background: oklch(0.9567 0.0211 252.5);
+  --zy-skill-blue-foreground: oklch(0.6234 0.2055 256.39);
   --zy-scroll-thumb: oklch(0.709 0.01 56.259);
   --zy-scroll-thumb-hover: oklch(0.553 0.013 58.071);
   --zy-gradient-1: oklch(0.97 0.001 106.424);
@@ -100,6 +102,8 @@
   --zy-model-tag-green-background: oklch(0.29 0.05 155);
   --zy-model-tag-green-foreground: oklch(0.84 0.08 155);
   --zy-model-tag-green-border: oklch(0.39 0.07 155);
+  --zy-skill-blue-background: oklch(0.3 0.05 256);
+  --zy-skill-blue-foreground: oklch(0.78 0.13 256);
   --zy-scroll-thumb: oklch(0.553 0.013 58.071);
   --zy-scroll-thumb-hover: oklch(0.709 0.01 56.259);
   --zy-gradient-1: oklch(0.268 0.007 34.298);

--- a/src/renderer/theme/themes/classic-dark.ts
+++ b/src/renderer/theme/themes/classic-dark.ts
@@ -33,6 +33,8 @@ export const classicDark: ThemeDefinition = {
     'model-tag-violet-background': 'oklch(0.3 0.06 300)',
     'model-tag-violet-foreground': 'oklch(0.83 0.08 300)',
     'model-tag-violet-border': 'oklch(0.42 0.08 300)',
+    'skill-blue-background': 'oklch(0.3 0.05 256)',
+    'skill-blue-foreground': 'oklch(0.78 0.13 256)',
     'model-tag-green-background': 'oklch(0.29 0.05 155)',
     'model-tag-green-foreground': 'oklch(0.84 0.08 155)',
     'model-tag-green-border': 'oklch(0.39 0.07 155)',

--- a/src/renderer/theme/themes/classic-light.ts
+++ b/src/renderer/theme/themes/classic-light.ts
@@ -36,6 +36,8 @@ export const classicLight: ThemeDefinition = {
     'model-tag-green-background': 'oklch(0.96 0.025 155)',
     'model-tag-green-foreground': 'oklch(0.45 0.1 155)',
     'model-tag-green-border': 'oklch(0.89 0.05 155)',
+    'skill-blue-background': 'oklch(0.9567 0.0211 252.5)',
+    'skill-blue-foreground': 'oklch(0.6234 0.2055 256.39)',
     'text-primary': 'oklch(0.147 0.004 49.25)',
     'text-muted-foreground': 'oklch(0.553 0.013 58.071)',
     'text-muted': 'oklch(0.553 0.013 58.071)',

--- a/src/renderer/theme/tokens/contract.ts
+++ b/src/renderer/theme/tokens/contract.ts
@@ -40,6 +40,8 @@ export const TOKEN_CONTRACT = {
   'model-tag-green-background': '--zy-model-tag-green-background',
   'model-tag-green-foreground': '--zy-model-tag-green-foreground',
   'model-tag-green-border': '--zy-model-tag-green-border',
+  'skill-blue-background': '--zy-skill-blue-background',
+  'skill-blue-foreground': '--zy-skill-blue-foreground',
 
   // ── Text hierarchy ──
   'text-primary': '--zy-text-primary',


### PR DESCRIPTION
## 概述

ActiveSkillBadge 从带边框的中性 Badge 改为 Kimi 式功能色胶囊：

- 静止：无边框无背景，蓝色（#1783ff）图标 + 文字
- hover：淡蓝色（#e7f2ff）胶囊底色浮现，关闭 X 同色系
- 深色主题使用对应的深色 token 值

## Token

新增 `--zy-skill-blue-foreground` / `--zy-skill-blue-background`（contract.ts、classic-light/dark、themes.css 四处同步，浅色值精确等于 #1783ff / #e7f2ff 的 oklch）。DESIGN.md 已登记为唯一的功能性蓝色例外，仅限技能胶囊使用。

## 验证

- tsc + oxlint 全绿，skillManager 25 单测通过
- 已用 Playwright 对胶囊的 rest/hover × 明/暗四态做截图自检