### PR TITLE
fix: provider 常量重构——统一模型基础 URL 与 API 格式配置

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -132,6 +132,7 @@ const mockDefaultResourceLoader = hoisted.mockDefaultResourceLoader;
 const mockGetModel = hoisted.mockGetModel;
 const mockModelRuntime = hoisted.mockModelRuntime;
 const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
+const mockResolveRawApiConfig = hoisted.mockResolveRawApiConfig;
 const mockResolveRawApiConfigForModelRef = hoisted.mockResolveRawApiConfigForModelRef;
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
@@ -310,6 +311,33 @@ describe('PiRuntimeAdapter', () => {
       expect(adapter.isSessionActive('test')).toBe(false);
       await adapter.startSession('test', 'Hello');
       expect(adapter.isSessionActive('test')).toBe(true);
+    });
+
+    it('uses the cloud fallback when provider metadata has no capacity limits', async () => {
+      mockResolveRawApiConfig.mockReturnValueOnce({
+        config: {
+          apiKey: 'sk-cloud',
+          baseURL: 'https://example.com/v1',
+          model: 'unknown-cloud-model',
+          apiType: 'openai',
+        },
+        providerMetadata: {
+          providerName: 'custom_0',
+          codingPlanEnabled: false,
+          supportsImage: false,
+        },
+      });
+
+      await adapter.startSession('cloud-fallback', 'Hello Pi');
+
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({
+            contextWindow: 256000,
+            maxTokens: 32768,
+          }),
+        }),
+      );
     });
 
     it('should throw on empty prompt with no images', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -358,7 +358,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       const resourceState: PiResourceState = {
         systemPrompt: basePrompt,
         skillIds: normalizeSkillIds(options.skillIds),
-        maxOutputTokens: DEFAULT_PI_MAX_TOKENS,
+        maxOutputTokens: DEFAULT_PI_LOCAL_MAX_TOKENS,
         fileToolsEnabled: options.confirmationMode !== 'text',
       };
 
@@ -1706,7 +1706,7 @@ async function resolvePiModel(
         ? (registeredModel as Record<string, unknown>)
         : customModel),
     modelRuntime,
-    maxOutputTokens: resolution.providerMetadata.maxTokens || DEFAULT_PI_MAX_TOKENS,
+    maxOutputTokens: resolution.providerMetadata.maxTokens || DEFAULT_PI_LOCAL_MAX_TOKENS,
     requestOptions: resolution.config.apiKey ? { apiKey: resolution.config.apiKey } : undefined,
   };
 }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1548,8 +1548,10 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
  * ZhiYuanAgent stores keys as DEEPSEEK_API_KEY, ANTHROPIC_API_KEY, etc.
  * Pi SDK looks up providers by name (deepseek, anthropic, openai, etc.).
  */
-const DEFAULT_PI_CONTEXT_WINDOW = 32768;
-const DEFAULT_PI_MAX_TOKENS = 4096;
+const DEFAULT_PI_LOCAL_CONTEXT_WINDOW = 32768;
+const DEFAULT_PI_LOCAL_MAX_TOKENS = 4096;
+const DEFAULT_PI_CLOUD_CONTEXT_WINDOW = 256000;
+const DEFAULT_PI_CLOUD_MAX_TOKENS = 32768;
 const PI_LOCAL_API_KEY = 'sk-zhiyuan-local';
 
 const PI_BUILTIN_PROVIDER_ID = {
@@ -1577,6 +1579,12 @@ function buildPiCustomModel(resolution: ApiConfigResolution): Record<string, unk
     throw new Error(resolution.error || 'Pi model configuration is unavailable.');
   }
 
+  const isLocalModel = isLocalProviderName(providerMetadata.providerName);
+  const fallbackContextWindow = isLocalModel
+    ? DEFAULT_PI_LOCAL_CONTEXT_WINDOW
+    : DEFAULT_PI_CLOUD_CONTEXT_WINDOW;
+  const fallbackMaxTokens = isLocalModel ? DEFAULT_PI_LOCAL_MAX_TOKENS : DEFAULT_PI_CLOUD_MAX_TOKENS;
+
   return {
     id: config.model,
     name: providerMetadata.modelName || config.model,
@@ -1592,8 +1600,8 @@ function buildPiCustomModel(resolution: ApiConfigResolution): Record<string, unk
       cacheWrite: 0,
     },
     contextWindow:
