### PR TITLE
feat(sidebar): 过长会话标题 hover 时走马灯展示

### DIFF
--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -23,6 +23,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
 import { AgentSidebarIndicator } from './constants';
+import OverflowingSessionTitle from './OverflowingSessionTitle';
 import { formatAgentTaskRelativeTime } from './time';
 import type { AgentSidebarTaskNode } from './types';
 
@@ -144,7 +145,7 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
           className="min-w-0 flex-1 border border-border bg-background px-1.5 py-0.5 text-[14px] font-normal"
         />
       ) : (
-        <span className="min-w-0 flex-1 truncate">{task.title}</span>
+        <OverflowingSessionTitle title={task.title} />
       )}
 
       {!isBatchMode && !isRenaming && (

--- a/src/renderer/components/agentSidebar/OverflowingSessionTitle.tsx
+++ b/src/renderer/components/agentSidebar/OverflowingSessionTitle.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { cn } from '@shared/lib/utils';
+
+import { getSessionTitleMarqueeMetrics } from './sessionTitleMarqueeMetrics';
+import type { SessionTitleMarqueeMetrics } from './sessionTitleMarqueeMetrics';
+
+interface SessionTitleMarqueeProps {
+  title: string;
+}
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const OverflowingSessionTitle: React.FC<SessionTitleMarqueeProps> = ({ title }) => {
+  const viewportRef = useRef<HTMLSpanElement>(null);
+  const movingTextRef = useRef<HTMLSpanElement>(null);
+  const isHoveredRef = useRef(false);
+  const [metrics, setMetrics] = useState<SessionTitleMarqueeMetrics | null>(null);
+
+  const stopMarquee = useCallback(() => {
+    setMetrics(null);
+  }, []);
+
+  const startMarquee = useCallback(() => {
+    const viewport = viewportRef.current;
+    const movingText = movingTextRef.current;
+    if (!viewport || !movingText || prefersReducedMotion()) {
+      setMetrics(null);
+      return;
+    }
+
+    setMetrics(
+      getSessionTitleMarqueeMetrics(
+        viewport.getBoundingClientRect().width,
+        movingText.getBoundingClientRect().width,
+      ),
+    );
+  }, []);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || typeof ResizeObserver === 'undefined') return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (isHoveredRef.current) startMarquee();
+    });
+    resizeObserver.observe(viewport);
+    return () => resizeObserver.disconnect();
+  }, [startMarquee]);
+
+  useEffect(() => {
+    setMetrics(null);
+  }, [title]);
+
+  const isAnimating = metrics !== null;
+
+  return (
+    <span
+      ref={viewportRef}
+      className="relative min-w-0 flex-1 overflow-hidden"
+      title={title}
+      onPointerEnter={() => {
+        isHoveredRef.current = true;
+        startMarquee();
+      }}
+      onPointerLeave={() => {
+        isHoveredRef.current = false;
+        stopMarquee();
+      }}
+    >
+      <span className={cn('block truncate', isAnimating ? 'opacity-0' : 'opacity-100')}>
+        {title}
+      </span>
+      <span
+        ref={movingTextRef}
+        aria-hidden="true"
+        className={cn(
+          'pointer-events-none absolute inset-y-0 left-0 flex w-max items-center whitespace-nowrap',
+          isAnimating ? 'opacity-100 transition-transform ease-linear' : 'opacity-0',
+        )}
+        style={{
+          transform: `translateX(-${metrics?.distancePx ?? 0}px)`,
+          transitionDuration: `${metrics?.durationMs ?? 0}ms`,
+        }}
+      >
+        {title}
+      </span>
+    </span>
+  );
+};
+
+export default OverflowingSessionTitle;

