### PR TITLE
feat(模型市场): 优化了模型市场中模型卡片的交互；优化了模型配置和APItoken的交互；优化了本地模型界面的交互

### DIFF
--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -28,6 +28,7 @@ import {
   LOCAL_INFERENCE_UNLOAD_MIN_BUSY_MS,
   LOCAL_INFERENCE_UNLOAD_SETTLE_POLL_INTERVAL_MS,
   LOCAL_INFERENCE_UNLOAD_SETTLE_TIMEOUT_MS,
+  localInferenceCompactButtonClass,
 } from './constants';
 import { useI18nLanguage } from './hooks/useI18nLanguage';
 import { useLocalInferenceAccessSettings } from './hooks/useLocalInferenceAccessSettings';
@@ -709,9 +710,9 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
               <div className="flex flex-wrap items-center justify-end gap-2">
                 <Button
                   type="button"
-                  variant="ghost"
+                  variant="outline"
+                  className={localInferenceCompactButtonClass}
                   size="sm"
-                  data-local-inference-toolbar-button="true"
                   onClick={openAccessSettings}
                 >
                   <Globe data-icon="inline-start" />
@@ -719,9 +720,9 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                 </Button>
                 <Button
                   type="button"
-                  variant="ghost"
+                  variant="outline"
+                  className={localInferenceCompactButtonClass}
                   size="sm"
