### PR TITLE
fix(workflows): enforce shortcut completion gates

### DIFF
--- a/SKILLs/deep-research/SKILL.md
+++ b/SKILLs/deep-research/SKILL.md
@@ -54,6 +54,10 @@ Decompose the question into 3–5 **meaningfully different** angles (definitions
 
 Each delegation task must be self-contained: the angle, the core question for context, the time range, the languages to search in, and the required output — a list of findings where each finding carries a source URL, publisher, date, and a one-line takeaway.
 
+When the controlled Deep Research shortcut is active, persist the 3–5 angles
+with `workflow_state` action `plan`, and record each source with action
+`source`. Those URLs are fetched by the runtime before they count.
+
 ### 3. Cross-Validate the Returns
 
 When the parallel researchers return:
@@ -66,7 +70,7 @@ When the parallel researchers return:
 
 ### 4. Loop on the Gaps
 
-Draft the report outline and audit it for gaps: unsupported claims, missing sub-questions, contradictions left unresolved. If material gaps remain, start an `agent_loop` (goal mode, goal = "all load-bearing claims in the outline are supported by 2+ independent sources") and use each iteration to attack the remaining gaps — with fresh `subagent` delegations where the gap needs new retrieval. Declare `done` only when the goal holds or the iterations stop changing the picture. Respect the loop's iteration cap; if it trips, deliver the report with the gaps explicitly listed.
+Draft the report outline and audit it for gaps: unsupported claims, missing sub-questions, contradictions left unresolved. If material gaps remain, start an `agent_loop` (goal mode, goal = "all load-bearing claims in the outline are supported by 2+ independent sources") and use each iteration to attack the remaining gaps — with fresh `subagent` delegations where the gap needs new retrieval. Declare `done` only when the goal holds or the iterations stop changing the picture. Respect the loop's iteration cap; if it trips, deliver the report with the gaps explicitly listed. In the controlled shortcut, `done` is only a completion request: it remains active until the recorded angles, researcher delegations, and reachable sources clear the runtime gate.
 
 ### 5. Synthesize the Report
 

--- a/SKILLs/deli-autoresearch/SKILL.md
+++ b/SKILLs/deli-autoresearch/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: deli-autoresearch
+name: zhiyuan_AutoResearch
 description: "A protocol framework for long-horizon autonomous research tasks. Targets three empirically-observed failure modes — cognitive loops, stalling, runtime fragility — by prescribing state management, stall detection, and watchdog mechanisms. Use when the user asks for academic research, literature surveys, paper writing, or any unattended multi-day research task. Triggers: academic research, 学术研究, literature review, 文献综述, paper writing, 论文写作, ICLR survey, autonomous research."
 metadata:
   version: "1.1"
   category: research
 ---
 
-<!-- Deli_AutoResearch: protocol framework for long-horizon autonomous tasks. Ships no executable code; prescribes conventions for state persistence, stall detection, and layered guardians. -->
+<!-- zhiyuan_AutoResearch: protocol framework for long-horizon autonomous tasks. Ships no executable code; prescribes conventions for state persistence, stall detection, and layered guardians. -->
 
-# Deli_AutoResearch
+# zhiyuan_AutoResearch
 
 This skill is a protocol framework for long-horizon autonomous tasks (days to weeks). It ships no executable code; instead it prescribes a set of battle-tested conventions: how state is persisted, how stalls are detected, how guardians are layered, and what constraints bind agent behavior. Implementation details are left to the adopter's environment.
 

--- a/SKILLs/deli-autoresearch/zhiyuan/metadata.yaml
+++ b/SKILLs/deli-autoresearch/zhiyuan/metadata.yaml
@@ -1,5 +1,5 @@
 name: 学术研究
 description: 面向长周期自主研究任务的协议框架：通过状态持久化、停滞检测与心跳看门狗机制，支撑文献综述、论文写作等无人值守的多日研究流程。
-author: Deli
+author: Zhiyuan
 license: Apache-2.0
 skillmd: ./SKILL.md

--- a/SKILLs/docx/SKILL.md
+++ b/SKILLs/docx/SKILL.md
@@ -185,6 +185,11 @@ scripts/docx_preview.sh doc.docx
 
 Final preview: `scripts/docx_preview.sh doc.docx`
 
+For the controlled Docs shortcut, save a nonempty validation report in the
+workspace after this pipeline, then record the DOCX with `workflow_state` role
+`deliverable` and the report with role `validation`. Do not finish from a
+claimed output path alone.
+
 ## Critical rules
 
 These prevent file corruption — OpenXML is strict about element ordering.

--- a/SKILLs/frontend-design/SKILL.md
+++ b/SKILLs/frontend-design/SKILL.md
@@ -46,3 +46,11 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
 Remember: you are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+
+## Delivery Gate
+
+Build or otherwise run the finished interface, inspect the rendered result,
+and save a nonempty validation report in the workspace. The controlled Website
+shortcut completes only after `workflow_state` records an existing HTML
+deliverable (role `deliverable`) and that validation report (role
+`validation`); never end after a design explanation or code sketch.

--- a/SKILLs/pptx/SKILL.md
+++ b/SKILLs/pptx/SKILL.md
@@ -123,6 +123,11 @@ Run with: `cd slides && node compile.js`
 
 See [QA Process](references/pitfalls.md#qa-process).
 
+After QA, write a concise nonempty QA report inside the workspace and render at
+least one slide preview image. In the controlled PPT shortcut, record the PPTX
+as `workflow_state` role `deliverable`, the report as `validation`, and the
+rendered image as `preview`. A file path in the answer is not completion.
+
 ### Output Structure
 
 ```

--- a/SKILLs/xlsx/SKILL.md
+++ b/SKILLs/xlsx/SKILL.md
@@ -124,6 +124,11 @@ Run `formula_check.py` for static validation. Use `libreoffice_recalc.py` for dy
 4. **Always produce the output file** — this is the #1 priority
 5. **Validate before delivery**: `formula_check.py` exit code 0 = safe
 
+For the controlled Sheets shortcut, save the validation output as a nonempty
+workspace report, then record the spreadsheet with `workflow_state` role
+`deliverable` and the report with role `validation`. A claimed file path does
+not complete the task.
+
 ## Utility Scripts
 
 ```bash

--- a/src/main/libs/agentEngine/piResearchTypes.ts
+++ b/src/main/libs/agentEngine/piResearchTypes.ts
@@ -92,7 +92,7 @@ export interface ResearchToolResult {
 }
 
 export const isAcademicResearchSkillSet = (skillIds: string[] | undefined): boolean =>
-  Boolean(skillIds?.includes(CoreSkillId.DeliAutoResearch));
+  Boolean(skillIds?.includes(CoreSkillId.ZhiyuanAutoResearch));
 
 export const isResearchSourceType = (value: unknown): value is ResearchSourceType =>
   value === ResearchSourceType.Primary || value === ResearchSourceType.Secondary;

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -250,6 +250,36 @@ describe('PiRuntimeAdapter', () => {
       }
     });
 
+    it('asks Work users how an arbitrary skill should execute before prompting Pi', async () => {
+      const onPermissionRequest = vi.fn();
+      adapter.on('permissionRequest', onPermissionRequest);
+
+      const start = adapter.startSession('generic-work-skill', 'Analyze this codebase', {
+        skillIds: ['code-review'],
+        sessionMode: 'work',
+      });
+      await vi.waitFor(() => expect(onPermissionRequest).toHaveBeenCalledTimes(1));
+
+      const [, request] = onPermissionRequest.mock.calls[0] as [string, { requestId: string }];
+      expect(mockSession.prompt).not.toHaveBeenCalled();
+      adapter.respondToPermission(request.requestId, {
+        behavior: 'allow',
+        updatedInput: { answers: { '技能任务执行方式': '持续执行至验收' } },
+      });
+      await start;
+
+      expect(mockSession.prompt).toHaveBeenCalledWith(
+        expect.stringContaining('Loop started. Iteration 1. Goal:'),
+      );
+
+      const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: { type: string }) => void;
+      listener({ type: 'agent_end' });
+      await Promise.resolve();
+      expect(mockSession.prompt).toHaveBeenLastCalledWith(
+        expect.stringContaining('protocol omission'),
+      );
+    });
+
     it('reactivates a completed academic loop when the same session receives a follow-up', async () => {
       const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-academic-follow-up-'));
       try {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -221,6 +221,35 @@ describe('PiRuntimeAdapter', () => {
       }
     });
 
+    it('keeps a sidebar PPT workflow alive when the model ends without a completion signal', async () => {
+      const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-ppt-runtime-'));
+      try {
+        await adapter.startSession('ppt-session', 'Create a deck', {
+          workspaceRoot,
+          skillIds: ['pptx'],
+        });
+        const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+          customTools: Array<{ name: string }>;
+        };
+        expect(sessionOptions.customTools.map(tool => tool.name)).toContain('workflow_state');
+        expect(mockSession.prompt).toHaveBeenCalledWith(
+          expect.stringContaining('Controlled PPT presentation workflow'),
+        );
+
+        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+          type: string;
+        }) => void;
+        listener({ type: 'agent_end' });
+        await Promise.resolve();
+
+        expect(mockSession.prompt).toHaveBeenLastCalledWith(
+          expect.stringContaining('workflow continuation'),
+        );
+      } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+      }
+    });
+
     it('reactivates a completed academic loop when the same session receives a follow-up', async () => {
       const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-academic-follow-up-'));
       try {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 
 const hoisted = vi.hoisted(() => {
@@ -172,11 +172,24 @@ import {
 
 describe('PiRuntimeAdapter', () => {
   let adapter: PiRuntimeAdapter;
+  const temporaryWorkspaceRoots = new Set<string>();
+  const createTemporaryWorkspace = (): string => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-runtime-'));
+    temporaryWorkspaceRoots.add(workspaceRoot);
+    return workspaceRoot;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockModelRuntimeCreate.mockResolvedValue(mockModelRuntime);
     adapter = new PiRuntimeAdapter();
+  });
+
+  afterEach(() => {
+    for (const workspaceRoot of temporaryWorkspaceRoots) {
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+    temporaryWorkspaceRoots.clear();
   });
 
   // ── Session lifecycle ──
@@ -252,11 +265,14 @@ describe('PiRuntimeAdapter', () => {
 
     it('asks Work users how an arbitrary skill should execute before prompting Pi', async () => {
       const onPermissionRequest = vi.fn();
+      const onComplete = vi.fn();
       adapter.on('permissionRequest', onPermissionRequest);
+      adapter.on('complete', onComplete);
 
       const start = adapter.startSession('generic-work-skill', 'Analyze this codebase', {
         skillIds: ['code-review'],
         sessionMode: 'work',
+        workspaceRoot: createTemporaryWorkspace(),
       });
       await vi.waitFor(() => expect(onPermissionRequest).toHaveBeenCalledTimes(1));
 
@@ -264,7 +280,7 @@ describe('PiRuntimeAdapter', () => {
       expect(mockSession.prompt).not.toHaveBeenCalled();
       adapter.respondToPermission(request.requestId, {
         behavior: 'allow',
-        updatedInput: { answers: { '技能任务执行方式': '持续执行至验收' } },
+        updatedInput: { answers: { 技能任务执行方式: '持续执行至验收' } },
       });
       await start;
 
@@ -272,12 +288,56 @@ describe('PiRuntimeAdapter', () => {
         expect.stringContaining('Loop started. Iteration 1. Goal:'),
       );
 
-      const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: { type: string }) => void;
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools: Array<{
+          name: string;
+          execute(
+            toolCallId: string,
+            params: Record<string, unknown>,
+          ): Promise<{ content: Array<{ text: string }> }>;
+        }>;
+      };
+      const loopTool = sessionOptions.customTools.find(tool => tool.name === 'agent_loop');
+      const acceptanceTool = sessionOptions.customTools.find(
+        tool => tool.name === 'work_acceptance',
+      );
+      expect(loopTool).toBeDefined();
+      expect(acceptanceTool).toBeDefined();
+
+      const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+        type: string;
+      }) => void;
+      await loopTool!.execute('done-too-early', {
+        action: 'done',
+        reason: 'I think it is complete',
+      });
       listener({ type: 'agent_end' });
       await Promise.resolve();
       expect(mockSession.prompt).toHaveBeenLastCalledWith(
-        expect.stringContaining('protocol omission'),
+        expect.stringContaining('has not received explicit user acceptance'),
       );
+      expect(onComplete).not.toHaveBeenCalled();
+
+      const acceptance = acceptanceTool!.execute('acceptance-call', {
+        summary: 'Implementation and tests are complete.',
+      });
+      await vi.waitFor(() => expect(onPermissionRequest).toHaveBeenCalledTimes(2));
+      const [, acceptanceRequest] = onPermissionRequest.mock.calls[1] as [
+        string,
+        { requestId: string; toolInput: { questions: Array<{ question: string }> } },
+      ];
+      const acceptanceQuestion = acceptanceRequest.toolInput.questions[0].question;
+      adapter.respondToPermission(acceptanceRequest.requestId, {
+        behavior: 'allow',
+        updatedInput: { answers: { [acceptanceQuestion]: '验收通过' } },
+      });
+      await acceptance;
+      await loopTool!.execute('done-after-acceptance', {
+        action: 'done',
+        reason: 'The user accepted the result',
+      });
+      listener({ type: 'agent_end' });
+      expect(onComplete).toHaveBeenCalledOnce();
     });
 
     it('reactivates a completed academic loop when the same session receives a follow-up', async () => {
@@ -529,31 +589,50 @@ describe('PiRuntimeAdapter', () => {
       expect(mockSession.prompt).toHaveBeenCalledTimes(3);
     });
 
-    it('should reload skill selection without replacing the active session', async () => {
+    it('should recreate the session when skill tool topology changes', async () => {
       await adapter.startSession('test', 'First', { skillIds: ['skill-a'] });
-      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+      await adapter.continueSession('test', 'Second', { skillIds: ['skill-b'] });
+
+      expect(mockSession.reload).not.toHaveBeenCalled();
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      const replacementLoader = mockDefaultResourceLoader.mock.calls[1]?.[0] as {
         skillsOverride: (base: { skills: Array<{ id: string }>; diagnostics: unknown[] }) => {
           skills: Array<{ id: string }>;
         };
       };
-
       expect(
-        loaderOptions.skillsOverride({
-          skills: [{ id: 'skill-a' }, { id: 'skill-b' }],
-          diagnostics: [],
-        }).skills,
-      ).toEqual([{ id: 'skill-a' }]);
-
-      await adapter.continueSession('test', 'Second', { skillIds: ['skill-b'] });
-
-      expect(mockSession.reload).toHaveBeenCalledOnce();
-      expect(mockCreateAgentSession).toHaveBeenCalledOnce();
-      expect(
-        loaderOptions.skillsOverride({
+        replacementLoader.skillsOverride({
           skills: [{ id: 'skill-a' }, { id: 'skill-b' }],
           diagnostics: [],
         }).skills,
       ).toEqual([{ id: 'skill-b' }]);
+    });
+
+    it('asks for execution mode when an arbitrary skill is added to a Work session', async () => {
+      const onPermissionRequest = vi.fn();
+      adapter.on('permissionRequest', onPermissionRequest);
+      const workspaceRoot = createTemporaryWorkspace();
+      await adapter.startSession('dynamic-skill', 'First', { sessionMode: 'work', workspaceRoot });
+
+      const continuation = adapter.continueSession('dynamic-skill', 'Use code review', {
+        skillIds: ['code-review'],
+        sessionMode: 'work',
+        workspaceRoot,
+      });
+      await vi.waitFor(() => expect(onPermissionRequest).toHaveBeenCalledOnce());
+      const [, request] = onPermissionRequest.mock.calls[0] as [string, { requestId: string }];
+      adapter.respondToPermission(request.requestId, {
+        behavior: 'allow',
+        updatedInput: { answers: { 技能任务执行方式: '完成本轮' } },
+      });
+      await continuation;
+
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      expect(mockSession.prompt).toHaveBeenLastCalledWith(
+        expect.stringContaining('Use code review'),
+      );
     });
 
     it('should recreate the session when expert tool topology changes', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -251,6 +251,40 @@ const normalizeSkillIds = (skillIds: string[] | undefined): string[] | undefined
     ? undefined
     : [...new Set(skillIds.map(skillId => skillId.trim()).filter(Boolean))].sort();
 
+const WorkExecutionQuestion = '技能任务执行方式';
+const WorkExecutionOption = {
+  SingleTurn: '完成本轮',
+  Persistent: '持续执行至验收',
+} as const;
+
+const buildWorkExecutionQuestion = (): PiAskUserQuestionInput => ({
+  questions: [
+    {
+      header: '执行方式',
+      question: WorkExecutionQuestion,
+      options: [
+        {
+          label: WorkExecutionOption.SingleTurn,
+          description: '让技能完成当前一轮任务；模型结束后会结束会话。',
+        },
+        {
+          label: WorkExecutionOption.Persistent,
+          description: '持续推进复杂任务；遗漏循环协议时会自动继续，直到模型明确完成。',
+        },
+      ],
+    },
+  ],
+});
+
+const chosePersistentWorkExecution = (response: PiAskUserQuestionResponse): boolean => {
+  if (response.behavior !== 'allow') return false;
+  const answers = response.updatedInput?.answers;
+  if (!answers || typeof answers !== 'object') return false;
+  return (
+    (answers as Record<string, unknown>)[WorkExecutionQuestion] === WorkExecutionOption.Persistent
+  );
+};
+
 const normalizeExpertIds = (expertIds: string[] | undefined): string[] =>
   expertIds === undefined
     ? []
@@ -536,13 +570,45 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       this.activeSessions.set(sessionId, active);
 
       // Send the prompt (may include conversation history for restart restores)
-      await session.prompt(
+      let initialPrompt =
         researchRun
           ? researchRun.buildInitialPrompt(options._piPromptOverride || prompt)
           : shortcutWorkflow
             ? shortcutWorkflow.buildInitialPrompt(options._piPromptOverride || prompt)
-            : options._piPromptOverride || prompt,
-      );
+            : options._piPromptOverride || prompt;
+
+      // Work sessions with an arbitrary selected skill need an explicit choice:
+      // direct one-turn execution, or a managed multi-turn loop. First-class
+      // workflows already own their completion policy, and agent-backed chat
+      // intentionally stays conversational.
+      const shouldAskWorkExecutionMode =
+        options.sessionMode === 'work' &&
+        Boolean(resourceState.skillIds?.length) &&
+        !researchRun &&
+        !shortcutWorkflow;
+      if (shouldAskWorkExecutionMode) {
+        const response = await this.requestAskUserQuestion(
+          sessionId,
+          `work-execution-mode-${sessionId}`,
+          buildWorkExecutionQuestion(),
+          abortController.signal,
+        );
+        if (chosePersistentWorkExecution(response)) {
+          const loopPrompt = agentLoop.start({
+            mode: PiAgentLoopMode.Goal,
+            goal: `Complete and verify the user's skill-assisted task: ${prompt}`,
+            passes: 0,
+            stages: [],
+          });
+          initialPrompt = `${loopPrompt}\n\n${initialPrompt}`;
+        }
+      }
+
+      // The user may stop the session while the execution-mode question is
+      // open. Do not revive an aborted Pi turn when that question resolves.
+      if (abortController.signal.aborted) return;
+
+      await session.prompt(initialPrompt);
     } catch (error) {
       this.activeSessions.delete(sessionId);
       if (abortController.signal.aborted) {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -54,6 +54,12 @@ import {
 import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
+import {
+  buildPiWorkAcceptanceTool,
+  buildWorkExecutionQuestion,
+  chosePersistentWorkExecution,
+  PiWorkExecutionController,
+} from './piWorkExecution';
 import { createPiLargeFileWriteSystemPrompt, PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
 import type {
   CoworkContinueOptions,
@@ -147,6 +153,8 @@ interface ActivePiSession {
   researchRun: PiResearchRunController | null;
   /** Present for every other first-class sidebar shortcut workflow. */
   shortcutWorkflow: PiShortcutWorkflowController | null;
+  /** Present for arbitrary skills loaded in Work mode. */
+  workExecution: PiWorkExecutionController | null;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
   /**
    * Error from the latest failed attempt (message_end with stopReason=error).
@@ -250,40 +258,6 @@ const normalizeSkillIds = (skillIds: string[] | undefined): string[] | undefined
   skillIds === undefined
     ? undefined
     : [...new Set(skillIds.map(skillId => skillId.trim()).filter(Boolean))].sort();
-
-const WorkExecutionQuestion = '技能任务执行方式';
-const WorkExecutionOption = {
-  SingleTurn: '完成本轮',
-  Persistent: '持续执行至验收',
-} as const;
-
-const buildWorkExecutionQuestion = (): PiAskUserQuestionInput => ({
-  questions: [
-    {
-      header: '执行方式',
-      question: WorkExecutionQuestion,
-      options: [
-        {
-          label: WorkExecutionOption.SingleTurn,
-          description: '让技能完成当前一轮任务；模型结束后会结束会话。',
-        },
-        {
-          label: WorkExecutionOption.Persistent,
-          description: '持续推进复杂任务；遗漏循环协议时会自动继续，直到模型明确完成。',
-        },
-      ],
-    },
-  ],
-});
-
-const chosePersistentWorkExecution = (response: PiAskUserQuestionResponse): boolean => {
-  if (response.behavior !== 'allow') return false;
-  const answers = response.updatedInput?.answers;
-  if (!answers || typeof answers !== 'object') return false;
-  return (
-    (answers as Record<string, unknown>)[WorkExecutionQuestion] === WorkExecutionOption.Persistent
-  );
-};
 
 const normalizeExpertIds = (expertIds: string[] | undefined): string[] =>
   expertIds === undefined
@@ -466,7 +440,23 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
           })
         : null;
       if (shortcutWorkflow) {
+        shortcutWorkflow.resumeForPrompt(prompt);
         customTools.push(buildPiShortcutWorkflowStateTool(shortcutWorkflow));
+      }
+      const shouldAskWorkExecutionMode =
+        options.sessionMode === 'work' &&
+        Boolean(resourceState.skillIds?.length) &&
+        !researchRun &&
+        !shortcutWorkflow;
+      const workExecution = shouldAskWorkExecutionMode
+        ? new PiWorkExecutionController({ sessionId, workspaceRoot, task: prompt })
+        : null;
+      if (workExecution) {
+        customTools.push(
+          buildPiWorkAcceptanceTool(workExecution, (toolCallId, input, signal) =>
+            this.requestAskUserQuestion(sessionId, toolCallId, input, signal),
+          ),
+        );
       }
 
       // Subagent tool: registered for every cowork session. When the session
@@ -510,12 +500,12 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
 
       // Agent loop tool: lets the LLM drive multi-iteration long-horizon
       // loops; the controller continues the session on agent_end.
-      const completionWorkflow = researchRun || shortcutWorkflow;
+      const completionWorkflow = researchRun || shortcutWorkflow || workExecution;
       const agentLoop = new PiAgentLoopController(completionWorkflow || undefined);
-      if (completionWorkflow) {
+      if (researchRun || shortcutWorkflow) {
         agentLoop.start({
           mode: PiAgentLoopMode.Goal,
-          goal: completionWorkflow.goal,
+          goal: (researchRun || shortcutWorkflow)!.goal,
           passes: 0,
           stages: [],
         });
@@ -557,6 +547,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         agentLoop,
         researchRun,
         shortcutWorkflow,
+        workExecution,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
       };
@@ -570,22 +561,16 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       this.activeSessions.set(sessionId, active);
 
       // Send the prompt (may include conversation history for restart restores)
-      let initialPrompt =
-        researchRun
-          ? researchRun.buildInitialPrompt(options._piPromptOverride || prompt)
-          : shortcutWorkflow
-            ? shortcutWorkflow.buildInitialPrompt(options._piPromptOverride || prompt)
-            : options._piPromptOverride || prompt;
+      let initialPrompt = researchRun
+        ? researchRun.buildInitialPrompt(options._piPromptOverride || prompt)
+        : shortcutWorkflow
+          ? shortcutWorkflow.buildInitialPrompt(options._piPromptOverride || prompt)
+          : options._piPromptOverride || prompt;
 
       // Work sessions with an arbitrary selected skill need an explicit choice:
       // direct one-turn execution, or a managed multi-turn loop. First-class
       // workflows already own their completion policy, and agent-backed chat
       // intentionally stays conversational.
-      const shouldAskWorkExecutionMode =
-        options.sessionMode === 'work' &&
-        Boolean(resourceState.skillIds?.length) &&
-        !researchRun &&
-        !shortcutWorkflow;
       if (shouldAskWorkExecutionMode) {
         const response = await this.requestAskUserQuestion(
           sessionId,
@@ -593,14 +578,16 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
           buildWorkExecutionQuestion(),
           abortController.signal,
         );
-        if (chosePersistentWorkExecution(response)) {
+        const persistent = chosePersistentWorkExecution(response);
+        workExecution!.selectMode(persistent, prompt);
+        if (persistent) {
           const loopPrompt = agentLoop.start({
             mode: PiAgentLoopMode.Goal,
-            goal: `Complete and verify the user's skill-assisted task: ${prompt}`,
+            goal: workExecution!.goal,
             passes: 0,
             stages: [],
           });
-          initialPrompt = `${loopPrompt}\n\n${initialPrompt}`;
+          initialPrompt = `${loopPrompt}\n\n${workExecution!.buildInitialPrompt(initialPrompt)}`;
         }
       }
 
@@ -659,6 +646,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         : normalizeExpertIds(options.expertIds);
     if (!haveSameStringList(requestedExpertIds, active.requestedExpertIds)) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
+      this.disposeSessionForRecreation(sessionId, active);
       return this.startSession(sessionId, prompt, {
         ...options,
         systemPrompt: requestedSystemPrompt ?? active.requestedSystemPrompt,
@@ -671,7 +659,18 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     const nextSystemPrompt = requestedSystemPrompt ?? active.requestedSystemPrompt;
     const promptChanged = nextSystemPrompt !== active.requestedSystemPrompt;
     const skillsChanged = !haveSameStringList(requestedSkillIds, active.requestedSkillIds);
-    if (promptChanged || skillsChanged) {
+    if (skillsChanged) {
+      const history = this.store?.getSession(sessionId)?.messages ?? [];
+      this.disposeSessionForRecreation(sessionId, active);
+      return this.startSession(sessionId, prompt, {
+        ...options,
+        systemPrompt: nextSystemPrompt,
+        skillIds: requestedSkillIds,
+        expertIds: requestedExpertIds,
+        _piPromptOverride: buildPiConversationPrompt(history, prompt),
+      });
+    }
+    if (promptChanged) {
       const previousSystemPrompt = active.resourceState.systemPrompt;
       const previousSkillIds = active.resourceState.skillIds;
       active.resourceState.systemPrompt = nextSystemPrompt;
@@ -682,9 +681,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         await active.piSession.reload();
         active.requestedSystemPrompt = nextSystemPrompt;
         active.requestedSkillIds = requestedSkillIds;
-        console.debug(
-          `[PiRuntime] reloaded session resources after ${promptChanged ? 'prompt' : 'skill'} change`,
-        );
+        console.debug('[PiRuntime] reloaded session resources after prompt change');
       } catch (error) {
         active.resourceState.systemPrompt = previousSystemPrompt;
         active.resourceState.skillIds = previousSkillIds;
@@ -718,7 +715,10 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     this.emit('message', sessionId, persisted);
 
     let nextPrompt = prompt;
-    const completionWorkflow = active.researchRun || active.shortcutWorkflow;
+    const completionWorkflow =
+      active.researchRun ||
+      active.shortcutWorkflow ||
+      (active.workExecution?.isPersistent() ? active.workExecution : null);
     if (completionWorkflow && !active.agentLoop.getState().active) {
       completionWorkflow.resumeForPrompt(prompt);
       active.agentLoop.start({
@@ -729,7 +729,9 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       });
       nextPrompt = active.researchRun
         ? active.researchRun.buildInitialPrompt(prompt)
-        : active.shortcutWorkflow!.buildInitialPrompt(prompt);
+        : active.shortcutWorkflow
+          ? active.shortcutWorkflow.buildInitialPrompt(prompt)
+          : active.workExecution!.buildInitialPrompt(prompt);
     }
 
     try {
@@ -764,6 +766,17 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     } catch (err) {
       console.warn('[PiRuntime] Failed to update model via patchSession:', err);
     }
+  }
+
+  private disposeSessionForRecreation(sessionId: string, active: ActivePiSession): void {
+    this.dismissAskUserQuestionsBySession(sessionId);
+    active.agentLoop.stop();
+    active.pendingError = null;
+    active.piSession.abortBash();
+    active.abortController.abort();
+    active.unsubscribe();
+    void active.piSession.abort();
+    this.activeSessions.delete(sessionId);
   }
 
   stopSession(sessionId: string): void {
@@ -1041,7 +1054,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         if (!event.toolCallId || !event.toolName) break;
         if (event.toolName === PiSubagentToolName) {
           active.researchRun?.recordSubagentStart(event.toolCallId, event.args);
-          active.shortcutWorkflow?.recordSubagentStart(event.args);
+          active.shortcutWorkflow?.recordSubagentStart(event.toolCallId, event.args);
         }
         const toolUseMsg: CoworkMessage = {
           id: randomUUID(),
@@ -1071,6 +1084,11 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         const resultText = extractToolResultText(event.result);
         if (event.toolName === PiSubagentToolName) {
           active.researchRun?.recordSubagentResult(
+            event.toolCallId,
+            resultText,
+            Boolean(event.isError),
+          );
+          active.shortcutWorkflow?.recordSubagentResult(
             event.toolCallId,
             resultText,
             Boolean(event.isError),

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -46,6 +46,12 @@ import { buildPiAgentLoopTool, PiAgentLoopController, PiAgentLoopMode } from './
 import { buildPiConversationPrompt } from './piConversationContext';
 import { isAcademicResearchSkillSet, PiResearchRunController } from './piResearchRun';
 import { buildPiResearchStateTool } from './piResearchStateTool';
+import {
+  PiShortcutWorkflowController,
+  resolveShortcutWorkflowKind,
+  ShortcutWorkflowKind,
+} from './piShortcutWorkflow';
+import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { createPiLargeFileWriteSystemPrompt, PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
@@ -139,6 +145,8 @@ interface ActivePiSession {
   agentLoop: PiAgentLoopController;
   /** Present only for the controlled academic-research workflow. */
   researchRun: PiResearchRunController | null;
+  /** Present for every other first-class sidebar shortcut workflow. */
+  shortcutWorkflow: PiShortcutWorkflowController | null;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
   /**
    * Error from the latest failed attempt (message_end with stopReason=error).
@@ -414,6 +422,18 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         researchRun.resumeForPrompt(prompt);
         customTools.push(buildPiResearchStateTool(researchRun));
       }
+      const shortcutKind = researchRun ? null : resolveShortcutWorkflowKind(resourceState.skillIds);
+      const shortcutWorkflow = shortcutKind
+        ? new PiShortcutWorkflowController({
+            sessionId,
+            workspaceRoot,
+            task: prompt,
+            kind: shortcutKind,
+          })
+        : null;
+      if (shortcutWorkflow) {
+        customTools.push(buildPiShortcutWorkflowStateTool(shortcutWorkflow));
+      }
 
       // Subagent tool: registered for every cowork session. When the session
       // agent is a Team Lead from a package, its presetId additionally exposes
@@ -438,7 +458,10 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         presetId: subagentPresetId,
         resolvedModel,
         workspaceRoot,
-        webSearchSkillPath: researchRun ? path.join(getSkillsRoot(), 'web-search') : undefined,
+        webSearchSkillPath:
+          researchRun || shortcutKind === ShortcutWorkflowKind.DeepResearch
+            ? path.join(getSkillsRoot(), 'web-search')
+            : undefined,
         createPiResourceLoader: (cwd, systemPrompt, maxOutputTokens, skillIds) =>
           this.createPiResourceLoader(pi, cwd, {
             systemPrompt,
@@ -453,11 +476,12 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
 
       // Agent loop tool: lets the LLM drive multi-iteration long-horizon
       // loops; the controller continues the session on agent_end.
-      const agentLoop = new PiAgentLoopController(researchRun || undefined);
-      if (researchRun) {
+      const completionWorkflow = researchRun || shortcutWorkflow;
+      const agentLoop = new PiAgentLoopController(completionWorkflow || undefined);
+      if (completionWorkflow) {
         agentLoop.start({
           mode: PiAgentLoopMode.Goal,
-          goal: researchRun.goal,
+          goal: completionWorkflow.goal,
           passes: 0,
           stages: [],
         });
@@ -498,6 +522,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         toolResultMessageIdByCallId: new Map(),
         agentLoop,
         researchRun,
+        shortcutWorkflow,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
       };
@@ -514,7 +539,9 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
       await session.prompt(
         researchRun
           ? researchRun.buildInitialPrompt(options._piPromptOverride || prompt)
-          : options._piPromptOverride || prompt,
+          : shortcutWorkflow
+            ? shortcutWorkflow.buildInitialPrompt(options._piPromptOverride || prompt)
+            : options._piPromptOverride || prompt,
       );
     } catch (error) {
       this.activeSessions.delete(sessionId);
@@ -625,15 +652,18 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     this.emit('message', sessionId, persisted);
 
     let nextPrompt = prompt;
-    if (active.researchRun && !active.agentLoop.getState().active) {
-      active.researchRun.resumeForPrompt(prompt);
+    const completionWorkflow = active.researchRun || active.shortcutWorkflow;
+    if (completionWorkflow && !active.agentLoop.getState().active) {
+      completionWorkflow.resumeForPrompt(prompt);
       active.agentLoop.start({
         mode: PiAgentLoopMode.Goal,
-        goal: active.researchRun.goal,
+        goal: completionWorkflow.goal,
         passes: 0,
         stages: [],
       });
-      nextPrompt = active.researchRun.buildInitialPrompt(prompt);
+      nextPrompt = active.researchRun
+        ? active.researchRun.buildInitialPrompt(prompt)
+        : active.shortcutWorkflow!.buildInitialPrompt(prompt);
     }
 
     try {
@@ -945,6 +975,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
         if (!event.toolCallId || !event.toolName) break;
         if (event.toolName === PiSubagentToolName) {
           active.researchRun?.recordSubagentStart(event.toolCallId, event.args);
+          active.shortcutWorkflow?.recordSubagentStart(event.args);
         }
         const toolUseMsg: CoworkMessage = {
           id: randomUUID(),

--- a/src/main/libs/agentEngine/piShortcutWorkflow.test.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflow.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
+import JSZip from 'jszip';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -42,7 +43,7 @@ describe('PiShortcutWorkflowController', () => {
     expect(resolveShortcutWorkflowKind(['xlsx'])).toBe(ShortcutWorkflowKind.Sheets);
   });
 
-  it('keeps a PPT workflow active until its deliverable, QA report, and preview are verified', () => {
+  it('keeps a PPT workflow active until its deliverable, QA report, and preview are verified', async () => {
     const run = createRun(ShortcutWorkflowKind.Ppt);
     run.requestCompletion('looks finished');
     expect(run.onAgentEnd()).toMatchObject({
@@ -51,21 +52,30 @@ describe('PiShortcutWorkflowController', () => {
     });
 
     const root = rootFor(run);
-    fs.writeFileSync(path.join(root, 'deck.pptx'), Buffer.from('PK\x03\x04deck'));
+    const archive = new JSZip();
+    archive.file('[Content_Types].xml', '<Types />');
+    archive.file('ppt/presentation.xml', '<p:presentation />');
+    archive.file('ppt/slides/slide1.xml', '<p:sld />');
+    fs.writeFileSync(
+      path.join(root, 'deck.pptx'),
+      await archive.generateAsync({ type: 'nodebuffer' }),
+    );
     fs.writeFileSync(path.join(root, 'qa.md'), 'Checked text and fixed the title overflow.');
     fs.writeFileSync(path.join(root, 'slide-1.png'), 'preview');
-    expect(run.recordFile('deck.pptx', 'deliverable')).toContain('Verified');
-    expect(run.recordFile('qa.md', 'validation')).toContain('Verified');
-    expect(run.recordFile('slide-1.png', 'preview')).toContain('Verified');
+    await expect(run.recordFile('deck.pptx', 'deliverable')).resolves.toContain('Verified');
+    await expect(run.recordFile('qa.md', 'validation')).resolves.toContain('Verified');
+    await expect(run.recordFile('slide-1.png', 'preview')).resolves.toContain('Verified');
 
     run.requestCompletion('all checks passed');
     expect(run.onAgentEnd()).toMatchObject({ shouldFinish: true });
   });
 
-  it('rejects a claimed Office output that is not an Office package', () => {
+  it('rejects a claimed Office output that is not a complete Office package', async () => {
     const run = createRun(ShortcutWorkflowKind.Docs);
-    fs.writeFileSync(path.join(rootFor(run), 'report.docx'), 'not a zip');
-    expect(run.recordFile('report.docx', 'deliverable')).toContain('not a valid ZIP package');
+    fs.writeFileSync(path.join(rootFor(run), 'report.docx'), 'PK\x03\x04not a real package');
+    await expect(run.recordFile('report.docx', 'deliverable')).resolves.toContain(
+      'not a valid ZIP package',
+    );
   });
 
   it('keeps deep research active until plan, researchers, and reachable sources are recorded', async () => {
@@ -80,18 +90,101 @@ describe('PiShortcutWorkflowController', () => {
     );
     const run = createRun(ShortcutWorkflowKind.DeepResearch);
     run.setResearchPlan(['definitions', 'primary data', 'counterevidence']);
-    run.recordSubagentStart({
+    run.recordSubagentStart('research-call', {
       parallel: [
         { agent: 'researcher', task: 'definitions' },
         { agent: 'researcher', task: 'data' },
         { agent: 'researcher', task: 'counterevidence' },
       ],
     });
+    run.recordSubagentResult(
+      'research-call',
+      [
+        '3/3 subagents succeeded.',
+        '## researcher (ok)\ndefinitions',
+        '## researcher (ok)\ndata',
+        '## researcher (ok)\ncounterevidence',
+      ].join('\n\n'),
+      false,
+    );
     for (let index = 0; index < 6; index += 1) {
       await run.verifySource(`https://source-${index}.example.test/report`);
     }
     run.requestCompletion('report is supported');
     expect(run.onAgentEnd()).toMatchObject({ shouldFinish: true });
+  });
+
+  it('does not count failed researcher starts as completed research', () => {
+    const run = createRun(ShortcutWorkflowKind.DeepResearch);
+    run.recordSubagentStart('failed-call', {
+      parallel: [
+        { agent: 'researcher', task: 'one' },
+        { agent: 'researcher', task: 'two' },
+        { agent: 'researcher', task: 'three' },
+      ],
+    });
+    run.recordSubagentResult('failed-call', '0/3 subagents succeeded.', true);
+    expect(run.getSnapshot()).toMatchObject({ researcherRuns: 0 });
+  });
+
+  it('does not count a failed researcher hidden among successful parallel agents', () => {
+    const run = createRun(ShortcutWorkflowKind.DeepResearch);
+    run.recordSubagentStart('mixed-call', {
+      parallel: [
+        { agent: 'researcher', task: 'research' },
+        { agent: 'scout', task: 'inspect' },
+      ],
+    });
+    run.recordSubagentResult(
+      'mixed-call',
+      '1/2 subagents succeeded.\n\n## researcher (failed)\nError: boom\n\n## scout (ok)\nfiles',
+      false,
+    );
+    expect(run.getSnapshot()).toMatchObject({ researcherRuns: 0 });
+  });
+
+  it('normalizes source fragments and tracking parameters before counting research evidence', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: vi.fn().mockReturnValue(null) },
+        body: { cancel: vi.fn() },
+      }),
+    );
+    const run = createRun(ShortcutWorkflowKind.DeepResearch);
+    await run.verifySource('https://source.example.test/report?utm_source=first#section');
+    await run.verifySource('https://source.example.test/report?fbclid=second#other');
+    expect(run.getSnapshot()).toMatchObject({
+      sources: ['https://source.example.test/report'],
+    });
+  });
+
+  it('clears old completion evidence before a follow-up task', async () => {
+    const run = createRun(ShortcutWorkflowKind.Docs);
+    const archive = new JSZip();
+    archive.file('[Content_Types].xml', '<Types />');
+    archive.file('word/document.xml', '<w:document />');
+    fs.writeFileSync(
+      path.join(rootFor(run), 'report.docx'),
+      await archive.generateAsync({ type: 'nodebuffer' }),
+    );
+    fs.writeFileSync(path.join(rootFor(run), 'qa.md'), 'validated');
+    await run.recordFile('report.docx', 'deliverable');
+    await run.recordFile('qa.md', 'validation');
+    run.requestCompletion('done');
+    expect(run.onAgentEnd().shouldFinish).toBe(true);
+
+    run.resumeForPrompt('Create a different report');
+    expect(run.getSnapshot()).toMatchObject({
+      task: 'Create a different report',
+      files: [],
+      completionFailures: expect.arrayContaining([
+        'no verified deliverable file is recorded',
+        'no verification report is recorded',
+      ]),
+    });
   });
 
   it('rejects deep-research redirects to a private target', async () => {

--- a/src/main/libs/agentEngine/piShortcutWorkflow.test.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflow.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PiShortcutWorkflowController,
+  resolveShortcutWorkflowKind,
+  ShortcutWorkflowKind,
+} from './piShortcutWorkflow';
+
+const roots: string[] = [];
+
+const createRun = (kind: ShortcutWorkflowKind): PiShortcutWorkflowController => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-shortcut-workflow-'));
+  roots.push(root);
+  return new PiShortcutWorkflowController({
+    sessionId: 'workflow-1',
+    workspaceRoot: root,
+    task: 'Create deliverable',
+    kind,
+  });
+};
+
+const rootFor = (run: PiShortcutWorkflowController): string =>
+  path.resolve(run.runDirectory, '..', '..', '..');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('PiShortcutWorkflowController', () => {
+  it('creates a controlled workflow for every non-academic sidebar shortcut', () => {
+    expect(resolveShortcutWorkflowKind(['pptx'])).toBe(ShortcutWorkflowKind.Ppt);
+    expect(resolveShortcutWorkflowKind(['deep-research', 'web-search'])).toBe(
+      ShortcutWorkflowKind.DeepResearch,
+    );
+    expect(resolveShortcutWorkflowKind(['docx'])).toBe(ShortcutWorkflowKind.Docs);
+    expect(resolveShortcutWorkflowKind(['frontend-design'])).toBe(ShortcutWorkflowKind.Website);
+    expect(resolveShortcutWorkflowKind(['xlsx'])).toBe(ShortcutWorkflowKind.Sheets);
+  });
+
+  it('keeps a PPT workflow active until its deliverable, QA report, and preview are verified', () => {
+    const run = createRun(ShortcutWorkflowKind.Ppt);
+    run.requestCompletion('looks finished');
+    expect(run.onAgentEnd()).toMatchObject({
+      shouldFinish: false,
+      nextPrompt: expect.stringContaining('Missing requirements'),
+    });
+
+    const root = rootFor(run);
+    fs.writeFileSync(path.join(root, 'deck.pptx'), Buffer.from('PK\x03\x04deck'));
+    fs.writeFileSync(path.join(root, 'qa.md'), 'Checked text and fixed the title overflow.');
+    fs.writeFileSync(path.join(root, 'slide-1.png'), 'preview');
+    expect(run.recordFile('deck.pptx', 'deliverable')).toContain('Verified');
+    expect(run.recordFile('qa.md', 'validation')).toContain('Verified');
+    expect(run.recordFile('slide-1.png', 'preview')).toContain('Verified');
+
+    run.requestCompletion('all checks passed');
+    expect(run.onAgentEnd()).toMatchObject({ shouldFinish: true });
+  });
+
+  it('rejects a claimed Office output that is not an Office package', () => {
+    const run = createRun(ShortcutWorkflowKind.Docs);
+    fs.writeFileSync(path.join(rootFor(run), 'report.docx'), 'not a zip');
+    expect(run.recordFile('report.docx', 'deliverable')).toContain('not a valid ZIP package');
+  });
+
+  it('keeps deep research active until plan, researchers, and reachable sources are recorded', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: vi.fn().mockReturnValue(null) },
+        body: { cancel: vi.fn() },
+      }),
+    );
+    const run = createRun(ShortcutWorkflowKind.DeepResearch);
+    run.setResearchPlan(['definitions', 'primary data', 'counterevidence']);
+    run.recordSubagentStart({
+      parallel: [
+        { agent: 'researcher', task: 'definitions' },
+        { agent: 'researcher', task: 'data' },
+        { agent: 'researcher', task: 'counterevidence' },
+      ],
+    });
+    for (let index = 0; index < 6; index += 1) {
+      await run.verifySource(`https://source-${index}.example.test/report`);
+    }
+    run.requestCompletion('report is supported');
+    expect(run.onAgentEnd()).toMatchObject({ shouldFinish: true });
+  });
+
+  it('rejects deep-research redirects to a private target', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: { get: vi.fn().mockReturnValue('http://127.0.0.1/private') },
+        body: { cancel: vi.fn() },
+      }),
+    );
+    const run = createRun(ShortcutWorkflowKind.DeepResearch);
+    await expect(run.verifySource('https://public.example.test/redirect')).resolves.toContain(
+      'redirect target is local, private, or unsafe',
+    );
+  });
+});

--- a/src/main/libs/agentEngine/piShortcutWorkflow.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflow.ts
@@ -2,9 +2,11 @@ import * as fs from 'fs';
 import path from 'path';
 
 import {
+  collectShortcutCompletionFailures,
   expectedExtensions,
-  isOfficeZip,
+  isValidOfficePackage,
   isSafePublicUrl,
+  normalizeResearchSourceUrl,
   ShortcutWorkflowKind,
   type WorkflowFileRole,
   type WorkflowState,
@@ -32,6 +34,7 @@ export class PiShortcutWorkflowController {
   readonly runDirectory: string;
   private readonly statePath: string;
   private state: WorkflowState;
+  private readonly pendingResearcherRuns = new Map<string, number>();
 
   constructor(private readonly options: PiShortcutWorkflowOptions) {
     this.runDirectory = path.join(
@@ -69,6 +72,11 @@ export class PiShortcutWorkflowController {
     this.state.task = task;
     this.state.iteration += 1;
     this.state.staleCount = 0;
+    this.state.files = [];
+    this.state.researchAngles = [];
+    this.state.sources = [];
+    this.state.researcherRuns = 0;
+    this.pendingResearcherRuns.clear();
     delete this.state.completionReason;
     this.writeState();
   }
@@ -81,7 +89,7 @@ export class PiShortcutWorkflowController {
   }
 
   onAgentEnd(): ShortcutWorkflowEndDecision {
-    const failures = this.completionFailures();
+    const failures = collectShortcutCompletionFailures(this.state);
     if (this.state.status === 'completion_requested' && failures.length === 0) {
       this.state.status = 'completed';
       this.writeState();
@@ -104,7 +112,7 @@ export class PiShortcutWorkflowController {
     };
   }
 
-  recordSubagentStart(args: unknown): void {
+  recordSubagentStart(toolCallId: string, args: unknown): void {
     if (
       this.options.kind !== ShortcutWorkflowKind.DeepResearch ||
       !args ||
@@ -115,13 +123,24 @@ export class PiShortcutWorkflowController {
     const count = [raw, ...(Array.isArray(raw.parallel) ? raw.parallel : [])].filter(
       value => (value as Record<string, unknown>).agent === 'researcher',
     ).length;
-    if (count > 0) {
-      this.state.researcherRuns += count;
-      this.writeState();
-    }
+    if (count > 0) this.pendingResearcherRuns.set(toolCallId, count);
   }
 
-  recordFile(rawPath: string, role: WorkflowFileRole): string {
+  recordSubagentResult(toolCallId: string, output: string, isError: boolean): void {
+    const requested = this.pendingResearcherRuns.get(toolCallId) || 0;
+    this.pendingResearcherRuns.delete(toolCallId);
+    if (requested === 0 || isError || !output.trim()) return;
+    const parallelSuccesses = [...output.matchAll(/^## researcher \(ok\)$/gm)].length;
+    const isParallelOutput = /^\d+\/\d+ subagents succeeded\./.test(output.trim());
+    const failed = /^(Error:|\(subagent timed out|Subagent ".*" failed:|Unknown agent)/i.test(
+      output.trim(),
+    );
+    const succeeded = isParallelOutput ? parallelSuccesses : failed ? 0 : 1;
+    this.state.researcherRuns += Math.min(requested, succeeded);
+    this.writeState();
+  }
+
+  async recordFile(rawPath: string, role: WorkflowFileRole): Promise<string> {
     const resolved = this.resolveWorkspacePath(rawPath);
     if (!resolved)
       return 'File was not recorded: use an existing file inside the selected workspace.';
@@ -142,7 +161,7 @@ export class PiShortcutWorkflowController {
           ] as ShortcutWorkflowKind[]
         ).includes(this.options.kind) &&
         ['.pptx', '.docx', '.xlsx', '.xlsm'].includes(path.extname(resolved).toLowerCase()) &&
-        !isOfficeZip(resolved)
+        !(await isValidOfficePackage(resolved, this.options.kind))
       ) {
         return 'File was not recorded: the Office deliverable is not a valid ZIP package.';
       }
@@ -191,9 +210,11 @@ export class PiShortcutWorkflowController {
         }
         await response.body?.cancel();
         if (!response.ok) return `Source was not recorded: URL returned HTTP ${response.status}.`;
-        if (!this.state.sources.includes(rawUrl)) this.state.sources.push(rawUrl);
+        const normalizedSource = normalizeResearchSourceUrl(current);
+        if (!this.state.sources.includes(normalizedSource))
+          this.state.sources.push(normalizedSource);
         this.writeState();
-        return `Verified and recorded source: ${rawUrl}`;
+        return `Verified and recorded source: ${normalizedSource}`;
       }
       return 'Source was not recorded: URL exceeded the redirect limit.';
     } catch (error) {
@@ -204,35 +225,9 @@ export class PiShortcutWorkflowController {
   getSnapshot(): Record<string, unknown> {
     return {
       ...this.state,
-      completionFailures: this.completionFailures(),
+      completionFailures: collectShortcutCompletionFailures(this.state),
       runDirectory: this.runDirectory,
     };
-  }
-
-  private completionFailures(): string[] {
-    if (this.options.kind === ShortcutWorkflowKind.DeepResearch) {
-      const failures: string[] = [];
-      if (this.state.researchAngles.length < 3)
-        failures.push('fewer than three research angles are recorded');
-      if (this.state.researcherRuns < 3)
-        failures.push('fewer than three researcher delegations ran');
-      if (this.state.sources.length < 6)
-        failures.push('fewer than six reachable sources are recorded');
-      return failures;
-    }
-    const failures: string[] = [];
-    const files = this.state.files;
-    if (!files.some(file => file.role === 'deliverable'))
-      failures.push('no verified deliverable file is recorded');
-    if (!files.some(file => file.role === 'validation'))
-      failures.push('no verification report is recorded');
-    if (
-      this.options.kind === ShortcutWorkflowKind.Ppt &&
-      !files.some(file => file.role === 'preview')
-    ) {
-      failures.push('no rendered slide preview is recorded');
-    }
-    return failures;
   }
 
   private kindInstructions(): string[] {

--- a/src/main/libs/agentEngine/piShortcutWorkflow.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflow.ts
@@ -1,0 +1,298 @@
+import * as fs from 'fs';
+import path from 'path';
+
+import {
+  expectedExtensions,
+  isOfficeZip,
+  isSafePublicUrl,
+  ShortcutWorkflowKind,
+  type WorkflowFileRole,
+  type WorkflowState,
+  workflowLabel,
+} from './piShortcutWorkflowPolicy';
+
+export { resolveShortcutWorkflowKind, ShortcutWorkflowKind } from './piShortcutWorkflowPolicy';
+
+export interface ShortcutWorkflowEndDecision {
+  shouldFinish: boolean;
+  reason?: string;
+  nextPrompt?: string;
+}
+
+export interface PiShortcutWorkflowOptions {
+  sessionId: string;
+  workspaceRoot: string;
+  task: string;
+  kind: ShortcutWorkflowKind;
+}
+
+const now = (): string => new Date().toISOString();
+
+export class PiShortcutWorkflowController {
+  readonly runDirectory: string;
+  private readonly statePath: string;
+  private state: WorkflowState;
+
+  constructor(private readonly options: PiShortcutWorkflowOptions) {
+    this.runDirectory = path.join(
+      options.workspaceRoot,
+      '.zhiyuan',
+      'shortcut-workflows',
+      options.sessionId,
+    );
+    this.statePath = path.join(this.runDirectory, 'state.json');
+    fs.mkdirSync(this.runDirectory, { recursive: true });
+    this.state = this.loadOrCreate();
+    this.writeState();
+  }
+
+  get goal(): string {
+    return `Produce a verified ${workflowLabel(this.options.kind)} for: ${this.state.task}`;
+  }
+
+  buildInitialPrompt(userPrompt: string): string {
+    return [
+      `## Controlled ${workflowLabel(this.options.kind)} workflow`,
+      `Durable workflow state: ${this.runDirectory}`,
+      'Do not finish after a plan, draft, or a claimed file path.',
+      'Work until the workflow_state tool has recorded every required deliverable and verification artifact.',
+      'Calling agent_loop done only requests completion; unmet gates automatically continue the workflow.',
+      ...this.kindInstructions(),
+      '',
+      userPrompt,
+    ].join('\n');
+  }
+
+  resumeForPrompt(task: string): void {
+    if (this.state.status === 'running' || this.state.status === 'completion_requested') return;
+    this.state.status = 'running';
+    this.state.task = task;
+    this.state.iteration += 1;
+    this.state.staleCount = 0;
+    delete this.state.completionReason;
+    this.writeState();
+  }
+
+  requestCompletion(reason: string): string {
+    this.state.status = 'completion_requested';
+    this.state.completionReason = reason;
+    this.writeState();
+    return 'Completion recorded as a request. The workflow remains active until every required deliverable and verification artifact is independently checked.';
+  }
+
+  onAgentEnd(): ShortcutWorkflowEndDecision {
+    const failures = this.completionFailures();
+    if (this.state.status === 'completion_requested' && failures.length === 0) {
+      this.state.status = 'completed';
+      this.writeState();
+      return { shouldFinish: true, reason: this.state.completionReason || 'Workflow gates passed' };
+    }
+    this.state.status =
+      failures.length > 0 && this.state.iteration >= 15 ? 'needs_attention' : 'running';
+    this.state.staleCount += 1;
+    this.state.iteration += 1;
+    this.writeState();
+    return {
+      shouldFinish: false,
+      nextPrompt: [
+        `## ${workflowLabel(this.options.kind)} workflow continuation`,
+        'The previous turn did not clear the completion gate. Continue work; do not merely describe what remains.',
+        'Missing requirements:',
+        ...failures.map(failure => `- ${failure}`),
+        ...this.kindInstructions(),
+      ].join('\n'),
+    };
+  }
+
+  recordSubagentStart(args: unknown): void {
+    if (
+      this.options.kind !== ShortcutWorkflowKind.DeepResearch ||
+      !args ||
+      typeof args !== 'object'
+    )
+      return;
+    const raw = args as Record<string, unknown>;
+    const count = [raw, ...(Array.isArray(raw.parallel) ? raw.parallel : [])].filter(
+      value => (value as Record<string, unknown>).agent === 'researcher',
+    ).length;
+    if (count > 0) {
+      this.state.researcherRuns += count;
+      this.writeState();
+    }
+  }
+
+  recordFile(rawPath: string, role: WorkflowFileRole): string {
+    const resolved = this.resolveWorkspacePath(rawPath);
+    if (!resolved)
+      return 'File was not recorded: use an existing file inside the selected workspace.';
+    const stat = fs.statSync(resolved);
+    if (!stat.isFile() || stat.size === 0)
+      return 'File was not recorded: it is missing, not a file, or empty.';
+    if (role === 'deliverable') {
+      const extensions = expectedExtensions(this.options.kind);
+      if (!extensions.includes(path.extname(resolved).toLowerCase())) {
+        return `File was not recorded: expected one of ${extensions.join(', ')}.`;
+      }
+      if (
+        (
+          [
+            ShortcutWorkflowKind.Ppt,
+            ShortcutWorkflowKind.Docs,
+            ShortcutWorkflowKind.Sheets,
+          ] as ShortcutWorkflowKind[]
+        ).includes(this.options.kind) &&
+        ['.pptx', '.docx', '.xlsx', '.xlsm'].includes(path.extname(resolved).toLowerCase()) &&
+        !isOfficeZip(resolved)
+      ) {
+        return 'File was not recorded: the Office deliverable is not a valid ZIP package.';
+      }
+    }
+    const normalized = path.relative(this.options.workspaceRoot, resolved);
+    const index = this.state.files.findIndex(
+      file => file.path === normalized && file.role === role,
+    );
+    const value = { path: normalized, role, verifiedAt: now() };
+    if (index >= 0) this.state.files[index] = value;
+    else this.state.files.push(value);
+    this.writeState();
+    return `Verified ${role} file: ${normalized}`;
+  }
+
+  setResearchPlan(angles: string[]): string {
+    if (this.options.kind !== ShortcutWorkflowKind.DeepResearch)
+      return 'Research plans apply only to deep research.';
+    const unique = [...new Set(angles.map(value => value.trim()).filter(Boolean))];
+    if (unique.length < 3) return 'Deep research needs at least three distinct research angles.';
+    this.state.researchAngles = unique;
+    this.writeState();
+    return `Recorded ${unique.length} research angles.`;
+  }
+
+  async verifySource(rawUrl: string): Promise<string> {
+    if (this.options.kind !== ShortcutWorkflowKind.DeepResearch)
+      return 'Sources apply only to deep research.';
+    if (!isSafePublicUrl(rawUrl))
+      return 'Source was not recorded: URL is unsafe or not public HTTP(S).';
+    try {
+      let current = new URL(rawUrl);
+      for (let redirects = 0; redirects <= 5; redirects += 1) {
+        const response = await fetch(current, {
+          signal: AbortSignal.timeout(15_000),
+          redirect: 'manual',
+        });
+        const location = response.headers.get('location');
+        if (response.status >= 300 && response.status < 400 && location) {
+          await response.body?.cancel();
+          current = new URL(location, current);
+          if (!isSafePublicUrl(current.toString())) {
+            return 'Source was not recorded: redirect target is local, private, or unsafe.';
+          }
+          continue;
+        }
+        await response.body?.cancel();
+        if (!response.ok) return `Source was not recorded: URL returned HTTP ${response.status}.`;
+        if (!this.state.sources.includes(rawUrl)) this.state.sources.push(rawUrl);
+        this.writeState();
+        return `Verified and recorded source: ${rawUrl}`;
+      }
+      return 'Source was not recorded: URL exceeded the redirect limit.';
+    } catch (error) {
+      return `Source was not recorded: fetch failed (${error instanceof Error ? error.message : String(error)}).`;
+    }
+  }
+
+  getSnapshot(): Record<string, unknown> {
+    return {
+      ...this.state,
+      completionFailures: this.completionFailures(),
+      runDirectory: this.runDirectory,
+    };
+  }
+
+  private completionFailures(): string[] {
+    if (this.options.kind === ShortcutWorkflowKind.DeepResearch) {
+      const failures: string[] = [];
+      if (this.state.researchAngles.length < 3)
+        failures.push('fewer than three research angles are recorded');
+      if (this.state.researcherRuns < 3)
+        failures.push('fewer than three researcher delegations ran');
+      if (this.state.sources.length < 6)
+        failures.push('fewer than six reachable sources are recorded');
+      return failures;
+    }
+    const failures: string[] = [];
+    const files = this.state.files;
+    if (!files.some(file => file.role === 'deliverable'))
+      failures.push('no verified deliverable file is recorded');
+    if (!files.some(file => file.role === 'validation'))
+      failures.push('no verification report is recorded');
+    if (
+      this.options.kind === ShortcutWorkflowKind.Ppt &&
+      !files.some(file => file.role === 'preview')
+    ) {
+      failures.push('no rendered slide preview is recorded');
+    }
+    return failures;
+  }
+
+  private kindInstructions(): string[] {
+    if (this.options.kind === ShortcutWorkflowKind.DeepResearch) {
+      return [
+        'Create at least three distinct research angles, launch researchers for them, and record six reachable sources with workflow_state before requesting completion.',
+      ];
+    }
+    const output = expectedExtensions(this.options.kind).join(' or ');
+    const instructions = [
+      `Create the requested ${output} deliverable, then call workflow_state with role "deliverable" to verify it exists and is nonempty.`,
+      'Write a nonempty validation report inside the workspace and call workflow_state with role "validation" after the check succeeds.',
+    ];
+    if (this.options.kind === ShortcutWorkflowKind.Ppt) {
+      instructions.push(
+        'Render at least one slide preview image, inspect it, and record it with role "preview".',
+      );
+    }
+    return instructions;
+  }
+
+  private resolveWorkspacePath(rawPath: string): string | null {
+    if (!rawPath.trim()) return null;
+    const resolved = path.resolve(this.options.workspaceRoot, rawPath);
+    const relative = path.relative(this.options.workspaceRoot, resolved);
+    if (relative.startsWith('..') || path.isAbsolute(relative) || !fs.existsSync(resolved))
+      return null;
+    return resolved;
+  }
+
+  private loadOrCreate(): WorkflowState {
+    try {
+      if (fs.existsSync(this.statePath)) {
+        const state = JSON.parse(fs.readFileSync(this.statePath, 'utf8')) as WorkflowState;
+        if (
+          state.version === 1 &&
+          state.sessionId === this.options.sessionId &&
+          state.kind === this.options.kind
+        )
+          return state;
+      }
+    } catch {}
+    return {
+      version: 1,
+      sessionId: this.options.sessionId,
+      kind: this.options.kind,
+      task: this.options.task,
+      status: 'running',
+      iteration: 1,
+      staleCount: 0,
+      files: [],
+      researchAngles: [],
+      sources: [],
+      researcherRuns: 0,
+      updatedAt: now(),
+    };
+  }
+
+  private writeState(): void {
+    this.state.updatedAt = now();
+    fs.writeFileSync(this.statePath, JSON.stringify(this.state, null, 2));
+  }
+}

--- a/src/main/libs/agentEngine/piShortcutWorkflowPolicy.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflowPolicy.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import { isIP } from 'node:net';
+
+import { CoreSkillId } from '../../../shared/skills/constants';
+
+export const ShortcutWorkflowKind = {
+  Ppt: 'ppt',
+  DeepResearch: 'deep-research',
+  Docs: 'docs',
+  Website: 'website',
+  Sheets: 'sheets',
+} as const;
+export type ShortcutWorkflowKind = (typeof ShortcutWorkflowKind)[keyof typeof ShortcutWorkflowKind];
+
+export type WorkflowFileRole = 'deliverable' | 'validation' | 'preview';
+
+export interface WorkflowFile {
+  path: string;
+  role: WorkflowFileRole;
+  verifiedAt: string;
+}
+
+export interface WorkflowState {
+  version: 1;
+  sessionId: string;
+  kind: ShortcutWorkflowKind;
+  task: string;
+  status: 'running' | 'completion_requested' | 'completed' | 'needs_attention';
+  iteration: number;
+  staleCount: number;
+  completionReason?: string;
+  files: WorkflowFile[];
+  researchAngles: string[];
+  sources: string[];
+  researcherRuns: number;
+  updatedAt: string;
+}
+
+export const resolveShortcutWorkflowKind = (
+  skillIds: string[] | undefined,
+): ShortcutWorkflowKind | null => {
+  if (!skillIds) return null;
+  if (skillIds.includes(CoreSkillId.Pptx)) return ShortcutWorkflowKind.Ppt;
+  if (skillIds.includes(CoreSkillId.DeepResearch)) return ShortcutWorkflowKind.DeepResearch;
+  if (skillIds.includes(CoreSkillId.Docx)) return ShortcutWorkflowKind.Docs;
+  if (skillIds.includes(CoreSkillId.FrontendDesign)) return ShortcutWorkflowKind.Website;
+  if (skillIds.includes(CoreSkillId.Xlsx)) return ShortcutWorkflowKind.Sheets;
+  return null;
+};
+
+export const workflowLabel = (kind: ShortcutWorkflowKind): string =>
+  ({
+    [ShortcutWorkflowKind.Ppt]: 'PPT presentation',
+    [ShortcutWorkflowKind.DeepResearch]: 'deep-research report',
+    [ShortcutWorkflowKind.Docs]: 'Word document',
+    [ShortcutWorkflowKind.Website]: 'website',
+    [ShortcutWorkflowKind.Sheets]: 'spreadsheet',
+  })[kind];
+
+export const expectedExtensions = (kind: ShortcutWorkflowKind): string[] =>
+  ({
+    [ShortcutWorkflowKind.Ppt]: ['.pptx'],
+    [ShortcutWorkflowKind.Docs]: ['.docx'],
+    [ShortcutWorkflowKind.Website]: ['.html', '.htm'],
+    [ShortcutWorkflowKind.Sheets]: ['.xlsx', '.xlsm', '.csv', '.tsv'],
+    [ShortcutWorkflowKind.DeepResearch]: [],
+  })[kind];
+
+export const isOfficeZip = (filePath: string): boolean => {
+  const header = Buffer.alloc(4);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    fs.readSync(fd, header, 0, header.length, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return header.subarray(0, 2).toString() === 'PK';
+};
+
+export const isSafePublicUrl = (rawUrl: string): boolean => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password)
+    return false;
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')) return false;
+  const ipVersion = isIP(hostname);
+  if (ipVersion === 6)
+    return (
+      hostname !== '::' &&
+      hostname !== '::1' &&
+      !hostname.startsWith('fc') &&
+      !hostname.startsWith('fd') &&
+      !hostname.startsWith('fe8') &&
+      !hostname.startsWith('fe9') &&
+      !hostname.startsWith('fea') &&
+      !hostname.startsWith('feb') &&
+      !hostname.startsWith('::ffff:')
+    );
+  if (ipVersion !== 4) return true;
+  const [first, second] = hostname.split('.').map(Number);
+  return !(
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+};

--- a/src/main/libs/agentEngine/piShortcutWorkflowPolicy.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflowPolicy.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { isIP } from 'node:net';
+import JSZip from 'jszip';
 
 import { CoreSkillId } from '../../../shared/skills/constants';
 
@@ -66,15 +67,87 @@ export const expectedExtensions = (kind: ShortcutWorkflowKind): string[] =>
     [ShortcutWorkflowKind.DeepResearch]: [],
   })[kind];
 
-export const isOfficeZip = (filePath: string): boolean => {
-  const header = Buffer.alloc(4);
-  const fd = fs.openSync(filePath, 'r');
-  try {
-    fs.readSync(fd, header, 0, header.length, 0);
-  } finally {
-    fs.closeSync(fd);
+const ResearchTrackingParameters = new Set([
+  'dclid',
+  'fbclid',
+  'gclid',
+  'mc_cid',
+  'mc_eid',
+  'msclkid',
+]);
+
+export const normalizeResearchSourceUrl = (source: URL): string => {
+  const normalized = new URL(source);
+  normalized.hash = '';
+  for (const key of [...normalized.searchParams.keys()]) {
+    if (key.toLowerCase().startsWith('utm_') || ResearchTrackingParameters.has(key.toLowerCase())) {
+      normalized.searchParams.delete(key);
+    }
   }
-  return header.subarray(0, 2).toString() === 'PK';
+  normalized.searchParams.sort();
+  return normalized.toString();
+};
+
+export const collectShortcutCompletionFailures = (state: WorkflowState): string[] => {
+  if (state.kind === ShortcutWorkflowKind.DeepResearch) {
+    const failures: string[] = [];
+    if (state.researchAngles.length < 3)
+      failures.push('fewer than three research angles are recorded');
+    if (state.researcherRuns < 3)
+      failures.push('fewer than three researcher delegations completed successfully');
+    if (state.sources.length < 6) failures.push('fewer than six reachable sources are recorded');
+    const sourceHosts = new Set(
+      state.sources.map(source => {
+        try {
+          return new URL(source).hostname;
+        } catch {
+          return '';
+        }
+      }),
+    );
+    sourceHosts.delete('');
+    if (sourceHosts.size < 3) failures.push('sources cover fewer than three distinct hosts');
+    return failures;
+  }
+  const failures: string[] = [];
+  if (!state.files.some(file => file.role === 'deliverable'))
+    failures.push('no verified deliverable file is recorded');
+  if (!state.files.some(file => file.role === 'validation'))
+    failures.push('no verification report is recorded');
+  if (state.kind === ShortcutWorkflowKind.Ppt && !state.files.some(file => file.role === 'preview'))
+    failures.push('no rendered slide preview is recorded');
+  return failures;
+};
+
+const officeRequiredEntries = (kind: ShortcutWorkflowKind): string[] => {
+  if (kind === ShortcutWorkflowKind.Ppt) return ['[Content_Types].xml', 'ppt/presentation.xml'];
+  if (kind === ShortcutWorkflowKind.Docs) return ['[Content_Types].xml', 'word/document.xml'];
+  if (kind === ShortcutWorkflowKind.Sheets) return ['[Content_Types].xml', 'xl/workbook.xml'];
+  return [];
+};
+
+export const isValidOfficePackage = async (
+  filePath: string,
+  kind: ShortcutWorkflowKind,
+): Promise<boolean> => {
+  try {
+    const archive = await JSZip.loadAsync(fs.readFileSync(filePath), { checkCRC32: true });
+    const names = Object.keys(archive.files);
+    if (!officeRequiredEntries(kind).every(entry => archive.file(entry))) return false;
+    if (
+      kind === ShortcutWorkflowKind.Ppt &&
+      !names.some(name => /^ppt\/slides\/slide\d+\.xml$/i.test(name))
+    )
+      return false;
+    if (
+      kind === ShortcutWorkflowKind.Sheets &&
+      !names.some(name => /^xl\/worksheets\/sheet\d+\.xml$/i.test(name))
+    )
+      return false;
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 export const isSafePublicUrl = (rawUrl: string): boolean => {

--- a/src/main/libs/agentEngine/piShortcutWorkflowStateTool.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflowStateTool.ts
@@ -1,0 +1,64 @@
+import { PiShortcutWorkflowController } from './piShortcutWorkflow';
+
+const toText = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const toList = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  const values = value.map(toText).filter(Boolean);
+  return values.length === value.length ? values : null;
+};
+
+interface ToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+}
+
+export const PiShortcutWorkflowStateToolName = 'workflow_state';
+
+/** Records only values independently checked by Pi's main process. */
+export function buildPiShortcutWorkflowStateTool(
+  controller: PiShortcutWorkflowController,
+): Record<string, unknown> {
+  const result = (text: string): ToolResult => ({
+    content: [{ type: 'text', text }],
+    details: controller.getSnapshot(),
+  });
+  return {
+    name: PiShortcutWorkflowStateToolName,
+    label: 'Workflow State',
+    description:
+      'Record workflow evidence that the main process independently checks. ' +
+      'Use file for deliverables, validation reports, and PPT previews; use plan and source for deep research.',
+    parameters: {
+      type: 'object',
+      properties: {
+        action: { type: 'string', enum: ['file', 'plan', 'source', 'status'] },
+        path: { type: 'string' },
+        role: { type: 'string', enum: ['deliverable', 'validation', 'preview'] },
+        angles: { type: 'array', items: { type: 'string' } },
+        url: { type: 'string' },
+      },
+      required: ['action'],
+      additionalProperties: false,
+    },
+    execute: async (_toolCallId: string, params: Record<string, unknown>): Promise<ToolResult> => {
+      const action = toText(params.action);
+      if (action === 'file') {
+        const role = toText(params.role);
+        if (role !== 'deliverable' && role !== 'validation' && role !== 'preview') {
+          return result('file requires role "deliverable", "validation", or "preview".');
+        }
+        return result(controller.recordFile(toText(params.path), role));
+      }
+      if (action === 'plan') {
+        const angles = toList(params.angles);
+        return result(
+          angles ? controller.setResearchPlan(angles) : 'plan requires string array "angles".',
+        );
+      }
+      if (action === 'source') return result(await controller.verifySource(toText(params.url)));
+      if (action === 'status') return result('Current workflow state returned in tool details.');
+      return result('Unknown workflow_state action.');
+    },
+  };
+}

--- a/src/main/libs/agentEngine/piShortcutWorkflowStateTool.ts
+++ b/src/main/libs/agentEngine/piShortcutWorkflowStateTool.ts
@@ -48,7 +48,7 @@ export function buildPiShortcutWorkflowStateTool(
         if (role !== 'deliverable' && role !== 'validation' && role !== 'preview') {
           return result('file requires role "deliverable", "validation", or "preview".');
         }
-        return result(controller.recordFile(toText(params.path), role));
+        return result(await controller.recordFile(toText(params.path), role));
       }
       if (action === 'plan') {
         const angles = toList(params.angles);

--- a/src/main/libs/agentEngine/piWorkExecution.ts
+++ b/src/main/libs/agentEngine/piWorkExecution.ts
@@ -1,0 +1,257 @@
+import * as fs from 'fs';
+import path from 'path';
+
+import type {
+  PiAskUserQuestionInput,
+  PiAskUserQuestionRequester,
+  PiAskUserQuestionResponse,
+} from './piAskUserQuestion';
+
+export const WorkExecutionQuestion = '技能任务执行方式';
+export const WorkExecutionOption = {
+  SingleTurn: '完成本轮',
+  Persistent: '持续执行至验收',
+} as const;
+
+export const PiWorkAcceptanceToolName = 'work_acceptance';
+
+type WorkExecutionMode = 'pending' | 'single' | 'persistent';
+
+interface WorkExecutionState {
+  version: 1;
+  sessionId: string;
+  task: string;
+  mode: WorkExecutionMode;
+  status: 'running' | 'completion_requested' | 'completed';
+  accepted: boolean;
+  iteration: number;
+  completionReason?: string;
+  acceptanceFeedback?: string;
+  updatedAt: string;
+}
+
+export const buildWorkExecutionQuestion = (): PiAskUserQuestionInput => ({
+  questions: [
+    {
+      header: '执行方式',
+      question: WorkExecutionQuestion,
+      options: [
+        {
+          label: WorkExecutionOption.SingleTurn,
+          description: '让技能完成当前一轮任务；模型结束后会结束会话。',
+        },
+        {
+          label: WorkExecutionOption.Persistent,
+          description: '持续推进复杂任务，并在模型申请完成时由你最终验收。',
+        },
+      ],
+    },
+  ],
+});
+
+export const chosePersistentWorkExecution = (response: PiAskUserQuestionResponse): boolean => {
+  if (response.behavior !== 'allow') return false;
+  const answers = response.updatedInput?.answers;
+  if (!answers || typeof answers !== 'object') return false;
+  return (
+    (answers as Record<string, unknown>)[WorkExecutionQuestion] === WorkExecutionOption.Persistent
+  );
+};
+
+const now = (): string => new Date().toISOString();
+
+export class PiWorkExecutionController {
+  readonly runDirectory: string;
+  private readonly statePath: string;
+  private state: WorkExecutionState;
+
+  constructor(
+    private readonly options: { sessionId: string; workspaceRoot: string; task: string },
+  ) {
+    this.runDirectory = path.join(
+      options.workspaceRoot,
+      '.zhiyuan',
+      'work-executions',
+      options.sessionId,
+    );
+    this.statePath = path.join(this.runDirectory, 'state.json');
+    fs.mkdirSync(this.runDirectory, { recursive: true });
+    this.state = this.loadOrCreate();
+    this.writeState();
+  }
+
+  get goal(): string {
+    return `Complete and obtain user acceptance for: ${this.state.task}`;
+  }
+
+  isPersistent(): boolean {
+    return this.state.mode === 'persistent';
+  }
+
+  selectMode(persistent: boolean, task: string): void {
+    this.state.mode = persistent ? 'persistent' : 'single';
+    this.state.task = task;
+    this.state.status = 'running';
+    this.state.accepted = false;
+    delete this.state.completionReason;
+    delete this.state.acceptanceFeedback;
+    this.writeState();
+  }
+
+  buildInitialPrompt(userPrompt: string): string {
+    return [
+      '## Persistent Work execution',
+      `Durable state: ${this.runDirectory}`,
+      'Continue until the requested work is implemented and verified.',
+      `Before calling agent_loop done, call ${PiWorkAcceptanceToolName} with a concise result and validation summary.`,
+      'Only an explicit user acceptance clears the completion gate.',
+      '',
+      userPrompt,
+    ].join('\n');
+  }
+
+  resumeForPrompt(task: string): void {
+    this.state.task = task;
+    this.state.status = 'running';
+    this.state.accepted = false;
+    this.state.iteration += 1;
+    delete this.state.completionReason;
+    delete this.state.acceptanceFeedback;
+    this.writeState();
+  }
+
+  requestCompletion(reason: string): string {
+    this.state.status = 'completion_requested';
+    this.state.completionReason = reason;
+    this.writeState();
+    return this.state.accepted
+      ? 'Completion requested after user acceptance. End this turn now.'
+      : `Completion remains blocked. Call ${PiWorkAcceptanceToolName} and wait for the user decision.`;
+  }
+
+  recordAcceptance(accepted: boolean, feedback: string): void {
+    this.state.accepted = accepted;
+    this.state.acceptanceFeedback = feedback;
+    if (!accepted) this.state.status = 'running';
+    this.writeState();
+  }
+
+  onAgentEnd(): { shouldFinish: boolean; reason?: string; nextPrompt?: string } {
+    if (this.state.mode !== 'persistent') {
+      return { shouldFinish: true, reason: 'Single-turn Work execution selected' };
+    }
+    if (this.state.status === 'completion_requested' && this.state.accepted) {
+      this.state.status = 'completed';
+      this.writeState();
+      return {
+        shouldFinish: true,
+        reason: this.state.completionReason || 'User accepted the Work result',
+      };
+    }
+    this.state.iteration += 1;
+    this.writeState();
+    if (this.state.accepted) {
+      return {
+        shouldFinish: false,
+        nextPrompt:
+          'The user accepted the result. Call agent_loop done with the final completion reason, then end the turn.',
+      };
+    }
+    return {
+      shouldFinish: false,
+      nextPrompt: [
+        '## Persistent Work continuation',
+        this.state.acceptanceFeedback
+          ? `Latest acceptance feedback: ${this.state.acceptanceFeedback}`
+          : 'The task has not received explicit user acceptance.',
+        `Continue concrete work and validation. When ready, call ${PiWorkAcceptanceToolName}; only after acceptance call agent_loop done.`,
+      ].join('\n'),
+    };
+  }
+
+  private loadOrCreate(): WorkExecutionState {
+    try {
+      if (fs.existsSync(this.statePath)) {
+        const parsed = JSON.parse(fs.readFileSync(this.statePath, 'utf8')) as WorkExecutionState;
+        if (parsed.version === 1 && parsed.sessionId === this.options.sessionId) return parsed;
+      }
+    } catch {}
+    return {
+      version: 1,
+      sessionId: this.options.sessionId,
+      task: this.options.task,
+      mode: 'pending',
+      status: 'running',
+      accepted: false,
+      iteration: 1,
+      updatedAt: now(),
+    };
+  }
+
+  private writeState(): void {
+    this.state.updatedAt = now();
+    fs.writeFileSync(this.statePath, JSON.stringify(this.state, null, 2));
+  }
+}
+
+export function buildPiWorkAcceptanceTool(
+  controller: PiWorkExecutionController,
+  request: PiAskUserQuestionRequester,
+): Record<string, unknown> {
+  return {
+    name: PiWorkAcceptanceToolName,
+    label: 'Work Acceptance',
+    description:
+      'Request final user acceptance for a persistent Work task after implementation and validation are complete.',
+    parameters: {
+      type: 'object',
+      properties: {
+        summary: {
+          type: 'string',
+          description: 'Concise result and validation summary shown to the user.',
+        },
+      },
+      required: ['summary'],
+      additionalProperties: false,
+    },
+    executionMode: 'sequential',
+    execute: async (toolCallId: string, params: Record<string, unknown>, signal?: AbortSignal) => {
+      const summary = typeof params.summary === 'string' ? params.summary.trim() : '';
+      const question = summary ? `当前结果是否达到要求？\n\n${summary}` : '当前结果是否达到要求？';
+      const response = await request(
+        toolCallId,
+        {
+          questions: [
+            {
+              header: '任务验收',
+              question,
+              options: [
+                { label: '验收通过', description: '允许任务完成。' },
+                { label: '继续完善', description: '保持任务运行并继续改进。' },
+              ],
+            },
+          ],
+        },
+        signal,
+      );
+      const answers = response.updatedInput?.answers;
+      const answer =
+        response.behavior === 'allow' && answers && typeof answers === 'object'
+          ? String((answers as Record<string, unknown>)[question] ?? '')
+          : response.message || '验收请求未获批准';
+      const accepted = answer === '验收通过';
+      controller.recordAcceptance(accepted, answer);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: accepted
+              ? 'User accepted the result. Call agent_loop done and end the turn.'
+              : `User requested more work (${answer || '继续完善'}). Continue the task.`,
+          },
+        ],
+        details: { accepted, answer },
+      };
+    },
+  };
+}

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -60,6 +60,8 @@ export type CoworkStartOptions = {
   autoApprove?: boolean;
   workspaceRoot?: string;
   confirmationMode?: 'modal' | 'text';
+  /** UI session mode, used to apply Work-only execution controls. */
+  sessionMode?: 'work' | 'chat';
   imageAttachments?: CoworkImageAttachment[];
   agentId?: string;
   expertIds?: string[];

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -75,6 +75,8 @@ export type CoworkStartOptions = {
 export type CoworkContinueOptions = {
   systemPrompt?: string;
   skillIds?: string[];
+  /** UI session mode, preserved when a skill change recreates the Pi session. */
+  sessionMode?: 'work' | 'chat';
   imageAttachments?: CoworkImageAttachment[];
   /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
   workspaceRoot?: string;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4291,6 +4291,7 @@ if (!gotTheLock) {
             skillIds: runtimeSkillIds,
             workspaceRoot: taskWorkingDirectory,
             confirmationMode: 'modal',
+            sessionMode: options.mode ?? CoworkSessionMode.Work,
             autoApprove: options.permissionMode === CoworkPermissionMode.AllowAll,
             imageAttachments: options.imageAttachments,
             agentId: options.agentId,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4442,6 +4442,10 @@ if (!gotTheLock) {
           .continueSession(options.sessionId, options.prompt, {
             systemPrompt: runtimeSystemPrompt,
             skillIds: runtimeSkillIds,
+            sessionMode:
+              existingSession?.mode === CoworkSessionMode.Chat
+                ? CoworkSessionMode.Chat
+                : CoworkSessionMode.Work,
             imageAttachments: options.imageAttachments,
             workspaceRoot: existingSession?.cwd,
             agentId: existingSession?.agentId,

--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -35,6 +35,11 @@ test('academic research selects Deli, deep research, and explicit web search tog
   for (const skillId of academic?.skillIds || []) expect(isCoreSkill(skillId)).toBe(true);
 });
 
+test('deep research selects explicit web search with its research protocol', () => {
+  const deepResearch = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'deep-research');
+  expect(deepResearch?.skillIds).toEqual(['deep-research', 'web-search']);
+});
+
 test('the chat skill allowlist is derived from CoreSkillId, not hardcoded', () => {
   const source = readFileSync(
     fileURLToPath(new URL('../cowork/CoworkPromptInput.tsx', import.meta.url)),

--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -2,7 +2,7 @@
  * Guards the wiring between the sidebar quick-skill shortcuts and the core
  * skill registry.
  *
- * Regression covered: a new shortcut was added for `deli-autoresearch` but
+ * Regression covered: a new academic-research shortcut was added but
  * CoworkPromptInput's hardcoded chat allowlist was not updated, so the skill
  * was filtered out of the chat skill list and the shortcut toasted
  * "skill unavailable" even though the skill is core (always enabled).
@@ -29,10 +29,29 @@ test('shortcut skillIds stay unique and match their entry ids where intended', (
   expect(new Set(skillIds).size).toBe(skillIds.length);
 });
 
-test('academic research selects Deli, deep research, and explicit web search together', () => {
+test('academic research selects Zhiyuan AutoResearch, deep research, and web search', () => {
   const academic = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'academic-research');
   expect(academic?.skillIds).toEqual(AcademicResearchSkillIds);
   for (const skillId of academic?.skillIds || []) expect(isCoreSkill(skillId)).toBe(true);
+});
+
+test('academic research does not expose the upstream Deli branding', () => {
+  const skillSource = readFileSync(
+    fileURLToPath(new URL('../../../../SKILLs/deli-autoresearch/SKILL.md', import.meta.url)),
+    'utf8',
+  );
+  const metadataSource = readFileSync(
+    fileURLToPath(
+      new URL('../../../../SKILLs/deli-autoresearch/zhiyuan/metadata.yaml', import.meta.url),
+    ),
+    'utf8',
+  );
+
+  expect(skillSource).toContain('name: zhiyuan_AutoResearch');
+  expect(skillSource).toContain('# zhiyuan_AutoResearch');
+  expect(skillSource).not.toMatch(/Deli[ _-]?AutoResearch/i);
+  expect(metadataSource).toContain('author: Zhiyuan');
+  expect(metadataSource).not.toMatch(/^author:\s*Deli\s*$/im);
 });
 
 test('deep research selects explicit web search with its research protocol', () => {

--- a/src/renderer/components/chat/constants.ts
+++ b/src/renderer/components/chat/constants.ts
@@ -1,6 +1,6 @@
 import { FileText, Globe, GraduationCap, Presentation, Table, Telescope } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { AcademicResearchSkillIds } from '@shared/skills/constants';
+import { AcademicResearchSkillIds, CoreSkillId } from '@shared/skills/constants';
 
 /**
  * Chat quick-skill shortcut entries.
@@ -30,6 +30,9 @@ export const CHAT_SKILL_SHORTCUTS: readonly ChatSkillShortcut[] = [
   {
     id: 'deep-research',
     skillId: 'deep-research',
+    // Deep research is a retrieval workflow. Selecting only its protocol
+    // leaves researchers without the bundled search capability.
+    skillIds: [CoreSkillId.DeepResearch, CoreSkillId.WebSearch],
     icon: Telescope,
     labelKey: 'chatSkillDeepResearch',
     placeholderKey: 'chatSkillPlaceholderDeepResearch',

--- a/src/shared/skills/constants.ts
+++ b/src/shared/skills/constants.ts
@@ -11,7 +11,7 @@ export const CoreSkillId = {
   Docx: 'docx',
   Xlsx: 'xlsx',
   DeepResearch: 'deep-research',
-  DeliAutoResearch: 'deli-autoresearch',
+  ZhiyuanAutoResearch: 'deli-autoresearch',
   WebSearch: 'web-search',
   FrontendDesign: 'frontend-design',
 } as const;
@@ -23,7 +23,7 @@ export const isCoreSkill = (id: string): id is CoreSkillId =>
 
 /** Skills that together form the first-class Academic Research workflow. */
 export const AcademicResearchSkillIds = [
-  CoreSkillId.DeliAutoResearch,
+  CoreSkillId.ZhiyuanAutoResearch,
   CoreSkillId.DeepResearch,
   CoreSkillId.WebSearch,
 ] as const;


### PR DESCRIPTION
## Summary

- add one durable completion controller for the PPT, deep research, document, website, and spreadsheet sidebar shortcuts
- keep shortcut sessions running when the model ends early; complete only after workflow-specific evidence is recorded
- require structurally valid Office output and validation records for artifact workflows
- require multi-angle delegated research with at least three successful researcher runs, six normalized reachable sources, and three distinct source hosts
- include web search in the deep-research shortcut and reject private or redirected-to-private research URLs
- ask Work-mode users with arbitrary skills whether to complete one turn or keep a managed loop running to explicit user acceptance
- recreate the Pi session when selected skills change so workflow controllers, tools, and questions match the new skill topology
- clear prior deliverable and research evidence when a completed workflow receives a new task
- expose the academic-research protocol as `zhiyuan_AutoResearch` and `Zhiyuan` while retaining its internal skill id for existing-session compatibility

## Root cause

Only the academic-research shortcut created a managed Pi loop. The other sidebar shortcuts were prompt-only, so a normal `agent_end` ended their session regardless of whether the work had been completed. The shared loop also accepted a generic completion signal without checking deliverables or research coverage.

The first Work-mode implementation still trusted the model's `done` signal, skill changes only reloaded prompt resources without rebuilding custom tools, and completed workflow state could satisfy a later task with stale evidence. Deep research counted researcher starts rather than successful results, while Office validation only checked the ZIP signature.

## Scope

- this follow-up intentionally does not add DNS or hostname SSRF hardening; the existing URL safety policy is unchanged

## Validation

- `npm run compile:electron`
- targeted academic-research, runtime, and workflow tests (70 passed)
- `npm test` (175 files passed; 1576 passed, 1 skipped)
- `npm run lint` (one pre-existing, unrelated hook-dependency warning)
- `npm run build`
