### PR TITLE
feat(cowork): 文件夹选择器重构为「进入项目工作」入口

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -45,11 +45,12 @@ import {
   type CoworkSessionExpertSnapshot,
   CoworkSessionExpertSource,
 } from '../shared/cowork/sessionExperts';
-import { ApiIpc, CoworkStreamIpc, McpIpc, SkillsIpc } from '../shared/ipc/channels';
+import { ApiIpc, CoworkStreamIpc, McpIpc, ProjectIpc, SkillsIpc } from '../shared/ipc/channels';
 import {
   ApiFetchSchema,
   ApiStreamSchema,
   CoworkSessionStartSchema,
+  ProjectCreateDirectorySchema,
 } from '../shared/ipc/schemas';
 import { PlatformRegistry } from '../shared/platform';
 import { ProviderName } from '../shared/providers';
@@ -4068,6 +4069,65 @@ if (!gotTheLock) {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to rename workspace',
+      };
+    }
+  });
+
+  // Project working-directory helpers
+  const getDefaultProjectBaseDir = () =>
+    path.join(app.getPath('documents'), 'ZhiYuanAgent', 'Workspaces');
+
+  ipcMain.handle(ProjectIpc.GetDefaultBaseDir, async () => {
+    try {
+      return { success: true, path: getDefaultProjectBaseDir() };
+    } catch (error) {
+      return {
+        success: false,
+        path: null,
+        error: error instanceof Error ? error.message : 'Failed to resolve default project path',
+      };
+    }
+  });
+
+  ipcMain.handle(ProjectIpc.CreateDirectory, async (_event, rawOptions: unknown) => {
+    try {
+      const options = ProjectCreateDirectorySchema.input.parse(rawOptions);
+      const name = options.name.trim();
+      if (!name || /[\\/:*?"<>|]/.test(name) || name === '.' || name === '..') {
+        return { success: false, path: null, code: 'invalid-name', error: 'Invalid project name' };
+      }
+      const baseDir = options.baseDir?.trim() || getDefaultProjectBaseDir();
+      const targetPath = path.join(baseDir, name);
+      if (fs.existsSync(targetPath)) {
+        return {
+          success: false,
+          path: null,
+          code: 'already-exists',
+          error: 'A directory with this name already exists',
+        };
+      }
+      await fs.promises.mkdir(targetPath, { recursive: true });
+      console.log('[Project] created project directory:', targetPath);
+      return { success: true, path: targetPath };
+    } catch (error) {
+      return {
+        success: false,
+        path: null,
+        error: error instanceof Error ? error.message : 'Failed to create project directory',
+      };
+    }
+  });
+
+  ipcMain.handle(ProjectIpc.EnsureScratchDir, async () => {
+    try {
+      const scratchDir = path.join(os.homedir(), '.zhiyuan', 'scratch');
+      await fs.promises.mkdir(scratchDir, { recursive: true });
+      return { success: true, path: scratchDir };
+    } catch (error) {
+      return {
+        success: false,
+        path: null,
+        error: error instanceof Error ? error.message : 'Failed to ensure scratch directory',
       };
     }
   });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -29,6 +29,7 @@ import {
   OpenAICodexOAuthIpc,
   OpenClawEngineIpc,
   PermissionsIpc,
+  ProjectIpc,
   ShellIpc,
   SkillsIpc,
   StoreIpc,
@@ -570,6 +571,13 @@ contextBridge.exposeInMainWorld('electron', {
       type?: 'none' | 'info' | 'error' | 'question' | 'warning';
       title?: string;
     }) => ipcRenderer.invoke(DialogIpc.ShowMessageBox, options),
+  },
+
+  project: {
+    getDefaultBaseDir: () => ipcRenderer.invoke(ProjectIpc.GetDefaultBaseDir),
+    createDirectory: (options: { name: string; baseDir?: string }) =>
+      ipcRenderer.invoke(ProjectIpc.CreateDirectory, options),
+    ensureScratchDir: () => ipcRenderer.invoke(ProjectIpc.EnsureScratchDir),
   },
 
   shell: {

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { FolderPlus } from 'lucide-react';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDispatch } from 'react-redux';
 
@@ -15,6 +15,7 @@ import {
 } from '../../store/slices/coworkSlice';
 import { CoworkSessionStatusValue } from '../../types/cowork';
 import { type CoworkOpenShareOptionsEventDetail, CoworkUiEvent } from '../cowork/constants';
+import CreateProjectDialog from '../cowork/CreateProjectDialog';
 import type { AgentSidebarTaskNode, WorkspaceSidebarNode } from './types';
 import { useWorkspaceSidebarState } from './useWorkspaceSidebarState';
 import WorkspaceTreeNode from './WorkspaceTreeNode';
@@ -102,10 +103,16 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
     }, 0);
   };
 
