### PR TITLE
feat(cowork): 项目移除入口（侧栏）

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -676,6 +676,30 @@ export class CoworkStore {
     return this.getWorkspace(id);
   }
 
+  /**
+   * Removes a workspace row and every session that belongs to it. Files on
+   * disk are never touched. Returns the ids of the deleted sessions so the
+   * renderer can drop them from its in-memory state.
+   */
+  deleteWorkspace(id: string): string[] {
+    const rows = this.db
+      .prepare('SELECT id FROM cowork_sessions WHERE workspace_id = ?')
+      .all(id) as { id: string }[];
+    const sessionIds = rows.map(row => row.id);
+    for (const sessionId of sessionIds) {
+      this.markMemorySourcesInactiveBySession(sessionId);
+    }
+    if (sessionIds.length > 0) {
+      const placeholders = sessionIds.map(() => '?').join(',');
+      this.db
+        .prepare(`DELETE FROM cowork_sessions WHERE id IN (${placeholders})`)
+        .run(...sessionIds);
+    }
+    this.db.prepare('DELETE FROM workspaces WHERE id = ?').run(id);
+    this.markOrphanImplicitMemoriesStale();
+    return sessionIds;
+  }
+
   createSession(
     title: string,
     cwd: string,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4073,6 +4073,22 @@ if (!gotTheLock) {
     }
   });
 
+  ipcMain.handle(WorkspaceIpc.Delete, async (_event, id: string) => {
+    try {
+      if (typeof id !== 'string' || !id.trim()) {
+        return { success: false, error: 'Workspace id is required' };
+      }
+      const deletedSessionIds = getCoworkStore().deleteWorkspace(id);
+      console.log(`[CoworkStore] removed a workspace along with ${deletedSessionIds.length} session(s)`);
+      return { success: true, deletedSessionIds };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to remove workspace',
+      };
+    }
+  });
+
   // Project working-directory helpers
   const getDefaultProjectBaseDir = () =>
     path.join(app.getPath('documents'), 'ZhiYuanAgent', 'Workspaces');

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -408,6 +408,7 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke(WorkspaceIpc.Ensure, options),
     renameWorkspace: (id: string, name: string) =>
       ipcRenderer.invoke(WorkspaceIpc.Rename, id, name),
+    deleteWorkspace: (id: string) => ipcRenderer.invoke(WorkspaceIpc.Delete, id),
     startSession: (options: {
       prompt: string;
       cwd?: string;

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/ui/button';
-import { FolderPlus } from 'lucide-react';
+import { Dialog, DialogContent, DialogFooter } from '@shared/components/ui/dialog';
+import { FolderPlus, TriangleAlert } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDispatch } from 'react-redux';
@@ -104,6 +105,15 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   };
 
   const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(false);