-                  data-local-inference-toolbar-button="true"
                   onClick={() => {
                     setDraftModelsDir(modelsDir);
                     setLibrarySettingsOpen(true);

--- a/src/renderer/components/localInference/components/LocalInferenceAccessSettingsDialog.tsx
+++ b/src/renderer/components/localInference/components/LocalInferenceAccessSettingsDialog.tsx
@@ -12,6 +12,7 @@ import { Switch } from '@shared/components/ui/switch';
 import { Globe, Lock, RefreshCw } from 'lucide-react';
 
 import { i18nService } from '../../../services/i18n';
+import { localInferenceCompactButtonClass } from '../constants';
 import { isValidLlamaCppPort } from '../hooks/useLocalInferenceAccessSettings';
 
 type LocalInferenceAccessSettingsDialogProps = {
@@ -138,10 +139,22 @@ model: "${modelName}"`}
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <Button type="button" variant="outline" onClick={onClose} disabled={saving}>
+            <Button
+              type="button"
+              variant="outline"
+              className={localInferenceCompactButtonClass}
+              onClick={onClose}
+              disabled={saving}
+            >
               {i18nService.t('cancel')}
             </Button>
-            <Button type="button" disabled={saving || !portValid} onClick={onSave}>
+            <Button
+              type="button"
+              variant="outline"
+              className={localInferenceCompactButtonClass}
+              disabled={saving || !portValid}
+              onClick={onSave}
+            >
               {i18nService.t('save')}
             </Button>
           </div>

--- a/src/renderer/components/localInference/components/MarketplaceModelCard.tsx
+++ b/src/renderer/components/localInference/components/MarketplaceModelCard.tsx
@@ -25,7 +25,10 @@ import {
   XiaomiIcon,
   ZhipuIcon,
 } from '../../icons/providers';
-import { localInferenceMutedTextClass } from '../constants';
+import {
+  localInferenceCompactButtonClass,
+  localInferenceMutedTextClass,
+} from '../constants';
 import type { InstallProgressState } from '../types';
 import {
   capabilityLabel,
@@ -45,7 +48,6 @@ const marketplaceCardTagBaseClassName = 'h-6 rounded-md px-2 py-0 text-xs font-n
 const marketplaceCardActionClassName =
   'relative z-20 transition-[opacity,transform] duration-200 ease-out group-hover/card:translate-x-0 group-hover/card:opacity-100 group-hover/card:pointer-events-auto';
 const marketplaceCardHiddenActionClassName = 'pointer-events-none translate-x-1 opacity-0';
-
 const marketplaceModelIcons = {
   [ProviderName.Anthropic]: AnthropicIcon,
   [ProviderName.DeepSeek]: DeepSeekIcon,
@@ -134,6 +136,7 @@ export function MarketplaceModelCard({
             >
               <Button
                 type="button"
+                className={localInferenceCompactButtonClass}
                 onClick={() => void openExternalUrl(model.detailUrl!)}
                 size="sm"
                 variant="outline"
@@ -214,6 +217,7 @@ export function MarketplaceModelCard({
             {installing ? (
               <Button
                 type="button"
+                className={localInferenceCompactButtonClass}
                 onClick={() => void window.electron.llamacpp.cancelInstall(model.repoId)}
                 size="sm"
                 variant="outline"
@@ -227,6 +231,7 @@ export function MarketplaceModelCard({
                 disabled={loading}
                 size="sm"
                 variant="outline"
+                className={localInferenceCompactButtonClass}
                 onClick={() => void onInstall(model)}
               >
                 <Download data-icon="inline-start" />

--- a/src/renderer/components/localInference/components/ModelLibrarySettingsModal.tsx
+++ b/src/renderer/components/localInference/components/ModelLibrarySettingsModal.tsx
@@ -10,6 +10,7 @@ import { Input } from '@shared/components/ui/input';
 import { FolderOpen, FolderUp, Settings2 } from 'lucide-react';
 
 import { i18nService } from '../../../services/i18n';
+import { localInferenceCompactButtonClass } from '../constants';
 
 type ModelLibrarySettingsModalProps = {
   isOpen: boolean;
@@ -67,6 +68,7 @@ export function ModelLibrarySettingsModal({
               <Button
                 type="button"
                 variant="outline"
+                className={localInferenceCompactButtonClass}
                 onClick={onPickDirectory}
                 disabled={saving}
               >
@@ -76,6 +78,7 @@ export function ModelLibrarySettingsModal({
               <Button
                 type="button"
                 variant="outline"
+                className={localInferenceCompactButtonClass}
                 onClick={onOpenDirectory}
                 disabled={saving}
               >

--- a/src/renderer/components/localInference/constants.ts
+++ b/src/renderer/components/localInference/constants.ts
@@ -35,3 +35,6 @@ export const smallDangerButtonClass =
 export const localInferenceMutedTextClass = 'text-muted-foreground';
 export const localInferenceSoftTextClass = 'text-foreground/75';
 export const localInferencePlaceholderTextClass = 'text-foreground/45';
+
+export const localInferenceCompactButtonClass =
+  'h-8 min-w-16 cursor-pointer px-3 shadow-none transition-[background-color,border-color,box-shadow] duration-200 ease-out hover:shadow-lg hover:shadow-foreground/10 active:shadow-inset';

--- a/src/renderer/components/localInference/panels/MarketplacePanel.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.tsx
@@ -23,7 +23,11 @@ import { i18nService } from '../../../services/i18n';
 import Modal from '../../common/Modal';
 import { EmptyState } from '../components/Common';
 import { MarketplaceModelCard } from '../components/MarketplaceModelCard';
-import { localInferenceMutedTextClass, MARKETPLACE_PAGE_SIZE } from '../constants';
+import {
+  localInferenceCompactButtonClass,
+  localInferenceMutedTextClass,
+  MARKETPLACE_PAGE_SIZE,
+} from '../constants';
 import type { InstallProgressState } from '../types';
 import {
   getInstallableMarketplaceModels,
@@ -305,7 +309,8 @@ export function MarketplacePanel({
               <Button
                 type="submit"
                 disabled={marketplaceLoading}
-                className={hasSearched ? 'h-9 text-xs' : 'h-16 rounded-2xl px-8 text-lg'}
+                className={`${localInferenceCompactButtonClass} self-center`}
+                variant="outline"
               >
                 {marketplaceLoading && (
                   <RefreshCw data-icon="inline-start" className="animate-spin" />
@@ -458,6 +463,7 @@ export function MarketplacePanel({
               type="button"
               onClick={handleClearToken}
               disabled={!savedToken}
+              className={localInferenceCompactButtonClass}
               size="sm"
               variant="destructive"
             >
@@ -469,10 +475,17 @@ export function MarketplacePanel({
                 onClick={() => setTokenModalOpen(false)}
                 size="sm"
                 variant="outline"
+                className={localInferenceCompactButtonClass}
               >
                 {i18nService.t('cancel')}
               </Button>
-              <Button type="button" onClick={() => void handleSaveToken()} size="sm">
+              <Button
+                type="button"
+                className={localInferenceCompactButtonClass}
+                onClick={() => void handleSaveToken()}
+                size="sm"
+                variant="outline"
+              >
                 {i18nService.t('marketplaceTokenSave')}
               </Button>
             </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -701,32 +701,6 @@ select::-ms-expand {
 [data-slot='button'][data-local-inference-launch-close-button='true']:hover:not(:disabled) svg {
   color: var(--lobster-destructive-foreground);
 }
-[data-slot='button'][data-local-inference-toolbar-button='true'] {
-  height: 32px;
-  border-color: var(--zy-border);
-  border-radius: 9999px;
-  background-color: var(--zy-surface);
-  color: var(--zy-text-secondary);
-  box-shadow: none;
-  font-weight: 500;
-  transition:
-    background-color 200ms ease,
-    border-color 200ms ease,
-    color 200ms ease,
-    transform 120ms ease;
-}
-[data-slot='button'][data-local-inference-toolbar-button='true']:hover:not(:disabled) {
-  border-color: var(--zy-border);
-  background-color: var(--zy-surface-raised);
-  color: var(--zy-text-secondary);
-  box-shadow: none;
-}
-[data-slot='button'][data-local-inference-toolbar-button='true'] svg {
-  color: var(--zy-text-secondary);
-}
-[data-slot='button'][data-local-inference-toolbar-button='true']:hover:not(:disabled) svg {
-  color: var(--zy-text-secondary);
-}
 [data-local-inference-secondary-action-button='true'],
 [data-local-inference-secondary-action-button='true']:hover:not(:disabled),
 [data-local-inference-secondary-action-button='true'] svg,


### PR DESCRIPTION
## 概要

  统一本地推理和模型市场中的按钮样式，增加一致的浅色轮廓样式、紧凑尺寸、悬停反馈和手形光标。

  ## 关联问题

  修复 #148 

  ## 修改内容

  - 统一模型市场与本地推理设置弹窗的紧凑按钮样式。
  - 更新模型市场搜索、API Token、访问设置和模型库设置按钮。
  - 增加统一的悬停阴影、按下反馈、手形光标和 `h-8` 尺寸。
  - 移除旧的胶囊形工具栏样式覆盖。

  ## 变更类型

  - [x] 问题修复
  - [ ] 新功能
  - [ ] 破坏性变更
  - [x] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 已在本地测试
  - [ ] 新增测试
  - [ ] 更新现有测试
  - [ ] 已进行手动测试

  ## 截图

  不适用。

  ## 检查清单

  - [x] 代码遵循项目样式规范
  - [x] 已完成代码自检
  - [ ] 已为复杂代码添加注释
  - [ ] 已同步更新相关文档
  - [x] 未引入新的警告
  - [ ] 已添加验证修复效果的测试
  - [x] 新增及现有单元测试均已通过

  ## Electron 特定变更

  - [ ] 修改主进程（`src/main/`）
  - [ ] 修改 Preload 脚本（`src/main/preload.ts`）
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 无 Electron 特定变更

  ## 补充说明

  相关 Vitest 测试已通过：

  - 2 个测试文件通过
  - 16 个测试通过

  Lint 仅报告 `src/renderer/components/mcp/McpManager.tsx` 中已有的 Hook 警告，未引入新的警告。

  完整测试命令因 Electron 原生模块重建时出现 Windows `spawn EPERM` 错误未能执行，因此直接运行了相关 Vitest 测试。