### PR TITLE
feat(本地推理): 优化了在日志全屏状态下直接关闭的黑屏以及模型卡片压缩问题

### DIFF
--- a/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
+++ b/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
@@ -3,7 +3,7 @@ import { Button } from '@shared/components/ui/button';
 import { LocalInferenceLogViewer } from './LocalInferenceLogViewer';
 import { cn } from '@shared/lib/utils';
 import { Download, X } from 'lucide-react';
-import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
+import type { CSSProperties, PointerEvent as ReactPointerEvent, TransitionEvent as ReactTransitionEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 import type { LlamaCppModelLaunchLogEvent } from '../../../../shared/llamacpp';
@@ -22,6 +22,7 @@ const MODEL_LAUNCH_LOG_SIDEBAR_MAX_WIDTH = 560;
 const MODEL_LAUNCH_LOG_MAIN_CONTENT_MIN_WIDTH = 520;
 const MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT = 900;
 const MODEL_LAUNCH_LOG_DETAIL_SEPARATOR = ' ';
+const MODEL_LAUNCH_LOG_TRANSITION_FALLBACK_MS = 50;
 
 const LlamaCppProcessLogMessage = {
   Stdout: 'llama-server stdout',
@@ -49,6 +50,8 @@ export function ModelLaunchLogSidebar({
   const [isEntered, setIsEntered] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isFullscreenExitPending, setIsFullscreenExitPending] = useState(false);
+  const [isFullscreenClosePending, setIsFullscreenClosePending] = useState(false);
+  const [isFullscreenLayoutReleasing, setIsFullscreenLayoutReleasing] = useState(false);
   const sidebarRef = useRef<HTMLElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(() => getMaxSidebarWidth());
@@ -75,6 +78,8 @@ export function ModelLaunchLogSidebar({
 
   useEffect(() => {
     if (state.visible) {
+      setIsFullscreenClosePending(false);
+      setIsFullscreenLayoutReleasing(false);
       setSidebarWidth(getMaxSidebarWidth(containerWidth));
       setIsPresent(true);
       const frame = window.requestAnimationFrame(() => {
@@ -85,27 +90,59 @@ export function ModelLaunchLogSidebar({
     }
 
     setIsEntered(false);
+    if (isFullscreen) {
+      setIsFullscreenClosePending(true);
+      return;
+    }
+
     const timeout = window.setTimeout(() => {
       setIsPresent(false);
-      if (isFullscreen) onFullscreenChange(false);
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS);
 
     return () => window.clearTimeout(timeout);
-  }, [containerWidth, isFullscreen, onFullscreenChange, state.visible]);
+  }, [containerWidth, isFullscreen, isFullscreenClosePending, state.visible]);
 
   const isPanelEntered = state.visible && isEntered;
   const isPanelClosing = !state.visible && isPresent;
-  const isVisualFullscreen = isFullscreen || isFullscreenExitPending;
+  const isVisualFullscreen =
+    isFullscreen || isFullscreenExitPending || isFullscreenClosePending || isFullscreenLayoutReleasing;
   const isCompact = containerWidth > 0 && containerWidth < MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT;
+  const isFullscreenCloseTransition = isVisualFullscreen && isPanelClosing;
+
   useEffect(() => {
     if (!isFullscreenExitPending) return;
 
     const timeout = window.setTimeout(() => {
       setIsFullscreenExitPending(false);
+      setIsFullscreenLayoutReleasing(true);
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS);
 
     return () => window.clearTimeout(timeout);
   }, [isFullscreenExitPending]);
+
+  useEffect(() => {
+    if (!isFullscreenClosePending) return;
+
+    const timeout = window.setTimeout(() => {
+      if (state.visible) return;
+      setIsPresent(false);
+      setIsFullscreenClosePending(false);
+      setIsFullscreenLayoutReleasing(true);
+      onFullscreenChange(false);
+    }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS + MODEL_LAUNCH_LOG_TRANSITION_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isFullscreenClosePending, onFullscreenChange, state.visible]);
+
+  useEffect(() => {
+    if (!isFullscreenLayoutReleasing) return;
+
+    const timeout = window.setTimeout(() => {
+      setIsFullscreenLayoutReleasing(false);
+    }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS + MODEL_LAUNCH_LOG_TRANSITION_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [isFullscreenLayoutReleasing]);
 
   const handleToggleFullscreen = () => {
     if (isFullscreen) {
@@ -120,6 +157,7 @@ export function ModelLaunchLogSidebar({
 
   const handleClose = () => {
     setIsFullscreenExitPending(false);
+    if (isFullscreen) setIsFullscreenClosePending(true);
     onClose();
   };
 
@@ -171,17 +209,41 @@ export function ModelLaunchLogSidebar({
     window.addEventListener('pointercancel', handlePointerEnd);
   };
 
+  const handleSidebarTransitionEnd = (event: ReactTransitionEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget || event.propertyName !== 'transform') return;
+    if (!isFullscreenClosePending || state.visible) return;
+
+    setIsPresent(false);
+    setIsFullscreenClosePending(false);
+    setIsFullscreenLayoutReleasing(true);
+    onFullscreenChange(false);
+  };
+
+  const handleLayoutReleaseTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || event.propertyName !== 'width') return;
+    setIsFullscreenLayoutReleasing(false);
+  };
+
   return (
     <>
       {isVisualFullscreen ? (
-        <div aria-hidden="true" className="shrink-0" style={{ width: sidebarWidth }} />
+        <div
+          aria-hidden="true"
+          className="shrink-0 transition-[width] ease-in-out"
+          style={{
+            width: isFullscreenLayoutReleasing ? 0 : sidebarWidth,
+            transitionDuration: `${LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS}ms`,
+          }}
+          onTransitionEnd={handleLayoutReleaseTransitionEnd}
+        />
       ) : null}
       <aside
         aria-hidden={!state.visible}
         ref={sidebarRef}
+        onTransitionEnd={handleSidebarTransitionEnd}
         className={cn(
           'flex h-full bg-background ease-in-out',
-          'overflow-hidden transition-[width]',
+          'overflow-hidden transition-[width,transform]',
           isVisualFullscreen
             ? 'absolute inset-y-0 right-0 z-30 shadow-xl'
             : isCompact
@@ -189,14 +251,22 @@ export function ModelLaunchLogSidebar({
               : 'relative shrink-0',
         )}
         style={{
-          width: isFullscreen
+          width: isFullscreen || isFullscreenClosePending
             ? '100%'
             : isFullscreenExitPending
               ? sidebarWidth
               : isPanelEntered
                 ? sidebarWidth
                 : 0,
-          transitionProperty: 'width',
+          transform:
+            (isFullscreen || isFullscreenClosePending) && !state.visible
+              ? 'translateX(100%)'
+              : 'translateX(0)',
+          transitionProperty: !isPresent
+            ? 'none'
+            : isFullscreenCloseTransition
+              ? 'transform'
+              : 'width',
           transitionTimingFunction: 'ease-in-out',
           transitionDuration: `${LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS}ms`,
         }}
@@ -218,11 +288,9 @@ export function ModelLaunchLogSidebar({
           <div
             className={cn(
               'flex h-full shrink-0 flex-col overflow-hidden transition-[transform,opacity] ease-in-out',
-              isFullscreen && isPanelClosing
-                ? 'translate-x-full opacity-0'
-                : isPanelEntered || isPanelClosing
-                  ? 'translate-x-0 opacity-100'
-                  : 'translate-x-8 opacity-0',
+              isPanelEntered || isPanelClosing
+                ? 'translate-x-0 opacity-100'
+                : 'translate-x-8 opacity-0',
             )}
             style={{
               width: '100%',


### PR DESCRIPTION
 ## 摘要

  更新本地推理页面的模型卡片布局，以及模型启动日志侧边栏的全屏、关闭和布局过渡效果。

  ## 修改内容

  - 将本地模型卡片从四列调整为居中的两列布局，并设置卡片宽度。
  - 移除日志显示时模型卡片的布局变化动画。
  - 根据 `DESIGN.md` 更新日志窗口圆角样式，并移除左侧灰色分隔线。
  - 在下载和关闭按钮之间增加全屏按钮。
  - 增加日志窗口从右侧展开、收缩和关闭的动画。
  - 全屏时固定左侧模型卡片区域，日志窗口覆盖在模型卡片上层。
  - 修复全屏关闭时模型卡片被 flex 布局压缩到左侧的问题。
  - 增加模型卡片区域随布局占位收缩而向右展开的过渡动画。

  ## 修改类型

  - [x] Bug 修复
  - [x] 新功能
  - [ ] 破坏性修改
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 本地验证
  - [ ] 新增测试
  - [ ] 更新已有测试
  - [ ] 手动交互测试

  已完成以下验证：

  - `npx oxlint src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx`
  - `npm run build:tsc`
  - `git diff --check`

  ## 检查清单

  - [x] 代码符合项目规范
  - [x] 已完成代码自查
  - [ ] 已为复杂逻辑添加必要注释
  - [ ] 已同步更新相关文档
  - [x] 没有引入本次修改相关的新警告
  - [ ] 已新增验证功能的测试
  - [ ] 新旧单元测试均已通过

  ## Electron 相关修改

  - [ ] 修改主进程 `src/main/`
  - [ ] 修改 preload 脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 无 Electron 相关修改

  ## 补充说明

  全屏关闭时，日志窗口只执行向右滑出的 `transform` 动画。日志窗口完全离场后，左侧布局占位再通过宽度动画收缩，模型卡片区域随之平滑向右展开，避免被 flex 布局压缩或瞬间跳变。