+  const [workspacePendingRemoval, setWorkspacePendingRemoval] =
+    useState<WorkspaceSidebarNode | null>(null);
+
+  const handleConfirmRemoveWorkspace = async () => {
+    const workspace = workspacePendingRemoval;
+    setWorkspacePendingRemoval(null);
+    if (!workspace) return;
+    await workspaceService.deleteWorkspace(workspace.id);
+  };
 
   const handleCreateWorkspace = () => {
     // Align with 「进入项目工作 → 新建空白项目」: open the create-project
@@ -147,6 +157,34 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
         onOpenChange={setIsCreateProjectOpen}
         onCreated={path => void handleProjectCreated(path)}
       />
+      <Dialog
+        open={workspacePendingRemoval !== null}
+        onOpenChange={open => {
+          if (!open) setWorkspacePendingRemoval(null);
+        }}
+      >
+        <DialogContent className="max-w-sm" showCloseButton={false}>
+          <div className="flex items-center gap-3">
+            <div className="rounded-full bg-red-100 p-2 dark:bg-red-900/30">
+              <TriangleAlert className="h-5 w-5 text-red-600 dark:text-red-500" />
+            </div>
+            <h2 className="text-base font-semibold">
+              {i18nService.t('removeProjectDialogTitle')}
+            </h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {i18nService.t('removeProjectDialogDescription')}
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setWorkspacePendingRemoval(null)}>
+              {i18nService.t('cancel')}
+            </Button>
+            <Button variant="destructive" onClick={() => void handleConfirmRemoveWorkspace()}>
+              {i18nService.t('removeProject')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <div className="sticky top-0 z-30 flex h-10 items-center justify-between bg-surface-raised px-1.5">
         <h2 className="min-w-0 truncate text-[14px] font-normal text-foreground opacity-[0.28]">
           {i18nService.t('workspaces')}
@@ -186,6 +224,9 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
               selectedIds={selectedIds}
               onToggleExpanded={toggleExpanded}
               onCreateTask={selectedWorkspace => void handleCreateTask(selectedWorkspace)}
+              onRemoveWorkspace={selectedWorkspace =>
+                setWorkspacePendingRemoval(selectedWorkspace)
+              }
               onRetryLoadTasks={workspaceId => void retryLoadTasks(workspaceId)}
               onLoadMoreTasks={workspaceId => void loadMoreTasks(workspaceId)}
               onCollapseTasks={collapseTasks}
@@ -223,6 +264,9 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
                   selectedIds={selectedIds}
                   onToggleExpanded={toggleScheduledExpanded}
                   onCreateTask={() => undefined}
+                  onRemoveWorkspace={selectedWorkspace =>
+                    setWorkspacePendingRemoval(selectedWorkspace)
+                  }
                   onRetryLoadTasks={workspaceId => void retryLoadTasks(workspaceId)}
                   onLoadMoreTasks={workspaceId => void loadMoreScheduledTasks(workspaceId)}
                   onCollapseTasks={collapseScheduledTasks}

--- a/src/renderer/components/agentSidebar/WorkspaceTreeNode.tsx
+++ b/src/renderer/components/agentSidebar/WorkspaceTreeNode.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@shared/components/ui/button';
-import { Folder, Pencil } from 'lucide-react';
+import { Folder, Pencil, Trash2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { isScratchWorkspacePath } from '../../utils/path';
 import AgentTaskRow from './AgentTaskRow';
 import ExpandAgentTasksRow from './ExpandAgentTasksRow';
 import type { AgentSidebarTaskNode, WorkspaceSidebarNode } from './types';
@@ -13,6 +14,7 @@ interface WorkspaceTreeNodeProps {
   selectedIds: Set<string>;
   onToggleExpanded: (workspaceId: string) => void;
   onCreateTask: (workspace: WorkspaceSidebarNode) => void;
+  onRemoveWorkspace?: (workspace: WorkspaceSidebarNode) => void;
   onRetryLoadTasks: (workspaceId: string) => void;
   onLoadMoreTasks: (workspaceId: string) => void;
   onCollapseTasks: (workspaceId: string) => void;
@@ -34,6 +36,7 @@ const WorkspaceTreeNode: React.FC<WorkspaceTreeNodeProps> = ({
   selectedIds,
   onToggleExpanded,
   onCreateTask,
+  onRemoveWorkspace,
   onRetryLoadTasks,
   onLoadMoreTasks,
   onCollapseTasks,
@@ -49,6 +52,8 @@ const WorkspaceTreeNode: React.FC<WorkspaceTreeNodeProps> = ({
   const [shouldRenderTasks, setShouldRenderTasks] = useState(workspace.isExpanded);
   const [isTaskGroupVisible, setIsTaskGroupVisible] = useState(workspace.isExpanded);
   const previousExpandedRef = useRef(workspace.isExpanded);
+  // The scratch workspace (「无项目」) is not removable — it always exists.
+  const canRemove = typeof onRemoveWorkspace === 'function' && !isScratchWorkspacePath(workspace.path);
 
   useEffect(() => {
     let frame = 0;
@@ -95,10 +100,21 @@ const WorkspaceTreeNode: React.FC<WorkspaceTreeNodeProps> = ({
             variant="ghost"
             size="icon-xs"
             onClick={() => onCreateTask(workspace)}
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-[0.3] hover:opacity-[0.46]"
+            className={`absolute top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-[0.3] hover:opacity-[0.46] ${canRemove ? 'right-7' : 'right-1.5'}`}
             aria-label={i18nService.t('myAgentSidebarNewTask')}
           >
             <Pencil className="size-3.5" />
+          </Button>
+        )}
+        {canRemove && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => onRemoveWorkspace?.(workspace)}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground opacity-0 group-hover:opacity-[0.3] hover:text-destructive hover:opacity-[0.46]"
+            aria-label={i18nService.t('removeProject')}
+          >
+            <Trash2 className="size-3.5" />
           </Button>
         )}
       </div>

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1179,6 +1179,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     workspaces: '项目',
     workspaceAdd: '添加项目',
     workspaceNoWorkspaces: '还没有项目',
+    removeProject: '移除项目',
+    removeProjectDialogTitle: '移除项目',
+    removeProjectDialogDescription:
+      '移除后，项目将从列表中消失，其中的任务记录会一并删除；磁盘上的文件不会被删除。',
     defaultAgentDisplayName: '主项目',
     myAgentSidebarPinned: '置顶',
     myAgentSidebarExpandMore: '展开显示',
@@ -3705,6 +3709,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     workspaces: 'Projects',
     workspaceAdd: 'Add project',
     workspaceNoWorkspaces: 'No projects yet',
+    removeProject: 'Remove project',
+    removeProjectDialogTitle: 'Remove project',
+    removeProjectDialogDescription:
+      'After removal, the project will disappear from the list and its task records will be deleted. Files on disk will not be deleted.',
     defaultAgentDisplayName: 'Primary Project',
     myAgentSidebarPinned: 'Pinned',
     myAgentSidebarExpandMore: 'Show more',

--- a/src/renderer/services/workspace.ts
+++ b/src/renderer/services/workspace.ts
@@ -4,6 +4,7 @@ import { store } from '../store';
 import {
   clearCurrentSession,
   clearCurrentSessionForWorkspaceChange,
+  deleteSessions as deleteSessionsAction,
 } from '../store/slices/coworkSlice';
 import {
   setCurrentWorkspaceId,
@@ -28,6 +29,9 @@ type LegacyCompatibleCoworkApi = {
     id: string,
     name: string,
   ) => Promise<{ success: boolean; workspace?: Workspace }>;
+  deleteWorkspace?: (
+    id: string,
+  ) => Promise<{ success: boolean; deletedSessionIds?: string[]; error?: string }>;
   getConfig?: () => Promise<{ success: boolean; config?: { workingDirectory?: string } }>;
 };
 
@@ -156,6 +160,44 @@ class WorkspaceService {
       ),
     );
     return renamedWorkspace;
+  }
+
+  /**
+   * Removes a workspace from the app together with its session records.
+   * Files on disk are never touched. When the removed workspace was the
+   * current selection, the selection and open session are cleared back to
+   * home (mirroring the mode-switch clear).
+   */
+  async deleteWorkspace(workspaceId: string): Promise<boolean> {
+    const cowork = getCompatibleCoworkApi();
+    if (!this.workspaceApiAvailable || typeof cowork?.deleteWorkspace !== 'function') {
+      return false;
+    }
+    const result = await cowork.deleteWorkspace(workspaceId);
+    if (!result.success) {
+      console.error('Failed to remove workspace:', result.error);
+      return false;
+    }
+
+    const deletedSessionIds = result.deletedSessionIds ?? [];
+    if (deletedSessionIds.length > 0) {
+      store.dispatch(deleteSessionsAction(deletedSessionIds));
+    }
+
+    const wasCurrent = store.getState().workspace.currentWorkspaceId === workspaceId;
+    store.dispatch(
+      setWorkspaces(
+        store.getState().workspace.workspaces.filter(item => item.id !== workspaceId),
+      ),
+    );
+    if (wasCurrent) {
+      // setWorkspaces auto-selects the next workspace when the current one
+      // disappears; override back to no selection (home) instead.
+      store.dispatch(clearCurrentSession());
+      store.dispatch(setCurrentWorkspaceId(null));
+      await localStore.removeItem(CURRENT_WORKSPACE_KEY);
+    }
+    return true;
   }
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -717,6 +717,13 @@ interface IElectronAPI {
       workspace?: import('../../shared/workspace').Workspace;
       error?: string;
     }>;
+    deleteWorkspace: (
+      id: string,
+    ) => Promise<{
+      success: boolean;
+      deletedSessionIds?: string[];
+      error?: string;
+    }>;
     startSession: (options: {
       prompt: string;
       cwd?: string;

--- a/src/shared/workspace/constants.ts
+++ b/src/shared/workspace/constants.ts
@@ -2,6 +2,7 @@ export const WorkspaceIpc = {
   List: 'cowork:workspace:list',
   Ensure: 'cowork:workspace:ensure',
   Rename: 'cowork:workspace:rename',
+  Delete: 'cowork:workspace:delete',
 } as const;
 
 export type WorkspaceIpc = (typeof WorkspaceIpc)[keyof typeof WorkspaceIpc];


### PR DESCRIPTION
## 概述

项目（工作区）此前只增不减。侧栏项目行新增 hover 显示的移除按钮，点击后弹确认框，如实告知两个后果：**项目与其中任务记录一并从应用中移除；磁盘文件不会被删除**（动作叫「移除」而非「删除」，不碰用户数据是底线）。

## 实现

- `coworkStore.deleteWorkspace`：级联删除项目下全部会话（复用 `deleteSessions` 的记忆源标记逻辑），返回被删会话 id 供渲染层同步
- 新增 `cowork:workspace:delete` IPC（channel 常量 + preload + 类型声明）
- `workspaceService.deleteWorkspace`：同步 Redux（移除会话、若删的是当前选中项目则清空选择回首页）并刷新项目列表
- UI：`WorkspaceTreeNode` 行内垃圾桶按钮（hover 显形，符合危险低频动作的设计例外；铅笔按钮让位）；`MyAgentSidebarTree` 挂确认 Dialog（与任务删除弹窗同款）；「无项目」scratch 分组不提供移除入口

## 测试

- renderer + electron 双 tsc、oxlint 全绿
- agentSidebar 单测通过；coworkStore 测试因本机 better-sqlite3 ABI 环境问题整体无法运行（既有问题，与本次无关）
- 待手动 smoke：移除普通项目（任务记录一并消失、磁盘文件仍在）、移除当前选中项目回首页、无项目分组无移除按钮