### PR TITLE
feat(本地推理): 优化了日志窗口在缩小时的模型卡片抖动问题

### DIFF
--- a/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
+++ b/src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx
@@ -50,8 +50,8 @@ export function ModelLaunchLogSidebar({
   const [isEntered, setIsEntered] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [isFullscreenExitPending, setIsFullscreenExitPending] = useState(false);
-  const [isFullscreenClosePending, setIsFullscreenClosePending] = useState(false);
-  const [isFullscreenLayoutReleasing, setIsFullscreenLayoutReleasing] = useState(false);
+  const [isClosePending, setIsClosePending] = useState(false);
+  const [isLayoutReleasing, setIsLayoutReleasing] = useState(false);
   const sidebarRef = useRef<HTMLElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(() => getMaxSidebarWidth());
@@ -78,8 +78,8 @@ export function ModelLaunchLogSidebar({
 
   useEffect(() => {
     if (state.visible) {
-      setIsFullscreenClosePending(false);
-      setIsFullscreenLayoutReleasing(false);
+      setIsClosePending(false);
+      setIsLayoutReleasing(false);
       setSidebarWidth(getMaxSidebarWidth(containerWidth));
       setIsPresent(true);
       const frame = window.requestAnimationFrame(() => {
@@ -90,59 +90,50 @@ export function ModelLaunchLogSidebar({
     }
 
     setIsEntered(false);
-    if (isFullscreen) {
-      setIsFullscreenClosePending(true);
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      setIsPresent(false);
-    }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS);
-
-    return () => window.clearTimeout(timeout);
-  }, [containerWidth, isFullscreen, isFullscreenClosePending, state.visible]);
+    if (!isPresent) return;
+    setIsClosePending(true);
+  }, [containerWidth, isPresent, state.visible]);
 
   const isPanelEntered = state.visible && isEntered;
   const isPanelClosing = !state.visible && isPresent;
-  const isVisualFullscreen =
-    isFullscreen || isFullscreenExitPending || isFullscreenClosePending || isFullscreenLayoutReleasing;
+  const isPanelOverlayActive =
+    isFullscreen || isFullscreenExitPending || isClosePending || isLayoutReleasing || isPanelClosing;
   const isCompact = containerWidth > 0 && containerWidth < MODEL_LAUNCH_LOG_COMPACT_BREAKPOINT;
-  const isFullscreenCloseTransition = isVisualFullscreen && isPanelClosing;
+  const isPanelCloseTransition = isPanelClosing;
 
   useEffect(() => {
     if (!isFullscreenExitPending) return;
 
     const timeout = window.setTimeout(() => {
       setIsFullscreenExitPending(false);
-      setIsFullscreenLayoutReleasing(true);
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS);
 
     return () => window.clearTimeout(timeout);
   }, [isFullscreenExitPending]);
 
   useEffect(() => {
-    if (!isFullscreenClosePending) return;
+    if (!isClosePending) return;
 
     const timeout = window.setTimeout(() => {
       if (state.visible) return;
       setIsPresent(false);
-      setIsFullscreenClosePending(false);
-      setIsFullscreenLayoutReleasing(true);
-      onFullscreenChange(false);
+      setIsClosePending(false);
+      setIsLayoutReleasing(true);
+      if (isFullscreen) onFullscreenChange(false);
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS + MODEL_LAUNCH_LOG_TRANSITION_FALLBACK_MS);
 
     return () => window.clearTimeout(timeout);
-  }, [isFullscreenClosePending, onFullscreenChange, state.visible]);
+  }, [isClosePending, isFullscreen, onFullscreenChange, state.visible]);
 
   useEffect(() => {
-    if (!isFullscreenLayoutReleasing) return;
+    if (!isLayoutReleasing) return;
 
     const timeout = window.setTimeout(() => {
-      setIsFullscreenLayoutReleasing(false);
+      setIsLayoutReleasing(false);
     }, LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS + MODEL_LAUNCH_LOG_TRANSITION_FALLBACK_MS);
 
     return () => window.clearTimeout(timeout);
-  }, [isFullscreenLayoutReleasing]);
+  }, [isLayoutReleasing]);
 
   const handleToggleFullscreen = () => {
     if (isFullscreen) {
@@ -157,7 +148,7 @@ export function ModelLaunchLogSidebar({
 
   const handleClose = () => {
     setIsFullscreenExitPending(false);
-    if (isFullscreen) setIsFullscreenClosePending(true);
+    setIsClosePending(true);
     onClose();
   };
 
@@ -211,27 +202,27 @@ export function ModelLaunchLogSidebar({
 
   const handleSidebarTransitionEnd = (event: ReactTransitionEvent<HTMLElement>) => {
     if (event.target !== event.currentTarget || event.propertyName !== 'transform') return;
-    if (!isFullscreenClosePending || state.visible) return;
+    if (!isClosePending || state.visible) return;
 
     setIsPresent(false);
-    setIsFullscreenClosePending(false);
-    setIsFullscreenLayoutReleasing(true);
-    onFullscreenChange(false);
+    setIsClosePending(false);
+    setIsLayoutReleasing(true);
+    if (isFullscreen) onFullscreenChange(false);
   };
 
   const handleLayoutReleaseTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
     if (event.target !== event.currentTarget || event.propertyName !== 'width') return;
-    setIsFullscreenLayoutReleasing(false);
+    setIsLayoutReleasing(false);
   };
 
   return (
     <>
-      {isVisualFullscreen ? (
+      {isPanelOverlayActive ? (
         <div
           aria-hidden="true"
           className="shrink-0 transition-[width] ease-in-out"
           style={{
-            width: isFullscreenLayoutReleasing ? 0 : sidebarWidth,
+            width: isLayoutReleasing ? 0 : sidebarWidth,
             transitionDuration: `${LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS}ms`,
           }}
           onTransitionEnd={handleLayoutReleaseTransitionEnd}
@@ -244,34 +235,34 @@ export function ModelLaunchLogSidebar({
         className={cn(
           'flex h-full bg-background ease-in-out',
           'overflow-hidden transition-[width,transform]',
-          isVisualFullscreen
+          isPanelOverlayActive
             ? 'absolute inset-y-0 right-0 z-30 shadow-xl'
             : isCompact
               ? 'absolute inset-y-0 right-0 z-20 shadow-xl'
               : 'relative shrink-0',
         )}
         style={{
-          width: isFullscreen || isFullscreenClosePending
+          width: isFullscreen
             ? '100%'
-            : isFullscreenExitPending
+            : isFullscreenExitPending || isClosePending || isPanelClosing
               ? sidebarWidth
               : isPanelEntered
                 ? sidebarWidth
                 : 0,
           transform:
-            (isFullscreen || isFullscreenClosePending) && !state.visible
+            isPanelClosing
               ? 'translateX(100%)'
               : 'translateX(0)',
           transitionProperty: !isPresent
             ? 'none'
-            : isFullscreenCloseTransition
+            : isPanelCloseTransition
               ? 'transform'
               : 'width',
           transitionTimingFunction: 'ease-in-out',
           transitionDuration: `${LOCAL_INFERENCE_MODEL_LAUNCH_LOG_TRANSITION_MS}ms`,
         }}
       >
-        {isPresent && !isVisualFullscreen ? (
+        {isPresent && !isPanelOverlayActive ? (
           <div
             role="separator"
             aria-orientation="vertical"


### PR DESCRIPTION
## 摘要

  修复模型启动日志在全屏状态下点击缩小按钮时，模型卡片先向右移动再返回原位置的问题。

  ## 关联问题

  Fixes #<issue-number>

  ## 修改内容

  - 区分“退出全屏”和“关闭日志”两种布局流程。
  - 退出全屏时保留右侧布局占位，避免模型卡片发生二次布局变化。
  - 仅在真正关闭日志时释放布局占位，并执行模型卡片区域向右展开动画。
  - 保持日志面板从全屏宽度平滑收缩到普通侧栏宽度。

  ## 修改类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 破坏性修改
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 本地验证
  - [ ] 新增测试
  - [ ] 更新已有测试
  - [ ] 手动交互测试

  已完成以下验证：

  - `npx oxlint src/renderer/components/localInference/components/ModelLaunchLogSidebar.tsx`
  - `npm run build:tsc`
  - `git diff --check`

  ## 截图

  本次修改暂无新增截图。

  ## 检查清单

  - [x] 代码符合项目规范
  - [x] 已完成代码自查
  - [ ] 已为复杂逻辑添加必要注释
  - [ ] 已同步更新相关文档
  - [x] 没有引入本次修改相关的新警告
  - [ ] 已新增验证功能的测试
  - [ ] 新旧单元测试均已通过

  ## Electron 相关修改

  - [ ] 修改主进程 `src/main/`
  - [ ] 修改 preload 脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 无 Electron 相关修改

  ## 补充说明

  退出全屏时不再释放右侧布局占位，因此模型卡片会保持固定位置。只有在关闭日志窗口时，才释放占位并触发模型卡片区域向右展开，避免出现向右后又向左返回的往返动画。