-      providerMetadata.contextWindow || providerMetadata.contextTokens || DEFAULT_PI_CONTEXT_WINDOW,
-    maxTokens: providerMetadata.maxTokens || DEFAULT_PI_MAX_TOKENS,
+      providerMetadata.contextWindow || providerMetadata.contextTokens || fallbackContextWindow,
+    maxTokens: providerMetadata.maxTokens || fallbackMaxTokens,
   };
 }
 

--- a/src/main/libs/claudeSettings.test.ts
+++ b/src/main/libs/claudeSettings.test.ts
@@ -78,6 +78,87 @@ test('resolveRawApiConfig forwards llama.cpp runtime metadata for the selected r
   });
 });
 
+test('resolveRawApiConfig uses registered DeepSeek V4 capacity when saved metadata is absent', () => {
+  setStoreGetter(
+    () =>
+      ({
+        get: (key: string) =>
+          key === 'app_config'
+            ? {
+                model: {
+                  defaultModel: 'deepseek-v4-flash',
+                  defaultModelProvider: ProviderName.DeepSeek,
+                },
+                providers: {
+                  [ProviderName.DeepSeek]: {
+                    enabled: true,
+                    apiKey: 'test-key',
+                    baseUrl: 'https://api.deepseek.com',
+                    apiFormat: 'openai',
+                    models: [
+                      {
+                        id: 'deepseek-v4-flash',
+                        name: 'DeepSeek V4 Flash',
+                        supportsImage: false,
+                      },
+                    ],
+                  },
+                },
+              }
+            : undefined,
+      }) as never,
+  );
+
+  const result = resolveRawApiConfig();
+
+  expect(result.providerMetadata).toMatchObject({
+    providerName: ProviderName.DeepSeek,
+    contextWindow: 1_000_000,
+    maxTokens: 384_000,
+  });
+});
+
+test('resolveRawApiConfig uses registered coding-plan capacity when saved metadata is absent', () => {
+  setStoreGetter(
+    () =>
+      ({
+        get: (key: string) =>
+          key === 'app_config'
+            ? {
+                model: {
+                  defaultModel: 'kimi-for-coding',
+                  defaultModelProvider: ProviderName.Moonshot,
+                },
+                providers: {
+                  [ProviderName.Moonshot]: {
+                    enabled: true,
+                    apiKey: 'test-key',
+                    baseUrl: 'https://api.moonshot.cn/v1',
+                    apiFormat: 'openai',
+                    codingPlanEnabled: true,
+                    models: [
+                      {
+                        id: 'kimi-for-coding',
+                        name: 'Kimi for Coding',
+                        supportsImage: true,
+                      },
+                    ],
+                  },
+                },
+              }
+            : undefined,
+      }) as never,
+  );
+
+  const result = resolveRawApiConfig();
+
+  expect(result.providerMetadata).toMatchObject({
+    providerName: ProviderName.Moonshot,
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  });
+});
+
 test('resolveAllEnabledProviderConfigs only exposes OpenClaw-eligible llama.cpp running models', () => {
   const eligible = buildLlamaCppRunningModelBinding({
     name: 'qwen-eligible',

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -217,26 +217,35 @@ function normalizeProviderModels(
 ): ProviderModelConfig[] {
   return (models ?? [])
     .filter(model => model.id?.trim())
-    .map(model => ({
-      ...model,
-      name: model.name || model.id,
-      supportsImage: ProviderRegistry.resolveModelSupportsImage(
-        providerName,
-        model.id,
-        model.supportsImage,
-      ),
-      contextWindow:
-        typeof model.contextWindow === 'number' && model.contextWindow > 0
-          ? model.contextWindow
-          : undefined,
-      contextTokens:
-        typeof model.contextTokens === 'number' && model.contextTokens > 0
-          ? model.contextTokens
-          : undefined,
-      maxTokens:
-        typeof model.maxTokens === 'number' && model.maxTokens > 0 ? model.maxTokens : undefined,
-      openClawEligibility: model.openClawEligibility ? { ...model.openClawEligibility } : undefined,
-    }));
+    .map(model => {
+      const providerDefinition = ProviderRegistry.get(providerName);
+      const registeredModel = [
+        ...(providerDefinition?.defaultModels ?? []),
+        ...(providerDefinition?.codingPlanModels ?? []),
+      ].find(candidate => candidate.id === model.id);
+      return {
+        ...model,
+        name: model.name || model.id,
+        supportsImage: ProviderRegistry.resolveModelSupportsImage(
+          providerName,
+          model.id,
+          model.supportsImage,
+        ),
+        contextWindow:
+          typeof model.contextWindow === 'number' && model.contextWindow > 0
+            ? model.contextWindow
+            : registeredModel?.contextWindow,
+        contextTokens:
+          typeof model.contextTokens === 'number' && model.contextTokens > 0
+            ? model.contextTokens
+            : undefined,
+        maxTokens:
+          typeof model.maxTokens === 'number' && model.maxTokens > 0
+            ? model.maxTokens
+            : registeredModel?.maxTokens,
+        openClawEligibility: model.openClawEligibility ? { ...model.openClawEligibility } : undefined,
+      };
+    });
 }
 
 const getStore = (): SqliteStore | null => {

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -3,6 +3,8 @@ import { type ApiFormat, type ProviderConfig, ProviderRegistry } from '@shared/p
 import { AppConfig, CONFIG_KEYS, defaultConfig, isCustomProvider } from '../config';
 import { localStore } from './store';
 
+type ProviderModelConfig = NonNullable<ProviderConfig['models']>[number];
+
 const getFixedProviderApiFormat = (providerKey: string): ApiFormat | null => {
   const def = ProviderRegistry.get(providerKey);
   if (def && !def.switchableBaseUrls) {
@@ -127,23 +129,125 @@ const REMOVED_PROVIDER_MODELS: Record<string, string[]> = {
 const ADDED_PROVIDER_MODELS: Record<
   string,
   {
-    models: Array<{ id: string; name: string; supportsImage?: boolean }>;
+    models: Array<{
+      id: string;
+      name: string;
+      supportsImage?: boolean;
+      contextWindow?: number;
+      maxTokens?: number;
+    }>;
     position: 'start' | 'end';
   }
 > = {
   deepseek: {
     models: [
-      { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', supportsImage: false },
-      { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', supportsImage: false },
+      {
+        id: 'deepseek-v4-flash',
+        name: 'DeepSeek V4 Flash',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+      },
+      {
+        id: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+      },
     ],
     position: 'start',
   },
   moonshot: {
-    models: [{ id: 'kimi-k2.6', name: 'Kimi K2.6', supportsImage: true }],
+    models: [
+      {
+        id: 'kimi-k3',
+        name: 'Kimi K3',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'kimi-k2.6',
+        name: 'Kimi K2.6',
+        supportsImage: true,
+        contextWindow: 256_000,
+      },
+    ],
+    position: 'start',
+  },
+  qwen: {
+    models: [
+      {
+        id: 'qwen3.7-max',
+        name: 'Qwen3.7 Max',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'qwen3.7-plus',
+        name: 'Qwen3.7 Plus',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+      },
+    ],
+    position: 'start',
+  },
+  zhipu: {
+    models: [
+      {
+        id: 'glm-5.2',
+        name: 'GLM 5.2',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 131_072,
+      },
+    ],
     position: 'start',
   },
   minimax: {
-    models: [{ id: 'MiniMax-M2.7', name: 'MiniMax M2.7', supportsImage: false }],
+    models: [
+      {
+        id: 'MiniMax-M3',
+        name: 'MiniMax M3',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'MiniMax-M2.7',
+        name: 'MiniMax M2.7',
+        supportsImage: false,
+        contextWindow: 204_800,
+        maxTokens: 131_072,
+      },
+    ],
+    position: 'start',
+  },
+  stepfun: {
+    models: [
+      {
+        id: 'step-3.7-flash',
+        name: 'Step 3.7 Flash',
+        supportsImage: false,
+        contextWindow: 256_000,
+        maxTokens: 256_000,
+      },
+    ],
+    position: 'start',
+  },
+  xiaomi: {
+    models: [
+      {
+        id: 'mimo-v2.5-pro-ultraspeed',
+        name: 'MiMo V2.5 Pro Ultraspeed',
+        supportsImage: false,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+    ],
     position: 'start',
   },
   openai: {
@@ -189,6 +293,18 @@ class ConfigService {
                 // Inject added models (for existing users who already have saved config)
                 const addedConfig = ADDED_PROVIDER_MODELS[providerKey];
                 if (addedConfig && mergedProvider.models) {
+                  const addedModelsById = new Map(addedConfig.models.map(model => [model.id, model]));
+                  mergedProvider.models = mergedProvider.models.map(
+                    (model: ProviderModelConfig) => {
+                      const addedModel = addedModelsById.get(model.id);
+                      if (!addedModel) return model;
+                      return {
+                        ...model,
+                        contextWindow: model.contextWindow ?? addedModel.contextWindow,
+                        maxTokens: model.maxTokens ?? addedModel.maxTokens,
+                      };
+                    },
+                  );
                   const existingIds = new Set(
                     mergedProvider.models.map((m: { id: string }) => m.id),
                   );

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -28,6 +28,29 @@ describe('ProviderRegistry', () => {
     expect(def!.region).toBe('global');
   });
 
+  test('stores verified cloud model capacity metadata', () => {
+    const expectations = [
+      [ProviderName.DeepSeek, 'deepseek-v4-flash', 1_000_000, 384_000],
+      [ProviderName.Moonshot, 'kimi-k3', 1_048_576, 131_072],
+      [ProviderName.Qwen, 'qwen3.7-plus', 1_000_000, 64_000],
+      [ProviderName.Zhipu, 'glm-5.2', 1_000_000, 131_072],
+      [ProviderName.Minimax, 'MiniMax-M3', 1_000_000, 128_000],
+      [ProviderName.StepFun, 'step-3.7-flash', 256_000, 256_000],
+      [ProviderName.Xiaomi, 'mimo-v2.5-pro', 1_048_576, 131_072],
+      [ProviderName.OpenAI, 'gpt-5.4', 1_050_000, 128_000],
+      [ProviderName.Gemini, 'gemini-3-pro-preview', 1_048_576, 65_536],
+      [ProviderName.Anthropic, 'claude-opus-4-6', 1_000_000, 128_000],
+      [ProviderName.OpenRouter, 'openai/gpt-5.2-codex', 400_000, 128_000],
+    ] as const;
+
+    for (const [providerName, modelId, contextWindow, maxTokens] of expectations) {
+      const model = ProviderRegistry.get(providerName)?.defaultModels.find(
+        candidate => candidate.id === modelId,
+      );
+      expect(model).toMatchObject({ contextWindow, maxTokens });
+    }
+  });
+
   test('get returns undefined for unknown provider', () => {
     expect(ProviderRegistry.get('nonexistent')).toBeUndefined();
     expect(ProviderRegistry.get(ProviderName.Custom)).toBeUndefined();

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -149,6 +149,8 @@ interface ProviderDefInput {
     readonly id: string;
     readonly name: string;
     readonly supportsImage: boolean;
+    readonly contextWindow?: number;
+    readonly maxTokens?: number;
   }[];
   /**
    * Coding Plan dedicated model list (only meaningful when codingPlanSupported=true).
@@ -159,6 +161,8 @@ interface ProviderDefInput {
     readonly id: string;
     readonly name: string;
     readonly supportsImage: boolean;
+    readonly contextWindow?: number;
+    readonly maxTokens?: number;
   }[];
   /**
    * The OpenClaw gateway provider ID used when building model refs (e.g. "provider/modelId").
@@ -194,9 +198,27 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash', supportsImage: false },
-      { id: 'deepseek-v4-pro', name: 'DeepSeek V4 Pro', supportsImage: false },
-      { id: 'deepseek-reasoner', name: 'DeepSeek Reasoner', supportsImage: false },
+      {
+        id: 'deepseek-v4-flash',
+        name: 'DeepSeek V4 Flash',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+      },
+      {
+        id: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+      },
+      {
+        id: 'deepseek-reasoner',
+        name: 'DeepSeek Reasoner',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+      },
     ],
   },
   {
@@ -223,10 +245,37 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'kimi-k2.6', name: 'Kimi K2.6', supportsImage: true },
-      { id: 'kimi-k2.5', name: 'Kimi K2.5', supportsImage: true },
+      {
+        id: 'kimi-k3',
+        name: 'Kimi K3',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'kimi-k2.6',
+        name: 'Kimi K2.6',
+        supportsImage: true,
+        contextWindow: 262_144,
+        maxTokens: 262_144,
+      },
+      {
+        id: 'kimi-k2.5',
+        name: 'Kimi K2.5',
+        supportsImage: true,
+        contextWindow: 262_144,
+        maxTokens: 262_144,
+      },
     ],
-    codingPlanModels: [{ id: 'kimi-for-coding', name: 'Kimi K2.5', supportsImage: true }],
+    codingPlanModels: [
+      {
+        id: 'kimi-for-coding',
+        name: 'Kimi for Coding',
+        supportsImage: true,
+        contextWindow: 262_144,
+        maxTokens: 32_768,
+      },
+    ],
   },
   {
     id: ProviderName.Qwen,
@@ -249,9 +298,41 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'qwen3.6-plus', name: 'Qwen3.6 Plus', supportsImage: true },
-      { id: 'qwen3.5-plus', name: 'Qwen3.5 Plus', supportsImage: true },
-      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus', supportsImage: false },
+      {
+        id: 'qwen3.7-max',
+        name: 'Qwen3.7 Max',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'qwen3.7-plus',
+        name: 'Qwen3.7 Plus',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: 'qwen3.6-plus',
+        name: 'Qwen3.6 Plus',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'qwen3.5-plus',
+        name: 'Qwen3.5 Plus',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'qwen3-coder-plus',
+        name: 'Qwen3 Coder Plus',
+        supportsImage: false,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
     ],
   },
   {
@@ -275,8 +356,27 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'glm-5', name: 'GLM 5', supportsImage: false },
-      { id: 'glm-4.7', name: 'GLM 4.7', supportsImage: false },
+      {
+        id: 'glm-5.2',
+        name: 'GLM 5.2',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'glm-5',
+        name: 'GLM 5',
+        supportsImage: false,
+        contextWindow: 204_800,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'glm-4.7',
+        name: 'GLM 4.7',
+        supportsImage: false,
+        contextWindow: 204_800,
+        maxTokens: 131_072,
+      },
     ],
   },
   {
@@ -295,8 +395,27 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'MiniMax-M2.7', name: 'MiniMax M2.7', supportsImage: false },
-      { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', supportsImage: false },
+      {
+        id: 'MiniMax-M3',
+        name: 'MiniMax M3',
+        supportsImage: false,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'MiniMax-M2.7',
+        name: 'MiniMax M2.7',
+        supportsImage: false,
+        contextWindow: 204_800,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'MiniMax-M2.5',
+        name: 'MiniMax M2.5',
+        supportsImage: false,
+        contextWindow: 204_800,
+        maxTokens: 131_072,
+      },
     ],
   },
   {
@@ -319,10 +438,28 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'doubao-seed-2-0-pro-260215', name: 'Doubao-Seed-2.0-pro', supportsImage: true },
+      {
+        id: 'doubao-seed-2-0-pro-260215',
+        name: 'Doubao-Seed-2.0-pro',
+        supportsImage: true,
+        contextWindow: 256_000,
+        maxTokens: 128_000,
+      },
       { id: 'ark-code-latest', name: 'Auto', supportsImage: true },
-      { id: 'doubao-seed-2-0-lite-260215', name: 'Doubao-Seed-2.0-lite', supportsImage: true },
-      { id: 'doubao-seed-2-0-mini-260215', name: 'Doubao-Seed-2.0-mini', supportsImage: true },
+      {
+        id: 'doubao-seed-2-0-lite-260215',
+        name: 'Doubao-Seed-2.0-lite',
+        supportsImage: true,
+        contextWindow: 256_000,
+        maxTokens: 32_000,
+      },
+      {
+        id: 'doubao-seed-2-0-mini-260215',
+        name: 'Doubao-Seed-2.0-mini',
+        supportsImage: true,
+        contextWindow: 256_000,
+        maxTokens: 32_000,
+      },
     ],
   },
   {
@@ -342,8 +479,20 @@ const PROVIDER_DEFINITIONS = [
     defaultModels: [
       { id: 'deepseek-v3.2', name: 'DeepSeek V3.2', supportsImage: false },
       { id: 'deepseek-r1', name: 'DeepSeek R1', supportsImage: false },
-      { id: 'ernie-4.5-8k', name: 'ERNIE 4.5 8K', supportsImage: false },
-      { id: 'ernie-4.5-turbo-8k', name: 'ERNIE 4.5 Turbo', supportsImage: false },
+      {
+        id: 'ernie-4.5-8k',
+        name: 'ERNIE 4.5 8K',
+        supportsImage: false,
+        contextWindow: 8_192,
+        maxTokens: 8_192,
+      },
+      {
+        id: 'ernie-4.5-turbo-8k',
+        name: 'ERNIE 4.5 Turbo',
+        supportsImage: false,
+        contextWindow: 8_192,
+        maxTokens: 8_192,
+      },
     ],
   },
   {
@@ -357,7 +506,22 @@ const PROVIDER_DEFINITIONS = [
     codingPlanSupported: false,
     region: 'china',
     enPriority: 0,
-    defaultModels: [{ id: 'step-3.5-flash', name: 'Step 3.5 Flash', supportsImage: false }],
+    defaultModels: [
+      {
+        id: 'step-3.7-flash',
+        name: 'Step 3.7 Flash',
+        supportsImage: false,
+        contextWindow: 256_000,
+        maxTokens: 256_000,
+      },
+      {
+        id: 'step-3.5-flash',
+        name: 'Step 3.5 Flash',
+        supportsImage: false,
+        contextWindow: 256_000,
+        maxTokens: 256_000,
+      },
+    ],
   },
   {
     id: ProviderName.Xiaomi,
@@ -379,10 +543,41 @@ const PROVIDER_DEFINITIONS = [
     region: 'china',
     enPriority: 0,
     defaultModels: [
-      { id: 'mimo-v2.5-pro', name: 'MiMo V2.5 Pro', supportsImage: false },
-      { id: 'mimo-v2.5', name: 'MiMo V2.5', supportsImage: true },
-      { id: 'mimo-v2-pro', name: 'MiMo V2 Pro', supportsImage: false },
-      { id: 'mimo-v2-flash', name: 'MiMo V2 Flash', supportsImage: false },
+      {
+        id: 'mimo-v2.5-pro-ultraspeed',
+        name: 'MiMo V2.5 Pro Ultraspeed',
+        supportsImage: false,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'mimo-v2.5-pro',
+        name: 'MiMo V2.5 Pro',
+        supportsImage: false,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'mimo-v2.5',
+        name: 'MiMo V2.5',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'mimo-v2-pro',
+        name: 'MiMo V2 Pro',
+        supportsImage: false,
+        contextWindow: 1_048_576,
+        maxTokens: 131_072,
+      },
+      {
+        id: 'mimo-v2-flash',
+        name: 'MiMo V2 Flash',
+        supportsImage: false,
+        contextWindow: 262_144,
+        maxTokens: 65_536,
+      },
     ],
   },
   {
@@ -428,10 +623,34 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 0,
     defaultModels: [
-      { id: 'gpt-5-mini', name: 'GPT-5 mini', supportsImage: true },
-      { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', supportsImage: true },
-      { id: 'gpt-4.1', name: 'GPT-4.1', supportsImage: true },
-      { id: 'gpt-4o', name: 'GPT-4o', supportsImage: true },
+      {
+        id: 'gpt-5-mini',
+        name: 'GPT-5 mini',
+        supportsImage: true,
+        contextWindow: 264_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: 'claude-haiku-4.5',
+        name: 'Claude Haiku 4.5',
+        supportsImage: true,
+        contextWindow: 200_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: 'gpt-4.1',
+        name: 'GPT-4.1',
+        supportsImage: true,
+        contextWindow: 128_000,
+        maxTokens: 16_384,
+      },
+      {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        supportsImage: true,
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
+      },
     ],
   },
   {
@@ -446,10 +665,34 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 1,
     defaultModels: [
-      { id: 'gpt-5.4', name: 'GPT-5.4', supportsImage: true },
-      { id: 'gpt-5.2', name: 'GPT-5.2', supportsImage: true },
-      { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', supportsImage: true },
-      { id: 'gpt-5.2-codex', name: 'GPT-5.2 Codex', supportsImage: true },
+      {
+        id: 'gpt-5.4',
+        name: 'GPT-5.4',
+        supportsImage: true,
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'gpt-5.2',
+        name: 'GPT-5.2',
+        supportsImage: true,
+        contextWindow: 400_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        supportsImage: true,
+        contextWindow: 400_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'gpt-5.2-codex',
+        name: 'GPT-5.2 Codex',
+        supportsImage: true,
+        contextWindow: 400_000,
+        maxTokens: 128_000,
+      },
     ],
   },
   {
@@ -464,9 +707,27 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 3,
     defaultModels: [
-      { id: 'gemini-3-pro-preview', name: 'Gemini 3 Pro', supportsImage: true },
-      { id: 'gemini-3.1-pro-preview', name: 'Gemini 3.1 Pro', supportsImage: true },
-      { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash', supportsImage: true },
+      {
+        id: 'gemini-3-pro-preview',
+        name: 'Gemini 3 Pro',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'gemini-3.1-pro-preview',
+        name: 'Gemini 3.1 Pro',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
+      {
+        id: 'gemini-3-flash-preview',
+        name: 'Gemini 3 Flash',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
     ],
   },
   {
@@ -481,9 +742,27 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 2,
     defaultModels: [
-      { id: 'claude-sonnet-4-5-20250929', name: 'Claude Sonnet 4.5', supportsImage: true },
-      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', supportsImage: true },
-      { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', supportsImage: true },
+      {
+        id: 'claude-sonnet-4-5-20250929',
+        name: 'Claude Sonnet 4.5',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'claude-opus-4-6',
+        name: 'Claude Opus 4.6',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
     ],
   },
   {
@@ -502,10 +781,34 @@ const PROVIDER_DEFINITIONS = [
     region: 'global',
     enPriority: 0,
     defaultModels: [
-      { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', supportsImage: true },
-      { id: 'anthropic/claude-opus-4.6', name: 'Claude Opus 4.6', supportsImage: true },
-      { id: 'openai/gpt-5.2-codex', name: 'GPT 5.2 Codex', supportsImage: true },
-      { id: 'google/gemini-3-pro-preview', name: 'Gemini 3 Pro', supportsImage: true },
+      {
+        id: 'anthropic/claude-sonnet-4.5',
+        name: 'Claude Sonnet 4.5',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 64_000,
+      },
+      {
+        id: 'anthropic/claude-opus-4.6',
+        name: 'Claude Opus 4.6',
+        supportsImage: true,
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'openai/gpt-5.2-codex',
+        name: 'GPT 5.2 Codex',
+        supportsImage: true,
+        contextWindow: 400_000,
+        maxTokens: 128_000,
+      },
+      {
+        id: 'google/gemini-3-pro-preview',
+        name: 'Gemini 3 Pro',
+        supportsImage: true,
+        contextWindow: 1_048_576,
+        maxTokens: 65_536,
+      },
     ],
   },
 ] as const satisfies readonly ProviderDefInput[];
@@ -550,11 +853,15 @@ export interface ProviderDef {
     readonly id: string;
     readonly name: string;
     readonly supportsImage: boolean;
+    readonly contextWindow?: number;
+    readonly maxTokens?: number;
   }[];
   readonly codingPlanModels?: readonly {
     readonly id: string;
     readonly name: string;
     readonly supportsImage: boolean;
+    readonly contextWindow?: number;
+    readonly maxTokens?: number;
   }[];
   readonly openClawProviderId: OpenClawProviderId;
 }


### PR DESCRIPTION
## 变更内容

- shared/providers/constants 重构，新增模型 baseUrl/apiFormat 映射
- claudeSettings / piRuntimeAdapter / config 服务适配
- 新增测试覆盖