### PR TITLE
fix(cowork): surface pi auto-retry failures once instead of per attempt

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -156,6 +156,9 @@ vi.mock('../claudeSettings', () => ({
 
 import { PiRuntimeAdapter } from './piRuntimeAdapter';
 import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
+import { PiAgentLoopAction, PiAgentLoopMode, PiAgentLoopToolName } from './piAgentLoop';
+import { CoworkErrorKind, type CoworkError } from '../../../common/coworkError';
+import type { CoworkStore } from '../../coworkStore';
 import {
   PiAssistantStopReason,
   PiBuiltinFileToolName,
@@ -1213,6 +1216,151 @@ describe('PiRuntimeAdapter', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // ── Auto-retry error storm (deferred error surfacing) ──
+
+  describe('auto-retry error storm', () => {
+    let listener: ((event: unknown) => void) | null = null;
+    let mockStore: {
+      updateSession: ReturnType<typeof vi.fn>;
+      updateMessage: ReturnType<typeof vi.fn>;
+      addMessage: ReturnType<typeof vi.fn>;
+      getSession: ReturnType<typeof vi.fn>;
+      getAgent: ReturnType<typeof vi.fn>;
+      listAgents: ReturnType<typeof vi.fn>;
+    };
+    let errors: CoworkError[];
+    let completes: string[];
+
+    const failedAttempt = (errorMessage: string) => {
+      listener!({
+        type: 'message_end',
+        message: { role: 'assistant', content: '', stopReason: 'error', errorMessage },
+      });
+      listener!({ type: 'turn_end' });
+      listener!({ type: 'agent_end' });
+    };
+
+    const successfulTurn = (text: string) => {
+      listener!({ type: 'turn_start' });
+      listener!({
+        type: 'message_update',
+        message: { role: 'assistant', content: [{ type: 'text', text }] },
+      });
+      listener!({
+        type: 'message_end',
+        message: { role: 'assistant', content: [{ type: 'text', text }], stopReason: 'stop' },
+      });
+      listener!({ type: 'agent_end' });
+    };
+
+    const systemErrorMessages = () =>
+      mockStore.addMessage.mock.calls.filter(
+        ([, message]) => (message as { type: string }).type === 'system',
+      );
+
+    beforeEach(() => {
+      listener = null;
+      mockSession.subscribe.mockImplementation((cb: (event: unknown) => void) => {
+        listener = cb;
+        return () => {};
+      });
+      mockStore = {
+        updateSession: vi.fn(),
+        updateMessage: vi.fn(),
+        addMessage: vi.fn((_sessionId: string, message: Record<string, unknown>) => ({
+          ...message,
+          id: (message.id as string) ?? 'stored-id',
+        })),
+        getSession: vi.fn(() => undefined),
+        getAgent: vi.fn(() => undefined),
+        listAgents: vi.fn(() => []),
+      };
+      adapter.setCoworkStore(mockStore as unknown as CoworkStore);
+      errors = [];
+      completes = [];
+      adapter.on('error', (_sid, error) => errors.push(error as CoworkError));
+      adapter.on('complete', sessionId => completes.push(sessionId));
+    });
+
+    it('surfaces no error when an auto-retry succeeds', async () => {
+      await adapter.startSession('test', 'Hi');
+
+      listener!({ type: 'turn_start' });
+      failedAttempt('429 Too Many Requests: overloaded');
+      listener!({ type: 'auto_retry_start' });
+      successfulTurn('Recovered answer');
+      listener!({ type: 'agent_settled' });
+
+      expect(errors).toHaveLength(0);
+      expect(systemErrorMessages()).toHaveLength(0);
+      expect(mockStore.updateSession).not.toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ status: 'error' }),
+      );
+      expect(completes).toEqual(['test']);
+      expect(mockStore.updateSession).toHaveBeenCalledWith('test', { status: 'completed' });
+    });
+
+    it('surfaces the error exactly once when auto-retries are exhausted', async () => {
+      await adapter.startSession('test', 'Hi');
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        listener!({ type: 'turn_start' });
+        failedAttempt('429 Too Many Requests: overloaded');
+        listener!({ type: attempt < 2 ? 'auto_retry_start' : 'auto_retry_end' });
+      }
+      listener!({ type: 'agent_settled' });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].kind).toBe(CoworkErrorKind.RateLimited);
+      expect(systemErrorMessages()).toHaveLength(1);
+      expect(mockStore.updateSession).toHaveBeenCalledWith('test', { status: 'error' });
+      expect(mockStore.updateSession).not.toHaveBeenCalledWith('test', { status: 'completed' });
+      expect(completes).toHaveLength(0);
+    });
+
+    it('surfaces a non-retryable error once on agent_settled', async () => {
+      await adapter.startSession('test', 'Hi');
+
+      listener!({ type: 'turn_start' });
+      failedAttempt('401 Unauthorized: invalid api key');
+      listener!({ type: 'agent_settled' });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].kind).toBe(CoworkErrorKind.AuthExpired);
+      expect(systemErrorMessages()).toHaveLength(1);
+      expect(completes).toHaveLength(0);
+    });
+
+    it('does not complete or continue the agent loop on a failed turn', async () => {
+      await adapter.startSession('test', 'Hi');
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools?: Array<{
+          name: string;
+          execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+        }>;
+      };
+      const loopTool = sessionOptions.customTools?.find(tool => tool.name === PiAgentLoopToolName);
+      expect(loopTool).toBeDefined();
+      // Arm the loop so agent_end would normally continue with iteration 2.
+      await loopTool!.execute('call-1', {
+        action: PiAgentLoopAction.Start,
+        mode: PiAgentLoopMode.Passes,
+        passes: 3,
+      });
+      await loopTool!.execute('call-2', { action: PiAgentLoopAction.Next, summary: 'iter 1 done' });
+
+      listener!({ type: 'turn_start' });
+      failedAttempt('429 Too Many Requests: overloaded');
+      listener!({ type: 'auto_retry_end' });
+
+      // No continuation prompt beyond the initial startSession prompt.
+      expect(mockSession.prompt).toHaveBeenCalledTimes(1);
+      expect(completes).toHaveLength(0);
+      expect(mockStore.updateSession).not.toHaveBeenCalledWith('test', { status: 'completed' });
     });
   });
 });

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 
-import { classifyCoworkError } from '../../../common/coworkError';
+import { classifyCoworkError, type CoworkError } from '../../../common/coworkError';
 import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { isLocalProviderName, ProviderName } from '../../../shared/providers';
