### PR TITLE
feat(cowork): 安全状态指示改为打字机轮播

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { cn } from '@shared/lib/utils';
-import { PanelLeft, Pencil, ShieldCheck } from 'lucide-react';
+import { PanelLeft, Pencil } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -55,6 +55,7 @@ import WindowTitleBar from '../window/WindowTitleBar';
 import { useAgentSelectedModel } from './agentModelSelection';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
 import CoworkSessionViewport from './CoworkSessionViewport';
+import SecurityStatusIndicator from './SecurityStatusIndicator';
 import { shouldClearQuickActionSelection } from '../quick-actions/quickActionSelection';
 
 export interface CoworkViewProps {
@@ -1282,12 +1283,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         )}
       </div>
       <div className="non-draggable flex items-center">
-        <div className="flex items-center gap-1.5 mr-2 px-2.5 py-1">
-          <ShieldCheck className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
-          <span className="text-xs text-green-600 dark:text-green-400 whitespace-nowrap">
-            {i18nService.t('zhiyuanGuardEnabled')}
-          </span>
-        </div>
+        <SecurityStatusIndicator />
         <WindowTitleBar inline />
       </div>
     </div>

--- a/src/renderer/components/cowork/SecurityStatusIndicator.tsx
+++ b/src/renderer/components/cowork/SecurityStatusIndicator.tsx
@@ -1,0 +1,85 @@
+import { ShieldCheck } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { i18nService } from '../../services/i18n';
+
+const PHRASE_KEYS = [
+  'securityPhraseGuard',
+  'securityPhraseSkillScan',
+  'securityPhraseCommandBlock',
+  'securityPhraseApproval',
+  'securityPhraseLocalWatch',
+] as const;
+
+const TYPE_INTERVAL_MS = 55;
+const HOLD_MS = 3200;
+const FADE_OUT_MS = 180;
+
+const prefersReducedMotion = (): boolean =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Security status in the title bar: cycles through security-related phrases
+ * with a typewriter effect (type in → hold → fade to next), so the indicator
+ * reads as an active guard rather than a static label. Falls back to the
+ * first static phrase when reduced motion is requested.
+ */
+const SecurityStatusIndicator: React.FC = () => {
+  const phrases = useMemo(() => PHRASE_KEYS.map(key => i18nService.t(key)), []);
+  const [reducedMotion] = useState(prefersReducedMotion);
+  const [phraseIndex, setPhraseIndex] = useState(0);
+  const [typedLength, setTypedLength] = useState(0);
+  const [isFadingOut, setIsFadingOut] = useState(false);
+
+  const currentPhrase = phrases[phraseIndex];
+  const isTyping = typedLength < currentPhrase.length;
+
+  // Type the current phrase character by character, then hold.
+  useEffect(() => {
+    if (reducedMotion) return;
+    if (isTyping) {
+      const timer = window.setTimeout(() => setTypedLength(len => len + 1), TYPE_INTERVAL_MS);
+      return () => window.clearTimeout(timer);
+    }
+    const holdTimer = window.setTimeout(() => setIsFadingOut(true), HOLD_MS);
+    return () => window.clearTimeout(holdTimer);
+  }, [isTyping, reducedMotion]);
+
+  // After the fade-out, advance to the next phrase and start typing again.
+  useEffect(() => {
+    if (!isFadingOut) return;
+    const timer = window.setTimeout(() => {
+      setIsFadingOut(false);
+      setTypedLength(0);
+      setPhraseIndex(index => (index + 1) % phrases.length);
+    }, FADE_OUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [isFadingOut, phrases.length]);
+
+  // Reserve the width of the longest phrase so the header doesn't jitter.
+  const minWidthEm = useMemo(
+    () => Math.max(...phrases.map(phrase => phrase.length)) + 1,
+    [phrases],
+  );
+
+  const text = reducedMotion ? phrases[0] : currentPhrase.slice(0, typedLength);
+
+  return (
+    <div className="flex items-center gap-1.5 mr-2 px-2.5 py-1">
+      <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-success" />
+      <span
+        className={`whitespace-nowrap text-xs text-success transition-opacity duration-200 ${isFadingOut ? 'opacity-0' : 'opacity-100'}`}
+        style={{ minWidth: `${minWidthEm}em` }}
+      >
+        {text}
+        {!reducedMotion && (
+          <span className="animate-pulse" aria-hidden>
+            {isTyping ? '▏' : ''}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
+
+export default SecurityStatusIndicator;

--- a/src/renderer/components/cowork/SecurityStatusIndicator.tsx
+++ b/src/renderer/components/cowork/SecurityStatusIndicator.tsx
@@ -1,7 +1,23 @@
-import { ShieldCheck } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+
+/** Custom shield-check glyph, drawn in the same family as the plus-menu icons. */
+const GuardShieldIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+    className={className}
+  >
+    <path d="M8 1.7l5.2 2v4.1c0 3.3-2.2 5.4-5.2 6.6-3-1.2-5.2-3.3-5.2-6.6V3.7z" />
+    <path d="M5.7 7.5l1.7 1.7 3.1-3.3" />
+  </svg>
+);
 
 const PHRASE_KEYS = [
   'securityPhraseGuard',
@@ -35,6 +51,7 @@ const SecurityStatusIndicator: React.FC = () => {
   const isTyping = typedLength < currentPhrase.length;
 
   // Type the current phrase character by character, then hold.
+  // typedLength must be a dependency so the effect re-runs after each tick.
   useEffect(() => {
     if (reducedMotion) return;
     if (isTyping) {
@@ -43,7 +60,7 @@ const SecurityStatusIndicator: React.FC = () => {
     }
     const holdTimer = window.setTimeout(() => setIsFadingOut(true), HOLD_MS);
     return () => window.clearTimeout(holdTimer);
-  }, [isTyping, reducedMotion]);
+  }, [isTyping, typedLength, reducedMotion]);
 
   // After the fade-out, advance to the next phrase and start typing again.
   useEffect(() => {
@@ -66,7 +83,7 @@ const SecurityStatusIndicator: React.FC = () => {
 
   return (
     <div className="flex items-center gap-1.5 mr-2 px-2.5 py-1">
-      <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-success" />
+      <GuardShieldIcon className="h-3.5 w-3.5 shrink-0 text-success" />
       <span
         className={`whitespace-nowrap text-xs text-success transition-opacity duration-200 ${isFadingOut ? 'opacity-0' : 'opacity-100'}`}
         style={{ minWidth: `${minWidthEm}em` }}

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1569,6 +1569,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Security scan
     zhiyuanGuardEnabled: '安全防护中',
+    securityPhraseGuard: '安全防护中',
+    securityPhraseSkillScan: '技能安装前安全扫描',
+    securityPhraseCommandBlock: '危险命令实时拦截',
+    securityPhraseApproval: '敏感操作需你确认',
+    securityPhraseLocalWatch: '本地环境持续守护',
     securityScanTitle: '技能安全扫描',
     securityRisk_safe: '风险评估',
     securityRisk_low: '风险评估',
@@ -4101,6 +4106,11 @@ const translations: Record<LanguageType, Record<string, string>> = {
 
     // Security scan
     zhiyuanGuardEnabled: 'Security Active',
+    securityPhraseGuard: 'Security active',
+    securityPhraseSkillScan: 'Skills scanned before install',
+    securityPhraseCommandBlock: 'Dangerous commands blocked',
+    securityPhraseApproval: 'Sensitive actions need approval',
+    securityPhraseLocalWatch: 'Watching over your workspace',
     securityScanTitle: 'Skill Security Scan',
     securityRisk_safe: 'Risk Assessment',
     securityRisk_low: 'Risk Assessment',


### PR DESCRIPTION
右上角静态的「安全防护中」改为打字机轮播指示器，让状态有生命感：

- 五句有真实功能依据的文案轮播：安全防护中 / 技能安装前安全扫描 / 危险命令实时拦截 / 敏感操作需你确认 / 本地环境持续守护
- 节奏：逐字打入（55ms/字）→ 停留 3.2s → 淡出切下一句；输入时带闪烁光标
- 预留最长文案宽度，标题栏不抖动；`prefers-reduced-motion` 下退化为静态文案（DESIGN.md 动效约束）
- 顺手把硬编码的 `text-green-600` 换成 `text-success` token

tsc 干净，lint 无新增问题。