### PR TITLE
fix(cowork): 修复提示词与 turn 完成状态

### DIFF
--- a/src/main/coworkLanguagePrompt.ts
+++ b/src/main/coworkLanguagePrompt.ts
@@ -27,20 +27,21 @@ const buildLanguagePrompt = (language: CoworkPromptLanguage): string => {
   ].join('\n');
 };
 
-const removePreviousLanguagePrompt = (systemPrompt: string): string => {
-  const start = systemPrompt.indexOf(LANGUAGE_PROMPT_START);
-  if (start < 0) return systemPrompt.trim();
-
-  const end = systemPrompt.indexOf(LANGUAGE_PROMPT_END, start);
-  if (end < 0) return systemPrompt.slice(0, start).trim();
-
-  return `${systemPrompt.slice(0, start)}${systemPrompt.slice(end + LANGUAGE_PROMPT_END.length)}`.trim();
+export const stripCoworkLanguagePrompts = (systemPrompt: string): string => {
+  let result = systemPrompt;
+  while (true) {
+    const start = result.indexOf(LANGUAGE_PROMPT_START);
+    if (start < 0) return result.trim();
+    const end = result.indexOf(LANGUAGE_PROMPT_END, start);
+    if (end < 0) return result.slice(0, start).trim();
+    result = `${result.slice(0, start)}${result.slice(end + LANGUAGE_PROMPT_END.length)}`;
+  }
 };
 
 export const applyCoworkLanguagePrompt = (
   systemPrompt: string | undefined,
   language: CoworkPromptLanguage,
 ): string => {
-  const basePrompt = removePreviousLanguagePrompt(systemPrompt?.trim() || '');
+  const basePrompt = stripCoworkLanguagePrompts(systemPrompt?.trim() || '');
   return [basePrompt, buildLanguagePrompt(language)].filter(Boolean).join('\n\n');
 };

--- a/src/main/coworkPrompt/composer.test.ts
+++ b/src/main/coworkPrompt/composer.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from 'vitest';
+
+import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
+import { applyCoworkLanguagePrompt } from '../coworkLanguagePrompt';
+import { composeCoworkSystemPrompt } from './composer';
+import { ZhiyuanIdentityPrompt } from './constants';
+
+const countOccurrences = (value: string, target: string): number => value.split(target).length - 1;
+
+const expert = (promptSnapshot: string) => ({
+  promptSnapshot,
+});
+
+test('keeps managed prompt sections idempotent across repeated composition', () => {
+  let prompt = 'User-configured instructions.';
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    prompt = composeCoworkSystemPrompt({ basePrompt: prompt, language: 'zh' });
+  }
+
+  expect(countOccurrences(prompt, ZhiyuanIdentityPrompt)).toBe(1);
+  expect(countOccurrences(prompt, buildScheduledTaskEnginePrompt())).toBe(1);
+  expect(countOccurrences(prompt, '<cowork-response-language>')).toBe(1);
+  expect(countOccurrences(prompt, 'User-configured instructions.')).toBe(1);
+});
+
+test('normalizes repeated legacy scheduled-task and language blocks', () => {
+  const scheduledPrompt = buildScheduledTaskEnginePrompt();
+  const legacyPrompt = applyCoworkLanguagePrompt(
+    ['Base prompt', ...Array.from({ length: 10 }, () => scheduledPrompt)].join('\n\n'),
+    'zh',
+  );
+  const composed = composeCoworkSystemPrompt({ basePrompt: legacyPrompt, language: 'en' });
+
+  expect(countOccurrences(composed, scheduledPrompt)).toBe(1);
+  expect(countOccurrences(composed, '<cowork-response-language>')).toBe(1);
+  expect(composed).toContain('The current application language is English.');
+});
+
+test('keeps the selected expert SOP exactly once', () => {
+  const selectedExpert = expert('Follow expert A SOP.');
+  let prompt = composeCoworkSystemPrompt({
+    basePrompt: 'Base prompt',
+    expertSnapshots: [selectedExpert],
+    language: 'zh',
+  });
+  prompt = composeCoworkSystemPrompt({
+    basePrompt: prompt,
+    expertSnapshots: [selectedExpert],
+    previousExpertSnapshots: [selectedExpert],
+    language: 'zh',
+  });
+
+  expect(countOccurrences(prompt, selectedExpert.promptSnapshot)).toBe(1);
+  expect(prompt).not.toContain(ZhiyuanIdentityPrompt);
+});
+
+test('removes the previous expert SOP when the selected expert changes', () => {
+  const previousExpert = expert('Follow expert A SOP.');
+  const nextExpert = expert('Follow expert B SOP.');
+  const previousPrompt = composeCoworkSystemPrompt({
+    basePrompt: 'Base prompt',
+    expertSnapshots: [previousExpert],
+    language: 'zh',
+  });
+  const nextPrompt = composeCoworkSystemPrompt({
+    basePrompt: previousPrompt,
+    expertSnapshots: [nextExpert],
+    previousExpertSnapshots: [previousExpert],
+    language: 'zh',
+  });
+
+  expect(nextPrompt).not.toContain(previousExpert.promptSnapshot);
+  expect(nextPrompt).toContain(nextExpert.promptSnapshot);
+  expect(nextPrompt).not.toContain(ZhiyuanIdentityPrompt);
+});

