### PR TITLE
fix(research): enforce durable academic research workflow

### DIFF
--- a/src/main/libs/agentEngine/piAgentLoop.test.ts
+++ b/src/main/libs/agentEngine/piAgentLoop.test.ts
@@ -120,13 +120,15 @@ describe('buildPiAgentLoopTool', () => {
       await callTool(tool, { action: 'start', mode: 'goal', goal: 'write a report' });
       expect(controller.getState().active).toBe(true);
 
-      // Turn ends without a loop signal: no continuation.
-      expect(controller.handleAgentEnd()).toEqual({ shouldContinue: false });
+      // A missing loop signal is a protocol omission, not an implicit completion.
+      const omission = controller.handleAgentEnd();
+      expect(omission.shouldContinue).toBe(true);
+      expect(omission.nextPrompt).toContain('protocol omission');
 
       await callTool(tool, { action: 'next', summary: 'drafted outline' });
       const decision = controller.handleAgentEnd();
       expect(decision.shouldContinue).toBe(true);
-      expect(decision.nextPrompt).toContain('Iteration 2');
+      expect(decision.nextPrompt).toContain('Iteration 3');
       expect(decision.nextPrompt).toContain('write a report');
       expect(decision.nextPrompt).toContain('drafted outline');
       expect(decision.nextPrompt).toContain('agent_loop');
@@ -246,7 +248,12 @@ describe('buildPiAgentLoopTool', () => {
       expect(state.goal).toBe('second goal');
       expect(state.currentStep).toBe(0);
       // The pending "next" from the old loop must not leak into the new one.
-      expect(controller.handleAgentEnd()).toEqual({ shouldContinue: false });
+      // The replacement remains active, so its missing signal triggers the
+      // new protocol-omission continuation rather than the old loop state.
+      const replacementDecision = controller.handleAgentEnd();
+      expect(replacementDecision.shouldContinue).toBe(true);
+      expect(replacementDecision.nextPrompt).toContain('second goal');
+      expect(replacementDecision.nextPrompt).not.toContain('progress');
     });
 
     it('returns no continuation after stop', async () => {

--- a/src/main/libs/agentEngine/piAgentLoop.ts
+++ b/src/main/libs/agentEngine/piAgentLoop.ts
@@ -21,9 +21,9 @@
  *      the previous iteration ended with "next", it prompts the Pi session
  *      with the next-iteration prompt instead of completing the session.
  *
- * State is held in memory only — no persistence. A safety cap
- * (AGENT_LOOP_MAX_ITERATIONS) forces a wrap-up iteration and then closes the
- * loop even if the LLM keeps signaling "next".
+ * Generic loops are memory-only. Academic-research loops additionally attach
+ * a persistent PiResearchRunController, which owns the evidence and review
+ * gates before a model may finish.
  */
 
 // ── Constants ──
@@ -110,6 +110,13 @@ export class PiAgentLoopController {
    */
   private wrapUpPending = false;
 
+  constructor(
+    private readonly researchRun?: {
+      onAgentEnd(): { shouldFinish: boolean; reason?: string; nextPrompt?: string };
+      requestCompletion(reason: string): string;
+    },
+  ) {}
+
   /** Read-only snapshot of the current loop state. */
   getState(): PiAgentLoopState {
     return { ...this.state, stages: [...this.state.stages] };
@@ -171,6 +178,10 @@ export class PiAgentLoopController {
     if (!this.state.active) {
       return 'No active loop. Start one with agent_loop action "start".';
     }
+    if (this.researchRun) {
+      this.state.lastSummary = reason;
+      return this.researchRun.requestCompletion(reason);
+    }
     this.finish(reason);
     return `Loop complete after ${this.state.currentStep + 1} iteration(s). Reason: ${reason}`;
   }
@@ -181,8 +192,53 @@ export class PiAgentLoopController {
    * session is allowed to complete.
    */
   handleAgentEnd(): PiAgentLoopContinueDecision {
-    if (!this.state.active || !this.pendingNext) {
+    if (!this.state.active) {
       return { shouldContinue: false };
+    }
+
+    if (this.researchRun) {
+      const researchDecision = this.researchRun.onAgentEnd();
+      if (researchDecision.shouldFinish) {
+        this.finish(researchDecision.reason || 'Academic research completion gate passed');
+        return { shouldContinue: false };
+      }
+      this.state.currentStep += 1;
+      this.pendingNext = false;
+      return {
+        shouldContinue: true,
+        nextPrompt:
+          researchDecision.nextPrompt ||
+          'Continue the academic research run and follow its persisted evidence protocol.',
+      };
+    }
+
+    // The dedicated wrap-up turn is the only generic-loop exception: it is
+    // intentionally terminal after the safety cap, even if the model omits a
+    // final tool call.
+    if (this.wrapUpPending) {
+      this.finish(
+        `Iteration limit of ${AGENT_LOOP_MAX_ITERATIONS} reached; loop closed after the wrap-up iteration`,
+      );
+      return { shouldContinue: false };
+    }
+
+    // A loop is a protocol, not a suggestion. If a model ends its turn without
+    // next/done, keep the loop alive and make the omission visible in the next
+    // prompt instead of silently emitting a completed session.
+    if (!this.pendingNext) {
+      const nextStep = this.state.currentStep + 1;
+      this.state.currentStep = nextStep;
+      if (nextStep >= AGENT_LOOP_MAX_ITERATIONS - 1) {
+        this.wrapUpPending = true;
+        return { shouldContinue: true, nextPrompt: this.buildWrapUpPrompt() };
+      }
+      return {
+        shouldContinue: true,
+        nextPrompt:
+          `## Agent Loop — protocol omission\nYou ended iteration ${nextStep} without calling agent_loop next or done. ` +
+          'The loop remains active. Continue the work now, then call next or done explicitly.\n\n' +
+          this.buildIterationPrompt(nextStep),
+      };
     }
 
     // The wrap-up iteration just ended — close the loop unconditionally.

--- a/src/main/libs/agentEngine/piResearchEvidence.ts
+++ b/src/main/libs/agentEngine/piResearchEvidence.ts
@@ -1,0 +1,214 @@
+import { isIP } from 'node:net';
+
+import { PiResearchRunStore } from './piResearchStore';
+import {
+  type ResearchClaim,
+  type ResearchRunState,
+  type ResearchSourceType,
+} from './piResearchTypes';
+
+const now = (): string => new Date().toISOString();
+
+const isBlockedIpv4 = (address: string): boolean => {
+  const octets = address.split('.').map(Number);
+  if (octets.length !== 4 || octets.some(octet => !Number.isInteger(octet))) return true;
+  const [first, second] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+};
+
+const isBlockedHostname = (hostname: string): boolean => {
+  const normalized = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true;
+  const ipVersion = isIP(normalized);
+  if (ipVersion === 4) return isBlockedIpv4(normalized);
+  if (ipVersion === 6) {
+    return (
+      normalized === '::' ||
+      normalized === '::1' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe8') ||
+      normalized.startsWith('fe9') ||
+      normalized.startsWith('fea') ||
+      normalized.startsWith('feb') ||
+      normalized.startsWith('::ffff:')
+    );
+  }
+  return false;
+};
+
+export async function verifyResearchSource(
+  state: ResearchRunState,
+  store: PiResearchRunStore,
+  url: string,
+  sourceType: ResearchSourceType,
+): Promise<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'Source was not recorded: URL is invalid.';
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return 'Source was not recorded: only http(s) URLs can be verified.';
+  }
+  if (parsed.username || parsed.password || isBlockedHostname(parsed.hostname)) {
+    return 'Source was not recorded: local, private, or credential-bearing URLs are not allowed.';
+  }
+  try {
+    let current = parsed;
+    let verified = false;
+    const signal = AbortSignal.timeout(15_000);
+    for (let redirectCount = 0; redirectCount <= 5; redirectCount += 1) {
+      const response = await fetch(current, { signal, redirect: 'manual' });
+      const location = response.headers?.get?.('location');
+      if (response.status >= 300 && response.status < 400 && location) {
+        await response.body?.cancel();
+        current = new URL(location, current);
+        if (
+          !['http:', 'https:'].includes(current.protocol) ||
+          current.username ||
+          current.password ||
+          isBlockedHostname(current.hostname)
+        ) {
+          return 'Source was not recorded: redirect target is local, private, or unsafe.';
+        }
+        continue;
+      }
+      await response.body?.cancel();
+      if (!response.ok) {
+        return `Source was not recorded: URL returned HTTP ${response.status}.`;
+      }
+      verified = true;
+      break;
+    }
+    if (!verified) return 'Source was not recorded: URL exceeded the redirect limit.';
+    if (current.toString() !== parsed.toString()) {
+      store.log(
+        'orchestrator',
+        'info',
+        'source_redirected',
+        `Verified redirect chain from ${parsed.toString()} to ${current.toString()}.`,
+      );
+    }
+  } catch (error) {
+    return `Source was not recorded: fetch failed (${error instanceof Error ? error.message : String(error)}).`;
+  }
+  const normalized = parsed.toString();
+  const existing = state.sources.find(source => source.url === normalized);
+  if (!existing) {
+    const verifiedAt = now();
+    state.sources.push({ url: normalized, sourceType, verifiedAt });
+    store.appendFinding({
+      type: 'verified_source',
+      url: normalized,
+      sourceType,
+      verifiedAt,
+    });
+    store.writeState(state);
+  }
+  return `Verified and recorded source: ${normalized}`;
+}
+
+export function setResearchPlan(
+  state: ResearchRunState,
+  store: PiResearchRunStore,
+  subquestions: string[],
+): string {
+  const unique = [...new Set(subquestions.map(question => question.trim()).filter(Boolean))];
+  if (unique.length === 0) {
+    return 'Plan was not recorded: provide at least one non-empty subquestion.';
+  }
+  const planChanged =
+    state.subquestions.map(question => question.question).join('\n') !== unique.join('\n');
+  if (planChanged && state.subquestions.length > 0) {
+    state.claims = [];
+    delete state.contradictionCheck;
+    store.log(
+      'orchestrator',
+      'decision',
+      'plan_changed',
+      'Existing claims and contradiction check were cleared because their question mapping is no longer valid.',
+    );
+  }
+  state.subquestions = unique.map((question, index) => ({
+    id: `q${index + 1}`,
+    question,
+  }));
+  store.writeState(state);
+  store.log('orchestrator', 'decision', 'plan_recorded', `${unique.length} subquestions recorded.`);
+  return `Recorded ${unique.length} subquestions.`;
+}
+
+export function addResearchDirection(
+  state: ResearchRunState,
+  store: PiResearchRunStore,
+  direction: string,
+): string {
+  const normalized = direction.trim();
+  if (!normalized) return 'Direction was not recorded: it is empty.';
+  if (state.directionsTried.includes(normalized)) {
+    return 'Direction was not recorded: it duplicates a previously tried direction.';
+  }
+  state.directionsTried.push(normalized);
+  store.writeDirections(state.directionsTried);
+  store.writeState(state);
+  store.log('orchestrator', 'decision', 'direction_recorded', normalized);
+  return 'Recorded a new research direction.';
+}
+
+export function addResearchClaim(
+  state: ResearchRunState,
+  store: PiResearchRunStore,
+  id: string,
+  questionId: string,
+  statement: string,
+  sourceUrls: string[],
+): string {
+  const normalizedId = id.trim();
+  const normalizedStatement = statement.trim();
+  if (!normalizedId) return 'Claim was not recorded: claimId is empty.';
+  if (!normalizedStatement) return 'Claim was not recorded: statement is empty.';
+  if (!state.subquestions.some(question => question.id === questionId)) {
+    return `Claim was not recorded: unknown question id "${questionId}".`;
+  }
+  const verified = new Set(state.sources.map(source => source.url));
+  const uniqueUrls = [...new Set(sourceUrls)];
+  if (uniqueUrls.length < 2 || uniqueUrls.some(url => !verified.has(url))) {
+    return 'Claim was not recorded: each load-bearing claim needs two verified source URLs.';
+  }
+  const claim: ResearchClaim = {
+    id: normalizedId,
+    questionId,
+    statement: normalizedStatement,
+    sourceUrls: uniqueUrls,
+  };
+  const index = state.claims.findIndex(existing => existing.id === normalizedId);
+  if (index >= 0) state.claims[index] = claim;
+  else state.claims.push(claim);
+  store.appendFinding({ type: 'claim', ...claim });
+  store.writeState(state);
+  return `Recorded claim "${normalizedId}" with ${uniqueUrls.length} verified sources.`;
+}
+
+export function setResearchContradictionCheck(
+  state: ResearchRunState,
+  store: PiResearchRunStore,
+  summary: string,
+): string {
+  if (!summary.trim()) return 'Contradiction check was not recorded: summary is empty.';
+  state.contradictionCheck = summary.trim();
+  store.writeState(state);
+  store.log('orchestrator', 'decision', 'contradiction_check_recorded', summary.trim());
+  return 'Recorded contradiction check.';
+}

--- a/src/main/libs/agentEngine/piResearchPolicy.ts
+++ b/src/main/libs/agentEngine/piResearchPolicy.ts
@@ -1,0 +1,98 @@
+import {
+  MIN_PRIMARY_SOURCE_RATIO,
+  MIN_RESEARCH_SUBQUESTIONS,
+  MIN_VERIFIED_SOURCES,
+  ResearchSourceType,
+  type ResearchRunState,
+} from './piResearchTypes';
+
+export function collectCompletionFailures(
+  state: ResearchRunState,
+  reviewerRanThisRequest: boolean,
+): string[] {
+  const failures: string[] = [];
+  if (!reviewerRanThisRequest && !state.review.passed) {
+    failures.push('an isolated reviewer has not completed the request');
+  }
+  if (!state.review.passed) failures.push('reviewer verdict is not REVIEW_VERDICT: PASS');
+  if (state.subquestions.length < MIN_RESEARCH_SUBQUESTIONS) {
+    failures.push(`fewer than ${MIN_RESEARCH_SUBQUESTIONS} subquestions are recorded`);
+  }
+  if (state.sources.length < MIN_VERIFIED_SOURCES) {
+    failures.push(`fewer than ${MIN_VERIFIED_SOURCES} verified sources are recorded`);
+  }
+  const primaryCount = state.sources.filter(
+    source => source.sourceType === ResearchSourceType.Primary,
+  ).length;
+  if (state.sources.length > 0 && primaryCount / state.sources.length < MIN_PRIMARY_SOURCE_RATIO) {
+    failures.push(`primary-source ratio is below ${MIN_PRIMARY_SOURCE_RATIO}`);
+  }
+  for (const question of state.subquestions) {
+    if (!state.claims.some(claim => claim.questionId === question.id)) {
+      failures.push(`subquestion ${question.id} has no supported claim`);
+    }
+  }
+  for (const claim of state.claims) {
+    if (!claim.statement?.trim()) {
+      failures.push(`claim ${claim.id} has no auditable statement`);
+    }
+    if (new Set(claim.sourceUrls).size < 2) {
+      failures.push(`claim ${claim.id} does not have two independent sources`);
+    }
+  }
+  for (let iteration = 1; iteration <= state.iteration; iteration += 1) {
+    if (!state.researcherIterations.includes(iteration)) {
+      failures.push(`iteration ${iteration} did not launch an isolated researcher`);
+    }
+  }
+  if (!state.contradictionCheck) failures.push('no contradiction check is recorded');
+  if (state.directionsTried.length < MIN_RESEARCH_SUBQUESTIONS) {
+    failures.push('fewer than three distinct research directions are recorded');
+  }
+  return failures;
+}
+
+export function buildResearchIterationPrompt(
+  state: ResearchRunState,
+  runDirectory: string,
+): string {
+  const pivot =
+    state.staleCount >= 2
+      ? 'Two or more stale iterations were detected. Change a structural research constraint: corpus, language, time window, methodology, or contrary evidence.'
+      : 'Choose a direction not present in directions_tried.json.';
+  return [
+    `## Academic research iteration ${state.iteration}`,
+    `State directory: ${runDirectory}`,
+    pivot,
+    'You must launch an isolated researcher subagent in this iteration. Record verified sources and claims through research_state before ending the turn.',
+    'When the work is incomplete, call agent_loop next. If you omit next/done, the controller will continue and record the protocol violation.',
+  ].join('\n');
+}
+
+export function buildResearchReviewPrompt(failures: string[], runDirectory: string): string {
+  const gateSummary = failures.length
+    ? failures.map(failure => `- ${failure}`).join('\n')
+    : '- none';
+  return [
+    '## Academic research completion review',
+    `State directory: ${runDirectory}`,
+    'Launch an isolated reviewer subagent now. Its task is to inspect the persisted evidence and return exactly REVIEW_VERDICT: PASS only when every gate is met; otherwise return REVIEW_VERDICT: FAIL followed by concrete gaps.',
+    'Current deterministic gate failures:',
+    gateSummary,
+    'If the reviewer or a gate fails, continue research and record the missing evidence. Do not call done again until the gaps are resolved.',
+  ].join('\n');
+}
+
+export function extractSubagentIds(args: unknown): string[] {
+  if (!args || typeof args !== 'object') return [];
+  const record = args as Record<string, unknown>;
+  const ids: string[] = [];
+  if (typeof record.agent === 'string') ids.push(record.agent);
+  for (const key of ['parallel', 'chain']) {
+    if (!Array.isArray(record[key])) continue;
+    for (const item of record[key] as Array<Record<string, unknown>>) {
+      if (typeof item?.agent === 'string') ids.push(item.agent);
+    }
+  }
+  return ids;
+}

--- a/src/main/libs/agentEngine/piResearchPolicy.ts
+++ b/src/main/libs/agentEngine/piResearchPolicy.ts
@@ -3,9 +3,43 @@ import {
   MIN_RESEARCH_ITERATIONS,
   MIN_RESEARCH_SUBQUESTIONS,
   MIN_VERIFIED_SOURCES,
+  ResearchRunStatus,
   ResearchSourceType,
   type ResearchRunState,
 } from './piResearchTypes';
+
+export function resumeResearchState(state: ResearchRunState, task: string): boolean {
+  if (
+    state.status !== ResearchRunStatus.Completed &&
+    state.status !== ResearchRunStatus.NeedsAttention
+  ) {
+    return false;
+  }
+  state.status = ResearchRunStatus.Running;
+  state.task = task;
+  state.iteration += 1;
+  state.staleCount = 0;
+  state.lastFindingCount = state.sources.length + state.claims.length;
+  state.review = { requested: false, passed: false };
+  delete state.completionReason;
+  return true;
+}
+
+export function buildResearchInitialPrompt(runDirectory: string, userPrompt: string): string {
+  return [
+    '## Academic research run initialized',
+    `Durable state directory: ${runDirectory}`,
+    'This is a controlled research run. Do not finish after a quick search.',
+    'Complete at least three distinct research iterations, each with an isolated researcher subagent.',
+    'First create at least three subquestions with research_state action "plan", then choose a novel direction with action "direction".',
+    'Every iteration must launch at least one isolated researcher subagent. Researchers have an explicit web-search capability.',
+    'For every source you rely on, call research_state action "verify_source"; this process opens the URL before it is recorded.',
+    'Record each load-bearing claim statement with two or more verified independent source URLs using action "claim".',
+    'Before requesting completion, record a contradiction scan with action "contradictions". Calling agent_loop done only requests review; it cannot complete the run by itself.',
+    '',
+    userPrompt,
+  ].join('\n');
+}
 
 export function collectCompletionFailures(
   state: ResearchRunState,

--- a/src/main/libs/agentEngine/piResearchPolicy.ts
+++ b/src/main/libs/agentEngine/piResearchPolicy.ts
@@ -1,5 +1,6 @@
 import {
   MIN_PRIMARY_SOURCE_RATIO,
+  MIN_RESEARCH_ITERATIONS,
   MIN_RESEARCH_SUBQUESTIONS,
   MIN_VERIFIED_SOURCES,
   ResearchSourceType,
@@ -15,6 +16,15 @@ export function collectCompletionFailures(
     failures.push('an isolated reviewer has not completed the request');
   }
   if (!state.review.passed) failures.push('reviewer verdict is not REVIEW_VERDICT: PASS');
+  failures.push(...collectEvidenceFailures(state));
+  return failures;
+}
+
+export function collectEvidenceFailures(state: ResearchRunState): string[] {
+  const failures: string[] = [];
+  if (state.iteration < MIN_RESEARCH_ITERATIONS) {
+    failures.push(`fewer than ${MIN_RESEARCH_ITERATIONS} research iterations are recorded`);
+  }
   if (state.subquestions.length < MIN_RESEARCH_SUBQUESTIONS) {
     failures.push(`fewer than ${MIN_RESEARCH_SUBQUESTIONS} subquestions are recorded`);
   }

--- a/src/main/libs/agentEngine/piResearchRun.test.ts
+++ b/src/main/libs/agentEngine/piResearchRun.test.ts
@@ -74,8 +74,15 @@ describe('PiResearchRunController', () => {
     run.setContradictionCheck('Conflicting results are scoped by population and publication date.');
     run.recordSubagentStart('research-1', { agent: 'researcher', task: 'retrieve literature' });
 
-    run.requestCompletion('All conclusions are documented.');
     let decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+    run.recordSubagentStart('research-2', { agent: 'researcher', task: 'seek contrary evidence' });
+    decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+    run.recordSubagentStart('research-3', { agent: 'researcher', task: 'compare methodologies' });
+
+    run.requestCompletion('All conclusions are documented.');
+    decision = run.onAgentEnd();
     expect(decision.shouldFinish).toBe(false);
     expect(decision.nextPrompt).toContain('isolated reviewer');
 
@@ -97,10 +104,10 @@ describe('PiResearchRunController', () => {
     expect(run.getSnapshot()).toMatchObject({
       status: 'running',
       task: 'Investigate a follow-up question.',
-      iteration: 2,
+      iteration: 4,
       review: { requested: false, passed: false },
       completionFailures: expect.arrayContaining([
-        'iteration 2 did not launch an isolated researcher',
+        'iteration 4 did not launch an isolated researcher',
       ]),
     });
   });
@@ -129,13 +136,31 @@ describe('PiResearchRunController', () => {
     expect(run.getSnapshot()).toMatchObject({ claims: [] });
   });
 
-  it('keeps an unfinished run alive and raises stale_count when an iteration launched no researcher', () => {
+  it('keeps an unfinished run on the same iteration when no researcher launched', () => {
     const run = createRun();
     const decision = run.onAgentEnd();
     expect(decision.shouldFinish).toBe(false);
     expect(decision.nextPrompt).toContain('must launch an isolated researcher');
-    expect(run.getSnapshot()).toMatchObject({ iteration: 2, staleCount: 1 });
+    expect(decision.nextPrompt).toContain('was not advanced');
+    expect(run.getSnapshot()).toMatchObject({ iteration: 1, staleCount: 1 });
+
+    run.recordSubagentStart('research-retry', { agent: 'researcher', task: 'retry iteration' });
+    expect(run.onAgentEnd().shouldFinish).toBe(false);
+    expect(run.getSnapshot()).toMatchObject({ iteration: 2 });
     expect(MIN_RESEARCH_SUBQUESTIONS).toBe(3);
+  });
+
+  it('returns an early completion request to research mode instead of deadlocking in review', () => {
+    const run = createRun();
+    run.recordSubagentStart('research-1', { agent: 'researcher', task: 'start discovery' });
+    run.requestCompletion('Finished too early.');
+
+    const decision = run.onAgentEnd();
+
+    expect(decision.shouldFinish).toBe(false);
+    expect(decision.nextPrompt).toContain('Completion deferred');
+    expect(decision.nextPrompt).toContain('fewer than 3 research iterations');
+    expect(run.getSnapshot()).toMatchObject({ status: 'running', iteration: 2 });
   });
 
   it('does not fetch local or private source URLs', async () => {

--- a/src/main/libs/agentEngine/piResearchRun.test.ts
+++ b/src/main/libs/agentEngine/piResearchRun.test.ts
@@ -1,0 +1,143 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MIN_RESEARCH_SUBQUESTIONS,
+  MIN_VERIFIED_SOURCES,
+  PiResearchRunController,
+  ResearchSourceType,
+} from './piResearchRun';
+
+const tempRoots: string[] = [];
+
+const createRun = (): PiResearchRunController => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-research-run-'));
+  tempRoots.push(root);
+  return new PiResearchRunController({
+    sessionId: 'session-1',
+    workspaceRoot: root,
+    task: 'Study test topic',
+  });
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('PiResearchRunController', () => {
+  it('creates Deli-compatible durable state files and reloads them for the same session', () => {
+    const run = createRun();
+    expect(fs.existsSync(path.join(run.runDirectory, 'state', 'task_spec.md'))).toBe(true);
+    expect(fs.existsSync(path.join(run.runDirectory, 'state', 'progress.json'))).toBe(true);
+    expect(fs.existsSync(path.join(run.runDirectory, 'state', 'findings.jsonl'))).toBe(true);
+    expect(fs.existsSync(path.join(run.runDirectory, 'state', 'directions_tried.json'))).toBe(true);
+    expect(fs.existsSync(path.join(run.runDirectory, 'logs', 'heartbeat.jsonl'))).toBe(true);
+
+    run.setPlan(['scope', 'evidence', 'limitations']);
+    run.addDirection('primary literature');
+    const restored = new PiResearchRunController({
+      sessionId: 'session-1',
+      workspaceRoot: path.dirname(path.dirname(path.dirname(run.runDirectory))),
+      task: 'ignored after restore',
+    });
+    expect(restored.getSnapshot()).toMatchObject({
+      subquestions: expect.arrayContaining([expect.objectContaining({ id: 'q1' })]),
+      directionsTried: ['primary literature'],
+    });
+  });
+
+  it('does not approve completion until an independent reviewer and every evidence gate pass', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const run = createRun();
+    run.setPlan(['scope', 'evidence', 'limitations']);
+    run.addDirection('primary literature');
+    run.addDirection('contrary findings');
+    run.addDirection('methodology comparison');
+
+    const urls = Array.from(
+      { length: MIN_VERIFIED_SOURCES },
+      (_, index) => `https://source-${index}.example.test/paper`,
+    );
+    for (const [index, url] of urls.entries()) {
+      await run.verifySource(
+        url,
+        index < 2 ? ResearchSourceType.Primary : ResearchSourceType.Secondary,
+      );
+    }
+    run.addClaim('claim-1', 'q1', 'The scoped result is supported.', urls.slice(0, 2));
+    run.addClaim('claim-2', 'q2', 'The evidence converges across sources.', urls.slice(2, 4));
+    run.addClaim('claim-3', 'q3', 'The limitations are explicitly bounded.', urls.slice(4, 6));
+    run.setContradictionCheck('Conflicting results are scoped by population and publication date.');
+    run.recordSubagentStart('research-1', { agent: 'researcher', task: 'retrieve literature' });
+
+    run.requestCompletion('All conclusions are documented.');
+    let decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+    expect(decision.nextPrompt).toContain('isolated reviewer');
+
+    run.recordSubagentStart('review-1', { agent: 'reviewer', task: 'audit evidence' });
+    run.recordSubagentResult('unrelated-researcher', 'REVIEW_VERDICT: PASS', false);
+    decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+
+    run.recordSubagentResult('review-1', 'Do not return REVIEW_VERDICT: PASS yet.', false);
+    decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+
+    run.recordSubagentStart('review-2', { agent: 'reviewer', task: 'audit corrected evidence' });
+    run.recordSubagentResult('review-2', 'REVIEW_VERDICT: PASS', false);
+    decision = run.onAgentEnd();
+    expect(decision).toMatchObject({ shouldFinish: true });
+  });
+
+  it('clears claims when the research plan changes and requires auditable claim text', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+    const run = createRun();
+    run.setPlan(['scope', 'evidence', 'limitations']);
+    await run.verifySource('https://one.example.test/paper', ResearchSourceType.Primary);
+    await run.verifySource('https://two.example.test/paper', ResearchSourceType.Primary);
+
+    expect(
+      run.addClaim('claim-1', 'q1', '', [
+        'https://one.example.test/paper',
+        'https://two.example.test/paper',
+      ]),
+    ).toContain('statement is empty');
+    expect(
+      run.addClaim('claim-1', 'q1', 'A supported statement.', [
+        'https://one.example.test/paper',
+        'https://two.example.test/paper',
+      ]),
+    ).toContain('Recorded claim');
+
+    run.setPlan(['new scope', 'new evidence', 'new limitations']);
+    expect(run.getSnapshot()).toMatchObject({ claims: [] });
+  });
+
+  it('keeps an unfinished run alive and raises stale_count when an iteration launched no researcher', () => {
+    const run = createRun();
+    const decision = run.onAgentEnd();
+    expect(decision.shouldFinish).toBe(false);
+    expect(decision.nextPrompt).toContain('must launch an isolated researcher');
+    expect(run.getSnapshot()).toMatchObject({ iteration: 2, staleCount: 1 });
+    expect(MIN_RESEARCH_SUBQUESTIONS).toBe(3);
+  });
+
+  it('does not fetch local or private source URLs', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const run = createRun();
+
+    await expect(
+      run.verifySource('http://127.0.0.1/admin', ResearchSourceType.Primary),
+    ).resolves.toContain('local, private');
+    await expect(
+      run.verifySource('http://169.254.169.254/latest/meta-data', ResearchSourceType.Primary),
+    ).resolves.toContain('local, private');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/libs/agentEngine/piResearchRun.test.ts
+++ b/src/main/libs/agentEngine/piResearchRun.test.ts
@@ -92,6 +92,17 @@ describe('PiResearchRunController', () => {
     run.recordSubagentResult('review-2', 'REVIEW_VERDICT: PASS', false);
     decision = run.onAgentEnd();
     expect(decision).toMatchObject({ shouldFinish: true });
+
+    run.resumeForPrompt('Investigate a follow-up question.');
+    expect(run.getSnapshot()).toMatchObject({
+      status: 'running',
+      task: 'Investigate a follow-up question.',
+      iteration: 2,
+      review: { requested: false, passed: false },
+      completionFailures: expect.arrayContaining([
+        'iteration 2 did not launch an isolated researcher',
+      ]),
+    });
   });
 
   it('clears claims when the research plan changes and requires auditable claim text', async () => {

--- a/src/main/libs/agentEngine/piResearchRun.ts
+++ b/src/main/libs/agentEngine/piResearchRun.ts
@@ -67,6 +67,33 @@ export class PiResearchRunController {
     return `Produce a verified academic research result for: ${this.state.task}`;
   }
 
+  resumeForPrompt(task: string): void {
+    if (
+      this.state.status !== ResearchRunStatus.Completed &&
+      this.state.status !== ResearchRunStatus.NeedsAttention
+    ) {
+      return;
+    }
+    this.state.status = ResearchRunStatus.Running;
+    this.state.task = task;
+    this.state.iteration += 1;
+    this.state.staleCount = 0;
+    this.state.lastFindingCount = this.state.sources.length + this.state.claims.length;
+    this.state.review = { requested: false, passed: false };
+    delete this.state.completionReason;
+    this.researcherRanThisIteration = false;
+    this.reviewerRanThisRequest = false;
+    this.reviewerToolCallIds.clear();
+    this.store.appendFollowUpTask(task);
+    this.store.writeState(this.state);
+    this.store.log(
+      'orchestrator',
+      'decision',
+      'run_resumed_for_follow_up',
+      `Academic research resumed at iteration ${this.state.iteration}.`,
+    );
+  }
+
   buildInitialPrompt(userPrompt: string): string {
     return [
       '## Academic research run initialized',

--- a/src/main/libs/agentEngine/piResearchRun.ts
+++ b/src/main/libs/agentEngine/piResearchRun.ts
@@ -15,11 +15,13 @@ import {
   verifyResearchSource,
 } from './piResearchEvidence';
 import {
+  buildResearchInitialPrompt,
   buildResearchIterationPrompt,
   buildResearchReviewPrompt,
   collectCompletionFailures,
   collectEvidenceFailures,
   extractSubagentIds,
+  resumeResearchState,
 } from './piResearchPolicy';
 import { PiResearchRunStore } from './piResearchStore';
 import {
@@ -70,19 +72,7 @@ export class PiResearchRunController {
   }
 
   resumeForPrompt(task: string): void {
-    if (
-      this.state.status !== ResearchRunStatus.Completed &&
-      this.state.status !== ResearchRunStatus.NeedsAttention
-    ) {
-      return;
-    }
-    this.state.status = ResearchRunStatus.Running;
-    this.state.task = task;
-    this.state.iteration += 1;
-    this.state.staleCount = 0;
-    this.state.lastFindingCount = this.state.sources.length + this.state.claims.length;
-    this.state.review = { requested: false, passed: false };
-    delete this.state.completionReason;
+    if (!resumeResearchState(this.state, task)) return;
     this.researcherRanThisIteration = false;
     this.reviewerRanThisRequest = false;
     this.reviewerToolCallIds.clear();
@@ -97,19 +87,7 @@ export class PiResearchRunController {
   }
 
   buildInitialPrompt(userPrompt: string): string {
-    return [
-      '## Academic research run initialized',
-      `Durable state directory: ${this.runDirectory}`,
-      'This is a controlled research run. Do not finish after a quick search.',
-      'Complete at least three distinct research iterations, each with an isolated researcher subagent.',
-      'First create at least three subquestions with research_state action "plan", then choose a novel direction with action "direction".',
-      'Every iteration must launch at least one isolated researcher subagent. Researchers have an explicit web-search capability.',
-      'For every source you rely on, call research_state action "verify_source"; this process opens the URL before it is recorded.',
-      'Record each load-bearing claim statement with two or more verified independent source URLs using action "claim".',
-      'Before requesting completion, record a contradiction scan with action "contradictions". Calling agent_loop done only requests review; it cannot complete the run by itself.',
-      '',
-      userPrompt,
-    ].join('\n');
+    return buildResearchInitialPrompt(this.runDirectory, userPrompt);
   }
 
   recordSubagentStart(toolCallId: string, args: unknown): void {
@@ -198,7 +176,7 @@ export class PiResearchRunController {
           deferredFailures.join('; '),
         );
       } else {
-        const failures = this.completionFailures();
+        const failures = collectCompletionFailures(this.state, this.reviewerRanThisRequest);
         if (this.state.review.passed && failures.length === 0) {
           this.state.status = ResearchRunStatus.Completed;
           this.store.writeState(this.state);
@@ -313,11 +291,7 @@ export class PiResearchRunController {
     return {
       ...this.state,
       runDirectory: this.runDirectory,
-      completionFailures: this.completionFailures(),
+      completionFailures: collectCompletionFailures(this.state, this.reviewerRanThisRequest),
     };
-  }
-
-  private completionFailures(): string[] {
-    return collectCompletionFailures(this.state, this.reviewerRanThisRequest);
   }
 }

--- a/src/main/libs/agentEngine/piResearchRun.ts
+++ b/src/main/libs/agentEngine/piResearchRun.ts
@@ -18,6 +18,7 @@ import {
   buildResearchIterationPrompt,
   buildResearchReviewPrompt,
   collectCompletionFailures,
+  collectEvidenceFailures,
   extractSubagentIds,
 } from './piResearchPolicy';
 import { PiResearchRunStore } from './piResearchStore';
@@ -33,6 +34,7 @@ import {
 export {
   isAcademicResearchSkillSet,
   MIN_PRIMARY_SOURCE_RATIO,
+  MIN_RESEARCH_ITERATIONS,
   MIN_RESEARCH_SUBQUESTIONS,
   MIN_VERIFIED_SOURCES,
   PiResearchStateAction,
@@ -99,6 +101,7 @@ export class PiResearchRunController {
       '## Academic research run initialized',
       `Durable state directory: ${this.runDirectory}`,
       'This is a controlled research run. Do not finish after a quick search.',
+      'Complete at least three distinct research iterations, each with an isolated researcher subagent.',
       'First create at least three subquestions with research_state action "plan", then choose a novel direction with action "direction".',
       'Every iteration must launch at least one isolated researcher subagent. Researchers have an explicit web-search capability.',
       'For every source you rely on, call research_state action "verify_source"; this process opens the URL before it is recorded.',
@@ -179,34 +182,71 @@ export class PiResearchRunController {
   }
 
   onAgentEnd(): ResearchEndDecision {
+    let deferredFailures: string[] = [];
     if (this.state.status === ResearchRunStatus.CompletionRequested) {
-      const failures = this.completionFailures();
-      if (this.state.review.passed && failures.length === 0) {
-        this.state.status = ResearchRunStatus.Completed;
+      deferredFailures = collectEvidenceFailures(this.state);
+      if (deferredFailures.length > 0) {
+        this.state.status = ResearchRunStatus.Running;
+        this.state.review = { requested: false, passed: false };
+        this.reviewerRanThisRequest = false;
+        this.reviewerToolCallIds.clear();
         this.store.writeState(this.state);
         this.store.log(
           'orchestrator',
-          'info',
-          'completion_approved',
-          this.state.completionReason || 'Approved',
+          'decision',
+          'completion_deferred',
+          deferredFailures.join('; '),
         );
+      } else {
+        const failures = this.completionFailures();
+        if (this.state.review.passed && failures.length === 0) {
+          this.state.status = ResearchRunStatus.Completed;
+          this.store.writeState(this.state);
+          this.store.log(
+            'orchestrator',
+            'info',
+            'completion_approved',
+            this.state.completionReason || 'Approved',
+          );
+          return {
+            shouldFinish: true,
+            reason: this.state.completionReason || 'Academic research gate passed',
+          };
+        }
         return {
-          shouldFinish: true,
-          reason: this.state.completionReason || 'Academic research gate passed',
+          shouldFinish: false,
+          nextPrompt: buildResearchReviewPrompt(failures, this.runDirectory),
         };
       }
-      return {
-        shouldFinish: false,
-        nextPrompt: buildResearchReviewPrompt(failures, this.runDirectory),
-      };
     }
 
     const previousFindingCount = this.state.sources.length + this.state.claims.length;
-    if (!this.researcherRanThisIteration || previousFindingCount <= this.state.lastFindingCount) {
+    if (!this.researcherRanThisIteration) {
       this.state.staleCount += 1;
-    } else {
-      this.state.staleCount = 0;
+      this.store.writeState(this.state);
+      this.store.log(
+        'orchestrator',
+        'warn',
+        'researcher_missing',
+        `Iteration ${this.state.iteration} was not advanced because no researcher subagent ran.`,
+      );
+      return {
+        shouldFinish: false,
+        nextPrompt: [
+          ...(deferredFailures.length > 0
+            ? [
+                '## Completion deferred — evidence gates remain open',
+                ...deferredFailures.map(failure => `- ${failure}`),
+                '',
+              ]
+            : []),
+          `Iteration ${this.state.iteration} was not advanced because no isolated researcher ran.`,
+          buildResearchIterationPrompt(this.state, this.runDirectory),
+        ].join('\n'),
+      };
     }
+    this.state.staleCount =
+      previousFindingCount <= this.state.lastFindingCount ? this.state.staleCount + 1 : 0;
     this.state.lastFindingCount = previousFindingCount;
     this.state.iteration += 1;
     this.researcherRanThisIteration = false;
@@ -236,7 +276,16 @@ export class PiResearchRunController {
 
     return {
       shouldFinish: false,
-      nextPrompt: buildResearchIterationPrompt(this.state, this.runDirectory),
+      nextPrompt: [
+        ...(deferredFailures.length > 0
+          ? [
+              '## Completion deferred — evidence gates remain open',
+              ...deferredFailures.map(failure => `- ${failure}`),
+              '',
+            ]
+          : []),
+        buildResearchIterationPrompt(this.state, this.runDirectory),
+      ].join('\n'),
     };
   }
 

--- a/src/main/libs/agentEngine/piResearchRun.ts
+++ b/src/main/libs/agentEngine/piResearchRun.ts
@@ -1,0 +1,247 @@
+/**
+ * Persistent academic-research run controller.
+ *
+ * The generic Pi loop decides how turns continue. This controller owns the
+ * research-specific invariants that a language model must not be allowed to
+ * waive: persisted evidence, direction diversity, independent review, and a
+ * deterministic completion gate.
+ */
+
+import {
+  addResearchClaim,
+  addResearchDirection,
+  setResearchContradictionCheck,
+  setResearchPlan,
+  verifyResearchSource,
+} from './piResearchEvidence';
+import {
+  buildResearchIterationPrompt,
+  buildResearchReviewPrompt,
+  collectCompletionFailures,
+  extractSubagentIds,
+} from './piResearchPolicy';
+import { PiResearchRunStore } from './piResearchStore';
+import {
+  RESEARCH_MAX_ITERATIONS,
+  ResearchRunStatus,
+  type PiResearchRunOptions,
+  type ResearchEndDecision,
+  type ResearchRunState,
+  type ResearchSourceType,
+} from './piResearchTypes';
+
+export {
+  isAcademicResearchSkillSet,
+  MIN_PRIMARY_SOURCE_RATIO,
+  MIN_RESEARCH_SUBQUESTIONS,
+  MIN_VERIFIED_SOURCES,
+  PiResearchStateAction,
+  PiResearchStateToolName,
+  RESEARCH_MAX_ITERATIONS,
+  ResearchRunStatus,
+  ResearchSourceType,
+} from './piResearchTypes';
+
+export class PiResearchRunController {
+  readonly runDirectory: string;
+  private readonly store: PiResearchRunStore;
+  private state: ResearchRunState;
+  private researcherRanThisIteration = false;
+  private reviewerRanThisRequest = false;
+  private readonly reviewerToolCallIds = new Set<string>();
+
+  constructor(options: PiResearchRunOptions) {
+    this.store = new PiResearchRunStore(options);
+    this.runDirectory = this.store.runDirectory;
+    this.state = this.store.loadOrCreate();
+    this.store.writeState(this.state);
+    this.store.log(
+      'orchestrator',
+      'info',
+      'run_resumed',
+      'Academic research state loaded and ready.',
+    );
+  }
+
+  get goal(): string {
+    return `Produce a verified academic research result for: ${this.state.task}`;
+  }
+
+  buildInitialPrompt(userPrompt: string): string {
+    return [
+      '## Academic research run initialized',
+      `Durable state directory: ${this.runDirectory}`,
+      'This is a controlled research run. Do not finish after a quick search.',
+      'First create at least three subquestions with research_state action "plan", then choose a novel direction with action "direction".',
+      'Every iteration must launch at least one isolated researcher subagent. Researchers have an explicit web-search capability.',
+      'For every source you rely on, call research_state action "verify_source"; this process opens the URL before it is recorded.',
+      'Record each load-bearing claim statement with two or more verified independent source URLs using action "claim".',
+      'Before requesting completion, record a contradiction scan with action "contradictions". Calling agent_loop done only requests review; it cannot complete the run by itself.',
+      '',
+      userPrompt,
+    ].join('\n');
+  }
+
+  recordSubagentStart(toolCallId: string, args: unknown): void {
+    const roles = extractSubagentIds(args);
+    if (roles.includes('researcher')) {
+      this.researcherRanThisIteration = true;
+      if (!this.state.researcherIterations.includes(this.state.iteration)) {
+        this.state.researcherIterations.push(this.state.iteration);
+        this.store.writeState(this.state);
+      }
+      this.store.log(
+        'orchestrator',
+        'info',
+        'researcher_started',
+        `Researcher subagent started: ${toolCallId}`,
+      );
+    }
+    if (this.state.review.requested && roles.includes('reviewer')) {
+      this.reviewerRanThisRequest = true;
+      this.reviewerToolCallIds.add(toolCallId);
+      this.store.log(
+        'orchestrator',
+        'info',
+        'reviewer_started',
+        `Independent reviewer started: ${toolCallId}`,
+      );
+    }
+  }
+
+  recordSubagentResult(toolCallId: string, output: string, isError: boolean): void {
+    if (
+      !this.state.review.requested ||
+      !this.reviewerRanThisRequest ||
+      !this.reviewerToolCallIds.has(toolCallId) ||
+      isError
+    ) {
+      return;
+    }
+    this.reviewerToolCallIds.delete(toolCallId);
+    if (output.trim() === 'REVIEW_VERDICT: PASS') {
+      this.state.review = { requested: true, passed: true, output };
+      this.store.writeState(this.state);
+      this.store.log(
+        'orchestrator',
+        'info',
+        'reviewer_passed',
+        `Reviewer accepted completion: ${toolCallId}`,
+      );
+      return;
+    }
+    this.state.review = { requested: true, passed: false, output };
+    this.store.writeState(this.state);
+    this.store.log(
+      'orchestrator',
+      'warn',
+      'reviewer_rejected',
+      `Reviewer did not issue PASS: ${toolCallId}`,
+    );
+  }
+
+  requestCompletion(reason: string): string {
+    this.state.status = ResearchRunStatus.CompletionRequested;
+    this.state.completionReason = reason;
+    this.state.review = { requested: true, passed: false };
+    this.reviewerRanThisRequest = false;
+    this.reviewerToolCallIds.clear();
+    this.store.writeState(this.state);
+    this.store.log('orchestrator', 'decision', 'completion_requested', reason);
+    return 'Completion recorded as a request. The run remains active until an isolated reviewer returns REVIEW_VERDICT: PASS and every evidence gate passes.';
+  }
+
+  onAgentEnd(): ResearchEndDecision {
+    if (this.state.status === ResearchRunStatus.CompletionRequested) {
+      const failures = this.completionFailures();
+      if (this.state.review.passed && failures.length === 0) {
+        this.state.status = ResearchRunStatus.Completed;
+        this.store.writeState(this.state);
+        this.store.log(
+          'orchestrator',
+          'info',
+          'completion_approved',
+          this.state.completionReason || 'Approved',
+        );
+        return {
+          shouldFinish: true,
+          reason: this.state.completionReason || 'Academic research gate passed',
+        };
+      }
+      return {
+        shouldFinish: false,
+        nextPrompt: buildResearchReviewPrompt(failures, this.runDirectory),
+      };
+    }
+
+    const previousFindingCount = this.state.sources.length + this.state.claims.length;
+    if (!this.researcherRanThisIteration || previousFindingCount <= this.state.lastFindingCount) {
+      this.state.staleCount += 1;
+    } else {
+      this.state.staleCount = 0;
+    }
+    this.state.lastFindingCount = previousFindingCount;
+    this.state.iteration += 1;
+    this.researcherRanThisIteration = false;
+    this.store.writeState(this.state);
+    this.store.log(
+      'orchestrator',
+      'info',
+      'iteration_advanced',
+      `Advanced to iteration ${this.state.iteration}.`,
+    );
+
+    if (this.state.iteration > RESEARCH_MAX_ITERATIONS) {
+      this.state.status = ResearchRunStatus.NeedsAttention;
+      this.store.writeState(this.state);
+      this.store.log(
+        'orchestrator',
+        'warn',
+        'iteration_cap_reached',
+        'Evidence gates remain unmet at the research iteration cap.',
+      );
+      return {
+        shouldFinish: false,
+        nextPrompt:
+          'The academic-research iteration cap was reached before the evidence gates passed. Do not claim completion. Summarize the verified evidence and the remaining gaps, then call agent_loop done to submit the report for reviewer evaluation.',
+      };
+    }
+
+    return {
+      shouldFinish: false,
+      nextPrompt: buildResearchIterationPrompt(this.state, this.runDirectory),
+    };
+  }
+
+  async verifySource(url: string, sourceType: ResearchSourceType): Promise<string> {
+    return verifyResearchSource(this.state, this.store, url, sourceType);
+  }
+
+  setPlan(subquestions: string[]): string {
+    return setResearchPlan(this.state, this.store, subquestions);
+  }
+
+  addDirection(direction: string): string {
+    return addResearchDirection(this.state, this.store, direction);
+  }
+
+  addClaim(id: string, questionId: string, statement: string, sourceUrls: string[]): string {
+    return addResearchClaim(this.state, this.store, id, questionId, statement, sourceUrls);
+  }
+
+  setContradictionCheck(summary: string): string {
+    return setResearchContradictionCheck(this.state, this.store, summary);
+  }
+
+  getSnapshot(): Record<string, unknown> {
+    return {
+      ...this.state,
+      runDirectory: this.runDirectory,
+      completionFailures: this.completionFailures(),
+    };
+  }
+
+  private completionFailures(): string[] {
+    return collectCompletionFailures(this.state, this.reviewerRanThisRequest);
+  }
+}

--- a/src/main/libs/agentEngine/piResearchStateTool.ts
+++ b/src/main/libs/agentEngine/piResearchStateTool.ts
@@ -1,0 +1,91 @@
+import { PiResearchRunController } from './piResearchRun';
+import {
+  isResearchSourceType,
+  PiResearchStateAction,
+  PiResearchStateToolName,
+  ResearchSourceType,
+  type ResearchToolResult,
+} from './piResearchTypes';
+
+const toText = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const toStringList = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  const items = value.map(item => toText(item)).filter(Boolean);
+  return items.length === value.length ? items : null;
+};
+
+export function buildPiResearchStateTool(
+  controller: PiResearchRunController,
+): Record<string, unknown> {
+  const result = (text: string): ResearchToolResult => ({
+    content: [{ type: 'text', text }],
+    details: controller.getSnapshot(),
+  });
+  return {
+    name: PiResearchStateToolName,
+    label: 'Research State',
+    description:
+      'Persist and verify academic-research evidence. Use plan, direction, verify_source, claim, and contradictions. Verified sources are fetched by this process before they count toward completion.',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: Object.values(PiResearchStateAction) },
+        subquestions: { type: 'array', items: { type: 'string' } },
+        direction: { type: 'string' },
+        url: { type: 'string' },
+        sourceType: {
+          type: 'string',
+          enum: [ResearchSourceType.Primary, ResearchSourceType.Secondary],
+        },
+        claimId: { type: 'string' },
+        questionId: { type: 'string' },
+        statement: { type: 'string' },
+        sourceUrls: { type: 'array', items: { type: 'string' } },
+        summary: { type: 'string' },
+      },
+      required: ['action'],
+      additionalProperties: false,
+    },
+    execute: async (
+      _toolCallId: string,
+      params: Record<string, unknown>,
+    ): Promise<ResearchToolResult> => {
+      const action = toText(params.action);
+      if (action === PiResearchStateAction.Plan) {
+        const subquestions = toStringList(params.subquestions);
+        return result(
+          subquestions
+            ? controller.setPlan(subquestions)
+            : 'plan requires a string array "subquestions".',
+        );
+      }
+      if (action === PiResearchStateAction.Direction) {
+        return result(controller.addDirection(toText(params.direction)));
+      }
+      if (action === PiResearchStateAction.VerifySource) {
+        const sourceType = params.sourceType;
+        if (!isResearchSourceType(sourceType)) {
+          return result('verify_source requires sourceType "primary" or "secondary".');
+        }
+        return result(await controller.verifySource(toText(params.url), sourceType));
+      }
+      if (action === PiResearchStateAction.Claim) {
+        const sourceUrls = toStringList(params.sourceUrls);
+        if (!sourceUrls) return result('claim requires a string array "sourceUrls".');
+        return result(
+          controller.addClaim(
+            toText(params.claimId),
+            toText(params.questionId),
+            toText(params.statement),
+            sourceUrls,
+          ),
+        );
+      }
+      if (action === PiResearchStateAction.Contradictions) {
+        return result(controller.setContradictionCheck(toText(params.summary)));
+      }
+      return result('Unknown research_state action.');
+    },
+  };
+}

--- a/src/main/libs/agentEngine/piResearchStore.ts
+++ b/src/main/libs/agentEngine/piResearchStore.ts
@@ -1,0 +1,144 @@
+import * as fs from 'fs';
+import path from 'path';
+
+import {
+  ResearchRunStatus,
+  type PiResearchRunOptions,
+  type ResearchRunState,
+} from './piResearchTypes';
+
+const RESEARCH_ROOT_DIR = '.zhiyuan/research';
+const STATE_DIR = 'state';
+const LOGS_DIR = 'logs';
+const STATE_FILENAME = 'research-state.json';
+
+const now = (): string => new Date().toISOString();
+
+export class PiResearchRunStore {
+  readonly runDirectory: string;
+  private readonly stateDirectory: string;
+  private readonly logsDirectory: string;
+  private readonly statePath: string;
+
+  constructor(private readonly options: PiResearchRunOptions) {
+    this.runDirectory = path.join(options.workspaceRoot, RESEARCH_ROOT_DIR, options.sessionId);
+    this.stateDirectory = path.join(this.runDirectory, STATE_DIR);
+    this.logsDirectory = path.join(this.runDirectory, LOGS_DIR);
+    this.statePath = path.join(this.runDirectory, STATE_FILENAME);
+    this.ensureLayout();
+  }
+
+  loadOrCreate(): ResearchRunState {
+    if (fs.existsSync(this.statePath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(this.statePath, 'utf8')) as ResearchRunState;
+        if (parsed.version === 1 && parsed.sessionId === this.options.sessionId) {
+          return {
+            ...parsed,
+            researcherIterations: parsed.researcherIterations || [],
+            claims: (parsed.claims || []).map(claim => ({
+              ...claim,
+              statement: claim.statement || '',
+            })),
+          };
+        }
+      } catch {
+        this.log(
+          'orchestrator',
+          'warn',
+          'state_parse_failed',
+          'Existing state was unreadable; a fresh state was created.',
+        );
+      }
+    }
+    return {
+      version: 1,
+      sessionId: this.options.sessionId,
+      task: this.options.task,
+      status: ResearchRunStatus.Running,
+      iteration: 1,
+      staleCount: 0,
+      lastFindingCount: 0,
+      researcherIterations: [],
+      subquestions: [],
+      sources: [],
+      claims: [],
+      directionsTried: [],
+      review: { requested: false, passed: false },
+      updatedAt: now(),
+    };
+  }
+
+  writeState(state: ResearchRunState): void {
+    state.updatedAt = now();
+    fs.writeFileSync(this.statePath, JSON.stringify(state, null, 2));
+    fs.writeFileSync(
+      path.join(this.stateDirectory, 'progress.json'),
+      JSON.stringify(
+        {
+          iteration: state.iteration,
+          total_findings: state.sources.length + state.claims.length,
+          status: state.status,
+          stale_count: state.staleCount,
+        },
+        null,
+        2,
+      ),
+    );
+    this.appendJsonl(path.join(this.stateDirectory, 'iteration_log.jsonl'), {
+      ts: now(),
+      iteration: state.iteration,
+      status: state.status,
+      sources: state.sources.length,
+      claims: state.claims.length,
+      staleCount: state.staleCount,
+    });
+  }
+
+  appendFinding(value: unknown): void {
+    this.appendJsonl(path.join(this.stateDirectory, 'findings.jsonl'), value);
+  }
+
+  writeDirections(directions: string[]): void {
+    fs.writeFileSync(
+      path.join(this.stateDirectory, 'directions_tried.json'),
+      JSON.stringify(directions, null, 2),
+    );
+  }
+
+  log(source: string, level: string, event: string, detail: string): void {
+    this.appendJsonl(path.join(this.logsDirectory, 'orchestrator.jsonl'), {
+      ts: now(),
+      source,
+      level,
+      event,
+      detail,
+    });
+  }
+
+  private ensureLayout(): void {
+    fs.mkdirSync(this.stateDirectory, { recursive: true });
+    fs.mkdirSync(this.logsDirectory, { recursive: true });
+    const taskSpecPath = path.join(this.stateDirectory, 'task_spec.md');
+    if (!fs.existsSync(taskSpecPath)) {
+      fs.writeFileSync(
+        taskSpecPath,
+        `# Academic research task\n\nSession: ${this.options.sessionId}\n\n${this.options.task}\n`,
+      );
+    }
+    for (const file of ['findings.jsonl', 'iteration_log.jsonl']) {
+      const filePath = path.join(this.stateDirectory, file);
+      if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, '');
+    }
+    const directionsPath = path.join(this.stateDirectory, 'directions_tried.json');
+    if (!fs.existsSync(directionsPath)) fs.writeFileSync(directionsPath, '[]\n');
+    for (const file of ['work.jsonl', 'orchestrator.jsonl', 'heartbeat.jsonl']) {
+      const filePath = path.join(this.logsDirectory, file);
+      if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, '');
+    }
+  }
+
+  private appendJsonl(filePath: string, value: unknown): void {
+    fs.appendFileSync(filePath, `${JSON.stringify(value)}\n`);
+  }
+}

--- a/src/main/libs/agentEngine/piResearchStore.ts
+++ b/src/main/libs/agentEngine/piResearchStore.ts
@@ -106,6 +106,13 @@ export class PiResearchRunStore {
     );
   }
 
+  appendFollowUpTask(task: string): void {
+    fs.appendFileSync(
+      path.join(this.stateDirectory, 'task_spec.md'),
+      `\n## Follow-up ${now()}\n\n${task}\n`,
+    );
+  }
+
   log(source: string, level: string, event: string, detail: string): void {
     this.appendJsonl(path.join(this.logsDirectory, 'orchestrator.jsonl'), {
       ts: now(),

--- a/src/main/libs/agentEngine/piResearchTypes.ts
+++ b/src/main/libs/agentEngine/piResearchTypes.ts
@@ -1,0 +1,97 @@
+import { CoreSkillId } from '../../../shared/skills/constants';
+
+export const PiResearchStateToolName = 'research_state';
+export const PiResearchStateAction = {
+  Plan: 'plan',
+  Direction: 'direction',
+  VerifySource: 'verify_source',
+  Claim: 'claim',
+  Contradictions: 'contradictions',
+} as const;
+export type PiResearchStateAction =
+  (typeof PiResearchStateAction)[keyof typeof PiResearchStateAction];
+
+export const RESEARCH_MAX_ITERATIONS = 15;
+export const MIN_RESEARCH_SUBQUESTIONS = 3;
+export const MIN_VERIFIED_SOURCES = 6;
+export const MIN_PRIMARY_SOURCE_RATIO = 0.3;
+
+export const ResearchRunStatus = {
+  Running: 'running',
+  CompletionRequested: 'completion_requested',
+  Completed: 'completed',
+  NeedsAttention: 'needs_attention',
+} as const;
+export type ResearchRunStatus = (typeof ResearchRunStatus)[keyof typeof ResearchRunStatus];
+
+export const ResearchSourceType = {
+  Primary: 'primary',
+  Secondary: 'secondary',
+} as const;
+export type ResearchSourceType = (typeof ResearchSourceType)[keyof typeof ResearchSourceType];
+
+export interface PiResearchRunOptions {
+  sessionId: string;
+  workspaceRoot: string;
+  task: string;
+}
+
+export interface ResearchSource {
+  url: string;
+  sourceType: ResearchSourceType;
+  verifiedAt: string;
+}
+
+export interface ResearchClaim {
+  id: string;
+  questionId: string;
+  statement: string;
+  sourceUrls: string[];
+}
+
+export interface ResearchQuestion {
+  id: string;
+  question: string;
+}
+
+export interface ResearchReview {
+  requested: boolean;
+  passed: boolean;
+  output?: string;
+}
+
+export interface ResearchRunState {
+  version: 1;
+  sessionId: string;
+  task: string;
+  status: ResearchRunStatus;
+  iteration: number;
+  staleCount: number;
+  lastFindingCount: number;
+  researcherIterations: number[];
+  subquestions: ResearchQuestion[];
+  sources: ResearchSource[];
+  claims: ResearchClaim[];
+  directionsTried: string[];
+  contradictionCheck?: string;
+  review: ResearchReview;
+  completionReason?: string;
+  updatedAt: string;
+}
+
+export interface ResearchEndDecision {
+  shouldFinish: boolean;
+  reason?: string;
+  nextPrompt?: string;
+}
+
+export interface ResearchToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+}
+
+export const isAcademicResearchSkillSet = (skillIds: string[] | undefined): boolean =>
+  Boolean(skillIds?.includes(CoreSkillId.DeliAutoResearch));
+
+export const isResearchSourceType = (value: unknown): value is ResearchSourceType =>
+  value === ResearchSourceType.Primary || value === ResearchSourceType.Secondary;

--- a/src/main/libs/agentEngine/piResearchTypes.ts
+++ b/src/main/libs/agentEngine/piResearchTypes.ts
@@ -12,6 +12,7 @@ export type PiResearchStateAction =
   (typeof PiResearchStateAction)[keyof typeof PiResearchStateAction];
 
 export const RESEARCH_MAX_ITERATIONS = 15;
+export const MIN_RESEARCH_ITERATIONS = 3;
 export const MIN_RESEARCH_SUBQUESTIONS = 3;
 export const MIN_VERIFIED_SOURCES = 6;
 export const MIN_PRIMARY_SOURCE_RATIO = 0.3;

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -4,7 +4,12 @@
  * Tests CoworkRuntime contract compliance using mocked Pi SDK modules.
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 
 const hoisted = vi.hoisted(() => {
   const mockSession = {
@@ -181,6 +186,39 @@ describe('PiRuntimeAdapter', () => {
       await adapter.startSession('test', 'Hello Pi');
       expect(mockSession.subscribe).toHaveBeenCalled();
       expect(mockSession.prompt).toHaveBeenCalledWith('Hello Pi');
+    });
+
+    it('initializes a controlled persistent run for academic research', async () => {
+      const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-academic-runtime-'));
+      try {
+        await adapter.startSession('academic-session', 'Research reliable agents', {
+          workspaceRoot,
+          skillIds: [...AcademicResearchSkillIds],
+        });
+        expect(mockSession.prompt).toHaveBeenCalledWith(
+          expect.stringContaining('Academic research run initialized'),
+        );
+        expect(
+          fs.existsSync(
+            path.join(
+              workspaceRoot,
+              '.zhiyuan',
+              'research',
+              'academic-session',
+              'state',
+              'progress.json',
+            ),
+          ),
+        ).toBe(true);
+        const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+          customTools: Array<{ name: string }>;
+        };
+        expect(sessionOptions.customTools.map(tool => tool.name)).toEqual(
+          expect.arrayContaining(['agent_loop', 'research_state', 'subagent']),
+        );
+      } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+      }
     });
 
     it('should inject the session system prompt through Pi resource loading', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -221,6 +221,44 @@ describe('PiRuntimeAdapter', () => {
       }
     });
 
+    it('reactivates a completed academic loop when the same session receives a follow-up', async () => {
+      const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-academic-follow-up-'));
+      try {
+        await adapter.startSession('academic-follow-up', 'Research reliable agents', {
+          workspaceRoot,
+          skillIds: [...AcademicResearchSkillIds],
+        });
+        const activeSessions = (
+          adapter as unknown as {
+            activeSessions: Map<
+              string,
+              {
+                agentLoop: {
+                  stop(): void;
+                  getState(): { active: boolean };
+                };
+              }
+            >;
+          }
+        ).activeSessions;
+        const active = activeSessions.get('academic-follow-up');
+        expect(active).toBeDefined();
+        active?.agentLoop.stop();
+        mockSession.prompt.mockClear();
+
+        await adapter.continueSession('academic-follow-up', 'Investigate a follow-up.', {
+          skillIds: [...AcademicResearchSkillIds],
+        });
+
+        expect(active?.agentLoop.getState().active).toBe(true);
+        expect(mockSession.prompt).toHaveBeenCalledWith(
+          expect.stringContaining('Academic research run initialized'),
+        );
+      } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+      }
+    });
+
     it('should inject the session system prompt through Pi resource loading', async () => {
       await adapter.startSession('test', 'Hello Pi', {
         systemPrompt: 'You are the selected expert.',

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -42,9 +42,11 @@ import {
   type PiAskUserQuestionInput,
   type PiAskUserQuestionResponse,
 } from './piAskUserQuestion';
-import { buildPiAgentLoopTool, PiAgentLoopController } from './piAgentLoop';
+import { buildPiAgentLoopTool, PiAgentLoopController, PiAgentLoopMode } from './piAgentLoop';
 import { buildPiConversationPrompt } from './piConversationContext';
-import { buildPiSubagentTool } from './piSubagentTool';
+import { isAcademicResearchSkillSet, PiResearchRunController } from './piResearchRun';
+import { buildPiResearchStateTool } from './piResearchStateTool';
+import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { createPiLargeFileWriteSystemPrompt, PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
 import type {
@@ -135,6 +137,8 @@ interface ActivePiSession {
   toolResultMessageIdByCallId: Map<string, string>;
   /** Long-horizon agent loop controller for this session (agent_loop tool). */
   agentLoop: PiAgentLoopController;
+  /** Present only for the controlled academic-research workflow. */
+  researchRun: PiResearchRunController | null;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
   /**
    * Error from the latest failed attempt (message_end with stopReason=error).
@@ -400,6 +404,16 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         customTools.push(mcpProxyTool);
       }
 
+      // Academic research is a controlled workflow, not a prompt-only label.
+      // It owns durable state and completion gates for the lifetime of this
+      // session (and reloads the same state directory after a session restart).
+      const researchRun = isAcademicResearchSkillSet(resourceState.skillIds)
+        ? new PiResearchRunController({ sessionId, workspaceRoot, task: prompt })
+        : null;
+      if (researchRun) {
+        customTools.push(buildPiResearchStateTool(researchRun));
+      }
+
       // Subagent tool: registered for every cowork session. When the session
       // agent is a Team Lead from a package, its presetId additionally exposes
       // the team member agents alongside the built-in profiles.
@@ -423,10 +437,11 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         presetId: subagentPresetId,
         resolvedModel,
         workspaceRoot,
-        createPiResourceLoader: (cwd, systemPrompt, maxOutputTokens) =>
+        webSearchSkillPath: researchRun ? path.join(getSkillsRoot(), 'web-search') : undefined,
+        createPiResourceLoader: (cwd, systemPrompt, maxOutputTokens, skillIds) =>
           this.createPiResourceLoader(pi, cwd, {
             systemPrompt,
-            skillIds: undefined,
+            skillIds,
             maxOutputTokens,
             fileToolsEnabled: true,
           }),
@@ -437,7 +452,15 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
 
       // Agent loop tool: lets the LLM drive multi-iteration long-horizon
       // loops; the controller continues the session on agent_end.
-      const agentLoop = new PiAgentLoopController();
+      const agentLoop = new PiAgentLoopController(researchRun || undefined);
+      if (researchRun) {
+        agentLoop.start({
+          mode: PiAgentLoopMode.Goal,
+          goal: researchRun.goal,
+          passes: 0,
+          stages: [],
+        });
+      }
       customTools.push(buildPiAgentLoopTool(agentLoop));
 
       if (customTools.length > 0) {
@@ -473,6 +496,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         aborted: false,
         toolResultMessageIdByCallId: new Map(),
         agentLoop,
+        researchRun,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
       };
@@ -486,7 +510,11 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       this.activeSessions.set(sessionId, active);
 
       // Send the prompt (may include conversation history for restart restores)
-      await session.prompt(options._piPromptOverride || prompt);
+      await session.prompt(
+        researchRun
+          ? researchRun.buildInitialPrompt(options._piPromptOverride || prompt)
+          : options._piPromptOverride || prompt,
+      );
     } catch (error) {
       this.activeSessions.delete(sessionId);
       if (abortController.signal.aborted) {
@@ -902,6 +930,9 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         // Agent invoked a tool → emit a tool_use message so the UI renders the tool card.
         // Mirrors OpenClaw adapter's tool_use construction.
         if (!event.toolCallId || !event.toolName) break;
+        if (event.toolName === PiSubagentToolName) {
+          active.researchRun?.recordSubagentStart(event.toolCallId, event.args);
+        }
         const toolUseMsg: CoworkMessage = {
           id: randomUUID(),
           type: 'tool_use',
@@ -928,6 +959,13 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         // Avoid duplicate result for the same call.
         if (active.toolResultMessageIdByCallId.has(event.toolCallId)) break;
         const resultText = extractToolResultText(event.result);
+        if (event.toolName === PiSubagentToolName) {
+          active.researchRun?.recordSubagentResult(
+            event.toolCallId,
+            resultText,
+            Boolean(event.isError),
+          );
+        }
         const toolResultMsg: CoworkMessage = {
           id: randomUUID(),
           type: 'tool_result',

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -411,6 +411,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         ? new PiResearchRunController({ sessionId, workspaceRoot, task: prompt })
         : null;
       if (researchRun) {
+        researchRun.resumeForPrompt(prompt);
         customTools.push(buildPiResearchStateTool(researchRun));
       }
 
@@ -623,8 +624,20 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     const persisted = this.store ? this.store.addMessage(sessionId, userMsg) : userMsg;
     this.emit('message', sessionId, persisted);
 
+    let nextPrompt = prompt;
+    if (active.researchRun && !active.agentLoop.getState().active) {
+      active.researchRun.resumeForPrompt(prompt);
+      active.agentLoop.start({
+        mode: PiAgentLoopMode.Goal,
+        goal: active.researchRun.goal,
+        passes: 0,
+        stages: [],
+      });
+      nextPrompt = active.researchRun.buildInitialPrompt(prompt);
+    }
+
     try {
-      await active.piSession.prompt(prompt);
+      await active.piSession.prompt(nextPrompt);
     } catch (error) {
       if (active.abortController.signal.aborted) {
         this.emit('sessionStopped', sessionId);

--- a/src/main/libs/agentEngine/piSubagentTool.test.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.test.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CoreSkillId } from '../../../shared/skills/constants';
 
 const hoisted = vi.hoisted(() => ({
   mockCreateAgentSession: vi.fn(),
@@ -206,6 +207,17 @@ describe('buildPiSubagentTool', () => {
         '/tmp/workspace',
         expect.stringContaining('research subagent'),
         4096,
+      );
+    });
+
+    it('gives researcher subagents an explicit web-search capability', async () => {
+      const { tool, deps } = buildTool({ webSearchSkillPath: '/tmp/web-search' });
+      await tool.execute('call-1', { agent: 'researcher', task: 'find primary sources' });
+      expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
+        '/tmp/workspace',
+        expect.stringContaining('/tmp/web-search/scripts/search.sh'),
+        4096,
+        [CoreSkillId.WebSearch],
       );
     });
 

--- a/src/main/libs/agentEngine/piSubagentTool.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.ts
@@ -20,6 +20,7 @@
 import * as fs from 'fs';
 import path from 'path';
 
+import { CoreSkillId } from '../../../shared/skills/constants';
 import { runPiSubagent, type PiSubagentSession } from './piSubagentExecution';
 
 // ── Constants ──
@@ -74,11 +75,14 @@ export interface PiSubagentToolDeps {
   presetId?: string | null;
   resolvedModel: PiSubagentResolvedModel;
   workspaceRoot?: string;
+  /** Absolute bundled web-search skill directory for researcher subagents. */
+  webSearchSkillPath?: string;
   /** Builds the per-session Pi resource loader for a subagent system prompt. */
   createPiResourceLoader(
     cwd: string,
     systemPrompt: string,
     maxOutputTokens: number,
+    skillIds?: string[],
   ): Promise<unknown>;
 }
 
@@ -245,11 +249,17 @@ async function runSubagent(
       // No customTools: subagents must not recursively spawn sub-subagents,
       // and AskUserQuestion is reserved for the parent session.
     };
-    subOptions.resourceLoader = await deps.createPiResourceLoader(
-      cwd,
-      profile.systemPrompt,
-      deps.resolvedModel.maxOutputTokens,
-    );
+    const researcherUsesWebSearch = profile.id === 'researcher' && Boolean(deps.webSearchSkillPath);
+    const systemPrompt = researcherUsesWebSearch
+      ? `${profile.systemPrompt}\n\nYou have an explicit retrieval capability. Before reporting a web claim, run the bundled web-search skill with Bash:\n` +
+        `bash "${path.join(deps.webSearchSkillPath || '', 'scripts/search.sh')}" "<query>" 10\n` +
+        'Open the returned primary sources where possible. Never substitute model memory for a retrieved citation.'
+      : profile.systemPrompt;
+    subOptions.resourceLoader = researcherUsesWebSearch
+      ? await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens, [
+          CoreSkillId.WebSearch,
+        ])
+      : await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens);
     if (deps.resolvedModel.modelRuntime) {
       subOptions.modelRuntime = deps.resolvedModel.modelRuntime;
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4421,7 +4421,11 @@ if (!gotTheLock) {
 
         const runtimeSkillIds = [
           ...new Set([
-            ...(options.activeSkillIds || []),
+            // A continuation normally arrives after the input cleared its
+            // one-shot skill chips. Preserve the session's saved workflow
+            // skills in that case so controlled academic research resumes
+            // with the same state and completion gates.
+            ...(options.activeSkillIds ?? existingSession?.activeSkillIds ?? []),
             ...(existingSession?.experts || []).flatMap(expert => expert.skillIds),
           ]),
         ];

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -17,16 +17,19 @@ const ChatSkillShortcuts: React.FC = () => {
 
   const handleSelect = (entry: ChatSkillShortcut) => {
     if (isStreaming) return;
+    const selectedSkillIds = entry.skillIds || [entry.skillId];
     // Require the skill to be enabled — disabled skills must not be
     // re-activated through the shortcut (matches SkillsPopover filtering).
-    const skill = skills.find(s => s.id === entry.skillId && s.enabled);
-    if (!skill) {
+    const allSkillsAvailable = selectedSkillIds.every(skillId =>
+      skills.some(skill => skill.id === skillId && skill.enabled),
+    );
+    if (!allSkillsAvailable) {
       window.dispatchEvent(
         new CustomEvent('app:showToast', { detail: i18nService.t('chatSkillUnavailable') }),
       );
       return;
     }
-    dispatch(setActiveSkillIds([skill.id]));
+    dispatch(setActiveSkillIds([...selectedSkillIds]));
     dispatch(clearCurrentSession());
     window.setTimeout(() => {
       window.dispatchEvent(new CustomEvent('cowork:focus-input', { detail: { clear: false } }));
@@ -43,7 +46,8 @@ const ChatSkillShortcuts: React.FC = () => {
       <div className="space-y-0.5">
         {CHAT_SKILL_SHORTCUTS.map(entry => {
           const Icon = entry.icon;
-          const isActive = activeSkillIds.includes(entry.skillId);
+          const selectedSkillIds = entry.skillIds || [entry.skillId];
+          const isActive = selectedSkillIds.every(skillId => activeSkillIds.includes(skillId));
           return (
             <button
               key={entry.id}

--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -7,7 +7,7 @@
  * was filtered out of the chat skill list and the shortcut toasted
  * "skill unavailable" even though the skill is core (always enabled).
  */
-import { CoreSkillId, isCoreSkill } from '@shared/skills/constants';
+import { AcademicResearchSkillIds, CoreSkillId, isCoreSkill } from '@shared/skills/constants';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
@@ -27,6 +27,12 @@ test('every chat quick-skill shortcut points at a core skill', () => {
 test('shortcut skillIds stay unique and match their entry ids where intended', () => {
   const skillIds = CHAT_SKILL_SHORTCUTS.map(entry => entry.skillId);
   expect(new Set(skillIds).size).toBe(skillIds.length);
+});
+
+test('academic research selects Deli, deep research, and explicit web search together', () => {
+  const academic = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'academic-research');
+  expect(academic?.skillIds).toEqual(AcademicResearchSkillIds);
+  for (const skillId of academic?.skillIds || []) expect(isCoreSkill(skillId)).toBe(true);
 });
 
 test('the chat skill allowlist is derived from CoreSkillId, not hardcoded', () => {

--- a/src/renderer/components/chat/constants.ts
+++ b/src/renderer/components/chat/constants.ts
@@ -1,5 +1,6 @@
 import { FileText, Globe, GraduationCap, Presentation, Table, Telescope } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { AcademicResearchSkillIds } from '@shared/skills/constants';
 
 /**
  * Chat quick-skill shortcut entries.
@@ -10,6 +11,8 @@ import type { LucideIcon } from 'lucide-react';
 export interface ChatSkillShortcut {
   id: string;
   skillId: string;
+  /** Additional capabilities selected with the primary shortcut skill. */
+  skillIds?: readonly string[];
   icon: LucideIcon;
   labelKey: string;
   /** Placeholder shown in the chat input while this skill is active. */
@@ -34,6 +37,7 @@ export const CHAT_SKILL_SHORTCUTS: readonly ChatSkillShortcut[] = [
   {
     id: 'academic-research',
     skillId: 'deli-autoresearch',
+    skillIds: AcademicResearchSkillIds,
     icon: GraduationCap,
     labelKey: 'chatSkillAcademicResearch',
     placeholderKey: 'chatSkillPlaceholderAcademicResearch',

--- a/src/shared/skills/constants.ts
+++ b/src/shared/skills/constants.ts
@@ -12,6 +12,7 @@ export const CoreSkillId = {
   Xlsx: 'xlsx',
   DeepResearch: 'deep-research',
   DeliAutoResearch: 'deli-autoresearch',
+  WebSearch: 'web-search',
   FrontendDesign: 'frontend-design',
 } as const;
 
@@ -19,3 +20,10 @@ export type CoreSkillId = (typeof CoreSkillId)[keyof typeof CoreSkillId];
 
 export const isCoreSkill = (id: string): id is CoreSkillId =>
   (Object.values(CoreSkillId) as string[]).includes(id);
+
+/** Skills that together form the first-class Academic Research workflow. */
+export const AcademicResearchSkillIds = [
+  CoreSkillId.DeliAutoResearch,
+  CoreSkillId.DeepResearch,
+  CoreSkillId.WebSearch,
+] as const;


### PR DESCRIPTION
## Summary

- turn the Academic Research shortcut into a controlled workflow that activates Deli AutoResearch, deep research, and web search together
- persist research plans, directions, verified sources, auditable claim statements, contradiction checks, iteration progress, and reviewer state under `.zhiyuan/research/<session-id>`
- keep the Pi loop alive when a model omits `next`/`done`, and require deterministic evidence gates plus an isolated reviewer before academic research can complete
- give academic researcher subagents an explicit bundled web-search capability while keeping ordinary subagent behavior unchanged
- preserve workflow skills when an existing session continues, and reject local/private/credential-bearing source-verification URLs

## Root cause

The sidebar shortcut previously behaved mostly like a prompt/skill selection. A Pi turn could end without a loop signal and be treated as complete, researcher subagents did not receive an explicit retrieval path, and no durable evidence or independent-review gate prevented a shallow run from finishing after a few searches.

## User impact

Academic Research now keeps iterating until the evidence chain is substantial enough to review. Completion requires at least three research iterations, three research questions, six reachable sources, a 30% primary-source ratio, supported claim statements, a contradiction scan, distinct research directions, researcher participation in every iteration, and an exact reviewer pass.

## Electron-specific behavior

- the main process writes durable research state inside the selected workspace
- public source URLs are opened by the main process for reachability checks before they count as evidence
- session continuation retains the saved Academic Research skill set

## Validation

- `npm test` — 173 files passed, 1560 tests passed, 1 skipped
- targeted academic/loop/runtime/shortcut suite — 5 files passed, 99 tests passed
- `npm run build`
- `npm run compile:electron`
- `npm run lint` — no errors; one pre-existing Hook dependency warning remains in `McpManager.tsx`
- `oxfmt --check` on all PR-owned files
- `git diff --check`