--- a/src/renderer/components/agentSidebar/sessionTitleMarquee.test.ts
+++ b/src/renderer/components/agentSidebar/sessionTitleMarquee.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+
+import { getSessionTitleMarqueeMetrics } from './sessionTitleMarqueeMetrics';
+
+test('does not animate a title that fits in the viewport', () => {
+  expect(getSessionTitleMarqueeMetrics(120, 120)).toBeNull();
+  expect(getSessionTitleMarqueeMetrics(120, 96)).toBeNull();
+});
+
+test('ignores subpixel overflow that would cause visual jitter', () => {
+  expect(getSessionTitleMarqueeMetrics(120, 120.75)).toBeNull();
+});
+
+test('stops when the content right edge reaches the viewport right edge', () => {
+  expect(getSessionTitleMarqueeMetrics(120, 240)).toEqual({
+    distancePx: 120,
+    durationMs: 2500,
+  });
+});
+
+test('preserves subpixel precision at the final character edge', () => {
+  expect(getSessionTitleMarqueeMetrics(180, 547.4375)).toEqual({
+    distancePx: 367.4375,
+    durationMs: 7655,
+  });
+});
+
+test('uses a minimum duration for short overflow distances', () => {
+  expect(getSessionTitleMarqueeMetrics(120, 130)).toEqual({
+    distancePx: 10,
+    durationMs: 900,
+  });
+});

--- a/src/renderer/components/agentSidebar/sessionTitleMarqueeMetrics.ts
+++ b/src/renderer/components/agentSidebar/sessionTitleMarqueeMetrics.ts
@@ -1,0 +1,24 @@
+const SESSION_TITLE_MARQUEE_MIN_DURATION_MS = 900;
+const SESSION_TITLE_MARQUEE_SPEED_PX_PER_SECOND = 48;
+const SESSION_TITLE_OVERFLOW_TOLERANCE_PX = 1;
+
+export interface SessionTitleMarqueeMetrics {
+  distancePx: number;
+  durationMs: number;
+}
+
+export const getSessionTitleMarqueeMetrics = (
+  viewportWidth: number,
+  contentWidth: number,
+): SessionTitleMarqueeMetrics | null => {
+  const distancePx = Math.max(0, contentWidth - viewportWidth);
+  if (distancePx <= SESSION_TITLE_OVERFLOW_TOLERANCE_PX) return null;
+
+  return {
+    distancePx,
+    durationMs: Math.max(
+      SESSION_TITLE_MARQUEE_MIN_DURATION_MS,
+      Math.round((distancePx / SESSION_TITLE_MARQUEE_SPEED_PX_PER_SECOND) * 1000),
+    ),
+  };
+};


### PR DESCRIPTION
## 概要

- 侧边栏会话标题仅在内容实际溢出时，于 hover 后播放一次走马灯动画
- 静态标题与动画标题共用同一裁剪区域，保持左右边缘完全一致
- 动画在最后一个字符完整显示时停止，不循环；指针移出后恢复静态省略状态

## 关联 Issue

无。

## 修改内容

- 新增 OverflowingSessionTitle 组件，使用 CSS transform 过渡展示完整标题
- 使用亚像素精度测量可视区域与文本宽度，使动画终点精确对齐右边缘
- 保留 prefers-reduced-motion 支持，减少动态效果时继续显示静态省略标题
- 监听侧边栏宽度变化，hover 期间自动重新计算动画距离
- 新增动画距离、持续时间、溢出容差和亚像素终点测试
- 保持工作模式历史会话原有 38px 左侧缩进不变

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化

## 测试

- [x] 本地测试
- [x] 新增单元测试
- [x] 手动交互测试
- [x] TypeScript 类型检查
- [x] 生产构建

验证命令：

- npm test -- sessionTitleMarquee（5 个测试通过）
- npm run build:tsc
- npm run lint（仅保留仓库已有的 McpManager hook 依赖警告，本次未新增警告）
- npm run build

交互验证结果：动画进行中产生预期水平位移；结束后文本右边缘与裁剪区域右边缘差值为 0px，最后字符完整显示并保持在终点。

## 截图

未附截图；已通过本地浏览器测试页验证静态省略、动画过程及精确终点。

## Checklist

- [x] 代码符合项目样式规范
- [x] 已完成自审
- [x] 本次改动无需额外说明性注释
- [x] 本次改动无需更新文档
- [x] 未引入新的警告
- [x] 已添加覆盖该功能的测试
- [x] 新增测试与生产构建均在本地通过

## Electron 相关变更

- [ ] 主进程变更
- [ ] preload 变更
- [ ] IPC 变更
- [ ] 窗口管理变更
- [x] 无

## 补充说明

本次仅修改 renderer 侧边栏标题展示，不影响会话状态、右侧操作按钮或会话数据。