--- a/src/main/coworkPrompt/composer.ts
+++ b/src/main/coworkPrompt/composer.ts
@@ -1,0 +1,107 @@
+import type { CoworkSessionExpertSnapshot } from '../../shared/cowork/sessionExperts';
+import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
+import {
+  applyCoworkLanguagePrompt,
+  type CoworkPromptLanguage,
+  stripCoworkLanguagePrompts,
+} from '../coworkLanguagePrompt';
+import { CoworkManagedPromptMarker, ZhiyuanIdentityPrompt } from './constants';
+
+type ExpertPromptSnapshot = Pick<CoworkSessionExpertSnapshot, 'promptSnapshot'>;
+
+export interface ComposeCoworkSystemPromptOptions {
+  basePrompt?: string;
+  expertSnapshots?: ExpertPromptSnapshot[];
+  previousExpertSnapshots?: ExpertPromptSnapshot[];
+  language: CoworkPromptLanguage;
+}
+
+const removeDelimitedBlocks = (value: string, startMarker: string, endMarker: string): string => {
+  let result = value;
+  while (true) {
+    const start = result.indexOf(startMarker);
+    if (start < 0) return result;
+    const end = result.indexOf(endMarker, start + startMarker.length);
+    if (end < 0) return result.slice(0, start);
+    result = `${result.slice(0, start)}${result.slice(end + endMarker.length)}`;
+  }
+};
+
+const removeExactText = (value: string, text: string): string =>
+  text ? value.split(text).join('') : value;
+
+const normalizeSectionSpacing = (value: string): string =>
+  value
+    .replace(/[\t ]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+const managedBlock = (start: string, content: string, end: string): string =>
+  [start, content, end].join('\n');
+
+export const stripManagedCoworkPrompt = (
+  systemPrompt: string | undefined,
+  previousExpertSnapshots: ExpertPromptSnapshot[] = [],
+): string => {
+  let result = stripCoworkLanguagePrompts(systemPrompt || '');
+  result = removeDelimitedBlocks(
+    result,
+    CoworkManagedPromptMarker.IdentityStart,
+    CoworkManagedPromptMarker.IdentityEnd,
+  );
+  result = removeDelimitedBlocks(
+    result,
+    CoworkManagedPromptMarker.ScheduledTasksStart,
+    CoworkManagedPromptMarker.ScheduledTasksEnd,
+  );
+  result = removeDelimitedBlocks(
+    result,
+    CoworkManagedPromptMarker.ExpertsStart,
+    CoworkManagedPromptMarker.ExpertsEnd,
+  );
+
+  // Normalize sessions created before managed markers were introduced.
+  result = removeExactText(result, ZhiyuanIdentityPrompt);
+  result = removeExactText(result, buildScheduledTaskEnginePrompt());
+  for (const expert of previousExpertSnapshots) {
+    result = removeExactText(result, expert.promptSnapshot.trim());
+  }
+  return normalizeSectionSpacing(result);
+};
+
+export const composeCoworkSystemPrompt = ({
+  basePrompt,
+  expertSnapshots = [],
+  previousExpertSnapshots = expertSnapshots,
+  language,
+}: ComposeCoworkSystemPromptOptions): string => {
+  const normalizedBasePrompt = stripManagedCoworkPrompt(basePrompt, previousExpertSnapshots);
+  const expertPrompt = expertSnapshots
+    .map(expert => expert.promptSnapshot.trim())
+    .filter(Boolean)
+    .join('\n\n');
+  const sections = [
+    expertPrompt
+      ? null
+      : managedBlock(
+          CoworkManagedPromptMarker.IdentityStart,
+          ZhiyuanIdentityPrompt,
+          CoworkManagedPromptMarker.IdentityEnd,
+        ),
+    managedBlock(
+      CoworkManagedPromptMarker.ScheduledTasksStart,
+      buildScheduledTaskEnginePrompt(),
+      CoworkManagedPromptMarker.ScheduledTasksEnd,
+    ),
+    normalizedBasePrompt,
+    expertPrompt
+      ? managedBlock(
+          CoworkManagedPromptMarker.ExpertsStart,
+          expertPrompt,
+          CoworkManagedPromptMarker.ExpertsEnd,
+        )
+      : null,
+  ].filter((section): section is string => Boolean(section));
+
+  return applyCoworkLanguagePrompt(sections.join('\n\n'), language);
+};

--- a/src/main/coworkPrompt/constants.ts
+++ b/src/main/coworkPrompt/constants.ts
@@ -1,0 +1,18 @@
+export const CoworkManagedPromptMarker = {
+  IdentityStart: '<cowork-managed-identity>',
+  IdentityEnd: '</cowork-managed-identity>',
+  ScheduledTasksStart: '<cowork-managed-scheduled-tasks>',
+  ScheduledTasksEnd: '</cowork-managed-scheduled-tasks>',
+  ExpertsStart: '<cowork-managed-experts>',
+  ExpertsEnd: '</cowork-managed-experts>',
+} as const;
+
+export const ZhiyuanIdentityPrompt = [
+  'You are 知远智能体 (ZhiYuan Agent).',
+  'The official Chinese product name is 知远智能体, and the official English product name is ZhiYuan Agent.',
+  '知远智能体 (ZhiYuan Agent) is a product of 北京容芯致远. Mention the company only when the user asks about product ownership, company background, or brand affiliation.',
+  'Treat 知远智能体 and ZhiYuan Agent as the only official product names. Do not translate, localize, transliterate, shorten, or replace them with any other variant or product identity.',
+  'When the user asks who you are, answer with the official product identity only. In Chinese, say "我是知远智能体。" You may add "英文名是 ZhiYuan Agent。". In English, say "I am ZhiYuan Agent." You may add "My Chinese product name is 知远智能体."',
+  'Do not use any other product name, model name, runtime name, or preset role as your identity.',
+  'OpenClaw, Ollama, and Cowork are implementation details; mention them only when the user asks about the runtime, local models, or integration details.',
+].join('\n');

--- a/src/main/libs/agentEngine/piConversationContext.test.ts
+++ b/src/main/libs/agentEngine/piConversationContext.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest';
+
+import type { CoworkMessage } from '../../coworkStore';
+import { buildPiConversationPrompt } from './piConversationContext';
+
+const message = (
+  id: string,
+  type: CoworkMessage['type'],
+  content: string,
+  metadata?: CoworkMessage['metadata'],
+): CoworkMessage => ({
+  id,
+  type,
+  content,
+  timestamp: 1,
+  metadata,
+});
+
+test('excludes thinking while preserving user, assistant, and tool facts', () => {
+  const prompt = buildPiConversationPrompt(
+    [
+      message('user-1', 'user', 'Inspect the project.'),
+      message('thinking-1', 'assistant', 'Private reasoning.', { isThinking: true }),
+      message('tool-1', 'tool_use', '', {
+        toolName: 'read',
+        toolInput: { path: 'src/app.ts' },
+      }),
+      message('result-1', 'tool_result', 'export const app = true;'),
+      message('answer-1', 'assistant', 'The app entry was found.'),
+    ],
+    'Continue.',
+  );
+
+  expect(prompt).toContain('User: Inspect the project.');
+  expect(prompt).toContain('Tool call (read): {"path":"src/app.ts"}');
+  expect(prompt).toContain('Tool result: export const app = true;');
+  expect(prompt).toContain('Assistant: The app entry was found.');
+  expect(prompt).not.toContain('Private reasoning.');
+  expect(prompt).toContain('User: Continue.');
+});
+
+test('keeps the latest complete entries when recovery context exceeds its budget', () => {
+  const messages = Array.from({ length: 10 }, (_, index) =>
+    message(`user-${index}`, 'user', `${index}:${'x'.repeat(7_900)}`),
+  );
+  const prompt = buildPiConversationPrompt(messages, 'Continue.');
+
+  expect(prompt).not.toContain('User: 0:');
+  expect(prompt).not.toContain('User: 1:');
+  expect(prompt).toContain('User: 9:');
+  expect(prompt.length).toBeLessThan(61_000);
+});

--- a/src/main/libs/agentEngine/piConversationContext.ts
+++ b/src/main/libs/agentEngine/piConversationContext.ts
@@ -1,0 +1,60 @@
+import type { CoworkMessage } from '../../coworkStore';
+
+const PiConversationContextLimit = {
+  TotalChars: 60_000,
+  EntryChars: 8_000,
+} as const;
+
+const truncateEntry = (value: string): string => {
+  const normalized = value.trim();
+  if (normalized.length <= PiConversationContextLimit.EntryChars) return normalized;
+  return `${normalized.slice(0, PiConversationContextLimit.EntryChars)}\n[truncated]`;
+};
+
+const formatHistoryMessage = (message: CoworkMessage): string | null => {
+  if (message.type === 'assistant') {
+    if (message.metadata?.isThinking) return null;
+    const content = truncateEntry(message.content);
+    return content ? `Assistant: ${content}` : null;
+  }
+  if (message.type === 'user') {
+    const content = truncateEntry(message.content);
+    return content ? `User: ${content}` : null;
+  }
+  if (message.type === 'tool_use') {
+    const toolName =
+      typeof message.metadata?.toolName === 'string' ? message.metadata.toolName : 'unknown';
+    const input = message.metadata?.toolInput;
+    const inputText = input ? truncateEntry(JSON.stringify(input)) : '';
+    return `Tool call (${toolName})${inputText ? `: ${inputText}` : ''}`;
+  }
+  if (message.type === 'tool_result') {
+    const content = truncateEntry(message.content || String(message.metadata?.toolResult || ''));
+    return content ? `Tool result: ${content}` : null;
+  }
+  return null;
+};
+
+export const buildPiConversationPrompt = (
+  messages: CoworkMessage[],
+  currentPrompt: string,
+): string => {
+  const entries = messages.map(formatHistoryMessage).filter((entry): entry is string => !!entry);
+  const selected: string[] = [];
+  let selectedChars = 0;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    const nextChars = selectedChars + entry.length + 2;
+    if (nextChars > PiConversationContextLimit.TotalChars) break;
+    selected.unshift(entry);
+    selectedChars = nextChars;
+  }
+  if (selected.length === 0) return currentPrompt;
+  return [
+    '=== PREVIOUS CONVERSATION (context only, do not re-execute) ===',
+    selected.join('\n\n'),
+    '=== END PREVIOUS CONVERSATION ===',
+    '',
+    `User: ${currentPrompt}`,
+  ].join('\n');
+};