@@ -136,6 +136,13 @@ interface ActivePiSession {
   /** Long-horizon agent loop controller for this session (agent_loop tool). */
   agentLoop: PiAgentLoopController;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
+  /**
+   * Error from the latest failed attempt (message_end with stopReason=error).
+   * Deferred — not persisted/emitted — because Pi may auto-retry the turn;
+   * flushPendingError surfaces it once the run settles (auto_retry_end /
+   * agent_settled). Cleared when a retry succeeds or the turn is reset.
+   */
+  pendingError: { message: string; classified: CoworkError } | null;
 }
 
 // ── Dynamic imports ──
@@ -467,6 +474,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         toolResultMessageIdByCallId: new Map(),
         agentLoop,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
+        pendingError: null,
       };
 
       // Subscribe to Pi events before sending the prompt
@@ -574,6 +582,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     active.lastCompletedAnswerText = '';
     active.toolResultMessageIdByCallId.clear();
     active.writeTokenLimitRecovery.reset();
+    active.pendingError = null;
 
     // Emit user message (persisted to SQLite, same as startSession).
     const userMsg: CoworkMessage = {
@@ -631,6 +640,8 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     // session object, which may be in an inconsistent state after abort.
     active.aborted = true;
     active.agentLoop.stop();
+    // Drop any deferred error without surfacing it — the user stopped the turn.
+    active.pendingError = null;
 
     // Only abort the current turn — keep the session entry in activeSessions
     // so isSessionActive still reports true for IM routing, but do not reuse
@@ -843,23 +854,17 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
                 : JSON.stringify(event.message.content)
               : '(no content)';
             console.error('[PiRuntime] Assistant error:', errMsg, 'detail:', errDetail);
-            // Persist a system error message so the error survives session
-            // switching and is visible in the message list.
-            // Store the classified error kind so the renderer can translate it
-            // into a user-friendly message via i18n (e.g. "任务执行出错，请重试…").
-            // Raw errMsg is kept for console diagnostics only.
-            const classified = classifyCoworkError(errMsg);
-            if (this.store) {
-              this.store.updateSession(sessionId, { status: 'error' });
-              this.store.addMessage(sessionId, {
-                type: 'system',
-                content: '',
-                metadata: { error: errMsg, errorKind: classified.kind },
-              });
-            }
-            this.emit('error', sessionId, classified);
+            // Defer surfacing: Pi may auto-retry this turn (auto_retry_start).
+            // Persisting/emitting here would produce one error bubble per failed
+            // attempt — flushPendingError surfaces the error exactly once when
+            // the run settles (auto_retry_end / agent_settled).
+            active.pendingError = { message: errMsg, classified: classifyCoworkError(errMsg) };
             return;
           }
+
+          // A successful assistant message after failed attempts means the retry
+          // recovered — drop the deferred error so it is never surfaced.
+          active.pendingError = null;
 
           const { text, thinking } = extractStreamingSnapshot(event.message);
           const finalThinking = thinking || active.thinkingText;
