### PR TITLE
fix(cowork): 文件夹选择行改为左对齐

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1209,8 +1209,8 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
           </PromptInputFooter>
         </PromptInput>
         {showFolderSelector && (
-          <div className="relative mt-1.5 flex justify-center">
-            <FolderSelectorPopover onSelectFolder={handleFolderSelect} side="top" align="center">
+          <div className="relative mt-1.5 flex justify-start">
+            <FolderSelectorPopover onSelectFolder={handleFolderSelect} side="top" align="start">
               <PromptInputButton
                 className={`gap-1.5 rounded-md text-muted-foreground hover:bg-surface-raised hover:text-foreground ${showFolderRequiredWarning ? 'ring-1 ring-warning text-warning animate-shake' : ''}`}
               >


### PR DESCRIPTION
Work 首页输入框下方的文件夹选择行（`project ▾`）原本居中悬浮，与输入框左边线不对齐。改为左对齐（与输入框左缘齐平），popover 也从同一侧弹出。一行 class 改动 + popover align 调整，tsc/lint 通过。