### PR TITLE
feat(cowork): 优化侧边栏历史会话交互

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from '@shared/components/ui/checkbox';
 import { Switch } from '@shared/components/ui/switch';
 import { cn } from '@shared/lib/utils';
 import { Cpu, Settings, TriangleAlert } from 'lucide-react';
-import { Clock, MessageCircle, PanelLeft, Pencil, Puzzle, Search, Trash2 } from 'lucide-react';
+import { Clock, MessageCircle, PanelLeft, Pencil, Puzzle, Search, Trash2, X } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -23,7 +23,11 @@ import {
   selectUnreadSessionIds,
 } from '../store/selectors/coworkSelectors';
 import { selectWorkMode } from '../store/selectors/workModeSelectors';
-import { clearLoadingSessionId, setCurrentSession, setLoadingSessionId } from '../store/slices/coworkSlice';
+import {
+  clearLoadingSessionId,
+  setCurrentSession,
+  setLoadingSessionId,
+} from '../store/slices/coworkSlice';
 import { WorkMode } from '../store/workMode/constants';
 import { setWorkMode } from '../store/workMode/workModeSlice';
 import type { CoworkSessionSummary } from '../types/cowork';
@@ -34,7 +38,6 @@ import { toggleBatchSelection, toggleVisibleBatchSelection } from './agentSideba
 import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
 import { sortAgentSidebarTasks, toAgentSidebarTaskNode } from './agentSidebar/useAgentSidebarState';
 import Modal from './common/Modal';