@@ -952,6 +957,10 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       case 'agent_end': {
         this.finalizeActiveThinking(sessionId, active);
         this.markFinalAnswer(sessionId, active);
+        // Failed attempt (deferred error pending): do not continue the agent
+        // loop, mark completed, or emit complete. flushPendingError surfaces
+        // the error when the run settles (auto_retry_end / agent_settled).
+        if (active.pendingError) break;
         // Agent loop: when the finished iteration signaled "next", continue
         // the session with the next iteration prompt instead of completing.
         const loopDecision = active.agentLoop.handleAgentEnd();
@@ -984,12 +993,51 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         // Pi is retrying after an error — silently wait
         break;
 
+      case 'auto_retry_end':
+        // Retries exhausted — surface the deferred error, if any.
+        this.flushPendingError(sessionId, active);
+        break;
+
+      case 'agent_settled':
+        // Run settled (covers non-retryable errors with no auto-retry) —
+        // surface the deferred error, if any. Idempotent after auto_retry_end.
+        this.flushPendingError(sessionId, active);
+        break;
+
       default:
         // Silently ignore unknown/internal events
         if (event.type && !event.type.startsWith('_')) {
           console.log('[PiRuntime] Unhandled event type:', event.type);
         }
     }
+  }
+
+  // ── Private: deferred error handling ──
+
+  /**
+   * Persist and emit a deferred turn error exactly once.
+   *
+   * message_end(stopReason=error) only records the error on the session because
+   * Pi may auto-retry the turn; this flush runs on auto_retry_end / agent_settled,
+   * when the run has genuinely failed. Idempotent — a second call is a no-op.
+   */
+  private flushPendingError(sessionId: string, active: ActivePiSession): void {
+    const pending = active.pendingError;
+    if (!pending) return;
+    active.pendingError = null;
+    // Persist a system error message so the error survives session switching
+    // and is visible in the message list. The classified kind lets the renderer
+    // translate it into a user-friendly i18n message; the raw message is kept
+    // for console diagnostics only.
+    if (this.store) {
+      this.store.updateSession(sessionId, { status: 'error' });
+      this.store.addMessage(sessionId, {
+        type: 'system',
+        content: '',
+        metadata: { error: pending.message, errorKind: pending.classified.kind },
+      });
+    }
+    this.emit('error', sessionId, pending.classified);
   }
 
   // ── Private: assistant message lifecycle ──
@@ -1583,7 +1631,9 @@ function buildPiCustomModel(resolution: ApiConfigResolution): Record<string, unk
   const fallbackContextWindow = isLocalModel
     ? DEFAULT_PI_LOCAL_CONTEXT_WINDOW
     : DEFAULT_PI_CLOUD_CONTEXT_WINDOW;
-  const fallbackMaxTokens = isLocalModel ? DEFAULT_PI_LOCAL_MAX_TOKENS : DEFAULT_PI_CLOUD_MAX_TOKENS;
+  const fallbackMaxTokens = isLocalModel
+    ? DEFAULT_PI_LOCAL_MAX_TOKENS
+    : DEFAULT_PI_CLOUD_MAX_TOKENS;
 
   return {
     id: config.model,


### PR DESCRIPTION
## 问题

限流/上游 429 时，pi SDK 会自动重试（默认 3 次），但 adapter 在**每次**失败尝试的 `message_end(error)` 都立即持久化 system 错误并 emit `error`——UI 出现 N 个相同的「请求过于频繁」气泡；同时每次尝试后的 `agent_end` 都标 completed + emit `complete`，「任务完成」和错误同时出现，状态自相矛盾。

生产日志实证：会话首个请求 429 → `auto_retry_start` ×3 → 全败 → `auto_retry_end` / `agent_settled`（后两个事件此前落在 Unhandled 日志里）。

## 修复

- 失败尝试的错误先暂存 `pendingError`，不发射；`agent_end` 见 pendingError 直接 break（不标 completed、不 emit complete、不触发 agent_loop 续跑）
- 在 `auto_retry_end`（重试耗尽）或 `agent_settled`（不可重试错误）统一发射一次，幂等
- 重试成功则清错，正常 complete

## 测试

新增 4 个用例（重试成功零错误 / 3 次 429 只报一次 / 不可重试错误 agent_settled 报一次 / 错误回合不 complete 不续跑 loop）。agentEngine 目录 152/152 全绿，tsc/lint 无新增。

注：429 本身是上游限速，本 PR 只修错误呈现；深研/学术研究的并行子 agent 会成倍消耗同一 key 的速率，后续如遇频繁限速再考虑降并发。
