### PR TITLE
修复最终 PPTX 交付件延迟显示

### DIFF
--- a/src/renderer/services/artifactDetectionService.test.ts
+++ b/src/renderer/services/artifactDetectionService.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ArtifactRole } from '../types/artifact';
+import type { CoworkMessage } from '../types/cowork';
+import { ArtifactDetectionService } from './artifactDetectionService';
+import type {
+  ArtifactDetectionWorkerRequest,
+  ArtifactDetectionWorkerResponse,
+} from './artifactDetection.worker';
+import { detectArtifactsFromMessages } from './artifactParser';
+
+class FakeArtifactDetectionWorker {
+  static requests: ArtifactDetectionWorkerRequest[] = [];
+
+  onmessage: ((event: MessageEvent<ArtifactDetectionWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+
+  postMessage(request: ArtifactDetectionWorkerRequest): void {
+    FakeArtifactDetectionWorker.requests.push(request);
+    this.onmessage?.({
+      data: {
+        seq: request.seq,
+        artifacts: detectArtifactsFromMessages(request.messages, request.sessionId),
+      },
+    } as MessageEvent<ArtifactDetectionWorkerResponse>);
+  }
+
+  terminate(): void {}
+}
+
+describe('ArtifactDetectionService', () => {
+  beforeEach(() => {
+    FakeArtifactDetectionWorker.requests = [];
+    vi.stubGlobal('Worker', FakeArtifactDetectionWorker);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('reprocesses an assistant message when the same id becomes the final answer', async () => {
+    const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
+    const service = new ArtifactDetectionService(
+      detected => detectedArtifacts.push(...detected),
+      () => {},
+    );
+    const messageId = 'assistant-message';
+    const sessionId = 'session-1';
+    const thinkingMessage: CoworkMessage = {
+      id: messageId,
+      type: 'assistant',
+      content: 'Preparing the presentation.',
+      timestamp: 1,
+      metadata: { isStreaming: false, isFinal: true, isThinking: true },
+    };
+
+    await service.processMessages([thinkingMessage], sessionId);
+
+    const finalMessage: CoworkMessage = {
+      ...thinkingMessage,
+      content: 'Final file: `C:/workspace/presentation.pptx`',
+      metadata: {
+        isStreaming: false,
+        isFinal: true,
+        isFinalAnswer: true,
+      },
+    };
+    await service.processMessages([finalMessage], sessionId);
+    await service.processMessages([finalMessage], sessionId);
+
+    expect(FakeArtifactDetectionWorker.requests).toHaveLength(2);
+    expect(detectedArtifacts).toHaveLength(1);
+    expect(detectedArtifacts[0].artifact).toMatchObject({
+      messageId,
+      filePath: 'C:/workspace/presentation.pptx',
+      role: ArtifactRole.Deliverable,
+    });
+  });
+});

--- a/src/renderer/services/artifactDetectionService.ts
+++ b/src/renderer/services/artifactDetectionService.ts
@@ -27,11 +27,48 @@ export type ArtifactDetectionResult = {
   needsFileLoad: boolean;
 };
 
+type ProcessedMessageSnapshot = {
+  type: CoworkMessage['type'];
+  content: string;
+  metadata: string;
+};
+
+function createMessageSnapshot(message: CoworkMessage): ProcessedMessageSnapshot {
+  const metadata = message.metadata;
+  return {
+    type: message.type,
+    content: message.content,
+    metadata: JSON.stringify({
+      toolName: metadata?.toolName,
+      toolInput: metadata?.toolInput,
+      toolUseId: metadata?.toolUseId,
+      isError: metadata?.isError,
+      error: metadata?.error,
+      isStreaming: metadata?.isStreaming,
+      isFinal: metadata?.isFinal,
+      isFinalAnswer: metadata?.isFinalAnswer,
+      isThinking: metadata?.isThinking,
+    }),
+  };
+}
+
+function hasMessageChanged(
+  previous: ProcessedMessageSnapshot | undefined,
+  current: ProcessedMessageSnapshot,
+): boolean {
+  return (
+    !previous ||
+    previous.type !== current.type ||
+    previous.content !== current.content ||
+    previous.metadata !== current.metadata
+  );
+}
+
 export class ArtifactDetectionService {
   private worker: Worker | null = null;
   private pending = new Map<number, (result: ArtifactDetectionResult[]) => void>();
   private seq = 0;
-  private processedMessageIds = new Set<string>();
+  private processedMessages = new Map<string, ProcessedMessageSnapshot>();
   private loadedFileIds = new Set<string>();
 
   constructor(
@@ -72,24 +109,29 @@ export class ArtifactDetectionService {
   }
 
   /**
-   * Process only messages that have not been processed yet.
+   * Process when messages are added or their artifact-relevant state changes.
    *
    * For incremental detection we send the full message list because tool_use
    * messages need to be paired with their tool_result, and the result may
-   * arrive later. The worker deduplicates via message ids naturally; we just
-   * avoid redundant work on the caller side by remembering the last message
-   * count and re-sending from the start only when new messages appear.
+   * arrive later. Assistant messages also update in place while streaming, so
+   * message ids alone cannot determine whether a snapshot was processed.
    */
   async processMessages(
     messages: CoworkMessage[],
     sessionId: string,
     cwd?: string | null,
   ): Promise<void> {
-    const unprocessed = messages.filter(m => !this.processedMessageIds.has(m.id));
-    if (unprocessed.length === 0) return;
+    const snapshots = messages.map(message => ({
+      id: message.id,
+      snapshot: createMessageSnapshot(message),
+    }));
+    const hasChanges = snapshots.some(({ id, snapshot }) =>
+      hasMessageChanged(this.processedMessages.get(id), snapshot),
+    );
+    if (!hasChanges) return;
 
-    for (const m of messages) {
-      this.processedMessageIds.add(m.id);
+    for (const { id, snapshot } of snapshots) {
+      this.processedMessages.set(id, snapshot);
     }
 
     const detected = await this.detect(messages, sessionId);
@@ -100,7 +142,7 @@ export class ArtifactDetectionService {
   }
 
   reset(): void {
-    this.processedMessageIds.clear();
+    this.processedMessages.clear();
     this.loadedFileIds.clear();
   }
 


### PR DESCRIPTION
## 问题

当助手消息在同一消息 ID 下从思考/流式状态更新为最终回答时，工件检测服务会因为该 ID 已处理而跳过后续内容。结果是最终回复中的 PPTX 交付件不会立即显示；切换到其他会话再返回后，服务状态重置，交付件才会出现。

## 根因

工件检测此前仅使用消息 ID 去重，没有识别同一消息的内容及工件相关元数据已经发生变化。

## 修复

- 使用消息类型、内容和工件相关元数据组成处理快照
- 同一消息 ID 的内容或状态变化时重新触发工件检测
- 完全相同的消息快照继续跳过，避免重复检测
- 新增回归测试，覆盖同一助手消息从思考态更新为包含 PPTX 路径的最终回答

## 验证

- 定向测试：3 个测试文件、22 个测试通过
- TypeScript 检查通过
- 格式检查通过
- Lint 通过，保留 1 个与本次修改无关的既有警告
- 生产构建通过
- 全量测试：1578 个通过、1 个跳过、3 个失败；失败均为最新 main 上已有的 Windows/POSIX 路径断言问题，与本次修改无关
