### PR TITLE
fix(artifacts): 识别回复中的裸文件路径工件

### DIFF
--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -136,6 +136,76 @@ describe('detectArtifactsFromMessages', () => {
     expect(artifacts[0].needsFileLoad).toBe(false);
   });
 
+  test('detects bare Windows PPTX paths in assistant messages', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'assistant-1',
+          type: 'assistant',
+          content: 'Created D:/workspace/presentations/刘德华_AndyLau.pptx',
+          timestamp: Date.now(),
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.type).toBe('document');
+    expect(artifacts[0].artifact.filePath).toBe('D:/workspace/presentations/刘德华_AndyLau.pptx');
+    expect(artifacts[0].needsFileLoad).toBe(true);
+  });
+
+  test('detects bare POSIX PPTX paths in assistant messages', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'assistant-1',
+          type: 'assistant',
+          content: 'Created /home/user/presentations/report.pptx',
+          timestamp: Date.now(),
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.filePath).toBe('/home/user/presentations/report.pptx');
+  });
+
+  test('deduplicates file links against their embedded paths', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'assistant-1',
+          type: 'assistant',
+          content: '[report.pptx](file:///D:/workspace/report.pptx)',
+          timestamp: Date.now(),
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.filePath).toBe('D:/workspace/report.pptx');
+  });
+
+  test('does not detect bare paths in thinking messages', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'assistant-thinking-1',
+          type: 'assistant',
+          content: 'Creating D:/workspace/report.pptx',
+          timestamp: Date.now(),
+          metadata: { isThinking: true },
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(0);
+  });
+
   test('keeps explicit write-tool outputs as artifacts', () => {
     const artifacts = detectArtifactsFromMessages(
       [

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -373,6 +373,14 @@ export function detectArtifactsFromMessages(
         }
       }
 
+      const filePaths = parseFilePathsFromText(msg.content, msg.id, sessionId);
+      for (const artifact of filePaths) {
+        const normalized = artifact.filePath ? normalizeFilePathForDedup(artifact.filePath) : '';
+        if (artifact.filePath && !seenFilePaths.has(normalized)) {
+          seenFilePaths.add(normalized);
+          detected.push({ artifact, needsFileLoad: true });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 问题背景

会话通过 Python 脚本成功生成 PPTX 后，最终回复只提供了文件裸路径。现有工件检测仅处理 `file://` Markdown 链接和写文件工具调用，因此通过 `bash` 生成的 PPTX 未进入工件列表，页面最终只展示了由 `write` 工具创建的 Python 脚本。

## 修改内容

- 在非思考态 Assistant 消息中复用现有裸文件路径解析能力
- 将裸路径结果接入现有 `seenFilePaths` 去重链路，避免与 `file://` 链接或写文件工具结果重复
- 保持 thinking 消息和工具目录列表不参与裸路径工件检测
- 补充 Windows、POSIX、中文 PPTX 文件名、链接去重和 thinking 排除测试

## 验证结果

- `npm test -- artifactParser`：通过，18/18
- `npm run build`：通过
- `npm run lint`：通过；保留主线已有的 `McpManager.tsx` Hook 依赖警告
- `npm test`：164 个测试文件通过，1 个现有发布脚本测试文件失败。失败原因为 Windows 环境下 `publish-update-manifest.mjs` 将盘符路径解析为 `C`，与本次工件解析改动无关