### PR TITLE
fix(sidebar): 修复批量操作无法多选会话

### DIFF
--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@shared/components/ui/button';
-import { Checkbox } from '@shared/components/ui/checkbox';
 import { Dialog, DialogContent, DialogFooter } from '@shared/components/ui/dialog';
 import {
   DropdownMenu,
@@ -22,6 +21,7 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { BatchSelectionCheckbox } from './BatchSelectionCheckbox';
 import { AgentSidebarIndicator } from './constants';
 import { formatAgentTaskRelativeTime } from './time';
 import type { AgentSidebarTaskNode } from './types';
@@ -121,12 +121,7 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
       aria-selected={isSelected}
     >
       {isBatchMode && (
-        <Checkbox
-          checked={isSelected}
-          onCheckedChange={() => onToggleSelection()}
-          onClick={e => e.stopPropagation()}
-          className="h-3.5 w-3.5 shrink-0"
-        />
+        <BatchSelectionCheckbox checked={isSelected} onToggleSelection={onToggleSelection} />
       )}
 
       {isRenaming ? (

--- a/src/renderer/components/agentSidebar/BatchSelectionCheckbox.test.ts
+++ b/src/renderer/components/agentSidebar/BatchSelectionCheckbox.test.ts
@@ -1,0 +1,22 @@
+import type { MouseEvent, ReactElement } from 'react';
+import { expect, test, vi } from 'vitest';
+
+import { BatchSelectionCheckbox } from './BatchSelectionCheckbox';
+
+test('contains visual and hidden checkbox clicks inside one propagation boundary', () => {
+  const onToggleSelection = vi.fn();
+  const stopPropagation = vi.fn();
+  const element = BatchSelectionCheckbox({ checked: false, onToggleSelection });
+
+  element.props.onClick({ stopPropagation } as unknown as MouseEvent<HTMLSpanElement>);
+  expect(stopPropagation).toHaveBeenCalledOnce();
+
+  const checkbox = element.props.children as ReactElement<{
+    checked: boolean;
+    onCheckedChange: () => void;
+  }>;
+  expect(checkbox.props.checked).toBe(false);
+
+  checkbox.props.onCheckedChange();
+  expect(onToggleSelection).toHaveBeenCalledOnce();
+});

--- a/src/renderer/components/agentSidebar/BatchSelectionCheckbox.tsx
+++ b/src/renderer/components/agentSidebar/BatchSelectionCheckbox.tsx
@@ -1,0 +1,21 @@
+import { Checkbox } from '@shared/components/ui/checkbox';
+
+interface BatchSelectionCheckboxProps {
+  checked: boolean;
+  onToggleSelection: () => void;
+}
+
+export const BatchSelectionCheckbox = ({
+  checked,
+  onToggleSelection,
+}: BatchSelectionCheckboxProps) => (
+  <span
+    className="flex shrink-0"
+    onClick={event => {
+      // Base UI also dispatches a bubbling click from the hidden input beside its visual root.
+      event.stopPropagation();
+    }}
+  >
+    <Checkbox checked={checked} onCheckedChange={() => onToggleSelection()} className="size-3.5" />
+  </span>
+);


### PR DESCRIPTION
## 概要

修复侧边栏历史会话从 more option 进入批量操作后，除触发会话外无法继续勾选其他会话的问题。

## 关联 Issue

无。

## 修改内容

- 为批量选择 Checkbox 增加统一的点击事件冒泡边界
- 同时拦截 Base UI 可视 Checkbox 根节点及其隐藏 input 派发的 click
- 保留 onCheckedChange 作为唯一的 Checkbox 选中状态更新入口
- 保持点击会话整行切换选中状态的原有行为
- 新增事件边界与单次选择回调的回归测试

## 根因

Base UI Checkbox 点击可视控件后，会对相邻的隐藏 input 再派发一个可冒泡的 click。原实现仅在可视 Checkbox 根节点停止冒泡，隐藏 input 的 click 仍会到达会话行并触发一次切换；随后 onCheckedChange 再触发一次切换，导致同一次点击被反向抵消。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化

## 测试

- [x] 本地测试
- [x] 新增单元测试
- [x] 手动交互测试
- [x] TypeScript 类型检查
- [x] 生产构建

验证结果：

- BatchSelectionCheckbox.test.ts 与 batchSelection.test.ts：2 个测试文件、3 个测试通过
- npm run build:tsc 通过
- npm run lint 通过；仅保留仓库已有的 McpManager hook 依赖警告，本次未新增警告
- npm run build 通过
- 浏览器真实组件验证：初始仅触发会话选中；点击第二个 Checkbox 后两个会话同时保持选中；再次点击可取消；点击整行仍可正常切换

## 截图

本次不涉及视觉样式变化，未附截图。

## Checklist

- [x] 代码符合项目样式规范
- [x] 已完成自审
- [x] 已对非直观的 Base UI 事件行为添加说明
- [x] 本次改动无需更新文档
- [x] 未引入新的警告
- [x] 已添加覆盖该问题的测试
- [x] 新增测试与生产构建均在本地通过

## Electron 相关变更

- [ ] 主进程变更
- [ ] preload 变更
- [ ] IPC 变更
- [ ] 窗口管理变更
- [x] 无

## 补充说明

本次仅调整 renderer 侧边栏批量选择的事件边界，不影响会话数据、删除流程、布局尺寸或其他 more option 操作。