### PR TITLE
fix(cowork): restore the blue active-skill capsule in the prompt toolbar

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Source-structure guard for CoworkPromptInput's skill badge placement.
+ *
+ * Why not render the component? CoworkPromptInput's import chain pulls in
+ * window.electron IPC services (cowork/agent/config), ai-elements, and
+ * module-level / render-time browser globals (`navigator.platform`,
+ * `configService.getConfig()` inside a useState initializer). Rendering it
+ * under this repo's node-environment Vitest setup (no jsdom) would require
+ * mocking most of the renderer service layer, so this guard pins the two
+ * facts PR #184 broke instead:
+ *
+ *   1. ActiveSkillBadge stays mounted in the prompt toolbar
+ *      (inside PromptInputTools, next to the "+" menu).
+ *   2. The broken textarea-internal grey-token implementation
+ *      (ResizeObserver width measurement, dynamic paddingLeft, placeholder
+ *      suppression while skills are active) stays gone.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./CoworkPromptInput.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('mounts ActiveSkillBadge inside the prompt toolbar', () => {
+  expect(source).toContain('<ActiveSkillBadge />');
+
+  const toolsOpen = source.indexOf('<PromptInputTools');
+  const badge = source.indexOf('<ActiveSkillBadge />');
+  const toolsClose = source.indexOf('</PromptInputTools>');
+  expect(toolsOpen).toBeGreaterThanOrEqual(0);
+  expect(toolsClose).toBeGreaterThan(toolsOpen);
+  expect(badge).toBeGreaterThan(toolsOpen);
+  expect(badge).toBeLessThan(toolsClose);
+});
+
+test('does not reintroduce the PR #184 textarea-token implementation', () => {
+  // ResizeObserver-driven width measurement for the inline tokens.
+  expect(source).not.toContain('skillTokensRef');
+  expect(source).not.toContain('skillTokenWidth');
+  // The broken version cleared the textarea placeholder while skills were active.
+  expect(source).not.toContain("? '' : placeholder");
+});

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -48,6 +48,7 @@ import { WorkMode } from '../../store/workMode/constants';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
+import { ActiveSkillBadge } from '../skills';
 import {
   resolveAgentModelSelection,
   resolveEffectiveModel,
@@ -59,7 +60,6 @@ import FolderSelectorPopover from './FolderSelectorPopover';
 import { LocalThinkingToggle } from './LocalThinkingToggle';
 import PermissionModeMenu from './PermissionModeMenu';
 import PromptPlusMenu from './PromptPlusMenu';
-import { PlusMenuSkillsIcon } from './plusMenuIcons';
 import { usePersistAgentModelSelection } from './usePersistAgentModelSelection';
 
 // CoworkAttachment is aliased from the Redux-persisted DraftAttachment type
@@ -294,28 +294,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
 
     const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
     const skills = useSelector((state: RootState) => state.skill.skills);
-    const selectedSkills = useMemo(
-      () =>
-        activeSkillIds
-          .map(id => skills.find(skill => skill.id === id))
-          .filter((skill): skill is Skill => skill !== undefined),
-      [activeSkillIds, skills],
-    );
-    const skillTokensRef = useRef<HTMLDivElement>(null);
-    const [skillTokenWidth, setSkillTokenWidth] = useState(0);
-
-    useEffect(() => {
-      const tokenContainer = skillTokensRef.current;
-      if (!tokenContainer || selectedSkills.length === 0) {
-        setSkillTokenWidth(0);
-        return;
-      }
-      const updateWidth = () => setSkillTokenWidth(tokenContainer.getBoundingClientRect().width);
-      updateWidth();
-      const observer = new ResizeObserver(updateWidth);
-      observer.observe(tokenContainer);
-      return () => observer.disconnect();
-    }, [selectedSkills]);
     const currentAgentSelectedModel = useAgentSelectedModel(
       currentAgentId,
       currentAgent?.model ?? '',
@@ -1153,46 +1131,15 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
           {isStreaming && !disabled && (
             <div className="pointer-events-none absolute inset-0 z-10 rounded-[inherit] bg-input/50 dark:bg-input/80" />
           )}
-          {selectedSkills.length > 0 && (
-            <div
-              ref={skillTokensRef}
-              className="absolute left-2 top-1 z-10 flex max-w-[45%] items-center gap-1 overflow-hidden"
-            >
-              {selectedSkills.map(skill => (
-                <span
-                  key={skill.id}
-                  className="group inline-flex min-w-0 shrink items-center gap-1 rounded-md bg-muted py-1 pl-1 pr-1.5 text-sm text-foreground"
-                >
-                  <PlusMenuSkillsIcon className="size-3.5 shrink-0 text-muted-foreground group-hover:hidden" />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="hidden size-4 shrink-0 rounded-sm p-0 group-hover:inline-flex hover:bg-background"
-                    onClick={() => dispatch(toggleActiveSkill(skill.id))}
-                    title={i18nService.t('clearSkill')}
-                  >
-                    <X className="size-3" />
-                  </Button>
-                  <span className="truncate">{skill.name}</span>
-                </span>
-              ))}
-            </div>
-          )}
           <PromptInputBody>
             <PromptInputTextarea
               ref={textareaRef}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
               onChange={e => setValue(e.currentTarget.value)}
-              placeholder={selectedSkills.length > 0 ? '' : placeholder}
+              placeholder={placeholder}
               disabled={disabled}
               className="min-h-20"
-              style={
-                skillTokenWidth > 0
-                  ? { paddingLeft: `${Math.ceil(skillTokenWidth) + 12}px` }
-                  : undefined
-              }
             />
           </PromptInputBody>
           <PromptInputFooter className="flex-wrap">
@@ -1239,6 +1186,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                       disabled={disabled || isStreaming}
                     />
                   )}
