### PR TITLE
fix(cowork): 修复大文件写入因输出 token 上限中断

### DIFF
--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -34,6 +34,7 @@ declare module '@earendil-works/pi-coding-agent' {
   export function createAgentSession(options?: Record<string, unknown>): Promise<{
     session: {
       prompt(text: string): Promise<void>;
+      steer(text: string): Promise<void>;
       abort(): Promise<void>;
       reload(): Promise<void>;
       setModel(model: unknown): Promise<void>;

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => {
   const mockSession = {
     prompt: vi.fn().mockResolvedValue(undefined),
+    steer: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn().mockResolvedValue(undefined),
     abortBash: vi.fn(),
     reload: vi.fn().mockResolvedValue(undefined),
@@ -154,6 +155,11 @@ vi.mock('../claudeSettings', () => ({
 
 import { PiRuntimeAdapter } from './piRuntimeAdapter';
 import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
+import {
+  PiAssistantStopReason,
+  PiBuiltinFileToolName,
+  PiContentBlockType,
+} from './piWriteTokenLimit';
 
 describe('PiRuntimeAdapter', () => {
   let adapter: PiRuntimeAdapter;
@@ -452,17 +458,27 @@ describe('PiRuntimeAdapter', () => {
     it('should return text when Chat mode is set', async () => {
       await adapter.startSession('test', 'Hello', { confirmationMode: 'text' });
       expect(adapter.getSessionConfirmationMode('test')).toBe('text');
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      expect(loaderOptions.appendSystemPromptOverride()).toEqual([PiAskUserQuestionSystemPrompt]);
     });
   });
 
   // ── Model updates ──
 
   describe('patchSession', () => {
-    it('should call setModel when model is provided', async () => {
+    it('should update the model and reload its write budget when the output limit changes', async () => {
       await adapter.startSession('test', 'Hello');
-      await adapter.patchSession('test', { model: 'llamacpp/qwen-local-2' });
+      await adapter.patchSession('test', { model: 'openai/gpt-5.2' });
       expect(mockSession.setModel).toHaveBeenCalled();
-      expect(mockResolveRawApiConfigForModelRef).toHaveBeenCalledWith('llamacpp/qwen-local-2');
+      expect(mockResolveRawApiConfigForModelRef).toHaveBeenCalledWith('openai/gpt-5.2');
+      expect(mockSession.reload).toHaveBeenCalledOnce();
+
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      expect(loaderOptions.appendSystemPromptOverride()[1]).toContain('8000 characters');
     });
 
     it('should not call setModel when no model in patch', async () => {
@@ -492,7 +508,10 @@ describe('PiRuntimeAdapter', () => {
       const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
         appendSystemPromptOverride: () => string[];
       };
-      expect(loaderOptions.appendSystemPromptOverride()).toEqual([PiAskUserQuestionSystemPrompt]);
+      expect(loaderOptions.appendSystemPromptOverride()).toEqual([
+        PiAskUserQuestionSystemPrompt,
+        expect.stringContaining('## Large File Writes'),
+      ]);
     });
 
     it('resolves a Pi AskUserQuestion tool call with the renderer response', async () => {
@@ -508,7 +527,10 @@ describe('PiRuntimeAdapter', () => {
       const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
         customTools?: Array<{
           name: string;
-          execute: (toolCallId: string, params: Record<string, unknown>) => Promise<{
+          execute: (
+            toolCallId: string,
+            params: Record<string, unknown>,
+          ) => Promise<{
             content: Array<{ text: string }>;
           }>;
         }>;
@@ -797,6 +819,29 @@ describe('PiRuntimeAdapter', () => {
       expect(updates[updates.length - 1]).toBe('Hello world');
       // No emitted content should ever contain a duplicated prefix.
       expect(updates.some(c => c.includes('HelHello') || c.includes('HelloHello'))).toBe(false);
+    });
+
+    it('should steer a truncated built-in write into the chunked workflow', async () => {
+      await adapter.startSession('test', 'Write a large file');
+
+      listener!({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          stopReason: PiAssistantStopReason.Length,
+          content: [
+            {
+              type: PiContentBlockType.ToolCall,
+              id: 'write-1',
+              name: PiBuiltinFileToolName.Write,
+              arguments: { path: 'large.md', content: 'partial' },
+            },
+          ],
+        },
+      });
+
+      expect(mockSession.steer).toHaveBeenCalledOnce();
+      expect(mockSession.steer).toHaveBeenCalledWith(expect.stringContaining('2048 characters'));
     });
 
     it('should mark an answer as final only after the agent run ends', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -43,7 +43,9 @@ import {
   type PiAskUserQuestionResponse,
 } from './piAskUserQuestion';
 import { buildPiConversationPrompt } from './piConversationContext';
+import { runPiSubagent } from './piSubagentExecution';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
+import { createPiLargeFileWriteSystemPrompt, PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
 import type {
   CoworkContinueOptions,
   CoworkRuntime,
@@ -57,6 +59,7 @@ import type {
 /** Minimal type for the Pi AgentSession — only the methods used by this adapter. */
 interface PiSession {
   prompt(text: string): Promise<void>;
+  steer(text: string): Promise<void>;
   abort(): Promise<void>;
   abortBash(): void;
   reload(): Promise<void>;
@@ -68,6 +71,9 @@ interface PiContentBlock {
   type: string;
   text?: string;
   thinking?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
 }
 
 interface PiEvent {
@@ -126,6 +132,7 @@ interface ActivePiSession {
   aborted: boolean;
   /** toolCallId → tool_result message id, for streaming updates + de-dup */
   toolResultMessageIdByCallId: Map<string, string>;
+  writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
 }
 
 // ── Dynamic imports ──
@@ -152,6 +159,8 @@ interface PiResourceLoader {
 interface PiResourceState {
   systemPrompt: string;
   skillIds: string[] | undefined;
+  maxOutputTokens: number;
+  fileToolsEnabled: boolean;
 }
 
 interface PiModelRuntime {
@@ -167,6 +176,7 @@ interface PiModelRuntime {
 type PiResolvedModel = {
   model: Record<string, unknown>;
   modelRuntime: PiModelRuntime | null;
+  maxOutputTokens: number;
   requestOptions?: {
     apiKey?: string;
   };
@@ -345,20 +355,23 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       const resourceState: PiResourceState = {
         systemPrompt: basePrompt,
         skillIds: normalizeSkillIds(options.skillIds),
+        maxOutputTokens: DEFAULT_PI_MAX_TOKENS,
+        fileToolsEnabled: options.confirmationMode !== 'text',
       };
 
       // Pi's createAgentSession does not accept a systemPrompt option. Its
       // default resource loader supplies the Pi Coding Assistant identity,
       // so override that loader per session to keep expert contexts isolated.
-      const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState);
-      sessionOptions.resourceLoader = resourceLoader;
-
       // Resolve model early — needed by both MCP proxy and subagent tool
       const resolvedModel = await resolvePiModel(pi, options.modelOverride);
+      resourceState.maxOutputTokens = resolvedModel.maxOutputTokens;
       sessionOptions.model = resolvedModel.model;
       if (resolvedModel.modelRuntime) {
         sessionOptions.modelRuntime = resolvedModel.modelRuntime;
       }
+
+      const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState);
+      sessionOptions.resourceLoader = resourceLoader;
 
       // Build custom tools: MCP proxy + optional subagent for Team Leads.
       // Each call creates a distinct tool instance for this Pi session, so its
@@ -441,6 +454,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         unsubscribe: () => {},
         aborted: false,
         toolResultMessageIdByCallId: new Map(),
+        writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
       };
 
       // Subscribe to Pi events before sending the prompt
@@ -547,6 +561,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     active.lastCompletedAnswerMessageId = null;
     active.lastCompletedAnswerText = '';
     active.toolResultMessageIdByCallId.clear();
+    active.writeTokenLimitRecovery.reset();
 
     // Emit user message (persisted to SQLite, same as startSession).
     const userMsg: CoworkMessage = {
@@ -579,9 +594,14 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     try {
       const pi = await getPiModules();
       const resolvedModel = await resolvePiModel(pi, patch.model, active.modelRuntime);
-      active.modelRuntime = resolvedModel.modelRuntime;
       const model = resolvedModel.model;
       await active.piSession.setModel(model);
+      active.modelRuntime = resolvedModel.modelRuntime;
+      active.writeTokenLimitRecovery = new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens);
+      if (active.resourceState.maxOutputTokens !== resolvedModel.maxOutputTokens) {
+        active.resourceState.maxOutputTokens = resolvedModel.maxOutputTokens;
+        await active.piSession.reload();
+      }
       console.log('[PiRuntime] Model updated via patchSession:', patch.model);
     } catch (err) {
       console.warn('[PiRuntime] Failed to update model via patchSession:', err);
@@ -686,7 +706,12 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       systemPromptOverride: () => resourceState.systemPrompt,
       // Pi bypasses tool promptGuidelines when systemPromptOverride is non-empty.
       // Append this policy so it remains present for both default and custom prompts.
-      appendSystemPromptOverride: (): string[] => [PiAskUserQuestionSystemPrompt],
+      appendSystemPromptOverride: (): string[] => [
+        PiAskUserQuestionSystemPrompt,
+        ...(resourceState.fileToolsEnabled
+          ? [createPiLargeFileWriteSystemPrompt(resourceState.maxOutputTokens)]
+          : []),
+      ],
     });
     await resourceLoader.reload();
     return resourceLoader;
@@ -790,6 +815,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
 
       case 'message_end': {
         if (event.message?.role === 'assistant') {
+          active.writeTokenLimitRecovery.queueIfNeeded(event.message, active.piSession);
           if (event.message.stopReason === 'error') {
             const { thinking } = extractStreamingSnapshot(event.message);
             if (thinking && thinking !== active.thinkingText) {
@@ -1493,7 +1519,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
    */
   private buildSubagentTool(
     presetId: string,
-    resolvedModel: { model: Record<string, unknown>; modelRuntime: PiModelRuntime | null },
+    resolvedModel: PiResolvedModel,
     workspaceRoot?: string,
   ): Record<string, unknown> | null {
     const piAgentsDir = this.getPiAgentsDir();
@@ -1514,7 +1540,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     if (availableAgents.length === 0) return null;
 
     const agentList = availableAgents.map(a => `  - ${a.id}`).join('\n');
-    const { model, modelRuntime } = resolvedModel;
+    const { model, modelRuntime, maxOutputTokens } = resolvedModel;
 
     return {
       name: 'subagent',
@@ -1598,7 +1624,12 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
           subOptions.resourceLoader = await this.createPiResourceLoader(
             pi,
             subOptions.cwd as string,
-            { systemPrompt, skillIds: undefined },
+            {
+              systemPrompt,
+              skillIds: undefined,
+              maxOutputTokens,
+              fileToolsEnabled: true,
+            },
           );
           if (modelRuntime) {
             subOptions.modelRuntime = modelRuntime;
@@ -1607,48 +1638,9 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
           const { session } = await pi.createAgentSession(subOptions);
           subSession = session;
 
-          // Collect the final output from the sub-session
-          const finalOutput = await new Promise<string>((resolve, reject) => {
-            const timeout = setTimeout(() => {
-              resolve('(subagent timed out after 120s)');
-            }, 120_000);
-
-            const unsubscribe = session.subscribe((event: PiEvent) => {
-              if (event.type === 'message_end' && event.message?.role === 'assistant') {
-                clearTimeout(timeout);
-                unsubscribe();
-
-                const msg = event.message;
-                if (Array.isArray(msg.content)) {
-                  const textBlocks = msg.content
-                    .filter((b: PiContentBlock) => b.type === 'text' && b.text)
-                    .map((b: PiContentBlock) => b.text!)
-                    .join('\n');
-                  resolve(textBlocks || '(no output)');
-                } else if (typeof msg.content === 'string') {
-                  resolve(msg.content || '(no output)');
-                } else {
-                  resolve('(no output)');
-                }
-              }
-
-              if (
-                event.type === 'error' ||
-                (event.type === 'message_end' && event.message?.stopReason === 'error')
-              ) {
-                clearTimeout(timeout);
-                unsubscribe();
-                const errorMsg = event.message?.errorMessage || 'Subagent encountered an error';
-                resolve(`Error: ${errorMsg}`);
-              }
-            });
-
-            // Send the task
-            session.prompt(task).catch((err: Error) => {
-              clearTimeout(timeout);
-              unsubscribe();
-              reject(err);
-            });
+          const finalOutput = await runPiSubagent(session, task, {
+            maxOutputTokens,
+            timeoutMs: 120_000,
           });
 
           return {
@@ -1837,6 +1829,7 @@ async function resolvePiModel(
         ? (registeredModel as Record<string, unknown>)
         : customModel),
     modelRuntime,
+    maxOutputTokens: resolution.providerMetadata.maxTokens || DEFAULT_PI_MAX_TOKENS,
     requestOptions: resolution.config.apiKey ? { apiKey: resolution.config.apiKey } : undefined,
   };
 }

--- a/src/main/libs/agentEngine/piSubagentExecution.test.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.test.ts
@@ -1,0 +1,168 @@
+import { expect, test, vi } from 'vitest';
+
+import {
+  PiMessageRole,
+  PiSubagentEventType,
+  runPiSubagent,
+  type PiSubagentSession,
+} from './piSubagentExecution';
+import {
+  PiAssistantStopReason,
+  PiBuiltinFileToolName,
+  PiContentBlockType,
+} from './piWriteTokenLimit';
+
+const createSession = () => {
+  let listener: ((event: { type: string; message?: never }) => void) | undefined;
+  let resolvePrompt: (() => void) | undefined;
+  const session: PiSubagentSession = {
+    prompt: vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePrompt = resolve;
+        }),
+    ),
+    steer: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(callback => {
+      listener = callback as typeof listener;
+      return vi.fn();
+    }),
+  };
+  return {
+    session,
+    emit: (event: object) => listener?.(event as never),
+    resolvePrompt: () => resolvePrompt?.(),
+  };
+};
+
+test('waits for agent_settled instead of returning after an intermediate assistant message', async () => {
+  const { session, emit, resolvePrompt } = createSession();
+  let settled = false;
+  const output = runPiSubagent(session, 'Implement it', {
+    maxOutputTokens: 4096,
+    timeoutMs: 10_000,
+  }).then(value => {
+    settled = true;
+    return value;
+  });
+
+  emit({
+    type: PiSubagentEventType.MessageEnd,
+    message: {
+      role: PiMessageRole.Assistant,
+      stopReason: PiAssistantStopReason.Stop,
+      content: [{ type: PiContentBlockType.Text, text: 'Intermediate' }],
+    },
+  });
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  emit({
+    type: PiSubagentEventType.MessageEnd,
+    message: {
+      role: PiMessageRole.Assistant,
+      stopReason: PiAssistantStopReason.Stop,
+      content: [{ type: PiContentBlockType.Text, text: 'Final answer' }],
+    },
+  });
+  emit({ type: PiSubagentEventType.AgentEnd });
+  resolvePrompt();
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  emit({ type: PiSubagentEventType.AgentSettled });
+
+  await expect(output).resolves.toBe('Final answer');
+});
+
+test('queues Pi write recovery and keeps waiting after a truncated subagent write', async () => {
+  const { session, emit, resolvePrompt } = createSession();
+  const output = runPiSubagent(session, 'Write a large file', {
+    maxOutputTokens: 4096,
+    timeoutMs: 10_000,
+  });
+
+  emit({
+    type: PiSubagentEventType.MessageEnd,
+    message: {
+      role: PiMessageRole.Assistant,
+      stopReason: PiAssistantStopReason.Length,
+      content: [
+        {
+          type: PiContentBlockType.ToolCall,
+          id: 'write-1',
+          name: PiBuiltinFileToolName.Write,
+          arguments: { path: 'large.md', content: 'partial' },
+        },
+      ],
+    },
+  });
+  expect(session.steer).toHaveBeenCalledOnce();
+
+  emit({
+    type: PiSubagentEventType.MessageEnd,
+    message: {
+      role: PiMessageRole.Assistant,
+      stopReason: PiAssistantStopReason.Stop,
+      content: [{ type: PiContentBlockType.Text, text: 'Completed' }],
+    },
+  });
+  emit({ type: PiSubagentEventType.AgentEnd });
+  emit({ type: PiSubagentEventType.AgentSettled });
+  resolvePrompt();
+
+  await expect(output).resolves.toBe('Completed');
+});
+
+test('returns a subagent error without waiting for agent_end', async () => {
+  const { session, emit } = createSession();
+  const output = runPiSubagent(session, 'Fail', {
+    maxOutputTokens: 4096,
+    timeoutMs: 10_000,
+  });
+
+  emit({
+    type: PiSubagentEventType.MessageEnd,
+    message: {
+      role: PiMessageRole.Assistant,
+      stopReason: PiAssistantStopReason.Error,
+      errorMessage: 'provider failed',
+      content: [],
+    },
+  });
+
+  await expect(output).resolves.toBe('Error: provider failed');
+});
+
+test('cleans up when subscribing throws synchronously', async () => {
+  const error = new Error('subscribe failed');
+  const session: PiSubagentSession = {
+    prompt: vi.fn().mockResolvedValue(undefined),
+    steer: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(() => {
+      throw error;
+    }),
+  };
+
+  await expect(
+    runPiSubagent(session, 'Implement it', { maxOutputTokens: 4096, timeoutMs: 10_000 }),
+  ).rejects.toBe(error);
+  expect(session.prompt).not.toHaveBeenCalled();
+});
+
+test('cleans up when prompting throws synchronously', async () => {
+  const error = new Error('prompt failed');
+  const unsubscribe = vi.fn();
+  const session: PiSubagentSession = {
+    prompt: vi.fn(() => {
+      throw error;
+    }),
+    steer: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(() => unsubscribe),
+  };
+
+  await expect(
+    runPiSubagent(session, 'Implement it', { maxOutputTokens: 4096, timeoutMs: 10_000 }),
+  ).rejects.toBe(error);
+  expect(unsubscribe).toHaveBeenCalledOnce();
+});

--- a/src/main/libs/agentEngine/piSubagentExecution.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.ts
@@ -1,0 +1,118 @@
+import {
+  PiAssistantStopReason,
+  PiContentBlockType,
+  PiWriteTokenLimitRecovery,
+  type PiWriteRecoveryMessage,
+} from './piWriteTokenLimit';
+
+export const PiSubagentEventType = {
+  AgentEnd: 'agent_end',
+  AgentSettled: 'agent_settled',
+  Error: 'error',
+  MessageEnd: 'message_end',
+} as const;
+
+export const PiMessageRole = {
+  Assistant: 'assistant',
+} as const;
+
+type PiSubagentMessage = PiWriteRecoveryMessage & {
+  role: string;
+  errorMessage?: string;
+};
+
+type PiSubagentEvent = {
+  type: string;
+  message?: PiSubagentMessage;
+};
+
+export type PiSubagentSession = {
+  prompt(text: string): Promise<void>;
+  steer(text: string): Promise<void>;
+  subscribe(listener: (event: PiSubagentEvent) => void): () => void;
+};
+
+export type RunPiSubagentOptions = {
+  maxOutputTokens: number;
+  timeoutMs: number;
+};
+
+const extractAssistantText = (message: PiSubagentMessage): string => {
+  if (typeof message.content === 'string') return message.content.trim();
+  return message.content
+    .filter(block => block.type === PiContentBlockType.Text && typeof block.text === 'string')
+    .map(block => block.text)
+    .join('\n')
+    .trim();
+};
+
+export const runPiSubagent = (
+  session: PiSubagentSession,
+  task: string,
+  options: RunPiSubagentOptions,
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const recovery = new PiWriteTokenLimitRecovery(options.maxOutputTokens);
+    let latestAnswer = '';
+    let settled = false;
+    let unsubscribe = (): void => {};
+
+    const finish = (output: string): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(output);
+    };
+
+    const fail = (error: unknown): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      unsubscribe();
+      reject(error);
+    };
+
+    const timeout = setTimeout(
+      () => finish(`(subagent timed out after ${Math.round(options.timeoutMs / 1000)}s)`),
+      options.timeoutMs,
+    );
+
+    try {
+      const subscribedUnsubscribe = session.subscribe(event => {
+        const message = event.message;
+        if (
+          event.type === PiSubagentEventType.MessageEnd &&
+          message?.role === PiMessageRole.Assistant
+        ) {
+          recovery.queueIfNeeded(message, session);
+          if (message.stopReason === PiAssistantStopReason.Error) {
+            finish(`Error: ${message.errorMessage || 'Subagent encountered an error'}`);
+            return;
+          }
+
+          const answer = extractAssistantText(message);
+          if (answer) latestAnswer = answer;
+        }
+
+        if (event.type === PiSubagentEventType.Error) {
+          finish(`Error: ${message?.errorMessage || 'Subagent encountered an error'}`);
+        } else if (event.type === PiSubagentEventType.AgentSettled) {
+          finish(latestAnswer || '(no output)');
+        }
+      });
+      unsubscribe = subscribedUnsubscribe;
+      if (settled) subscribedUnsubscribe();
+    } catch (error) {
+      fail(error);
+      return;
+    }
+
+    if (settled) return;
+
+    try {
+      void session.prompt(task).catch(error => fail(error));
+    } catch (error) {
+      fail(error);
+    }
+  });

--- a/src/main/libs/agentEngine/piWriteTokenLimit.test.ts
+++ b/src/main/libs/agentEngine/piWriteTokenLimit.test.ts
@@ -1,0 +1,198 @@
+import { expect, test, vi } from 'vitest';
+
+import {
+  calculatePiWriteChunkCharacterLimit,
+  createPiLargeFileWriteSystemPrompt,
+  PiAssistantStopReason,
+  PiBuiltinFileToolName,
+  PiContentBlockType,
+  PiWriteTokenLimitRecovery,
+} from './piWriteTokenLimit';
+
+const writeCall = (id: string, path: string) => ({
+  type: PiContentBlockType.ToolCall,
+  id,
+  name: PiBuiltinFileToolName.Write,
+  arguments: { path, content: 'partial' },
+});
+
+test('derives a conservative character budget from the model output limit', () => {
+  expect(calculatePiWriteChunkCharacterLimit(4096)).toBe(2048);
+  expect(calculatePiWriteChunkCharacterLimit(16384)).toBe(8000);
+  expect(calculatePiWriteChunkCharacterLimit(512)).toBe(256);
+  expect(calculatePiWriteChunkCharacterLimit(1)).toBe(1);
+  expect(calculatePiWriteChunkCharacterLimit(Number.NaN)).toBe(2048);
+});
+
+test('instructs Pi to reuse write, edit, read, grep, and bash for chunked writes', () => {
+  const prompt = createPiLargeFileWriteSystemPrompt(4096);
+
+  expect(prompt).toContain('built-in write tool');
+  expect(prompt).toContain('2048 characters');
+  expect(prompt).toContain('use edit');
+  expect(prompt).toContain('read or grep');
+  expect(prompt).toContain('built-in bash tool');
+  expect(prompt).toContain('only one content-bearing write or edit call');
+});
+
+test('does not steer normal responses or truncated non-write calls', () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  const session = { steer: vi.fn().mockResolvedValue(undefined) };
+
+  expect(
+    recovery.queueIfNeeded(
+      { stopReason: PiAssistantStopReason.Stop, content: [writeCall('write-1', 'src/file.ts')] },
+      session,
+    ),
+  ).toBe(false);
+  expect(
+    recovery.queueIfNeeded(
+      {
+        stopReason: PiAssistantStopReason.Length,
+        content: [
+          {
+            type: PiContentBlockType.ToolCall,
+            id: 'bash-1',
+            name: PiBuiltinFileToolName.Bash,
+            arguments: {},
+          },
+        ],
+      },
+      session,
+    ),
+  ).toBe(false);
+  expect(session.steer).not.toHaveBeenCalled();
+});
+
+test('steers each truncated write call once and resets for the next user turn', () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  const session = { steer: vi.fn().mockResolvedValue(undefined) };
+  const firstMessage = {
+    stopReason: PiAssistantStopReason.Length,
+    content: [writeCall('write-1', 'src\\large.ts'), writeCall('write-2', 'src/other.ts')],
+  };
+
+  expect(recovery.queueIfNeeded(firstMessage, session)).toBe(true);
+  expect(recovery.queueIfNeeded(firstMessage, session)).toBe(false);
+  expect(
+    recovery.queueIfNeeded(
+      {
+        stopReason: PiAssistantStopReason.Length,
+        content: [writeCall('write-3', 'src/other.ts')],
+      },
+      session,
+    ),
+  ).toBe(true);
+  expect(session.steer).toHaveBeenCalledTimes(2);
+  expect(session.steer).toHaveBeenCalledWith(expect.stringContaining('2048 characters'));
+
+  recovery.reset();
+  expect(recovery.queueIfNeeded(firstMessage, session)).toBe(true);
+  expect(session.steer).toHaveBeenCalledTimes(3);
+});
+
+test('caps recovery attempts within one user turn', () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  const session = { steer: vi.fn().mockResolvedValue(undefined) };
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    expect(
+      recovery.queueIfNeeded(
+        {
+          stopReason: PiAssistantStopReason.Length,
+          content: [writeCall(`write-${attempt}`, 'large.md')],
+        },
+        session,
+      ),
+    ).toBe(true);
+  }
+  expect(
+    recovery.queueIfNeeded(
+      {
+        stopReason: PiAssistantStopReason.Length,
+        content: [writeCall('write-4', 'large.md')],
+      },
+      session,
+    ),
+  ).toBe(false);
+  expect(session.steer).toHaveBeenCalledTimes(3);
+});
+
+test('allows recovery to be queued again when Pi rejects steering', async () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  const steerError = new Error('session stopped');
+  const session = { steer: vi.fn().mockRejectedValueOnce(steerError).mockResolvedValue(undefined) };
+  const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const message = {
+    stopReason: PiAssistantStopReason.Length,
+    content: [writeCall('write-1', 'large.md')],
+  };
+
+  expect(recovery.queueIfNeeded(message, session)).toBe(true);
+  await vi.waitFor(() =>
+    expect(warning).toHaveBeenCalledWith(
+      '[PiWriteRecovery] failed to queue chunked write guidance:',
+      steerError,
+    ),
+  );
+  expect(recovery.queueIfNeeded(message, session)).toBe(true);
+  expect(session.steer).toHaveBeenCalledTimes(2);
+
+  warning.mockRestore();
+});
+
+test('allows recovery after a synchronous steering failure', () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  const steerError = new Error('session stopped');
+  const session = {
+    steer: vi.fn(() => {
+      throw steerError;
+    }),
+  };
+  const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const message = {
+    stopReason: PiAssistantStopReason.Length,
+    content: [writeCall('write-1', 'large.md')],
+  };
+
+  expect(recovery.queueIfNeeded(message, session)).toBe(false);
+  expect(recovery.queueIfNeeded(message, session)).toBe(false);
+  expect(session.steer).toHaveBeenCalledTimes(2);
+  expect(warning).toHaveBeenCalledWith(
+    '[PiWriteRecovery] failed to queue chunked write guidance:',
+    steerError,
+  );
+
+  warning.mockRestore();
+});
+
+test('does not let a delayed failure clear recovery state from a newer user turn', async () => {
+  const recovery = new PiWriteTokenLimitRecovery(4096);
+  let rejectFirstSteer: ((error: Error) => void) | undefined;
+  const session = {
+    steer: vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirstSteer = reject;
+          }),
+      )
+      .mockResolvedValue(undefined),
+  };
+  const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const message = {
+    stopReason: PiAssistantStopReason.Length,
+    content: [writeCall('write-1', 'large.md')],
+  };
+
+  expect(recovery.queueIfNeeded(message, session)).toBe(true);
+  recovery.reset();
+  expect(recovery.queueIfNeeded(message, session)).toBe(true);
+
+  rejectFirstSteer?.(new Error('late failure'));
+  await vi.waitFor(() => expect(warning).toHaveBeenCalled());
+  expect(recovery.queueIfNeeded(message, session)).toBe(false);
+
+  warning.mockRestore();
+});

--- a/src/main/libs/agentEngine/piWriteTokenLimit.ts
+++ b/src/main/libs/agentEngine/piWriteTokenLimit.ts
@@ -1,0 +1,141 @@
+export const PiAssistantStopReason = {
+  Error: 'error',
+  Length: 'length',
+  Stop: 'stop',
+} as const;
+
+export const PiBuiltinFileToolName = {
+  Bash: 'bash',
+  Write: 'write',
+} as const;
+
+export const PiContentBlockType = {
+  Text: 'text',
+  ToolCall: 'toolCall',
+} as const;
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+const MAX_CHUNK_CHARACTERS = 8000;
+const CHUNK_CHARACTERS_PER_OUTPUT_TOKEN = 0.5;
+const MAX_WRITE_RECOVERY_ATTEMPTS = 3;
+const UNKNOWN_WRITE_CALL_KEY = '__unknown_write_call__';
+
+type PiMessageContentBlock = {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+};
+
+export type PiWriteRecoveryMessage = {
+  stopReason?: string;
+  content: string | PiMessageContentBlock[];
+};
+
+export type PiSteeringSession = {
+  steer(text: string): Promise<void>;
+};
+
+const normalizeMaxOutputTokens = (maxOutputTokens: number): number =>
+  Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
+    ? maxOutputTokens
+    : DEFAULT_MAX_OUTPUT_TOKENS;
+
+export const calculatePiWriteChunkCharacterLimit = (maxOutputTokens: number): number =>
+  Math.min(
+    MAX_CHUNK_CHARACTERS,
+    Math.max(
+      1,
+      Math.floor(normalizeMaxOutputTokens(maxOutputTokens) * CHUNK_CHARACTERS_PER_OUTPUT_TOKEN),
+    ),
+  );
+
+export const createPiLargeFileWriteSystemPrompt = (maxOutputTokens: number): string => {
+  const chunkCharacterLimit = calculatePiWriteChunkCharacterLimit(maxOutputTokens);
+  return [
+    '## Large File Writes',
+    '',
+    '- Use the built-in write tool only for new files or complete rewrites that fit safely in one response.',
+    `- Never put more than ${chunkCharacterLimit} characters in a single write.content or edit.edits[].newText when generating a large file.`,
+    '- For a large new file, use write to create a small skeleton with a unique continuation marker, then use edit to replace that marker with one content chunk plus the same marker.',
+    '- Emit only one content-bearing write or edit call per assistant response during a chunked write. Continue with the next chunk after the tool result.',
+    '- Remove the continuation marker and verify the completed file with read or grep before reporting success.',
+    '- For a complete rewrite of an existing file, assemble and verify a sibling temporary file first, then use the built-in bash tool to replace the target only after the temporary file is complete.',
+    '- If a write call hits the output token limit, do not retry the full content. Switch to the chunked write and edit workflow immediately.',
+  ].join('\n');
+};
+
+const getWriteCallKeys = (message: PiWriteRecoveryMessage): string[] => {
+  if (message.stopReason !== PiAssistantStopReason.Length || !Array.isArray(message.content)) {
+    return [];
+  }
+
+  const keys = message.content
+    .filter(
+      block =>
+        block.type === PiContentBlockType.ToolCall &&
+        block.name?.toLowerCase() === PiBuiltinFileToolName.Write,
+    )
+    .map(block => {
+      if (block.id?.trim()) return `call:${block.id.trim()}`;
+
+      const rawPath = block.arguments?.path ?? block.arguments?.file_path;
+      if (typeof rawPath === 'string' && rawPath.trim()) {
+        return `path:${rawPath.trim().replace(/\\/g, '/')}`;
+      }
+      return UNKNOWN_WRITE_CALL_KEY;
+    });
+
+  return [...new Set(keys)];
+};
+
+export class PiWriteTokenLimitRecovery {
+  private readonly recoveredWriteCalls = new Set<string>();
+  private readonly chunkCharacterLimit: number;
+  private recoveryAttempts = 0;
+  private generation = 0;
+
+  constructor(maxOutputTokens: number) {
+    this.chunkCharacterLimit = calculatePiWriteChunkCharacterLimit(maxOutputTokens);
+  }
+
+  reset(): void {
+    this.generation += 1;
+    this.recoveredWriteCalls.clear();
+    this.recoveryAttempts = 0;
+  }
+
+  queueIfNeeded(message: PiWriteRecoveryMessage, session: PiSteeringSession): boolean {
+    const writeCallKeys = getWriteCallKeys(message);
+    const newKeys = writeCallKeys.filter(key => !this.recoveredWriteCalls.has(key));
+    if (newKeys.length === 0 || this.recoveryAttempts >= MAX_WRITE_RECOVERY_ATTEMPTS) return false;
+
+    const queuedGeneration = this.generation;
+    for (const key of newKeys) this.recoveredWriteCalls.add(key);
+    this.recoveryAttempts += 1;
+    const prompt = [
+      'The previous built-in write call hit the output token limit and was not executed.',
+      'Do not retry the complete content in one call.',
+      'Use write to create a small skeleton with a unique continuation marker, then use edit to replace the marker with one chunk plus the marker on each subsequent model turn.',
+      `Keep each write.content or edit.edits[].newText payload at or below ${this.chunkCharacterLimit} characters and emit only one content-bearing file mutation per response.`,
+      'Remove the marker and verify the completed file before reporting success.',
+    ].join(' ');
+
+    const rollback = (error: unknown): void => {
+      if (queuedGeneration === this.generation) {
+        for (const key of newKeys) this.recoveredWriteCalls.delete(key);
+        this.recoveryAttempts = Math.max(0, this.recoveryAttempts - 1);
+      }
+      console.warn('[PiWriteRecovery] failed to queue chunked write guidance:', error);
+    };
+
+    try {
+      void session.steer(prompt).catch(error => rollback(error));
+    } catch (error) {
+      rollback(error);
+      return false;
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
## 背景

Pi 内置 `write` 工具的参数由模型生成。当大文件内容超过模型单次输出上限时，assistant 消息会以 `stopReason: length` 结束，工具调用无法完整生成，因此 `write` 不会执行，现有运行时也不会自动切换到分块写入。

## 改动内容

- 根据当前模型的最大输出 token 动态计算安全的单次写入字符数，并为 Work 模式与专家会话注入大文件分块写入指南。
- 复用 Pi 原生 `write`、`edit`、`read`、`grep`、`bash` 工具完成骨架创建、分块追加、结果验证和安全替换，不新增文件工具。
- 检测 `stopReason: length` 且包含内置 `write` 调用的消息，通过 Pi 原生 `steer()` 自动切换到分块工作流。
- 按 tool-call ID 去重，每个用户 turn 最多恢复 3 次，并隔离跨 turn 的异步状态，避免重复恢复或异常循环。
- 模型切换时同步刷新写入预算。
- 专家子会话改为等待 Pi 的 `agent_settled`，避免中间 assistant 消息结束后提前中止后续工具执行。

## 兼容性

- Chat 模式不注入文件写入策略。
- Skill、MCP、AskUserQuestion 和专家工具的既有注册及调用链路保持不变。
- 正常用户 turn 不增加额外模型请求；仅在实际发生 `write` 输出截断时触发恢复。
- 不涉及 Renderer、IPC、存储结构或用户可见文案变更。

## 验证

- `npm test -- piWriteTokenLimit piSubagentExecution piRuntimeAdapter`：61 条测试通过。
- `npm run compile:electron`：通过。
- `npm run build`：通过。
- `npm run lint`：通过；保留 `McpManager.tsx:195` 的既有 hooks 依赖警告。
- 格式检查与 `git diff --check`：通过。

## 已知既有问题

全量测试中 `scripts/release/update-manifest-lib.test.ts` 的 2 个 Windows 路径用例仍失败，原因是将 `C:\...` 错误解析为仓库下的 `C` 路径，与本次改动无关。