### PR TITLE
fix(ui): 模态遮罩去模糊，只保留轻微变暗

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -207,7 +207,7 @@ Tailwind 工具类经 `index.css` 中 `@theme` 块桥接：`--color-background: 
 | 禁用态                     | `opacity-50`（配合 `pointer-events-none`）                                                          |
 | 非激活的分段选项           | `opacity-50` + 激活时恢复（参见下方范例）                                                           |
 | 加载骨架闪烁               | `animate-shimmer` 内置                                                                              |
-| 模态遮罩                   | `bg-black/40` + `backdrop-blur-sm`（`.modal-backdrop`）                                             |
+| 模态遮罩                   | `bg-black/10`（`.modal-backdrop` 与共享 Dialog/Sheet overlay），只变暗、**不使用 backdrop-blur**     |
 | 其余一切"让颜色变浅"的需求 | **禁止用 opacity 实现**，改用对应的弱档 token（`text-secondary`、`border-subtle`、`primary-muted`） |
 
 原因：opacity 会让元素与背后的内容混色，在明暗两套主题下表现不一致；token 才能在两套主题中各自取到正确的值。

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -530,9 +530,9 @@ select::-ms-expand {
   border-top-width: 1px;
 }
 
-/* Modal backdrop */
+/* Modal backdrop: dim only, no blur (Kimi-style — the content stays sharp) */
 .modal-backdrop {
-  @apply bg-black/40 backdrop-blur-sm;
+  @apply bg-black/10;
   animation: fade-in 0.2s ease-out;
 }
 

--- a/src/shared/components/ui/dialog.tsx
+++ b/src/shared/components/ui/dialog.tsx
@@ -25,7 +25,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-[open]:animate-in data-[open]:fade-in-0 data-[closed]:animate-out data-[closed]:fade-out-0',
+        'fixed inset-0 isolate z-50 bg-black/10 duration-100 data-[open]:animate-in data-[open]:fade-in-0 data-[closed]:animate-out data-[closed]:fade-out-0',
         className,
       )}
       {...props}

--- a/src/shared/components/ui/sheet.tsx
+++ b/src/shared/components/ui/sheet.tsx
@@ -25,7 +25,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs',
+        'fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0',
         className,
       )}
       {...props}


### PR DESCRIPTION
全屏 backdrop-blur 让每次弹窗背景都糊成一片。对齐 Kimi 的处理——背景只轻微变暗、内容保持锐利：

- 共享 Dialog / Sheet overlay：移除 `backdrop-blur-xs`，保留 `bg-black/10`
- 旧 `.modal-backdrop`：`bg-black/40 + backdrop-blur-sm` → `bg-black/10`（与共享组件统一）
- DESIGN.md 透明度表已同步登记「遮罩只变暗、不使用 backdrop-blur」

tsc + lint 通过。toast、图片预览等非模态场景的 blur 未动。