### PR TITLE
fix: marketplace 模型卡片网格最大宽度限制

### DIFF
--- a/src/renderer/components/localInference/panels/MarketplacePanel.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.tsx
@@ -342,7 +342,7 @@ export function MarketplacePanel({
         <div className="flex flex-1 flex-col">
           <div
             ref={gridRef}
-            className="grid auto-rows-min content-start gap-3 md:grid-cols-2 2xl:grid-cols-4"
+            className="mx-auto grid w-full max-w-5xl auto-rows-min content-start gap-3 md:grid-cols-2"
           >
             {visibleModels.map(model => {
               const progress = getMarketplaceInstallProgress(installProgress, model);


### PR DESCRIPTION
## 变更内容

- MarketplacePanel 网格添加 max-w-5xl 限制最大宽度
- 移除 2xl 四列布局，避免超宽屏卡片过度拉伸