--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -35,6 +35,7 @@ declare module '@earendil-works/pi-coding-agent' {
     session: {
       prompt(text: string): Promise<void>;
       abort(): Promise<void>;
+      reload(): Promise<void>;
       setModel(model: unknown): Promise<void>;
       subscribe(
         listener: (event: {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -11,6 +11,7 @@ const hoisted = vi.hoisted(() => {
     prompt: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn().mockResolvedValue(undefined),
     abortBash: vi.fn(),
+    reload: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
     subscribe: vi.fn().mockReturnValue(() => {}),
   };
@@ -332,15 +333,64 @@ describe('PiRuntimeAdapter', () => {
       expect(mockSession.prompt).toHaveBeenCalledTimes(2);
     });
 
-    it('should recreate an active session when its system prompt changes', async () => {
+    it('should reload an active session when its system prompt changes', async () => {
       await adapter.startSession('test', 'First', { systemPrompt: 'You are the original expert.' });
       await adapter.continueSession('test', 'Second', {
         systemPrompt: 'You are the replacement expert.',
       });
 
-      expect(mockSession.abort).toHaveBeenCalled();
-      expect(mockDefaultResourceLoader).toHaveBeenCalledTimes(2);
+      expect(mockSession.reload).toHaveBeenCalledOnce();
+      expect(mockSession.abort).not.toHaveBeenCalled();
+      expect(mockDefaultResourceLoader).toHaveBeenCalledOnce();
+      expect(mockCreateAgentSession).toHaveBeenCalledOnce();
       expect(mockSession.prompt).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not reload or recreate an active session when resources are unchanged', async () => {
+      const options = { systemPrompt: 'Stable prompt', skillIds: ['skill-b', 'skill-a'] };
+      await adapter.startSession('test', 'First', options);
+      await adapter.continueSession('test', 'Second', options);
+      await adapter.continueSession('test', 'Third', options);
+
+      expect(mockSession.reload).not.toHaveBeenCalled();
+      expect(mockCreateAgentSession).toHaveBeenCalledOnce();
+      expect(mockSession.prompt).toHaveBeenCalledTimes(3);
+    });
+
+    it('should reload skill selection without replacing the active session', async () => {
+      await adapter.startSession('test', 'First', { skillIds: ['skill-a'] });
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        skillsOverride: (base: { skills: Array<{ id: string }>; diagnostics: unknown[] }) => {
+          skills: Array<{ id: string }>;
+        };
+      };
+
+      expect(
+        loaderOptions.skillsOverride({
+          skills: [{ id: 'skill-a' }, { id: 'skill-b' }],
+          diagnostics: [],
+        }).skills,
+      ).toEqual([{ id: 'skill-a' }]);
+
+      await adapter.continueSession('test', 'Second', { skillIds: ['skill-b'] });
+
+      expect(mockSession.reload).toHaveBeenCalledOnce();
+      expect(mockCreateAgentSession).toHaveBeenCalledOnce();
+      expect(
+        loaderOptions.skillsOverride({
+          skills: [{ id: 'skill-a' }, { id: 'skill-b' }],
+          diagnostics: [],
+        }).skills,
+      ).toEqual([{ id: 'skill-b' }]);
+    });
+
+    it('should recreate the session when expert tool topology changes', async () => {
+      await adapter.startSession('test', 'First', { expertIds: ['expert-a'] });
+      await adapter.continueSession('test', 'Second', { expertIds: ['expert-b'] });
+
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      expect(mockSession.reload).not.toHaveBeenCalled();
     });
   });
 
@@ -770,6 +820,45 @@ describe('PiRuntimeAdapter', () => {
           isFinalAnswer: true,
         },
       });
+    });
+
+    it('should preserve the latest answer across a trailing thinking-only internal turn', async () => {
+      const updates: Array<{
+        messageId: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }> = [];
+      adapter.on('messageUpdate', (_sid, messageId, content, metadata) =>
+        updates.push({ messageId, content, metadata }),
+      );
+
+      await adapter.startSession('test', 'Hi');
+      driveAssistantTurn('Answer before trailing reasoning');
+      listener!({ type: 'turn_start' });
+      listener!({
+        type: 'message_update',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Checking completion.' }],
+        },
+      });
+      listener!({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'Checking completion.' }],
+          stopReason: 'length',
+        },
+      });
+      listener!({ type: 'agent_end' });
+
+      expect(
+        updates.some(
+          update =>
+            update.content === 'Answer before trailing reasoning' &&
+            update.metadata?.isFinalAnswer === true,
+        ),
+      ).toBe(true);
     });
 
     it('should render thinking as a separate isThinking message, not as the answer', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -42,6 +42,7 @@ import {
   type PiAskUserQuestionInput,
   type PiAskUserQuestionResponse,
 } from './piAskUserQuestion';
+import { buildPiConversationPrompt } from './piConversationContext';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import type {
   CoworkContinueOptions,
@@ -58,6 +59,7 @@ interface PiSession {
   prompt(text: string): Promise<void>;
   abort(): Promise<void>;
   abortBash(): void;
+  reload(): Promise<void>;
   setModel(model: unknown): Promise<void>;
   subscribe(listener: (event: PiEvent) => void): () => void;
 }
@@ -101,6 +103,9 @@ interface ActivePiSession {
   modelRuntime: PiModelRuntime | null;
   /** System prompt requested by the current Cowork session snapshot. */
   requestedSystemPrompt: string;
+  requestedSkillIds: string[] | undefined;
+  requestedExpertIds: string[];
+  resourceState: PiResourceState;
   /** Message id for the visible answer (text) bubble of the current turn. */
   assistantMessageId: string | null;
   /** Message id for the thinking bubble of the current turn. */
@@ -142,6 +147,11 @@ interface PiModules {
 
 interface PiResourceLoader {
   reload(): Promise<void>;
+}
+
+interface PiResourceState {
+  systemPrompt: string;
+  skillIds: string[] | undefined;
 }
 
 interface PiModelRuntime {
@@ -203,6 +213,23 @@ const MESSAGE_UPDATE_THROTTLE_MS = 200;
  * and flush the latest content on finalize.
  */
 const STORE_UPDATE_THROTTLE_MS = 250;
+
+const normalizeSkillIds = (skillIds: string[] | undefined): string[] | undefined =>
+  skillIds === undefined
+    ? undefined
+    : [...new Set(skillIds.map(skillId => skillId.trim()).filter(Boolean))].sort();
+
+const normalizeExpertIds = (expertIds: string[] | undefined): string[] =>
+  expertIds === undefined
+    ? []
+    : [...new Set(expertIds.map(expertId => expertId.trim()).filter(Boolean))];
+
+const haveSameStringList = (left: string[] | undefined, right: string[] | undefined): boolean =>
+  left === right ||
+  (left !== undefined &&
+    right !== undefined &&
+    left.length === right.length &&
+    left.every((value, index) => value === right[index]));
 
 // ── PiRuntimeAdapter ──
 
@@ -315,26 +342,15 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       // pi's formatSkillsForPrompt — no manual injection here to avoid
       // duplicating the skills section.
       const basePrompt = options.systemPrompt?.trim() || '';
-      const history = options.conversationHistory;
-      const historyBlock =
-        history && history.length > 0
-          ? [
-              '=== PREVIOUS CONVERSATION (context only, do not re-execute) ===',
-              ...history.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`),
-              '=== END PREVIOUS CONVERSATION ===',
-            ].join('\n')
-          : '';
-      const effectiveSystemPrompt = [basePrompt, historyBlock].filter(Boolean).join('\n\n');
+      const resourceState: PiResourceState = {
+        systemPrompt: basePrompt,
+        skillIds: normalizeSkillIds(options.skillIds),
+      };
 
       // Pi's createAgentSession does not accept a systemPrompt option. Its
       // default resource loader supplies the Pi Coding Assistant identity,
       // so override that loader per session to keep expert contexts isolated.
-      const resourceLoader = await this.createPiResourceLoader(
-        pi,
-        workspaceRoot,
-        effectiveSystemPrompt,
-        options.skillIds,
-      );
+      const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState);
       sessionOptions.resourceLoader = resourceLoader;
 
       // Resolve model early — needed by both MCP proxy and subagent tool
@@ -410,7 +426,10 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         piSession: session,
         abortController,
         modelRuntime: resolvedModel.modelRuntime,
-        requestedSystemPrompt: options.systemPrompt?.trim() || '',
+        requestedSystemPrompt: basePrompt,
+        requestedSkillIds: resourceState.skillIds,
+        requestedExpertIds: normalizeExpertIds(options.expertIds),
+        resourceState,
         assistantMessageId: null,
         thinkingMessageId: null,
         answerText: '',
@@ -460,14 +479,8 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         `[PiRuntime] continueSession: session ${sessionId} not active or was aborted, restoring context via prompt`,
       );
       const storedSession = this.store?.getSession(sessionId);
-      // Load previous messages and embed them as context prepended to the PI prompt.
-      // The user message saved/emitted to the renderer stays the clean original prompt.
       const history = storedSession?.messages ?? [];
-      const contextParts = history
-        .filter(m => m.type === 'user' || m.type === 'assistant')
-        .map(m => `${m.type === 'user' ? 'User' : 'Assistant'}: ${m.content}`);
-      const piPrompt =
-        contextParts.length > 0 ? `${contextParts.join('\n\n')}\n\nUser: ${prompt}` : prompt;
+      const piPrompt = buildPiConversationPrompt(history, prompt);
       return this.startSession(sessionId, prompt, {
         ...options,
         systemPrompt: options.systemPrompt ?? storedSession?.systemPrompt,
@@ -480,20 +493,49 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     }
 
     const requestedSystemPrompt = options.systemPrompt?.trim();
-    if (
-      requestedSystemPrompt !== undefined &&
-      requestedSystemPrompt !== active.requestedSystemPrompt
-    ) {
+    const requestedSkillIds =
+      options.skillIds === undefined
+        ? active.requestedSkillIds
+        : normalizeSkillIds(options.skillIds);
+    const requestedExpertIds =
+      options.expertIds === undefined
+        ? active.requestedExpertIds
+        : normalizeExpertIds(options.expertIds);
+    if (!haveSameStringList(requestedExpertIds, active.requestedExpertIds)) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
       return this.startSession(sessionId, prompt, {
         ...options,
-        conversationHistory: history
-          .filter(
-            (message): message is CoworkMessage & { type: 'user' | 'assistant' } =>
-              message.type === 'user' || message.type === 'assistant',
-          )
-          .map(message => ({ role: message.type, content: message.content })),
+        systemPrompt: requestedSystemPrompt ?? active.requestedSystemPrompt,
+        skillIds: requestedSkillIds,
+        expertIds: requestedExpertIds,
+        _piPromptOverride: buildPiConversationPrompt(history, prompt),
       });
+    }
+
+    const nextSystemPrompt = requestedSystemPrompt ?? active.requestedSystemPrompt;
+    const promptChanged = nextSystemPrompt !== active.requestedSystemPrompt;
+    const skillsChanged = !haveSameStringList(requestedSkillIds, active.requestedSkillIds);
+    if (promptChanged || skillsChanged) {
+      const previousSystemPrompt = active.resourceState.systemPrompt;
+      const previousSkillIds = active.resourceState.skillIds;
+      active.resourceState.systemPrompt = nextSystemPrompt;
+      active.resourceState.skillIds = requestedSkillIds;
+      try {
+        // Pi reloads the existing ResourceLoader without replacing transcript
+        // state, model, MCP tools, or custom expert tools.
+        await active.piSession.reload();
+        active.requestedSystemPrompt = nextSystemPrompt;
+        active.requestedSkillIds = requestedSkillIds;
+        console.debug(
+          `[PiRuntime] reloaded session resources after ${promptChanged ? 'prompt' : 'skill'} change`,
+        );
+      } catch (error) {
+        active.resourceState.systemPrompt = previousSystemPrompt;
+        active.resourceState.skillIds = previousSkillIds;
+        const message = error instanceof Error ? error.message : String(error);
+        this.emit('error', sessionId, classifyCoworkError(message));
+        throw error;
+      }
     }
 
     // Reset turn state
@@ -617,8 +659,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   private async createPiResourceLoader(
     pi: PiModules,
     cwd: string,
-    systemPrompt: string,
-    skillIds?: string[],
+    resourceState: PiResourceState,
   ): Promise<PiResourceLoader> {
     const resourceLoader = new pi.DefaultResourceLoader({
       cwd,
@@ -628,16 +669,21 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       // dev-only tooling skills like ai-sdk/shadcn into user sessions).
       noSkills: true,
       additionalSkillPaths: this.resolveZhiyuanSkillDirs(),
-      skillsOverride:
-        skillIds === undefined
-          ? undefined
-          : (base: { skills: Array<{ name?: string; id?: string }>; diagnostics: unknown[] }) => ({
+      skillsOverride: (base: {
+        skills: Array<{ name?: string; id?: string }>;
+        diagnostics: unknown[];
+      }) =>
+        resourceState.skillIds === undefined
+          ? base
+          : {
               ...base,
               skills: base.skills.filter(
-                skill => skillIds.includes(skill.id || '') || skillIds.includes(skill.name || ''),
+                skill =>
+                  resourceState.skillIds?.includes(skill.id || '') ||
+                  resourceState.skillIds?.includes(skill.name || ''),
               ),
-            }),
-      systemPromptOverride: () => systemPrompt || '',
+            },
+      systemPromptOverride: () => resourceState.systemPrompt,
       // Pi bypasses tool promptGuidelines when systemPromptOverride is non-empty.
       // Append this policy so it remains present for both default and custom prompts.
       appendSystemPromptOverride: (): string[] => [PiAskUserQuestionSystemPrompt],
@@ -709,8 +755,6 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         active.answerText = '';
         active.thinkingText = '';
         active.thinkingLifecycle.reset();
-        active.lastCompletedAnswerMessageId = null;
-        active.lastCompletedAnswerText = '';
         break;
 
       case 'message_start':
@@ -1554,7 +1598,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
           subOptions.resourceLoader = await this.createPiResourceLoader(
             pi,
             subOptions.cwd as string,
-            systemPrompt,
+            { systemPrompt, skillIds: undefined },
           );
           if (modelRuntime) {
             subOptions.modelRuntime = modelRuntime;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,7 +23,6 @@ import path from 'path';
 
 import type { OpenClawSessionPatch } from '../common/openclawSession';
 import { buildSessionTitleFromInput } from '../common/sessionTitle';
-import { buildScheduledTaskEnginePrompt } from '../scheduledTask/enginePrompt';
 import {
   migrateScheduledTaskRunsToOpenclaw,
   migrateScheduledTasksToOpenclaw,
@@ -43,6 +42,7 @@ import {
 } from '../shared/cowork/constants';
 import {
   type CoworkSessionExpertInput,
+  type CoworkSessionExpertSnapshot,
   CoworkSessionExpertSource,
 } from '../shared/cowork/sessionExperts';
 import { ApiIpc, CoworkStreamIpc, McpIpc, SkillsIpc } from '../shared/ipc/channels';
@@ -59,7 +59,8 @@ import { searchAnySearchGateway } from './libs/anysearchGateway';
 import { resolveAnySearchGatewayToken, resolveAnySearchGatewayUrl } from './libs/anysearchGatewayCredentials';
 import { APP_DATA_DIR_NAME, APP_NAME, DB_FILENAME } from './appConstants';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
-import { applyCoworkLanguagePrompt, type CoworkPromptLanguage } from './coworkLanguagePrompt';
+import type { CoworkPromptLanguage } from './coworkLanguagePrompt';
+import { composeCoworkSystemPrompt } from './coworkPrompt/composer';
 import {
   type CoworkExecutionMode,
   type CoworkMessageType,
@@ -2547,30 +2548,32 @@ const getIMGatewayManager = () => {
   return imGatewayManager;
 };
 
-function mergeCoworkSystemPrompt(
-  systemPrompt?: string,
-  skipZhiyuanIdentity = false,
-): string | undefined {
-  const zhiyuanIdentity = [
-    'You are 知远智能体 (ZhiYuan Agent).',
-    'The official Chinese product name is 知远智能体, and the official English product name is ZhiYuan Agent.',
-    '知远智能体 (ZhiYuan Agent) is a product of 北京容芯致远. Mention the company only when the user asks about product ownership, company background, or brand affiliation.',
-    'Treat 知远智能体 and ZhiYuan Agent as the only official product names. Do not translate, localize, transliterate, shorten, or replace them with any other variant or product identity.',
-    'When the user asks who you are, answer with the official product identity only. In Chinese, say "我是知远智能体。" You may add "英文名是 ZhiYuan Agent。". In English, say "I am ZhiYuan Agent." You may add "My Chinese product name is 知远智能体."',
-    'Do not use any other product name, model name, runtime name, or preset role as your identity.',
-    'OpenClaw, Ollama, and Cowork are implementation details; mention them only when the user asks about the runtime, local models, or integration details.',
-  ].join('\n');
-  const sections = [
-    skipZhiyuanIdentity ? null : zhiyuanIdentity,
-    buildScheduledTaskEnginePrompt(),
-    systemPrompt?.trim() || '',
-  ].filter(Boolean);
-  if (sections.length === 0) return undefined;
-
+const resolveCoworkPromptLanguage = (): CoworkPromptLanguage => {
   const configuredLanguage = getStore().get<AppConfigSettings>('app_config')?.language;
-  const language: CoworkPromptLanguage = configuredLanguage === 'en' ? 'en' : 'zh';
-  return applyCoworkLanguagePrompt(sections.join('\n\n'), language);
-}
+  return configuredLanguage === 'en' ? 'en' : 'zh';
+};
+
+const haveSameExpertSnapshots = (
+  left: CoworkSessionExpertSnapshot[],
+  right: CoworkSessionExpertInput[],
+): boolean =>
+  left.length === right.length &&
+  left.every(
+    (expert, index) =>
+      expert.expertId === right[index]?.expertId &&
+      expert.contentHash === right[index]?.contentHash,
+  );
+
+const haveSameExpertIds = (
+  experts: CoworkSessionExpertSnapshot[],
+  requestedExpertIds: string[],
+): boolean => {
+  const normalizedIds = [...new Set(requestedExpertIds.map(id => id.trim()).filter(Boolean))];
+  return (
+    experts.length === normalizedIds.length &&
+    experts.every((expert, index) => expert.expertId === normalizedIds[index])
+  );
+};
 
 const resolveSessionExpertSnapshots = (expertIds: string[]): CoworkSessionExpertInput[] => {
   const snapshots: CoworkSessionExpertInput[] = [];
@@ -4112,16 +4115,16 @@ if (!gotTheLock) {
         const expertSnapshots = resolveSessionExpertSnapshots(
           options.expertIds ?? fallbackExpertIds,
         );
-        const expertPrompt = expertSnapshots.map(expert => expert.promptSnapshot).join('\n\n');
-        const isExpertSession = expertSnapshots.length > 0;
-        const sessionPrompt = [
-          selectedAgent && !isExpertSession ? selectedAgent.systemPrompt : undefined,
-          options.systemPrompt ?? config.systemPrompt,
-          expertPrompt,
-        ]
-          .filter((prompt): prompt is string => Boolean(prompt?.trim()))
-          .join('\n\n');
-        const systemPrompt = mergeCoworkSystemPrompt(sessionPrompt, isExpertSession);
+        // The renderer already includes the selected non-expert agent prompt when
+        // present. Treat that request value as the source prompt instead of
+        // appending the same agent prompt again in the main process.
+        const basePrompt =
+          options.systemPrompt ?? selectedAgent?.systemPrompt ?? config.systemPrompt;
+        const systemPrompt = composeCoworkSystemPrompt({
+          basePrompt,
+          expertSnapshots,
+          language: resolveCoworkPromptLanguage(),
+        });
         const workspace = options.workspaceId
           ? coworkStoreInstance.getWorkspace(options.workspaceId)
           : null;
@@ -4293,23 +4296,29 @@ if (!gotTheLock) {
         const runtime = getPiRuntimeAdapter();
         const store = getCoworkStore();
         let existingSession = store.getSession(options.sessionId);
-        if (options.expertIds !== undefined && existingSession) {
-          const expertSnapshots = resolveSessionExpertSnapshots(options.expertIds);
-          let basePrompt = existingSession.systemPrompt;
-          for (const expert of existingSession.experts) {
-            basePrompt = basePrompt.split(expert.promptSnapshot).join('');
+        if (existingSession) {
+          const previousExpertSnapshots = existingSession.experts;
+          const expertSnapshots =
+            options.expertIds === undefined ||
+            haveSameExpertIds(previousExpertSnapshots, options.expertIds)
+              ? previousExpertSnapshots
+              : resolveSessionExpertSnapshots(options.expertIds);
+          const nextSystemPrompt = composeCoworkSystemPrompt({
+            basePrompt: existingSession.systemPrompt || options.systemPrompt,
+            expertSnapshots,
+            previousExpertSnapshots,
+            language: resolveCoworkPromptLanguage(),
+          });
+          const expertsChanged = !haveSameExpertSnapshots(previousExpertSnapshots, expertSnapshots);
+          if (expertsChanged) {
+            store.replaceSessionExperts(options.sessionId, expertSnapshots);
           }
-          const expertPrompt = expertSnapshots.map(expert => expert.promptSnapshot).join('\n\n');
-          const sessionPrompt = [basePrompt, expertPrompt]
-            .filter((prompt): prompt is string => Boolean(prompt?.trim()))
-            .join('\n\n');
-          const nextSystemPrompt = mergeCoworkSystemPrompt(
-            sessionPrompt,
-            expertSnapshots.length > 0,
-          );
-          store.replaceSessionExperts(options.sessionId, expertSnapshots);
-          store.updateSession(options.sessionId, { systemPrompt: nextSystemPrompt || '' });
-          existingSession = store.getSession(options.sessionId);
+          if (nextSystemPrompt !== existingSession.systemPrompt) {
+            store.updateSession(options.sessionId, { systemPrompt: nextSystemPrompt });
+          }
+          if (expertsChanged || nextSystemPrompt !== existingSession.systemPrompt) {
+            existingSession = store.getSession(options.sessionId);
+          }
         }
         if (options.imageAttachments?.length) {
           console.log('[Cowork:ContinueSession] imageAttachments received via IPC:', {
@@ -4341,12 +4350,12 @@ if (!gotTheLock) {
           ]),
         ];
 
-        const configuredLanguage = getStore().get<AppConfigSettings>('app_config')?.language;
-        const language: CoworkPromptLanguage = configuredLanguage === 'en' ? 'en' : 'zh';
-        const runtimeSystemPrompt = applyCoworkLanguagePrompt(
-          existingSession?.systemPrompt || options.systemPrompt,
-          language,
-        );
+        const runtimeSystemPrompt = existingSession
+          ? existingSession.systemPrompt
+          : composeCoworkSystemPrompt({
+              basePrompt: options.systemPrompt,
+              language: resolveCoworkPromptLanguage(),
+            });
 
         runtime
           .continueSession(options.sessionId, options.prompt, {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -956,6 +956,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             resolveLocalFilePath={resolveLocalFilePath}
             showTypingIndicator
             showCopyButtons={!isStreaming}
+            isTurnComplete={false}
           />
         </div>
       );
@@ -1018,6 +1019,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 mapDisplayText={mapDisplayText}
                 showTypingIndicator={showTypingIndicator}
                 showCopyButtons={!isStreaming || !isLastTurn}
+                isTurnComplete={!isStreaming || !isLastTurn}
               />
             </div>
           )}

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -43,6 +43,7 @@ export const TurnBlock: React.FC<{
   mapDisplayText?: (value: string) => string;
   showTypingIndicator?: boolean;
   showCopyButtons?: boolean;
+  isTurnComplete?: boolean;
 }> = ({
   turn,
   artifacts,
@@ -50,6 +51,7 @@ export const TurnBlock: React.FC<{
   mapDisplayText,
   showTypingIndicator = false,
   showCopyButtons = true,
+  isTurnComplete = true,
 }) => {
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
@@ -149,10 +151,10 @@ export const TurnBlock: React.FC<{
           key={item.message.id}
           className={mutedExecution ? 'text-muted-foreground' : undefined}
           isStreaming={isStreaming}
-          defaultOpen={true}
+          defaultOpen={isStreaming}
           autoClose={false}
           duration={durationSeconds}
-          showConnector
+          showConnector={!isLastInSequence}
         >
           <ReasoningTrigger
             getThinkingMessage={(s, d) => {
@@ -161,7 +163,7 @@ export const TurnBlock: React.FC<{
               return <p>思考内容</p>;
             }}
           />
-          <ReasoningContent>{content}</ReasoningContent>
+          <ReasoningContent className="pl-4">{content}</ReasoningContent>
         </Reasoning>
       );
     }
@@ -277,16 +279,19 @@ export const TurnBlock: React.FC<{
     );
   };
   const visibleGroups = groups.filter(group => !isEmptyAnswerGroup(group));
-  const executionSummary = getExecutionSummary(visibleAssistantItems);
-  const finalAnswerIndex = getFinalAnswerIndex(visibleAssistantItems);
-  const finalAnswerStarted =
-    finalAnswerIndex === visibleAssistantItems.length - 1 &&
-    lastAnswerGroupIndex >= 0 &&
-    lastAnswerGroupIndex === groups.length - 1 &&
-    !isEmptyAnswerGroup(groups[lastAnswerGroupIndex]);
-  const previousGroups = finalAnswerStarted ? groups.slice(0, lastAnswerGroupIndex) : [];
-  const finalAnswerGroup = finalAnswerStarted ? groups[lastAnswerGroupIndex] : null;
-  const previousItems = previousGroups.flatMap(group => group.items);
+  const finalAnswerIndex = getFinalAnswerIndex(visibleAssistantItems, isTurnComplete);
+  const finalAnswerItem = finalAnswerIndex >= 0 ? visibleAssistantItems[finalAnswerIndex] : null;
+  const executionItems =
+    finalAnswerIndex >= 0
+      ? visibleAssistantItems.filter((_, index) => index !== finalAnswerIndex)
+      : [];
+  const executionSummary = getExecutionSummary(executionItems);
+
+  const isExecutionStep = (item: (typeof visibleAssistantItems)[number] | undefined) =>
+    item?.type === 'tool_group' ||
+    item?.type === 'tool_result' ||
+    item?.type === 'system' ||
+    (item?.type === 'assistant' && Boolean(item.message.metadata?.isThinking));
 
   const renderExecutionGroup = (
     group: (typeof groups)[number],
@@ -308,7 +313,10 @@ export const TurnBlock: React.FC<{
           : SparklesIcon
       : SparklesIcon;
     return (
-      <ChainOfThought key={groupKey} defaultOpen={false}>
+      <ChainOfThought
+        key={`${groupKey}-${isStreaming ? 'active' : 'complete'}`}
+        defaultOpen={isStreaming}
+      >
         <ChainOfThoughtHeader icon={headerIcon}>
           {isStreaming ? (
             <Shimmer duration={1}>{getExecutionStatusText(group.status!)}</Shimmer>
@@ -329,26 +337,18 @@ export const TurnBlock: React.FC<{
       <div className="max-w-5xl min-w-[320px] mx-auto">
         <div className="flex items-start gap-3">
           <div className="flex min-w-0 flex-1 flex-col gap-3 px-4 py-3">
-            {finalAnswerStarted && previousItems.length > 0 && (
+            {finalAnswerItem && executionItems.length > 0 && (
               <ExecutionSummary summary={executionSummary}>
-                {previousGroups.map(group =>
-                  group.items.map((item, index) => {
-                    const isAnswer =
-                      item.type === 'assistant' && !item.message.metadata?.isThinking;
-                    return renderItem(
-                      item,
-                      index,
-                      false,
-                      true,
-                      !isAnswer,
-                      isAnswer || index === group.items.length - 1,
-                    );
-                  }),
-                )}
+                {executionItems.map((item, index) => {
+                  const isAnswer = item.type === 'assistant' && !item.message.metadata?.isThinking;
+                  const connectsToNextStep =
+                    isExecutionStep(item) && isExecutionStep(executionItems[index + 1]);
+                  return renderItem(item, index, false, true, !isAnswer, !connectsToNextStep);
+                })}
               </ExecutionSummary>
             )}
-            {finalAnswerStarted && finalAnswerGroup
-              ? renderExecutionGroup(finalAnswerGroup, 'final-answer', true)
+            {finalAnswerItem
+              ? renderItem(finalAnswerItem, finalAnswerIndex, true)
               : visibleGroups.map((group, index) =>
                   renderExecutionGroup(
                     group,

--- a/src/renderer/components/cowork/helpers/executionStatus.test.ts
+++ b/src/renderer/components/cowork/helpers/executionStatus.test.ts
@@ -142,3 +142,99 @@ test('recognizes only an explicitly marked final answer', () => {
   expect(getFinalAnswerIndex([activeTool, answer])).toBe(-1);
   expect(getFinalAnswerIndex([activeTool, answer, finalAnswer])).toBe(2);
 });
+
+test('uses the last completed answer as a fallback after the turn completes', () => {
+  const completedAnswer: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'answer-1',
+      type: 'assistant',
+      content: 'Completed answer',
+      timestamp: 1,
+      metadata: { isStreaming: false, isFinal: true },
+    },
+  };
+  const trailingThinking: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'thinking-1',
+      type: 'assistant',
+      content: 'Trailing internal step',
+      timestamp: 2,
+      metadata: { isThinking: true, isStreaming: false, isFinal: true },
+    },
+  };
+
+  expect(getFinalAnswerIndex([completedAnswer, trailingThinking], false)).toBe(-1);
+  expect(getFinalAnswerIndex([completedAnswer, trailingThinking], true)).toBe(0);
+});
+
+test('does not use a streaming answer as the completed fallback', () => {
+  const completedAnswer: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'answer-0',
+      type: 'assistant',
+      content: 'Prior completed answer',
+      timestamp: 0,
+      metadata: { isStreaming: false, isFinal: true },
+    },
+  };
+  const streamingAnswer: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'answer-1',
+      type: 'assistant',
+      content: 'Still streaming',
+      timestamp: 1,
+      metadata: { isStreaming: true, isFinal: false },
+    },
+  };
+
+  expect(getFinalAnswerIndex([completedAnswer, streamingAnswer], true)).toBe(-1);
+});
+
+test('does not use the completed fallback while a tool is incomplete', () => {
+  const completedAnswer: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'answer-1',
+      type: 'assistant',
+      content: 'Intermediate answer',
+      timestamp: 1,
+      metadata: { isStreaming: false, isFinal: true },
+    },
+  };
+
+  expect(
+    getFinalAnswerIndex(
+      [completedAnswer, toolGroup('read-1', 'read', { path: 'src/app.ts' })],
+      true,
+    ),
+  ).toBe(-1);
+});
+
+test('keeps an explicit final answer when completed steps follow it', () => {
+  const finalAnswer: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'answer-1',
+      type: 'assistant',
+      content: 'Final answer',
+      timestamp: 1,
+      metadata: { isStreaming: false, isFinal: true, isFinalAnswer: true },
+    },
+  };
+  const trailingThinking: AssistantTurnItem = {
+    type: 'assistant',
+    message: {
+      id: 'thinking-1',
+      type: 'assistant',
+      content: 'Trailing internal step',
+      timestamp: 2,
+      metadata: { isThinking: true, isStreaming: false, isFinal: true },
+    },
+  };
+
+  expect(getFinalAnswerIndex([finalAnswer, trailingThinking])).toBe(0);
+});

--- a/src/renderer/components/cowork/helpers/executionStatus.ts
+++ b/src/renderer/components/cowork/helpers/executionStatus.ts
@@ -61,13 +61,34 @@ export const getCurrentExecutionStatus = (
   return null;
 };
 
-export const getFinalAnswerIndex = (items: AssistantTurnItem[]): number => {
+export const getFinalAnswerIndex = (
+  items: AssistantTurnItem[],
+  allowCompletedFallback = false,
+): number => {
   for (let index = items.length - 1; index >= 0; index -= 1) {
     const item = items[index];
     if (
       item.type === 'assistant' &&
       !item.message.metadata?.isThinking &&
       item.message.metadata?.isFinalAnswer === true &&
+      hasText(item.message.content)
+    ) {
+      return index;
+    }
+  }
+  const hasStreamingAnswer = items.some(
+    item =>
+      item.type === 'assistant' &&
+      !item.message.metadata?.isThinking &&
+      item.message.metadata?.isStreaming,
+  );
+  if (!allowCompletedFallback || hasStreamingAnswer || getCurrentExecutionStatus(items)) return -1;
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (
+      item.type === 'assistant' &&
+      !item.message.metadata?.isThinking &&
+      !item.message.metadata?.isStreaming &&
       hasText(item.message.content)
     ) {
       return index;


### PR DESCRIPTION
## 变更概述

- 引入幂等的 Cowork 提示词组合流程，避免身份、定时任务、语言规则和专家 SOP 在多轮对话中重复累积
- 在 Prompt 或 Skill 变化时刷新现有会话资源，仅在专家工具拓扑变化时重建会话
- 优化会话恢复上下文，排除思考内容，保留必要的用户、助手及工具调用信息，并限制恢复预算
- 修复 turn 完成后中间执行步骤未收起的问题
- 修复最终答案后存在尾随思考时无法正确识别最终答案的问题

## 兼容性

- 普通用户 turn 在配置未变化时不会新增 reload 或重建，不增加等待时间
- Skill 仍通过现有 ResourceLoader 加载和筛选
- MCP 代理及专家自定义工具沿用原有创建与执行链路
- 未新增手写 UI 组件，继续使用现有 AI Elements

## 验证

- [x] 关键回归测试：63 项通过
- [x] Electron TypeScript 编译
- [x] Renderer/生产构建
- [x] oxlint
- [x] Git diff whitespace 检查

## 测试说明

完整测试套件中 159 个测试文件通过、1452 项测试通过、1 项跳过。Windows 发布工具的 2 项既有路径测试因绝对路径盘符解析失败，和本次改动无关。