+                  <ActiveSkillBadge />
                 </>
               )}
             </PromptInputTools>

--- a/src/renderer/components/skills/ActiveSkillBadge.test.ts
+++ b/src/renderer/components/skills/ActiveSkillBadge.test.ts
@@ -1,0 +1,201 @@
+/**
+ * SSR contract tests for the active skill badge.
+ *
+ * The repo's Vitest config runs in the `node` environment without jsdom or
+ * @testing-library and only includes `*.test.ts` (no JSX), so these tests
+ * render via React.createElement + react-dom/server's renderToStaticMarkup.
+ * Effects never run during SSR, which conveniently sidesteps browser-only
+ * APIs (ResizeObserver, window, etc.).
+ *
+ * These tests pin the design contract that PR #184 once broke: the badge
+ * renders blue pill chips (`rounded-full` + `--zy-skill-blue-*` tokens) with
+ * semantic shortcut labels for core skills, instead of grey `bg-muted`
+ * square tokens showing the raw skill name.
+ */
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Provider } from 'react-redux';
+import type { Store } from 'redux';
+import { expect, test, vi } from 'vitest';
+
+import type { LocalizedQuickAction } from '../../types/quickAction';
+import type { Skill } from '../../types/skill';
+import ActiveSkillBadge from './ActiveSkillBadge';
+
+vi.mock('../../services/i18n', () => {
+  const translations: Record<string, string> = {
+    chatSkillDeepResearch: '深度研究',
+    clearSkill: '移除技能',
+    clearAll: '全部清除',
+    clearAllSkills: '清除全部技能',
+  };
+  return {
+    i18nService: {
+      t: (key: string) => translations[key] ?? key,
+    },
+  };
+});
+
+vi.mock('../../services/skillIcon', () => ({
+  resolveSkillIconUrl: (iconUrl?: string) => iconUrl,
+}));
+
+interface FakeState {
+  skill: {
+    skills: Skill[];
+    activeSkillIds: string[];
+  };
+  quickAction: {
+    actions: LocalizedQuickAction[];
+    selectedActionId: string | null;
+    selectedPromptId: string | null;
+    isLoading: boolean;
+  };
+}
+
+const makeSkill = (overrides: Partial<Skill> & { id: string }): Skill => ({
+  name: overrides.id,
+  description: '',
+  enabled: true,
+  pinned: false,
+  isOfficial: false,
+  isBuiltIn: false,
+  updatedAt: 0,
+  prompt: '',
+  skillPath: `/skills/${overrides.id}/SKILL.md`,
+  ...overrides,
+});
+
+const makeQuickAction = (id: string, skillMapping: string): LocalizedQuickAction => ({
+  id,
+  label: id,
+  icon: 'bolt',
+  color: '#000000',
+  skillMapping,
+  prompts: [],
+});
+
+const makeState = (partial?: {
+  skills?: Skill[];
+  activeSkillIds?: string[];
+  actions?: LocalizedQuickAction[];
+  selectedActionId?: string | null;
+}): FakeState => ({
+  skill: {
+    skills: partial?.skills ?? [],
+    activeSkillIds: partial?.activeSkillIds ?? [],
+  },
+  quickAction: {
+    actions: partial?.actions ?? [],
+    selectedActionId: partial?.selectedActionId ?? null,
+    selectedPromptId: null,
+    isLoading: false,
+  },
+});
+
+// react-redux's Provider only needs getState/dispatch/subscribe at runtime;
+// a full Redux store would drag in the whole slice graph and its IPC services.
+const createFakeStore = (state: FakeState): Store =>
+  ({
+    getState: () => state,
+    dispatch: vi.fn(),
+    subscribe: () => () => {},
+  }) as unknown as Store;
+
+const renderBadge = (state: FakeState): string =>
+  renderToStaticMarkup(
+    React.createElement(Provider, {
+      store: createFakeStore(state),
+      // eslint-disable-next-line react/no-children-prop -- .test.ts files cannot use JSX
+      children: React.createElement(ActiveSkillBadge),
+    }),
+  );
+
+const countRemoveButtons = (html: string): number => html.match(/title="移除技能"/g)?.length ?? 0;
+
+test('renders nothing when no skill is active and no quick action is selected', () => {
+  expect(renderBadge(makeState())).toBe('');
+});
+
+test('renders core skills as blue pill chips with the semantic shortcut label', () => {
+  const html = renderBadge(
+    makeState({
+      skills: [makeSkill({ id: 'deep-research', name: 'deep-research-raw-name' })],
+      activeSkillIds: ['deep-research'],
+    }),
+  );
+
+  // Name contract: the shortcut labelKey wins over the raw skill name.
+  expect(html).toContain('深度研究');
+  expect(html).not.toContain('deep-research-raw-name');
+
+  // Style contract: blue capsule, not the PR #184 grey square token.
+  expect(html).toContain('rounded-full');
+  expect(html).toContain('text-(--zy-skill-blue-foreground)');
+  expect(html).toContain('hover:bg-(--zy-skill-blue-background)');
+  expect(html).not.toContain('bg-muted');
+});
+
+test('falls back to displayName then name for non-core skills', () => {
+  const html = renderBadge(
+    makeState({
+      skills: [
+        makeSkill({ id: 'custom-a', name: 'raw-name-a', displayName: '我的技能' }),
+        makeSkill({ id: 'custom-b', name: 'Plain Name' }),
+      ],
+      activeSkillIds: ['custom-a', 'custom-b'],
+    }),
+  );
+
+  expect(html).toContain('我的技能');
+  expect(html).toContain('Plain Name');
+  expect(html).not.toContain('raw-name-a');
+});
+
+test('renders a remove button titled with the clearSkill label for every chip', () => {
+  const html = renderBadge(
+    makeState({
+      skills: [
+        makeSkill({ id: 'deep-research' }),
+        makeSkill({ id: 'custom-b', name: 'Plain Name' }),
+      ],
+      activeSkillIds: ['deep-research', 'custom-b'],
+    }),
+  );
+
+  expect(countRemoveButtons(html)).toBe(2);
+  // With more than one active skill a "clear all" action is also offered.
+  expect(html).toContain('title="清除全部技能"');
+});
+
+test('renders the quick action skill chip when only a quick action is selected', () => {
+  const html = renderBadge(
+    makeState({
+      skills: [makeSkill({ id: 'deep-research' })],
+      activeSkillIds: [],
+      actions: [makeQuickAction('qa-deep', 'deep-research')],
+      selectedActionId: 'qa-deep',
+    }),
+  );
+
+  expect(html).toContain('深度研究');
+  expect(countRemoveButtons(html)).toBe(1);
+});
+
+test('hides the quick action fallback chip while real skills are active', () => {
+  const html = renderBadge(
+    makeState({
+      skills: [
+        makeSkill({ id: 'custom-b', name: 'Plain Name' }),
+        makeSkill({ id: 'deep-research' }),
+      ],
+      activeSkillIds: ['custom-b'],
+      actions: [makeQuickAction('qa-deep', 'deep-research')],
+      selectedActionId: 'qa-deep',
+    }),
+  );
+
+  expect(html).toContain('Plain Name');
+  expect(html).not.toContain('深度研究');
+  expect(countRemoveButtons(html)).toBe(1);
+});


### PR DESCRIPTION
## 问题

PR #184 把 ActiveSkillBadge 替换成了覆盖在输入框内的灰色 token，破坏了设计：

- **颜色**：灰色 `bg-muted` → 应为蓝色胶囊（字 #1783ff / 底 #e7f2ff）
- **名称**：直接显示 `skill.name` → 核心技能应显示语义化标签（如「深度研究」）
- **位置**：绝对定位在 textarea 内部 → 应在工具栏 + 号旁

## 修复

- 删除输入框内的 token 覆盖层及其 ResizeObserver 宽度追踪逻辑（-55 行）
- 工具栏恢复渲染 `<ActiveSkillBadge />`（组件本身的蓝色胶囊设计未被破坏，无需改动）
- 保留 #184 引入的合理行为：提交后清空激活技能、提交失败时恢复、Backspace 逐个移除

## 验证

- `tsc --noEmit` 通过
- `oxlint` 0 errors（仅 main 既有 McpManager warning）
- `oxfmt` 已格式化