### PR TITLE
fix(sidebar): 修复历史会话滚动边界和渐变遮罩

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -607,12 +607,12 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
           </div>
         </div>
-        <div className="relative min-h-0 flex-1">
+        <div className="relative flex min-h-0 flex-1 flex-col">
           {workMode !== WorkMode.Chat && renderSearchControl()}
 
           <div
             ref={agentScrollContainerRef}
-            className="scrollbar-hidden h-full overflow-y-auto px-3 pb-10"
+            className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-3 pb-10"
             onScroll={handleAgentScroll}
           >
             <div className={cn(workMode === WorkMode.Chat && 'hidden')}>
@@ -707,14 +707,11 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
           </div>
           <div
-            className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-24 bg-linear-to-b from-surface-raised to-transparent transition-opacity duration-150 ${
-              agentScrollEdges.top ? 'opacity-100' : 'opacity-0'
-            }`}
-          />
-          <div
-            className={`pointer-events-none absolute inset-x-0 top-[68px] z-10 h-10 bg-linear-to-b from-surface-raised to-transparent transition-opacity duration-150 ${
-              agentScrollEdges.top ? 'opacity-100' : 'opacity-0'
-            }`}
+            className={cn(
+              'pointer-events-none absolute inset-x-0 z-10 h-24 bg-linear-to-b from-surface-raised to-transparent transition-opacity duration-150',
+              workMode === WorkMode.Chat ? 'top-0' : 'top-8',
+              agentScrollEdges.top ? 'opacity-100' : 'opacity-0',
+            )}
           />
           <div
             className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 h-16 bg-linear-to-t from-surface-raised to-transparent transition-opacity duration-150 ${


### PR DESCRIPTION
## 问题

- 工作模式新增内联搜索后，历史会话顶部渐变仍从父容器顶部开始，导致遮罩覆盖搜索区域。
- 滚动容器继续使用完整高度，叠加搜索控件高度后超出可用空间，底部会话内容与设置入口重叠。
- 历史会话顶部存在一层从 68px 位置重新开始的重复渐变，滚动时会在列表中间形成额外发白区域。

## 修复

- 将搜索和历史会话区域改为纵向 flex 布局，让滚动容器通过 `min-h-0 flex-1` 只占据剩余高度。
- 工作模式的顶部渐变从搜索控件下方开始，对话模式保持原有顶部边缘位置。
- 删除重复的第二层顶部渐变，只保留真实滚动边缘遮罩。
- 保留工作模式历史会话名称的原有嵌套缩进。

## 验证

- `npm.cmd run build:tsc`
- `npm.cmd run lint`（仅存在原有 `McpManager.tsx` Hooks 警告）
- `git diff --check origin/main...HEAD`