-  const handleCreateWorkspace = async () => {
-    const result = await window.electron.dialog.selectDirectory();
-    if (!result.success || !result.path) return;
-    const workspace = await workspaceService.ensureWorkspace(result.path);
+  const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
+
+  const handleCreateWorkspace = () => {
+    // Align with 「进入项目工作 → 新建空白项目」: open the create-project
+    // dialog instead of the native directory picker.
+    setIsCreateProjectOpen(true);
+  };
+
+  const handleProjectCreated = async (projectPath: string) => {
+    const workspace = await workspaceService.ensureWorkspace(projectPath);
     if (workspace) await workspaceService.selectWorkspace(workspace.id);
   };
 
@@ -135,6 +142,11 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
 
   return (
     <div className="pb-3" role="tree" aria-label={i18nService.t('workspaces')}>
+      <CreateProjectDialog
+        open={isCreateProjectOpen}
+        onOpenChange={setIsCreateProjectOpen}
+        onCreated={path => void handleProjectCreated(path)}
+      />
       <div className="sticky top-0 z-30 flex h-10 items-center justify-between bg-surface-raised px-1.5">
         <h2 className="min-w-0 truncate text-[14px] font-normal text-foreground opacity-[0.28]">
           {i18nService.t('workspaces')}

--- a/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { CoworkSessionMode } from '../../../shared/cowork/constants';
 import { coworkService } from '../../services/cowork';
+import { i18nService } from '../../services/i18n';
 import { localStore } from '../../services/store';
 import { RootState } from '../../store';
 import {
@@ -13,6 +14,7 @@ import {
 import { WorkMode, type WorkMode as WorkModeType } from '../../store/workMode/constants';
 import type { CoworkSessionSummary } from '../../types/cowork';
 import { CoworkSessionStatusValue } from '../../types/cowork';
+import { isScratchWorkspacePath } from '../../utils/path';
 import { AgentSidebarIndicator, AgentSidebarPageSize, isScheduledSessionTitle } from './constants';
 import type {
   AgentSidebarTaskNode,
@@ -281,7 +283,11 @@ export const useWorkspaceSidebarState = (workMode: WorkModeType = WorkMode.Work)
         const visible = taskExpanded ? filtered : filtered.slice(0, AgentSidebarPageSize.Preview);
         return {
           id: workspace.id,
-          name: workspace.name,
+          // The scratch workspace (「不使用文件夹」) displays as 无项目 instead
+          // of its folder basename.
+          name: isScratchWorkspacePath(workspace.path)
+            ? i18nService.t('noProject')
+            : workspace.name,
           path: workspace.path,
           isExpanded: expanded,
           isTaskListExpanded: taskExpanded,

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -48,7 +48,6 @@ import { WorkMode } from '../../store/workMode/constants';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
-import { getCompactFolderName } from '../../utils/path';
 import {
   resolveAgentModelSelection,
   resolveEffectiveModel,
@@ -723,11 +722,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       }
     };
 
-    const truncatePath = (path: string, maxLength = 30): string => {
-      if (!path) return i18nService.t('noFolderSelected');
-      return getCompactFolderName(path, maxLength) || i18nService.t('noFolderSelected');
-    };
-
     const handleFolderSelect = (path: string) => {
       if (onWorkingDirectoryChange) {
         onWorkingDirectoryChange(path);
@@ -1283,26 +1277,11 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
           <div className="relative mt-1.5 flex justify-start">
             <FolderSelectorPopover onSelectFolder={handleFolderSelect} side="top" align="start">
               <PromptInputButton
-                className={`gap-1.5 rounded-md text-muted-foreground hover:bg-surface-raised hover:text-foreground ${showFolderRequiredWarning ? 'ring-1 ring-warning text-warning animate-shake' : ''}`}
+                className={`gap-1 px-2 text-sm hover:bg-surface-raised ${showFolderRequiredWarning ? 'ring-1 ring-warning text-warning animate-shake' : ''}`}
               >
-                <Folder className="h-3.5 w-3.5 shrink-0" />
-                <span className="max-w-[200px] truncate text-xs">
-                  {truncatePath(workingDirectory)}
-                </span>
-                <ChevronDown className="h-3 w-3 shrink-0" />
-                {workingDirectory && (
-                  <span
-                    role="button"
-                    tabIndex={-1}
-                    onClick={e => {
-                      e.stopPropagation();
-                      handleFolderSelect('');
-                    }}
-                    className="shrink-0 ml-0.5 p-0.5 rounded hover:bg-surface-raised transition-colors"
-                  >
-                    <X className="h-3 w-3" />
-                  </span>
-                )}
+                <Folder className="size-4 shrink-0" />
+                <span>{i18nService.t('enterProjectWork')}</span>
+                <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
               </PromptInputButton>
             </FolderSelectorPopover>
             {showFolderRequiredWarning && (

--- a/src/renderer/components/cowork/CreateProjectDialog.tsx
+++ b/src/renderer/components/cowork/CreateProjectDialog.tsx
@@ -1,0 +1,172 @@
+import { Button } from '@shared/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@shared/components/ui/dialog';
+import { Input } from '@shared/components/ui/input';
+import { Label } from '@shared/components/ui/label';
+import { FolderOpen, LoaderCircle } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { i18nService } from '../../services/i18n';
+
+interface CreateProjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the newly created project directory path */
+  onCreated: (path: string) => void;
+}
+
+const ILLEGAL_NAME_CHARS = /[\\/:*?"<>|]/;
+
+const showToast = (message: string) => {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+};
+
+/**
+ * 「创建项目」dialog: creates a new empty project directory under a base path
+ * (default: <Documents>/ZhiYuanAgent/Workspaces) and hands the new path back
+ * to the folder-selection flow.
+ */
+const CreateProjectDialog: React.FC<CreateProjectDialogProps> = ({
+  open,
+  onOpenChange,
+  onCreated,
+}) => {
+  const [name, setName] = useState('');
+  const [baseDir, setBaseDir] = useState('');
+  const [nameError, setNameError] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Reset the form and load the default base path each time the dialog opens
+  useEffect(() => {
+    if (!open) return;
+    setName('');
+    setNameError('');
+    setIsSaving(false);
+    let cancelled = false;
+    void window.electron.project.getDefaultBaseDir().then(result => {
+      if (!cancelled && result.success && result.path) setBaseDir(result.path);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const handleBrowse = useCallback(async () => {
+    try {
+      const result = await window.electron.dialog.selectDirectory();
+      if (result.success && result.path) setBaseDir(result.path);
+    } catch (error) {
+      console.error('[CreateProjectDialog] Failed to select directory:', error);
+    }
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError(i18nService.t('projectNameRequired'));
+      return;
+    }
+    if (ILLEGAL_NAME_CHARS.test(trimmedName) || trimmedName === '.' || trimmedName === '..') {
+      setNameError(i18nService.t('projectNameInvalid'));
+      return;
+    }
+    setNameError('');
+    setIsSaving(true);
+    try {
+      const result = await window.electron.project.createDirectory({
+        name: trimmedName,
+        baseDir: baseDir || undefined,
+      });
+      if (result.success && result.path) {
+        onOpenChange(false);
+        onCreated(result.path);
+      } else if (result.code === 'already-exists') {
+        showToast(i18nService.t('projectAlreadyExists'));
+      } else if (result.code === 'invalid-name') {
+        setNameError(i18nService.t('projectNameInvalid'));
+      } else {
+        showToast(i18nService.t('projectCreateFailed'));
+      }
+    } catch (error) {
+      console.error('[CreateProjectDialog] Failed to create project directory:', error);
+      showToast(i18nService.t('projectCreateFailed'));
+    } finally {
+      setIsSaving(false);
+    }
+  }, [name, baseDir, onCreated, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={nextOpen => !isSaving && onOpenChange(nextOpen)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{i18nService.t('createProjectTitle')}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-1">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="create-project-name">
+              {i18nService.t('projectNameLabel')}
+              <span className="text-destructive"> *</span>
+            </Label>
+            <Input
+              id="create-project-name"
+              value={name}
+              onChange={event => {
+                setName(event.target.value);
+                if (nameError) setNameError('');
+              }}
+              placeholder={i18nService.t('createProjectNamePlaceholder')}
+              disabled={isSaving}
+              autoFocus
+            />
+            {nameError && <p className="text-xs text-destructive">{nameError}</p>}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="create-project-path">
+              {i18nService.t('projectPathLabel')}
+              <span className="text-destructive"> *</span>
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="create-project-path"
+                value={baseDir}
+                readOnly
+                disabled={isSaving}
+                className="flex-1 truncate text-muted-foreground"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleBrowse()}
+                disabled={isSaving}
+              >
+                <FolderOpen className="size-4" />
+                {i18nService.t('browse')}
+              </Button>
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            {i18nService.t('cancel')}
+          </Button>
+          <Button type="button" onClick={() => void handleSave()} disabled={isSaving}>
+            {isSaving && <LoaderCircle className="size-4 animate-spin" />}
+            {i18nService.t('save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CreateProjectDialog;

--- a/src/renderer/components/cowork/FolderSelectorPopover.tsx
+++ b/src/renderer/components/cowork/FolderSelectorPopover.tsx
@@ -2,17 +2,19 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
-import { Clock, Folder, FolderPlus } from 'lucide-react';
+import { Clock, Folder, FolderOpen, FolderX, Plus } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { getCompactFolderName } from '../../utils/path';
+import CreateProjectDialog from './CreateProjectDialog';
 
 interface FolderSelectorPopoverProps {
   /** Trigger element (typically a Button) */
@@ -37,6 +39,7 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
   align = 'start',
 }) => {
   const [open, setOpen] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [recentFolders, setRecentFolders] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -59,7 +62,19 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
     }
   }, [open]);
 
-  const handleAddFolder = useCallback(async () => {
+  const handleCreateProject = useCallback(() => {
+    setOpen(false);
+    setCreateDialogOpen(true);
+  }, []);
+
+  const handleProjectCreated = useCallback(
+    (path: string) => {
+      onSelectFolder(path);
+    },
+    [onSelectFolder],
+  );
+
+  const handleUseExistingFolder = useCallback(async () => {
     setOpen(false);
     try {
       const result = await window.electron.dialog.selectDirectory();
@@ -76,6 +91,25 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
       }
     } catch (error) {
       console.error('Failed to select directory:', error);
+    }
+  }, [onSelectFolder]);
+
+  const handleUseNoFolder = useCallback(async () => {
+    setOpen(false);
+    try {
+      const result = await window.electron.project.ensureScratchDir();
+      if (result.success && result.path) {
+        onSelectFolder(result.path);
+      } else {
+        window.dispatchEvent(
+          new CustomEvent('app:showToast', { detail: i18nService.t('projectCreateFailed') }),
+        );
+      }
+    } catch (error) {
+      console.error('Failed to ensure scratch directory:', error);
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', { detail: i18nService.t('projectCreateFailed') }),
+      );
     }
   }, [onSelectFolder]);
 
@@ -99,42 +133,64 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
   };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger render={children as React.ReactElement} />
-      <DropdownMenuContent side={side} align={align} className="w-56">
-        {/* Add Folder option */}
-        <DropdownMenuItem onClick={handleAddFolder}>
-          <FolderPlus className="h-4 w-4 text-muted-foreground" />
-          <span>{i18nService.t('addFolder')}</span>
-        </DropdownMenuItem>
+    <>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger render={children as React.ReactElement} />
+        <DropdownMenuContent side={side} align={align} className="w-56">
+          {/* New blank project */}
+          <DropdownMenuItem onClick={handleCreateProject}>
+            <Plus className="h-4 w-4 text-muted-foreground" />
+            <span>{i18nService.t('createBlankProject')}</span>
+          </DropdownMenuItem>
 
-        {/* Recent Folders submenu */}
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-            <span>{i18nService.t('recentFolders')}</span>
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="max-h-28 overflow-y-auto">
-            {isLoading ? (
-              <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                {i18nService.t('loading')}
-              </div>
-            ) : recentFolders.length === 0 ? (
-              <div className="px-2 py-1.5 text-sm text-muted-foreground">
-                {i18nService.t('noRecentFolders')}
-              </div>
-            ) : (
-              recentFolders.map((folder, index) => (
-                <DropdownMenuItem key={index} onClick={() => handleSelectRecentFolder(folder)}>
-                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="truncate">{truncatePath(folder)}</span>
-                </DropdownMenuItem>
-              ))
-            )}
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {/* Use existing folder (native picker) */}
+          <DropdownMenuItem onClick={() => void handleUseExistingFolder()}>
+            <FolderOpen className="h-4 w-4 text-muted-foreground" />
+            <span>{i18nService.t('useExistingFolder')}</span>
+          </DropdownMenuItem>
+
+          {/* Scratch workspace without a folder */}
+          <DropdownMenuItem onClick={() => void handleUseNoFolder()}>
+            <FolderX className="h-4 w-4 text-muted-foreground" />
+            <span>{i18nService.t('useNoFolder')}</span>
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          {/* Recent Folders submenu */}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              <span>{i18nService.t('recentFolders')}</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="max-h-28 overflow-y-auto">
+              {isLoading ? (
+                <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                  {i18nService.t('loading')}
+                </div>
+              ) : recentFolders.length === 0 ? (
+                <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                  {i18nService.t('noRecentFolders')}
+                </div>
+              ) : (
+                recentFolders.map((folder, index) => (
+                  <DropdownMenuItem key={index} onClick={() => handleSelectRecentFolder(folder)}>
+                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="truncate">{truncatePath(folder)}</span>
+                  </DropdownMenuItem>
+                ))
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <CreateProjectDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        onCreated={handleProjectCreated}
+      />
+    </>
   );
 };
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1174,9 +1174,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Multi-Agent 管理
     createAgent: '创建 Agent',
     myAgents: '我的项目',
-    workspaces: '工作区',
-    workspaceAdd: '添加工作区',
-    workspaceNoWorkspaces: '还没有工作区',
+    workspaces: '项目',
+    workspaceAdd: '添加项目',
+    workspaceNoWorkspaces: '还没有项目',
     defaultAgentDisplayName: '主项目',
     myAgentSidebarPinned: '置顶',
     myAgentSidebarExpandMore: '展开显示',
@@ -1417,6 +1417,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderDriveRootNotAllowed:
       '不支持使用磁盘根目录作为工作目录，请选择一个子文件夹（例如 D:\\Projects）。',
     coworkOpenFolder: '打开文件夹',
+    enterProjectWork: '进入项目工作',
+    createBlankProject: '新建空白项目',
+    useExistingFolder: '使用现有文件夹',
+    useNoFolder: '不使用文件夹',
+    createProjectTitle: '创建项目',
+    createProjectNamePlaceholder: '请输入文件夹名称',
+    projectPathLabel: '选择项目路径',
+    projectNameRequired: '请输入项目名称',
+    projectNameInvalid: '项目名称不能包含 \\ / : * ? " < > | 字符',
+    projectAlreadyExists: '同名项目已存在，请更换名称',
+    projectCreateFailed: '创建项目失败，请重试',
 
     // Cowork 错误消息
     coworkErrorAuthInvalid: 'API 密钥无效或已过期，请在设置中检查并更新您的 API 密钥。',
@@ -3687,9 +3698,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Multi-Agent management
     createAgent: 'Create Agent',
     myAgents: 'My Projects',
-    workspaces: 'Workspaces',
-    workspaceAdd: 'Add workspace',
-    workspaceNoWorkspaces: 'No workspaces yet',
+    workspaces: 'Projects',
+    workspaceAdd: 'Add project',
+    workspaceNoWorkspaces: 'No projects yet',
     defaultAgentDisplayName: 'Primary Project',
     myAgentSidebarPinned: 'Pinned',
     myAgentSidebarExpandMore: 'Show more',
@@ -3941,6 +3952,17 @@ const translations: Record<LanguageType, Record<string, string>> = {
     folderDriveRootNotAllowed:
       'Drive root directories are not supported as working directories. Please select a subfolder (e.g. D:\\Projects).',
     coworkOpenFolder: 'Open folder',
+    enterProjectWork: 'Work in a Project',
+    createBlankProject: 'New Blank Project',
+    useExistingFolder: 'Use Existing Folder',
+    useNoFolder: "Don't Use a Folder",
+    createProjectTitle: 'Create Project',
+    createProjectNamePlaceholder: 'Enter a folder name',
+    projectPathLabel: 'Project Location',
+    projectNameRequired: 'Please enter a project name',
+    projectNameInvalid: 'The project name cannot contain \\ / : * ? " < > | characters',
+    projectAlreadyExists: 'A project with this name already exists',
+    projectCreateFailed: 'Failed to create the project. Please try again.',
 
     // Cowork error messages
     coworkErrorAuthInvalid:

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -895,6 +895,19 @@ interface IElectronAPI {
       title?: string;
     }) => Promise<{ response: number }>;
   };
+  project: {
+    getDefaultBaseDir: () => Promise<{ success: boolean; path: string | null; error?: string }>;
+    createDirectory: (options: {
+      name: string;
+      baseDir?: string;
+    }) => Promise<{
+      success: boolean;
+      path: string | null;
+      code?: 'invalid-name' | 'already-exists';
+      error?: string;
+    }>;
+    ensureScratchDir: () => Promise<{ success: boolean; path: string | null; error?: string }>;
+  };
   shell: {
     openPath: (filePath: string) => Promise<{ success: boolean; error?: string }>;
     showItemInFolder: (filePath: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -23,3 +23,13 @@ export const getCompactFolderName = (rawPath: string, maxLength?: number): strin
 
   return folderName;
 };
+
+/**
+ * Matches the shared scratch workspace directory created by the
+ * `project:ensureScratchDir` IPC (`<home>/.zhiyuan/scratch`). Used to display
+ * that workspace as 「无项目」 instead of its folder basename.
+ */
+export const isScratchWorkspacePath = (rawPath: string): boolean => {
+  const normalized = rawPath.trim().replace(/[\\/]+$/, '');
+  return /[\\/]\.zhiyuan[\\/]scratch$/i.test(normalized);
+};

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -185,6 +185,14 @@ export const CoworkStreamIpc = {
 } as const;
 export type CoworkStreamIpc = (typeof CoworkStreamIpc)[keyof typeof CoworkStreamIpc];
 
+// ─── Project (working directory helpers) ────────────────────────────────────
+export const ProjectIpc = {
+  GetDefaultBaseDir: 'project:getDefaultBaseDir',
+  CreateDirectory: 'project:createDirectory',
+  EnsureScratchDir: 'project:ensureScratchDir',
+} as const;
+export type ProjectIpc = (typeof ProjectIpc)[keyof typeof ProjectIpc];
+
 // ─── Dialog ─────────────────────────────────────────────────────────────────
 export const DialogIpc = {
   SelectDirectory: 'dialog:selectDirectory',

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -378,6 +378,16 @@ export const CoworkBootstrapWriteSchema = {
   output: IpcResult({}),
 };
 
+// ─── Project (working directory helpers) ────────────────────────────────────
+
+export const ProjectCreateDirectorySchema = {
+  input: z.object({
+    name: z.string().min(1),
+    baseDir: z.string().min(1).optional(),
+  }),
+  output: IpcResult({ path: z.string() }),
+};
+
 // ─── Dialog ─────────────────────────────────────────────────────────────────
 
 export const DialogSelectFileSchema = {


### PR DESCRIPTION
## 概述

Work 首页输入框下方的文件夹选择器重构为「进入项目工作」入口，对齐 Kimi 的交互模型：

- 触发器：静态标签「进入项目工作」+ 下拉箭头（DESIGN.md 工具栏按钮范式），不再显示路径，移除 X 清除钮（由「不使用文件夹」选项承担）
- 菜单三选项 + 保留「最近使用」子菜单：
  1. **新建空白项目** → 创建项目弹窗（项目名称 + 项目路径，默认 `文档/ZhiYuanAgent/Workspaces` 可浏览修改），保存即建目录并选中
  2. **使用现有文件夹** → 原生目录选择器（保留驱动器根目录拦截）
  3. **不使用文件夹** → 共享 scratch 工作区（`~/.zhiyuan/scratch`），解决"无文件夹"与引擎必须有 cwd 的架构冲突；侧栏该分组显示为「无项目」（按路径映射，无 schema 变更）

## 术语统一

i18n 全局「工作区」→「项目」（中英同步）：`workspaces`/`workspaceAdd`/`workspaceNoWorkspaces` 等；第三方产品名（Slack 工作区、Google Workspace）保留原文。

## Electron 相关变更

- 新增 IPC（channel 常量 + zod schema + preload + 类型声明）：`project:getDefaultBaseDir`、`project:createDirectory`（校验非法名/拒绝覆盖已存在目录）、`project:ensureScratchDir`
- 无数据库 schema 变更

## 测试

- renderer + electron 双 tsc、oxlint 全绿；agentSidebar 13 个单测通过
- 全量 vitest 中的 43 个失败均为环境遗留（better-sqlite3 ABI 与正在运行的 app 冲突 + `update-manifest-lib` 的 Windows 路径 bug），与本 PR 无关
- 待手动 smoke：三个菜单路径、创建项目（重名/非法名拦截）、无选择时的提交拦截警告、侧栏「无项目」分组