-import CoworkSearchModal from './cowork/CoworkSearchModal';
 import LoginButton from './LoginButton';
 
 interface SidebarProps {
@@ -85,7 +88,13 @@ const Sidebar: React.FC<SidebarProps> = ({
   const currentSessionId = useSelector(selectCurrentSessionId);
   const unreadSessionIds = useSelector(selectUnreadSessionIds);
   const workMode = useSelector(selectWorkMode);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  // Inline sidebar search stays mounted so filtering does not shift the list.
+  // The full result set is fetched while typing so filtering stays instant.
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchCorpus, setSearchCorpus] = useState<CoworkSessionSummary[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchControlRef = useRef<HTMLDivElement>(null);
   const [isBatchMode, setIsBatchMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [recentlyDeletedSessionIds, setRecentlyDeletedSessionIds] = useState<string[]>([]);
@@ -93,34 +102,53 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
   const [agentScrollEdges, setAgentScrollEdges] = useState({ top: false, bottom: false });
-  const handleWorkModeChange = useCallback((checked: boolean) => {
-    const mode = checked ? WorkMode.Chat : WorkMode.Work;
-    dispatch(setWorkMode(mode));
-    if (mode === WorkMode.Chat) {
-      onShowCowork();
-    }
-    setIsBatchMode(false);
-    setSelectedIds(new Set());
-    setShowBatchDeleteConfirm(false);
-    void configService.updateConfig({ workMode: mode });
-  }, [dispatch, onShowCowork]);
+  const handleWorkModeChange = useCallback(
+    (checked: boolean) => {
+      const mode = checked ? WorkMode.Chat : WorkMode.Work;
+      dispatch(setWorkMode(mode));
+      if (mode === WorkMode.Chat) {
+        onShowCowork();
+      }
+      setIsBatchMode(false);
+      setSelectedIds(new Set());
+      setShowBatchDeleteConfirm(false);
+      void configService.updateConfig({ workMode: mode });
+    },
+    [dispatch, onShowCowork],
+  );
 
   // Filter sessions by workMode — chat sessions only visible in chat mode
   const sessions = React.useMemo(
     () =>
-      workMode === WorkMode.Chat
-        ? chatSessions
-        : allSessions.filter(s => s.mode !== WorkMode.Chat),
+      workMode === WorkMode.Chat ? chatSessions : allSessions.filter(s => s.mode !== WorkMode.Chat),
     [allSessions, chatSessions, workMode],
   );
 
   // Chat mode: map sessions to AgentSidebarTaskNode for AgentTaskRow rendering
   const unreadSessionIdSet = React.useMemo(() => new Set(unreadSessionIds), [unreadSessionIds]);
+  const searchQueryTrimmed = searchQuery.trim().toLowerCase();
+  // Search results come from searchCorpus (global, cross-agent) and may NOT be in
+  // the mode-filtered Redux `sessions`, so resolve clicks via this corpus map.
+  const searchSessionById = React.useMemo(() => {
+    const map = new Map<string, CoworkSessionSummary>();
+    searchCorpus.forEach(s => map.set(s.id, s));
+    return map;
+  }, [searchCorpus]);
   const chatTaskNodes = React.useMemo(() => {
     if (workMode !== WorkMode.Chat) return [];
-    const sorted = sortAgentSidebarTasks(sessions, streamingSessionIds);
+    const scoped = searchQueryTrimmed
+      ? sessions.filter(s => s.title.toLowerCase().includes(searchQueryTrimmed))
+      : sessions;
+    const sorted = sortAgentSidebarTasks(scoped, streamingSessionIds);
     return sorted.map(s => toAgentSidebarTaskNode(s, currentSessionId, unreadSessionIdSet));
-  }, [workMode, sessions, currentSessionId, unreadSessionIdSet, streamingSessionIds]);
+  }, [
+    workMode,
+    sessions,
+    currentSessionId,
+    unreadSessionIdSet,
+    streamingSessionIds,
+    searchQueryTrimmed,
+  ]);
 
   const isResizingRef = useRef(false);
   const resizeStartXRef = useRef(0);
@@ -134,7 +162,8 @@ const Sidebar: React.FC<SidebarProps> = ({
   useEffect(() => {
     const handleSearch = () => {
       onShowCowork();
-      setIsSearchOpen(true);
+      setSearchActive(true);
+      window.setTimeout(() => searchInputRef.current?.focus(), 0);
     };
     window.addEventListener('cowork:shortcut:search', handleSearch);
     return () => {
@@ -142,9 +171,42 @@ const Sidebar: React.FC<SidebarProps> = ({
     };
   }, [onShowCowork]);
 
+  // Clicking outside the search control clears the active query.
+  useEffect(() => {
+    if (!searchActive) return;
+    const handlePointerDown = (event: MouseEvent) => {
+      if (searchControlRef.current?.contains(event.target as Node)) return;
+      setSearchActive(false);
+      setSearchQuery('');
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [searchActive]);
+
+  // Load the searchable corpus ONCE when search is activated, then filter it
+  // client-side as the user types. Fetching per keystroke re-triggered the
+  // loading overlay (a full-size absolute layer) and a tree rebuild on every
+  // change, most visibly a stutter when deleting the last character (query 1 to 0).
+  // With a single load, typing and clearing are synchronous filters.
+  useEffect(() => {
+    if (!searchActive) {
+      setSearchCorpus([]);
+      return;
+    }
+    let cancelled = false;
+    void coworkService.listSessionsForSearch(100, 0).then(result => {
+      if (cancelled) return;
+      setSearchCorpus(result?.success ? (result.sessions ?? []) : []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [searchActive]);
+
   useEffect(() => {
     if (!isCollapsed) return;
-    setIsSearchOpen(false);
+    setSearchActive(false);
+    setSearchQuery('');
     setIsBatchMode(false);
     setSelectedIds(new Set());
     setShowBatchDeleteConfirm(false);
@@ -328,6 +390,75 @@ const Sidebar: React.FC<SidebarProps> = ({
     };
   }, [updateAgentScrollEdges]);
 
+  const renderSearchControl = (isChatMode = false) => (
+    <div className={cn('shrink-0 bg-surface-raised', !isChatMode && 'px-3')}>
+      <div
+        ref={searchControlRef}
+        role={searchActive ? undefined : 'button'}
+        tabIndex={searchActive ? undefined : 0}
+        aria-label={i18nService.t(workMode === WorkMode.Chat ? 'searchChats' : 'search')}
+        onClick={() => {
+          if (!searchActive) {
+            setSearchActive(true);
+            window.setTimeout(() => searchInputRef.current?.focus(), 0);
+          }
+        }}
+        onKeyDown={event => {
+          if (!searchActive && (event.key === 'Enter' || event.key === ' ')) {
+            event.preventDefault();
+            setSearchActive(true);
+            window.setTimeout(() => searchInputRef.current?.focus(), 0);
+          }
+        }}
+        className={cn(
+          'inline-flex h-8 w-full items-center justify-start gap-2 overflow-hidden rounded-lg px-3 text-left text-[14px] font-normal text-muted-foreground',
+          searchActive
+            ? 'cursor-text bg-background'
+            : 'cursor-pointer transition-colors hover:bg-black/3 dark:hover:bg-white/4',
+        )}
+      >
+        <Search className="h-4 w-4 shrink-0" />
+        {searchActive ? (
+          <>
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={event => setSearchQuery(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Escape') {
+                  setSearchActive(false);
+                  setSearchQuery('');
+                  searchInputRef.current?.blur();
+                }
+              }}
+              placeholder={i18nService.t(workMode === WorkMode.Chat ? 'searchChats' : 'search')}
+              className="h-full min-h-0 min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-none text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                aria-label={i18nService.t('clearSearch')}
+                onClick={event => {
+                  event.stopPropagation();
+                  setSearchQuery('');
+                  searchInputRef.current?.focus();
+                }}
+                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </>
+        ) : (
+          <span className="flex-1 truncate text-[14px] leading-none">
+            {i18nService.t(workMode === WorkMode.Chat ? 'searchChats' : 'search')}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <aside
       className={`relative shrink-0 overflow-hidden bg-surface-raised ${
@@ -344,11 +475,19 @@ const Sidebar: React.FC<SidebarProps> = ({
           transitionDuration: `${SIDEBAR_COLLAPSE_TRANSITION_MS}ms`,
         }}
       >
-        <div className="pt-3 pb-3">
+        <div className={cn('pt-3', workMode === WorkMode.Chat ? 'pb-0' : 'pb-3')}>
           <div className="draggable sidebar-header-drag h-8 flex items-center justify-between px-3">
             <div className={`flex items-center gap-2 ${isMac ? 'pl-[68px]' : ''}`}>
-              <img src="zhiyuan-logo-light.svg" alt="知远" className="logo-light h-5 w-auto select-none" />
-              <img src="zhiyuan-logo-dark.svg" alt="知远" className="logo-dark h-5 w-auto select-none" />
+              <img
+                src="zhiyuan-logo-light.svg"
+                alt="知远"
+                className="logo-light h-5 w-auto select-none"
+              />
+              <img
+                src="zhiyuan-logo-dark.svg"
+                alt="知远"
+                className="logo-dark h-5 w-auto select-none"
+              />
             </div>
             <Button
               type="button"
@@ -361,7 +500,12 @@ const Sidebar: React.FC<SidebarProps> = ({
               <PanelLeft className="h-4 w-4" />
             </Button>
           </div>
-          <div className="mt-[5px] space-y-0.5 px-3 pb-3">
+          <div
+            className={cn(
+              'mt-[5px] space-y-0.5 px-3',
+              workMode === WorkMode.Chat ? 'pb-0' : 'pb-3',
+            )}
+          >
             <div
               className="relative h-7 w-full cursor-pointer"
               onClick={() => handleWorkModeChange(workMode !== WorkMode.Chat)}
@@ -410,7 +554,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                 type="button"
                 variant="ghost"
                 onClick={() => {
-                  setIsSearchOpen(false);
                   onShowLocalInference();
                 }}
                 className={
@@ -424,24 +567,11 @@ const Sidebar: React.FC<SidebarProps> = ({
                 {i18nService.t('localInferenceTitle')}
               </Button>
             )}
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => {
-                onShowCowork();
-                setIsSearchOpen(true);
-              }}
-              className={sidebarNavItemClassName}
-            >
-              <Search className="h-4 w-4 shrink-0" />
-              {i18nService.t(workMode === WorkMode.Chat ? 'searchChats' : 'search')}
-            </Button>
             {workMode !== WorkMode.Chat && (
               <Button
                 type="button"
                 variant="ghost"
                 onClick={() => {
-                  setIsSearchOpen(false);
                   onShowScheduledTasks();
                 }}
                 className={
@@ -461,7 +591,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                   type="button"
                   variant="ghost"
                   onClick={() => {
-                    setIsSearchOpen(false);
                     onShowExpert();
                   }}
                   className={
@@ -479,6 +608,8 @@ const Sidebar: React.FC<SidebarProps> = ({
           </div>
         </div>
         <div className="relative min-h-0 flex-1">
+          {workMode !== WorkMode.Chat && renderSearchControl()}
+
           <div
             ref={agentScrollContainerRef}
             className="scrollbar-hidden h-full overflow-y-auto px-3 pb-10"
@@ -495,13 +626,22 @@ const Sidebar: React.FC<SidebarProps> = ({
                 onVisibleSessionsChange={
                   workMode === WorkMode.Work ? handleVisibleSessionsChange : undefined
                 }
+                onDismissSearch={() => {
+                  setSearchActive(false);
+                  setSearchQuery('');
+                }}
                 workMode={WorkMode.Work}
+                searchQuery={searchQuery}
+                searchCorpus={searchCorpus}
               />
             </div>
             {workMode === WorkMode.Chat && (
               <>
-                <ChatSkillShortcuts />
-                <div className="sticky top-0 z-30 flex h-10 items-center bg-surface-raised px-1.5">
+                <div>
+                  <ChatSkillShortcuts />
+                </div>
+                {renderSearchControl(true)}
+                <div className="sticky top-0 z-30 flex h-9 items-center bg-surface-raised px-1.5">
                   <h2 className="min-w-0 truncate text-[14px] font-normal text-foreground opacity-[0.28]">
                     {i18nService.t('chatRecentTitle')}
                   </h2>
@@ -510,7 +650,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                   <div className="flex items-center justify-center py-10 px-4 text-sm text-muted-foreground">
                     {i18nService.t('loading')}
                   </div>
-                ) : chatTaskNodes.length === 0 ? (
+                ) : chatTaskNodes.length === 0 && !searchQuery.trim() ? (
                   <div className="flex flex-col items-center justify-center py-10 px-4">
                     <MessageCircle className="size-10 text-muted-foreground mb-3" />
                     <p className="text-sm font-medium text-muted-foreground mb-1">
@@ -528,14 +668,23 @@ const Sidebar: React.FC<SidebarProps> = ({
                         task={task}
                         isBatchMode={isBatchMode}
                         isSelected={isBatchMode ? selectedIds.has(task.id) : task.isSelected}
+                        isNested={false}
                         onSelect={() => {
-                          const session = sessions.find(s => s.id === task.id);
-                          if (session) void handleSelectSession(session);
+                          const session =
+                            searchSessionById.get(task.id) ?? sessions.find(s => s.id === task.id);
+                          if (session) {
+                            setSearchActive(false);
+                            setSearchQuery('');
+                            void handleSelectSession(session);
+                          }
                         }}
                         onDelete={() => handleDeleteSession(task.id)}
                         onShare={async () => {
-                          const session = sessions.find(s => s.id === task.id);
+                          const session =
+                            searchSessionById.get(task.id) ?? sessions.find(s => s.id === task.id);
                           if (session) {
+                            setSearchActive(false);
+                            setSearchQuery('');
                             await handleSelectSession(session);
                             window.setTimeout(() => {
                               window.dispatchEvent(
@@ -579,14 +728,6 @@ const Sidebar: React.FC<SidebarProps> = ({
             onMouseDown={handleResizeStart}
           />
         )}
-        <CoworkSearchModal
-          isOpen={isSearchOpen}
-          onClose={() => setIsSearchOpen(false)}
-          sessions={sessions}
-          currentSessionId={currentSessionId}
-          onSelectSession={handleSelectSession}
-          workMode={workMode}
-        />
         {isBatchMode ? (
           <div className="px-3 pb-3 pt-1 flex items-center justify-between">
             <label className="flex items-center justify-start gap-2 cursor-pointer text-sm text-muted-foreground">

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
 import { Input } from '@shared/components/ui/input';
+import { cn } from '@shared/lib/utils';
 import {
   Ellipsis,
   ListChecks,
@@ -29,6 +30,7 @@ interface AgentTaskRowProps {
   task: AgentSidebarTaskNode;
   isBatchMode: boolean;
   isSelected: boolean;
+  isNested?: boolean;
   showBatchOption?: boolean;
   onSelect: () => void;
   onDelete: () => Promise<void>;
@@ -43,6 +45,7 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
   task,
   isBatchMode,
   isSelected,
+  isNested = true,
   showBatchOption = false,
   onSelect,
   onDelete,
@@ -54,7 +57,6 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
 }) => {
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
-  const [suppressPinHover, setSuppressPinHover] = useState(false);
   const [renameValue, setRenameValue] = useState(task.title);
   const [menuOpen, setMenuOpen] = useState(false);
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -96,45 +98,28 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
       ? i18nService.t('myAgentSidebarRunning')
       : i18nService.t('myAgentSidebarUnreadResult');
   const relativeTime = formatAgentTaskRelativeTime(task.updatedAt || task.createdAt);
-  const showRelativeTime = task.indicator === AgentSidebarIndicator.None;
+  const isRunning = task.indicator === AgentSidebarIndicator.Running;
+  const showRelativeTime = !isRunning;
   const pinLabel = task.pinned
     ? i18nService.t('coworkUnpinSession')
     : i18nService.t('coworkPinSession');
 
   return (
     <div
-      className={`group relative ml-[-6px] flex h-[30px] w-[calc(100%+12px)] cursor-pointer items-center gap-2 rounded-md ${
-        isBatchMode ? 'pl-4' : 'pl-[38px]'
-      } ${!isBatchMode && !isRenaming ? 'pr-8' : 'pr-2.5'} text-[14px] font-normal transition-colors ${
+      className={`group relative ${
+        isNested ? 'ml-[-6px] w-[calc(100%+12px)]' : 'ml-0 w-full'
+      } flex h-[30px] cursor-pointer items-center gap-2 rounded-md ${
+        isBatchMode ? 'pl-4' : isNested ? 'pl-[38px]' : 'pl-3'
+      } ${!isBatchMode && !isRenaming ? 'pr-[58px]' : 'pr-2.5'} text-[14px] font-normal transition-colors ${
         isSelected
           ? 'bg-black/3 text-foreground dark:bg-white/4'
           : 'text-muted-foreground hover:bg-black/3 hover:text-foreground dark:hover:bg-white/4'
       }`}
       onClick={handleRowClick}
-      onMouseMove={() => setSuppressPinHover(false)}
-      onMouseLeave={() => setSuppressPinHover(false)}
       role="treeitem"
       aria-level={2}
       aria-selected={isSelected}
     >
-      {!isBatchMode && !isRenaming && (
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          onClick={event => {
-            event.stopPropagation();
-            setSuppressPinHover(true);
-            event.currentTarget.blur();
-            void onTogglePin(!task.pinned);
-          }}
-          className={`absolute left-[13px] top-1/2 -translate-y-1/2 ${suppressPinHover ? 'pointer-events-none opacity-0' : task.pinned ? 'opacity-[0.46]' : 'pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-[0.3]'}`}
-          aria-label={pinLabel}
-          title={pinLabel}
-        >
-          <Pin className="h-3.5 w-3.5" />
-        </Button>
-      )}
-
       {isBatchMode && (
         <Checkbox
           checked={isSelected}
@@ -159,70 +144,86 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
           className="min-w-0 flex-1 border border-border bg-background px-1.5 py-0.5 text-[14px] font-normal"
         />
       ) : (
-        <>
-          <span className="min-w-0 flex-1 truncate">{task.title}</span>
-          {task.indicator === AgentSidebarIndicator.Running && (
-            <span
-              className="inline-flex h-3 w-3 shrink-0 items-center justify-center transition-opacity group-hover:opacity-0"
-              title={indicatorLabel}
-            >
-              <Loader className="h-3 w-3 animate-spin text-muted-foreground" />
-            </span>
-          )}
-          {task.indicator === AgentSidebarIndicator.CompletedUnread && (
-            <span
-              className="h-[7px] w-[7px] shrink-0 rounded-full bg-ring transition-opacity group-hover:opacity-0"
-              title={indicatorLabel}
-            />
-          )}
+        <span className="min-w-0 flex-1 truncate">{task.title}</span>
+      )}
+
+      {!isBatchMode && !isRenaming && (
+        <div className="absolute right-1 top-1/2 flex h-6 w-[52px] -translate-y-1/2 items-center justify-end">
           {showRelativeTime && (
             <span
-              className="shrink-0 whitespace-nowrap text-[12px] font-normal text-foreground opacity-[0.28] transition-opacity group-hover:opacity-0"
+              className="absolute inset-y-0 right-0 flex items-center whitespace-nowrap text-[12px] font-normal text-foreground opacity-[0.28] transition-opacity group-hover:pointer-events-none group-hover:opacity-0"
               title={relativeTime.full}
             >
               {relativeTime.compact}
             </span>
           )}
-        </>
-      )}
-
-      {!isBatchMode && !isRenaming && (
-        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                className={`absolute right-1 top-1/2 -translate-y-1/2 ${menuOpen ? 'opacity-[0.46]' : 'opacity-0 group-hover:opacity-[0.3]'}`}
-                aria-label={i18nService.t('coworkSessionActions')}
-              >
-                <Ellipsis className="h-4 w-4" />
-              </Button>
-            }
-          ></DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-[124px]">
-            {showBatchOption && (
-              <DropdownMenuItem onClick={() => onEnterBatchMode()}>
-                <ListChecks className="h-3.5 w-3.5" /> {i18nService.t('batchOperations')}
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem onClick={() => setIsRenaming(true)}>
-              <Pencil className="h-3.5 w-3.5" /> {i18nService.t('renameConversation')}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => void onTogglePin(!task.pinned)}>
-              <Pin className="h-3.5 w-3.5" /> {pinLabel}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => void onShare()}>
-              <Share className="h-3.5 w-3.5" /> {i18nService.t('coworkShareSession')}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-red-500 focus:text-red-500"
-              onClick={() => setShowConfirmDelete(true)}
+          {isRunning && (
+            <span
+              className="absolute inset-y-0 right-0 inline-flex size-6 items-center justify-center transition-opacity group-hover:pointer-events-none group-hover:opacity-0"
+              title={indicatorLabel}
             >
-              <Trash2 className="h-3.5 w-3.5" /> {i18nService.t('deleteSession')}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <Loader className="size-3 animate-spin text-muted-foreground" />
+            </span>
+          )}
+          <div className="absolute right-0 flex items-center gap-0.5">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={event => {
+                event.stopPropagation();
+                event.currentTarget.blur();
+                void onTogglePin(!task.pinned);
+              }}
+              className={cn(
+                'pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-[0.3]',
+                task.pinned && 'text-foreground group-hover:opacity-[0.46]',
+              )}
+              aria-label={pinLabel}
+              title={pinLabel}
+            >
+              <Pin className={task.pinned ? 'fill-current' : undefined} />
+            </Button>
+            <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className={cn(
+                      'pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-[0.3]',
+                      menuOpen && 'pointer-events-auto opacity-[0.46]',
+                    )}
+                    aria-label={i18nService.t('coworkSessionActions')}
+                  >
+                    <Ellipsis />
+                  </Button>
+                }
+              ></DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[124px]">
+                {showBatchOption && (
+                  <DropdownMenuItem onClick={() => onEnterBatchMode()}>
+                    <ListChecks className="h-3.5 w-3.5" /> {i18nService.t('batchOperations')}
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem onClick={() => setIsRenaming(true)}>
+                  <Pencil className="h-3.5 w-3.5" /> {i18nService.t('renameConversation')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void onTogglePin(!task.pinned)}>
+                  <Pin className="h-3.5 w-3.5" /> {pinLabel}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => void onShare()}>
+                  <Share className="h-3.5 w-3.5" /> {i18nService.t('coworkShareSession')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-red-500 focus:text-red-500"
+                  onClick={() => setShowConfirmDelete(true)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" /> {i18nService.t('deleteSession')}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       )}
 
       <Dialog

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -14,7 +14,7 @@ import {
   setCurrentSession,
   setLoadingSessionId,
 } from '../../store/slices/coworkSlice';
-import { CoworkSessionStatusValue } from '../../types/cowork';
+import { CoworkSessionStatusValue, type CoworkSessionSummary } from '../../types/cowork';
 import { type CoworkOpenShareOptionsEventDetail, CoworkUiEvent } from '../cowork/constants';
 import CreateProjectDialog from '../cowork/CreateProjectDialog';
 import type { AgentSidebarTaskNode, WorkspaceSidebarNode } from './types';
@@ -29,7 +29,10 @@ interface MyAgentSidebarTreeProps {
   onToggleSelection: (sessionId: string) => void;
   onEnterBatchMode: (sessionId: string) => void;
   onVisibleSessionsChange?: (ids: string[]) => void;
+  onDismissSearch?: () => void;
   workMode?: 'work' | 'chat';
+  searchQuery?: string;
+  searchCorpus?: CoworkSessionSummary[];
 }
 
 const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
@@ -40,7 +43,10 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   onToggleSelection,
   onEnterBatchMode,
   onVisibleSessionsChange,
+  onDismissSearch,
   workMode = 'work',
+  searchQuery = '',
+  searchCorpus = [],
 }) => {
   const dispatch = useDispatch();
   const {
@@ -55,7 +61,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
     collapseScheduledTasks,
     toggleExpanded,
     toggleScheduledExpanded,
-  } = useWorkspaceSidebarState(workMode);
+  } = useWorkspaceSidebarState(workMode, searchQuery, searchCorpus);
 
   useEffect(() => {
     onVisibleSessionsChange?.([
@@ -89,6 +95,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
       }
 
       onShowCowork();
+      onDismissSearch?.();
       await coworkService.loadSession(task.id);
     } finally {
       dispatch(clearLoadingSessionId(task.id));
@@ -168,9 +175,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
             <div className="rounded-full bg-red-100 p-2 dark:bg-red-900/30">
               <TriangleAlert className="h-5 w-5 text-red-600 dark:text-red-500" />
             </div>
-            <h2 className="text-base font-semibold">
-              {i18nService.t('removeProjectDialogTitle')}
-            </h2>
+            <h2 className="text-base font-semibold">{i18nService.t('removeProjectDialogTitle')}</h2>
           </div>
           <p className="text-sm text-muted-foreground">
             {i18nService.t('removeProjectDialogDescription')}
@@ -185,7 +190,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      <div className="sticky top-0 z-30 flex h-10 items-center justify-between bg-surface-raised px-1.5">
+      <div className="sticky top-0 z-30 flex h-9 items-center justify-between bg-surface-raised px-1.5">
         <h2 className="min-w-0 truncate text-[14px] font-normal text-foreground opacity-[0.28]">
           {i18nService.t('workspaces')}
         </h2>
@@ -224,9 +229,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
               selectedIds={selectedIds}
               onToggleExpanded={toggleExpanded}
               onCreateTask={selectedWorkspace => void handleCreateTask(selectedWorkspace)}
-              onRemoveWorkspace={selectedWorkspace =>
-                setWorkspacePendingRemoval(selectedWorkspace)
-              }
+              onRemoveWorkspace={selectedWorkspace => setWorkspacePendingRemoval(selectedWorkspace)}
               onRetryLoadTasks={workspaceId => void retryLoadTasks(workspaceId)}
               onLoadMoreTasks={workspaceId => void loadMoreTasks(workspaceId)}
               onCollapseTasks={collapseTasks}

--- a/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
@@ -68,7 +68,11 @@ const sortTasks = (tasks: CoworkSessionSummary[]) =>
     return (b.updatedAt || b.createdAt) - (a.updatedAt || a.createdAt);
   });
 
-export const useWorkspaceSidebarState = (workMode: WorkModeType = WorkMode.Work) => {
+export const useWorkspaceSidebarState = (
+  workMode: WorkModeType = WorkMode.Work,
+  searchQuery = '',
+  searchCorpus: CoworkSessionSummary[] = [],
+) => {
   const workspaces = useSelector((state: RootState) => state.workspace.workspaces);
   const currentSessionId = useSelector(selectCurrentSessionId);
   const sessions = useSelector(selectCoworkSessions);
@@ -316,6 +320,58 @@ export const useWorkspaceSidebarState = (workMode: WorkModeType = WorkMode.Work)
     [buildWorkspaceNodes, scheduledExpandedIds, scheduledExpandedTaskIds],
   );
 
+  const searching = searchQuery.trim().length > 0;
+  const searchSource = useMemo<Record<string, CoworkSessionSummary[]>>(() => {
+    if (!searching) return {};
+    const byWorkspace = new Map<string, CoworkSessionSummary[]>();
+    for (const session of searchCorpus) {
+      if (!modeMatches(session, workMode)) continue;
+      const key = session.workspaceId ?? '__none__';
+      const list = byWorkspace.get(key);
+      if (list) list.push(session);
+      else byWorkspace.set(key, [session]);
+    }
+    return Object.fromEntries(byWorkspace);
+  }, [searchCorpus, searching, workMode]);
+
+  const searchedWorkspaceNodes = useMemo(() => {
+    if (!searching) return { workspaceNodes, scheduledWorkspaceNodes };
+    const query = searchQuery.trim().toLowerCase();
+    const buildSearchNodes = (nodes: WorkspaceSidebarNode[], scheduled: boolean) =>
+      nodes.flatMap(node => {
+        const tasks = sortTasks(
+          (searchSource[node.id] ?? []).filter(
+            session =>
+              isScheduledSessionTitle(session.title) === scheduled &&
+              session.title.toLowerCase().includes(query),
+          ),
+        );
+        if (tasks.length === 0) return [];
+        return [
+          {
+            ...node,
+            isExpanded: true,
+            isTaskListExpanded: true,
+            canExpandTasks: false,
+            canCollapseTasks: false,
+            tasks: tasks.map(session => toTaskNode(session, currentSessionId, unreadSet)),
+          },
+        ];
+      });
+    return {
+      workspaceNodes: buildSearchNodes(workspaceNodes, false),
+      scheduledWorkspaceNodes: buildSearchNodes(scheduledWorkspaceNodes, true),
+    };
+  }, [
+    currentSessionId,
+    searchQuery,
+    searchSource,
+    searching,
+    unreadSet,
+    workspaceNodes,
+    scheduledWorkspaceNodes,
+  ]);
+
   const collapseScheduledTasks = useCallback((workspaceId: string) => {
     setScheduledExpandedTaskIds(current => current.filter(id => id !== workspaceId));
   }, []);
@@ -328,8 +384,8 @@ export const useWorkspaceSidebarState = (workMode: WorkModeType = WorkMode.Work)
   }, []);
 
   return {
-    workspaceNodes,
-    scheduledWorkspaceNodes,
+    workspaceNodes: searchedWorkspaceNodes.workspaceNodes,
+    scheduledWorkspaceNodes: searchedWorkspaceNodes.scheduledWorkspaceNodes,
     patchTaskPreview,
     removeTaskPreview,
     retryLoadTasks,

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -34,8 +34,8 @@ const ChatSkillShortcuts: React.FC = () => {
   };
 
   return (
-    <div className="mb-1">
-      <div className="flex h-10 items-center px-1.5">
+    <div className="mb-2">
+      <div className="flex h-9 items-center px-1.5">
         <h2 className="min-w-0 truncate text-[14px] font-normal text-foreground opacity-[0.28]">
           {i18nService.t('chatQuickSkillsTitle')}
         </h2>


### PR DESCRIPTION
## 概要

- 优化工作模式和对话模式的历史会话操作区展示。
- 调整搜索、快捷技能、项目及最近对话区域的对齐与间距。
- 固定搜索控件高度，避免切换为输入框时出现约 1px 抖动。

## 交互规则

- 空闲且未悬停：仅显示时间。
- 空闲且悬停：依次显示置顶和更多操作。
- 运行中且未悬停：仅显示 12px 加载指示器。
- 运行中且悬停：依次显示置顶和更多操作。
- 置顶激活时使用实心图标，未激活时使用空心图标。

## 布局调整

- 工作模式搜索位于“项目”上方，对话模式搜索位于“最近对话”上方，并保持两种模式的垂直间距一致。
- 对话模式的快捷技能靠近新建对话，快捷技能与上下内容的间距保持一致。
- 历史会话和搜索与新建会话图标左对齐。
- 工作模式历史会话名称继续保留原有嵌套缩进。

## 验证

- `npm.cmd run build`
- `npm.cmd run lint`（仅存在原有 `McpManager.tsx` Hooks 警告）
- 相关 Vitest：2 个测试文件、6 个测试通过
- `npm.cmd run build:tsc`