### PR TITLE
feat(release): publish Ubuntu-first Linux desktop builds

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -107,17 +107,32 @@ jobs:
       - name: Install Electron system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0
+          sudo apt-get install -y \
+            libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
+            libxss1 libxtst6 libuuid1 xdg-utils xvfb
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Build Linux
         run: bun run dist:linux
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify the packaged renderer in a virtual Ubuntu desktop
+        shell: bash
+        run: |
+          mapfile -t executables < <(find release/linux-unpacked -maxdepth 1 -type f -perm -111)
+          if [[ ${#executables[@]} -ne 1 ]]; then
+            echo 'Expected exactly one packaged Linux executable' >&2
+            printf '%s\n' "${executables[@]}" >&2
+            exit 1
+          fi
+          node scripts/verify-linux-renderer.mjs \
+            "${executables[0]}" \
+            release/linux-render-smoke.png
       - uses: actions/upload-artifact@v4
         with:
           name: linux-build
           path: |
             release/*.AppImage
             release/*.deb
+            release/linux-render-smoke.png
           retention-days: 7

--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -117,18 +117,12 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
       - name: Verify the packaged renderer in a virtual Ubuntu desktop
-        shell: bash
-        run: |
-          mapfile -t executables < <(find release/linux-unpacked -maxdepth 1 -type f -perm -111)
-          if [[ ${#executables[@]} -ne 1 ]]; then
-            echo 'Expected exactly one packaged Linux executable' >&2
-            printf '%s\n' "${executables[@]}" >&2
-            exit 1
-          fi
-          node scripts/verify-linux-renderer.mjs \
-            "${executables[0]}" \
-            release/linux-render-smoke.png
+        run: >-
+          node scripts/verify-linux-renderer.mjs
+          release/linux-unpacked
+          release/linux-render-smoke.png
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: linux-build
           path: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -108,8 +108,57 @@ jobs:
       - uses: actions/upload-artifact@v4
         with: { name: darwin-arm64-default, path: "release/*.dmg" }
 
+  build-linux-x64:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.commit }}
+      - uses: actions/setup-node@v4
+        with: { node-version: "24.x" }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: "1.3.14" }
+      # OpenClaw is built with pnpm upstream; Bun remains this repository's installer.
+      - uses: pnpm/action-setup@v4
+        with: { version: 10 }
+      - name: Install Electron and virtual desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
+            libxss1 libxtst6 libuuid1 xdg-utils xvfb
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build Ubuntu deb and Linux AppImage
+        run: bun run dist:linux
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify the packaged renderer in a virtual Ubuntu desktop
+        shell: bash
+        run: |
+          mapfile -t executables < <(find release/linux-unpacked -maxdepth 1 -type f -perm -111)
+          if [[ ${#executables[@]} -ne 1 ]]; then
+            echo 'Expected exactly one packaged Linux executable' >&2
+            printf '%s\n' "${executables[@]}" >&2
+            exit 1
+          fi
+          node scripts/verify-linux-renderer.mjs \
+            "${executables[0]}" \
+            release/linux-render-smoke.png
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-default
+          path: |
+            release/*.deb
+            release/*.AppImage
+            release/linux-render-smoke.png
+
   publish:
-    needs: [prepare-release, build-windows-lite, build-macos-arm64]
+    needs: [prepare-release, build-windows-lite, build-macos-arm64, build-linux-x64]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -129,12 +178,19 @@ jobs:
         run: |
           mapfile -t windows_artifacts < <(find artifacts/win32-x64-lite -type f -name '*.exe')
           mapfile -t macos_artifacts < <(find artifacts/darwin-arm64-default -type f -name '*.dmg')
-          if [[ ${#windows_artifacts[@]} -ne 1 || ${#macos_artifacts[@]} -ne 1 ]]; then
-            echo 'Expected exactly one Windows installer and one macOS installer' >&2
+          mapfile -t linux_deb_artifacts < <(find artifacts/linux-x64-default -type f -name '*.deb')
+          mapfile -t linux_appimage_artifacts < <(find artifacts/linux-x64-default -type f -name '*.AppImage')
+          if [[ ${#windows_artifacts[@]} -ne 1 ||
+                ${#macos_artifacts[@]} -ne 1 ||
+                ${#linux_deb_artifacts[@]} -ne 1 ||
+                ${#linux_appimage_artifacts[@]} -ne 1 ]]; then
+            echo 'Expected exactly one Windows, macOS, Ubuntu deb, and AppImage installer' >&2
             exit 1
           fi
           echo "windows=${windows_artifacts[0]}" >> "$GITHUB_OUTPUT"
           echo "macos=${macos_artifacts[0]}" >> "$GITHUB_OUTPUT"
+          echo "linux_deb=${linux_deb_artifacts[0]}" >> "$GITHUB_OUTPUT"
+          echo "linux_appimage=${linux_appimage_artifacts[0]}" >> "$GITHUB_OUTPUT"
       - name: Create and verify signed manifest
         run: |
           node scripts/release/publish-update-manifest.mjs \
@@ -142,7 +198,9 @@ jobs:
             '${{ needs.prepare-release.outputs.version }}' \
             '${{ needs.prepare-release.outputs.commit }}' \
             '${{ steps.artifacts.outputs.windows }}:win32:x64:lite' \
-            '${{ steps.artifacts.outputs.macos }}:darwin:arm64:default'
+            '${{ steps.artifacts.outputs.macos }}:darwin:arm64:default' \
+            '${{ steps.artifacts.outputs.linux_deb }}:linux:x64:deb' \
+            '${{ steps.artifacts.outputs.linux_appimage }}:linux:x64:appimage'
         env:
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PRIVATE_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PRIVATE_KEY_BASE64 }}
@@ -194,18 +252,30 @@ jobs:
           version='${{ needs.prepare-release.outputs.version }}'
           windows_path='${{ steps.artifacts.outputs.windows }}'
           macos_path='${{ steps.artifacts.outputs.macos }}'
+          linux_deb_path='${{ steps.artifacts.outputs.linux_deb }}'
+          linux_appimage_path='${{ steps.artifacts.outputs.linux_appimage }}'
           windows_key="releases/$version/win32-x64-lite/$(basename "$windows_path")"
           macos_key="releases/$version/darwin-arm64-default/$(basename "$macos_path")"
+          linux_deb_key="releases/$version/linux-x64-deb/$(basename "$linux_deb_path")"
+          linux_appimage_key="releases/$version/linux-x64-appimage/$(basename "$linux_appimage_path")"
 
           aws s3 cp "$windows_path" "s3://$R2_BUCKET/$windows_key" \
             --cache-control 'public, max-age=31536000, immutable'
           aws s3 cp "$macos_path" "s3://$R2_BUCKET/$macos_key" \
             --cache-control 'public, max-age=31536000, immutable'
+          aws s3 cp "$linux_deb_path" "s3://$R2_BUCKET/$linux_deb_key" \
+            --cache-control 'public, max-age=31536000, immutable'
+          aws s3 cp "$linux_appimage_path" "s3://$R2_BUCKET/$linux_appimage_key" \
+            --cache-control 'public, max-age=31536000, immutable'
 
           windows_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$windows_key" --query ContentLength --output text)
           macos_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$macos_key" --query ContentLength --output text)
+          linux_deb_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$linux_deb_key" --query ContentLength --output text)
+          linux_appimage_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$linux_appimage_key" --query ContentLength --output text)
           [[ "$windows_remote_size" == "$(stat --format='%s' "$windows_path")" ]]
           [[ "$macos_remote_size" == "$(stat --format='%s' "$macos_path")" ]]
+          [[ "$linux_deb_remote_size" == "$(stat --format='%s' "$linux_deb_path")" ]]
+          [[ "$linux_appimage_remote_size" == "$(stat --format='%s' "$linux_appimage_path")" ]]
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -254,7 +324,9 @@ jobs:
           node scripts/release/verify-published-update.mjs \
             '${{ needs.prepare-release.outputs.version }}' \
             win32:x64:lite \
-            darwin:arm64:default
+            darwin:arm64:default \
+            linux:x64:deb \
+            linux:x64:appimage
           smoke_status=$?
           set -e
 

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -138,18 +138,12 @@ jobs:
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
       - name: Verify the packaged renderer in a virtual Ubuntu desktop
-        shell: bash
-        run: |
-          mapfile -t executables < <(find release/linux-unpacked -maxdepth 1 -type f -perm -111)
-          if [[ ${#executables[@]} -ne 1 ]]; then
-            echo 'Expected exactly one packaged Linux executable' >&2
-            printf '%s\n' "${executables[@]}" >&2
-            exit 1
-          fi
-          node scripts/verify-linux-renderer.mjs \
-            "${executables[0]}" \
-            release/linux-render-smoke.png
+        run: >-
+          node scripts/verify-linux-renderer.mjs
+          release/linux-unpacked
+          release/linux-render-smoke.png
       - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: linux-x64-default
           path: |

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -174,6 +174,7 @@
     "target": ["AppImage", "deb"],
     "icon": "build/icons/png",
     "category": "Utility",
+    "artifactName": "${productName}-${version}-${arch}.${ext}",
     "extraResources": [
       {
         "from": "SKILLs",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "dist:win": "npm run dist:win:lite",
     "dist:win:lite": "npm run openclaw:runtime:win-x64 && npm run prepare:update-release && cross-env RONGXINAI_WIN_LLAMACPP_BACKEND_BUNDLE=lite node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env RONGXINAI_WIN_LLAMACPP_BACKEND_BUNDLE=lite electron-builder --win nsis --x64 --config electron-builder.json --publish never",
     "dist:win:full": "npm run openclaw:runtime:win-x64 && npm run prepare:update-release && cross-env RONGXINAI_WIN_LLAMACPP_BACKEND_BUNDLE=full node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env RONGXINAI_WIN_LLAMACPP_BACKEND_BUNDLE=full electron-builder --win nsis --x64 --config electron-builder.json --publish never",
-    "predist:linux": "npm run openclaw:runtime:linux-x64",
+    "predist:linux": "npm run openclaw:runtime:linux-x64 && node scripts/ensure-build-version.js && npm run prepare:update-release",
     "dist:linux": "npm run build && npm run compile:electron && npm run build:skills && npm run prepare:modelscope-tokens && electron-builder --linux --publish never",
     "clean:release": "rimraf release",
     "generate:tray-icons": "node scripts/generate-tray-icons.js",

--- a/scripts/release/publish-update-manifest.mjs
+++ b/scripts/release/publish-update-manifest.mjs
@@ -19,6 +19,25 @@ const privateKey = crypto.createPrivateKey({
   type: 'pkcs8',
 });
 
+function resolveArtifactFormat(platform, variant) {
+  if (platform === 'win32' && (variant === 'lite' || variant === 'full')) {
+    return {
+      extension: '.exe',
+      contentType: 'application/vnd.microsoft.portable-executable',
+    };
+  }
+  if (platform === 'darwin' && variant === 'default') {
+    return { extension: '.dmg', contentType: 'application/x-apple-diskimage' };
+  }
+  if (platform === 'linux' && variant === 'deb') {
+    return { extension: '.deb', contentType: 'application/vnd.debian.binary-package' };
+  }
+  if (platform === 'linux' && variant === 'appimage') {
+    return { extension: '.appimage', contentType: 'application/vnd.appimage' };
+  }
+  throw new Error(`Unsupported release target: ${platform}:${variant}`);
+}
+
 const artifacts = await Promise.all(
   specs.map(async spec => {
     const [file, platform, arch, variant] = spec.split(':');
@@ -28,8 +47,8 @@ const artifacts = await Promise.all(
 
     const content = await fs.readFile(file);
     const extension = path.extname(file).toLowerCase();
-    const expectedExtension = platform === 'darwin' ? '.dmg' : '.exe';
-    if (extension !== expectedExtension || content.length === 0) {
+    const format = resolveArtifactFormat(platform, variant);
+    if (extension !== format.extension || content.length === 0) {
       throw new Error(`Invalid ${platform} artifact: ${file}`);
     }
 
@@ -51,10 +70,7 @@ const artifacts = await Promise.all(
         url: `https://downloads.rongxzyai.com/releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`,
         size: content.length,
         sha256: crypto.createHash('sha256').update(content).digest('hex'),
-        contentType:
-          extension === '.dmg'
-            ? 'application/x-apple-diskimage'
-            : 'application/vnd.microsoft.portable-executable',
+        contentType: format.contentType,
       },
       source: {
         commitSha,

--- a/scripts/release/update-manifest-lib.test.ts
+++ b/scripts/release/update-manifest-lib.test.ts
@@ -39,9 +39,13 @@ describe('online update release tools', () => {
   function createManifest(version: string, filename = 'installer') {
     const windowsArtifact = path.join(temporaryDirectory, `${filename}.exe`);
     const macosArtifact = path.join(temporaryDirectory, `${filename}.dmg`);
+    const linuxDebArtifact = path.join(temporaryDirectory, `${filename}.deb`);
+    const linuxAppImageArtifact = path.join(temporaryDirectory, `${filename}.AppImage`);
     const manifestPath = path.join(temporaryDirectory, `${version}-${filename}.json`);
     fs.writeFileSync(windowsArtifact, 'windows artifact');
     fs.writeFileSync(macosArtifact, 'macos artifact');
+    fs.writeFileSync(linuxDebArtifact, 'linux deb artifact');
+    fs.writeFileSync(linuxAppImageArtifact, 'linux appimage artifact');
 
     const result = runScript(
       'publish-update-manifest.mjs',
@@ -51,6 +55,8 @@ describe('online update release tools', () => {
         'a'.repeat(40),
         `${windowsArtifact}:win32:x64:lite`,
         `${macosArtifact}:darwin:arm64:default`,
+        `${linuxDebArtifact}:linux:x64:deb`,
+        `${linuxAppImageArtifact}:linux:x64:appimage`,
       ],
       releaseEnvironment,
     );
@@ -58,6 +64,34 @@ describe('online update release tools', () => {
     expect(result.status).toBe(0);
     return manifestPath;
   }
+
+  test('publishes signed Ubuntu deb and AppImage targets with their content types', () => {
+    const manifestPath = createManifest('2026.7.4', 'linux');
+    const collection = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      manifests: Array<{ payload: string }>;
+    };
+    const payloads = collection.manifests.map(envelope =>
+      JSON.parse(Buffer.from(envelope.payload, 'base64url').toString('utf8')),
+    );
+
+    expect(
+      payloads.map(payload => ({
+        target: `${payload.artifact.platform}:${payload.artifact.arch}:${payload.artifact.variant}`,
+        contentType: payload.artifact.contentType,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          target: 'linux:x64:deb',
+          contentType: 'application/vnd.debian.binary-package',
+        },
+        {
+          target: 'linux:x64:appimage',
+          contentType: 'application/vnd.appimage',
+        },
+      ]),
+    );
+  });
 
   test('enforces monotonic versions and same-version artifact idempotency', () => {
     const currentManifest = createManifest('2026.7.3', 'current');

--- a/scripts/verify-linux-renderer.mjs
+++ b/scripts/verify-linux-renderer.mjs
@@ -40,7 +40,7 @@ let applicationOutput = '';
 
 const application = spawn(
   'xvfb-run',
-  ['-a', executablePath, `--remote-debugging-port=${remoteDebuggingPort}`],
+  ['-a', executablePath, '--no-sandbox', `--remote-debugging-port=${remoteDebuggingPort}`],
   {
     detached: true,
     env: {

--- a/scripts/verify-linux-renderer.mjs
+++ b/scripts/verify-linux-renderer.mjs
@@ -1,0 +1,268 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { inflateSync } from 'node:zlib';
+
+const [executablePath, screenshotPath = 'release/linux-render-smoke.png'] =
+  process.argv.slice(2);
+if (!executablePath) {
+  throw new Error(
+    'usage: verify-linux-renderer.mjs <linux-unpacked-executable> [screenshot-output]',
+  );
+}
+
+const remoteDebuggingPort = 9222;
+let applicationOutput = '';
+
+const application = spawn(
+  'xvfb-run',
+  ['-a', executablePath, `--remote-debugging-port=${remoteDebuggingPort}`],
+  {
+    detached: true,
+    env: {
+      ...process.env,
+      ELECTRON_ENABLE_LOGGING: 'true',
+      ZHIYUAN_ENABLE_GPU: 'false',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+);
+
+for (const stream of [application.stdout, application.stderr]) {
+  stream?.on('data', chunk => {
+    applicationOutput = `${applicationOutput}${chunk.toString()}`.slice(-20_000);
+  });
+}
+
+function delay(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function waitForPageTarget() {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (application.exitCode !== null) {
+      throw new Error(`Linux application exited before rendering:\n${applicationOutput}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${remoteDebuggingPort}/json/list`, {
+        signal: AbortSignal.timeout(1_500),
+      });
+      if (response.ok) {
+        const targets = await response.json();
+        const page = targets.find(
+          target =>
+            target.type === 'page' &&
+            typeof target.webSocketDebuggerUrl === 'string' &&
+            typeof target.url === 'string' &&
+            target.url.startsWith('file:'),
+        );
+        if (page) return page;
+      }
+    } catch {
+      // The DevTools endpoint is expected to be unavailable while Electron starts.
+    }
+    await delay(500);
+  }
+  throw new Error(`Timed out waiting for the Linux renderer:\n${applicationOutput}`);
+}
+
+function connectToDevTools(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(webSocketDebuggerUrl);
+    const pending = new Map();
+    let sequence = 0;
+
+    socket.addEventListener('open', () => {
+      resolve({
+        send(method, params = {}) {
+          const id = (sequence += 1);
+          socket.send(JSON.stringify({ id, method, params }));
+          return new Promise((resolveCommand, rejectCommand) => {
+            pending.set(id, { resolve: resolveCommand, reject: rejectCommand });
+          });
+        },
+        close() {
+          socket.close();
+        },
+      });
+    });
+    socket.addEventListener('message', event => {
+      const message = JSON.parse(String(event.data));
+      if (!message.id || !pending.has(message.id)) return;
+      const command = pending.get(message.id);
+      pending.delete(message.id);
+      if (message.error) {
+        command.reject(new Error(message.error.message));
+      } else {
+        command.resolve(message.result);
+      }
+    });
+    socket.addEventListener('error', () => reject(new Error('DevTools WebSocket failed')));
+  });
+}
+
+async function waitForRenderedContent(devTools) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const evaluation = await devTools.send('Runtime.evaluate', {
+      expression: `(() => {
+        const root = document.getElementById('root');
+        return {
+          readyState: document.readyState,
+          rootChildren: root?.childElementCount ?? 0,
+          text: document.body?.innerText?.trim().slice(0, 500) ?? ''
+        };
+      })()`,
+      returnByValue: true,
+    });
+    const state = evaluation.result?.value;
+    if (state?.readyState === 'complete' && state.rootChildren > 0 && state.text.length >= 10) {
+      return state;
+    }
+    await delay(500);
+  }
+  throw new Error(`Renderer loaded but did not show application content:\n${applicationOutput}`);
+}
+
+function paethPredictor(left, above, upperLeft) {
+  const estimate = left + above - upperLeft;
+  const leftDistance = Math.abs(estimate - left);
+  const aboveDistance = Math.abs(estimate - above);
+  const upperLeftDistance = Math.abs(estimate - upperLeft);
+  if (leftDistance <= aboveDistance && leftDistance <= upperLeftDistance) return left;
+  return aboveDistance <= upperLeftDistance ? above : upperLeft;
+}
+
+function analyzeScreenshot(png) {
+  const signature = png.subarray(0, 8).toString('hex');
+  if (signature !== '89504e470d0a1a0a') throw new Error('DevTools returned an invalid PNG');
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  const imageDataChunks = [];
+
+  while (offset < png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.subarray(offset + 4, offset + 8).toString('ascii');
+    const data = png.subarray(offset + 8, offset + 8 + length);
+    offset += length + 12;
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+      interlace = data[12];
+    } else if (type === 'IDAT') {
+      imageDataChunks.push(data);
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+
+  const bytesPerPixel = colorType === 6 ? 4 : colorType === 2 ? 3 : 0;
+  if (!width || !height || bitDepth !== 8 || !bytesPerPixel || interlace !== 0) {
+    throw new Error(
+      `Unsupported screenshot PNG format: ${width}x${height}, depth=${bitDepth}, color=${colorType}, interlace=${interlace}`,
+    );
+  }
+
+  const inflated = inflateSync(Buffer.concat(imageDataChunks));
+  const rowLength = width * bytesPerPixel;
+  const previous = Buffer.alloc(rowLength);
+  const current = Buffer.alloc(rowLength);
+  const distinctColors = new Set();
+  let darkSamples = 0;
+  let samples = 0;
+  let inputOffset = 0;
+
+  for (let y = 0; y < height; y += 1) {
+    const filter = inflated[inputOffset];
+    inputOffset += 1;
+    for (let x = 0; x < rowLength; x += 1) {
+      const encoded = inflated[inputOffset + x];
+      const left = x >= bytesPerPixel ? current[x - bytesPerPixel] : 0;
+      const above = previous[x];
+      const upperLeft = x >= bytesPerPixel ? previous[x - bytesPerPixel] : 0;
+      if (filter === 0) current[x] = encoded;
+      else if (filter === 1) current[x] = (encoded + left) & 0xff;
+      else if (filter === 2) current[x] = (encoded + above) & 0xff;
+      else if (filter === 3) current[x] = (encoded + Math.floor((left + above) / 2)) & 0xff;
+      else if (filter === 4) {
+        current[x] = (encoded + paethPredictor(left, above, upperLeft)) & 0xff;
+      } else {
+        throw new Error(`Unsupported PNG row filter: ${filter}`);
+      }
+    }
+    inputOffset += rowLength;
+
+    if (y % 8 === 0) {
+      for (let x = 0; x < width; x += 8) {
+        const pixelOffset = x * bytesPerPixel;
+        const red = current[pixelOffset];
+        const green = current[pixelOffset + 1];
+        const blue = current[pixelOffset + 2];
+        distinctColors.add(`${red >> 4}:${green >> 4}:${blue >> 4}`);
+        if (red < 235 || green < 235 || blue < 235) darkSamples += 1;
+        samples += 1;
+      }
+    }
+    current.copy(previous);
+  }
+
+  return {
+    width,
+    height,
+    distinctColors: distinctColors.size,
+    nonWhiteRatio: samples ? darkSamples / samples : 0,
+  };
+}
+
+async function stopApplication() {
+  if (!application.pid || application.exitCode !== null) return;
+  try {
+    process.kill(-application.pid, 'SIGTERM');
+  } catch {
+    // The application may already have exited after the smoke test.
+  }
+  await Promise.race([new Promise(resolve => application.once('exit', resolve)), delay(5_000)]);
+  if (application.exitCode === null) {
+    try {
+      process.kill(-application.pid, 'SIGKILL');
+    } catch {
+      // Ignore a race with normal shutdown.
+    }
+  }
+}
+
+let devTools;
+try {
+  const page = await waitForPageTarget();
+  devTools = await connectToDevTools(page.webSocketDebuggerUrl);
+  await devTools.send('Page.enable');
+  const renderedState = await waitForRenderedContent(devTools);
+  const screenshot = await devTools.send('Page.captureScreenshot', {
+    format: 'png',
+    captureBeyondViewport: false,
+  });
+  const screenshotBytes = Buffer.from(screenshot.data, 'base64');
+  const screenshotAnalysis = analyzeScreenshot(screenshotBytes);
+  if (screenshotAnalysis.distinctColors < 8 || screenshotAnalysis.nonWhiteRatio < 0.01) {
+    throw new Error(
+      `Linux renderer screenshot appears blank: ${JSON.stringify(screenshotAnalysis)}`,
+    );
+  }
+
+  await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+  await fs.writeFile(screenshotPath, screenshotBytes);
+  console.log(
+    `[LinuxRendererSmoke] rendered ${renderedState.rootChildren} root element(s) with visible text; screenshot ${screenshotAnalysis.width}x${screenshotAnalysis.height}, ${screenshotAnalysis.distinctColors} sampled colors`,
+  );
+} finally {
+  devTools?.close();
+  await stopApplication();
+}

--- a/scripts/verify-linux-renderer.mjs
+++ b/scripts/verify-linux-renderer.mjs
@@ -3,14 +3,38 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { inflateSync } from 'node:zlib';
 
-const [executablePath, screenshotPath = 'release/linux-render-smoke.png'] =
+const [executableInput, screenshotPath = 'release/linux-render-smoke.png'] =
   process.argv.slice(2);
-if (!executablePath) {
+if (!executableInput) {
   throw new Error(
-    'usage: verify-linux-renderer.mjs <linux-unpacked-executable> [screenshot-output]',
+    'usage: verify-linux-renderer.mjs <linux-unpacked-directory-or-executable> [screenshot-output]',
   );
 }
 
+async function resolveExecutable(inputPath) {
+  const inputStat = await fs.stat(inputPath);
+  if (inputStat.isFile()) return inputPath;
+  if (!inputStat.isDirectory()) {
+    throw new Error(`Linux renderer input is not a file or directory: ${inputPath}`);
+  }
+
+  const builderConfig = JSON.parse(
+    await fs.readFile(new URL('../electron-builder.json', import.meta.url), 'utf8'),
+  );
+  const executableName = builderConfig.executableName ?? builderConfig.productName;
+  if (!executableName) {
+    throw new Error('electron-builder.json does not define executableName or productName');
+  }
+
+  const resolvedPath = path.join(inputPath, executableName);
+  const resolvedStat = await fs.stat(resolvedPath);
+  if (!resolvedStat.isFile() || (resolvedStat.mode & 0o111) === 0) {
+    throw new Error(`Packaged Linux executable is missing or not executable: ${resolvedPath}`);
+  }
+  return resolvedPath;
+}
+
+const executablePath = await resolveExecutable(executableInput);
 const remoteDebuggingPort = 9222;
 let applicationOutput = '';
 
@@ -239,17 +263,38 @@ async function stopApplication() {
   }
 }
 
-let devTools;
-try {
-  const page = await waitForPageTarget();
-  devTools = await connectToDevTools(page.webSocketDebuggerUrl);
-  await devTools.send('Page.enable');
-  const renderedState = await waitForRenderedContent(devTools);
+async function captureScreenshot(devTools) {
   const screenshot = await devTools.send('Page.captureScreenshot', {
     format: 'png',
     captureBeyondViewport: false,
   });
   const screenshotBytes = Buffer.from(screenshot.data, 'base64');
+  await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+  await fs.writeFile(screenshotPath, screenshotBytes);
+  return screenshotBytes;
+}
+
+let devTools;
+try {
+  const page = await waitForPageTarget();
+  devTools = await connectToDevTools(page.webSocketDebuggerUrl);
+  await devTools.send('Page.enable');
+  let renderedState;
+  try {
+    renderedState = await waitForRenderedContent(devTools);
+  } catch (error) {
+    try {
+      await captureScreenshot(devTools);
+      console.error(`[LinuxRendererSmoke] saved failure screenshot to ${screenshotPath}`);
+    } catch (screenshotError) {
+      console.error(
+        `[LinuxRendererSmoke] could not capture failure screenshot: ${screenshotError.message}`,
+      );
+    }
+    throw error;
+  }
+
+  const screenshotBytes = await captureScreenshot(devTools);
   const screenshotAnalysis = analyzeScreenshot(screenshotBytes);
   if (screenshotAnalysis.distinctColors < 8 || screenshotAnalysis.nonWhiteRatio < 0.01) {
     throw new Error(
@@ -257,8 +302,6 @@ try {
     );
   }
 
-  await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
-  await fs.writeFile(screenshotPath, screenshotBytes);
   console.log(
     `[LinuxRendererSmoke] rendered ${renderedState.rootChildren} root element(s) with visible text; screenshot ${screenshotAnalysis.width}x${screenshotAnalysis.height}, ${screenshotAnalysis.distinctColors} sampled colors`,
   );

--- a/src/main/libs/appUpdateCoordinator.test.ts
+++ b/src/main/libs/appUpdateCoordinator.test.ts
@@ -32,7 +32,22 @@ class MemoryStore {
   }
 }
 
-function signedManifest(privateKey: crypto.KeyObject) {
+type ManifestTarget = {
+  platform: 'darwin' | 'linux';
+  arch: 'arm64' | 'x64';
+  variant: 'appimage' | 'deb' | 'default';
+  filename: string;
+};
+
+function signedManifest(
+  privateKey: crypto.KeyObject,
+  target: ManifestTarget = {
+    platform: 'darwin',
+    arch: 'arm64',
+    variant: 'default',
+    filename: 'ZhiYuan.dmg',
+  },
+) {
   const payload = {
     channel: 'stable',
     version: '2026.7.2',
@@ -44,10 +59,10 @@ function signedManifest(privateKey: crypto.KeyObject) {
       en: { title: 'Test release', items: ['Bug fixes'] },
     },
     artifact: {
-      platform: 'darwin',
-      arch: 'arm64',
-      variant: 'default',
-      url: 'https://downloads.rongxzyai.com/releases/2026.7.2/darwin-arm64-default/ZhiYuan.dmg',
+      platform: target.platform,
+      arch: target.arch,
+      variant: target.variant,
+      url: `https://downloads.rongxzyai.com/releases/2026.7.2/${target.platform}-${target.arch}-${target.variant}/${target.filename}`,
       size: 1024,
       sha256: 'a'.repeat(64),
     },
@@ -65,6 +80,7 @@ function signedManifest(privateKey: crypto.KeyObject) {
 describe('AppUpdateCoordinator manifest cache', () => {
   const originalPlatform = process.platform;
   const originalArch = process.arch;
+  const originalAppImage = process.env.APPIMAGE;
   let privateKey: crypto.KeyObject;
   let publicKeyBase64: string;
 
@@ -81,6 +97,11 @@ describe('AppUpdateCoordinator manifest cache', () => {
     delete (APP_UPDATE_TRUSTED_KEYS as Record<string, string>)['test-release-key'];
     Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform });
     Object.defineProperty(process, 'arch', { configurable: true, value: originalArch });
+    if (originalAppImage === undefined) {
+      delete process.env.APPIMAGE;
+    } else {
+      process.env.APPIMAGE = originalAppImage;
+    }
     vi.unstubAllGlobals();
   });
 
@@ -132,5 +153,52 @@ describe('AppUpdateCoordinator manifest cache', () => {
 
     expect(restartedResult.updateFound).toBe(true);
     expect(restartedResult.state.status).toBe(AppUpdateStatus.Available);
+  });
+
+  test.each([
+    {
+      name: 'AppImage',
+      appImage: '/opt/zhiyuan/zhiyuan.AppImage',
+      variant: 'appimage' as const,
+      filename: 'ZhiYuan.AppImage',
+    },
+    {
+      name: 'Ubuntu deb',
+      appImage: undefined,
+      variant: 'deb' as const,
+      filename: 'zhiyuan_amd64.deb',
+    },
+  ])('selects the matching Linux $name update artifact', async target => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' });
+    Object.defineProperty(process, 'arch', { configurable: true, value: 'x64' });
+    if (target.appImage) {
+      process.env.APPIMAGE = target.appImage;
+    } else {
+      delete process.env.APPIMAGE;
+    }
+
+    const envelope = signedManifest(privateKey, {
+      platform: 'linux',
+      arch: 'x64',
+      variant: target.variant,
+      filename: target.filename,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(envelope), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await new AppUpdateCoordinator(
+      new MemoryStore() as unknown as SqliteStore,
+    ).checkNow();
+    const requestedUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+
+    expect(result.updateFound).toBe(true);
+    expect(result.state.info?.url).toContain(target.filename);
+    expect(requestedUrl.searchParams.get('platform')).toBe('linux');
+    expect(requestedUrl.searchParams.get('variant')).toBe(target.variant);
   });
 });

--- a/src/main/libs/appUpdateCoordinator.ts
+++ b/src/main/libs/appUpdateCoordinator.ts
@@ -18,6 +18,8 @@ import type { SqliteStore } from '../sqliteStore';
 const UPDATE_ENDPOINT = 'https://updates.rongxzyai.com/v1/updates/latest';
 const DOWNLOAD_HOST = 'downloads.rongxzyai.com';
 const MANIFEST_CACHE_KEY_PREFIX = 'app_update_manifest_cache';
+const SUPPORTED_UPDATE_PLATFORMS = new Set(['win32', 'darwin', 'linux']);
+const SUPPORTED_UPDATE_ARCHITECTURES = new Set(['x64', 'arm64']);
 
 type ManifestReleaseNotes = {
   zh?: { title?: unknown; items?: unknown };
@@ -161,7 +163,9 @@ export class AppUpdateCoordinator {
     const platform = process.platform;
     const arch = process.arch;
     const variant = this.resolveBuildVariant();
-    if (!['win32', 'darwin'].includes(platform) || !['x64', 'arm64'].includes(arch)) return null;
+    if (!SUPPORTED_UPDATE_PLATFORMS.has(platform) || !SUPPORTED_UPDATE_ARCHITECTURES.has(arch)) {
+      return null;
+    }
 
     const cacheKey = `${MANIFEST_CACHE_KEY_PREFIX}:${platform}:${arch}:${variant}`;
     const cachedManifest = this.readCachedManifest(cacheKey);
@@ -277,7 +281,14 @@ export class AppUpdateCoordinator {
     }
 
     const downloadUrl = new URL(artifact.url);
-    const expectedExtension = target.platform === 'darwin' ? '.dmg' : '.exe';
+    const expectedExtension =
+      target.platform === 'darwin'
+        ? '.dmg'
+        : target.platform === 'linux'
+          ? target.variant === 'appimage'
+            ? '.appimage'
+            : '.deb'
+          : '.exe';
     if (
       downloadUrl.protocol !== 'https:' ||
       downloadUrl.hostname !== DOWNLOAD_HOST ||
@@ -308,6 +319,9 @@ export class AppUpdateCoordinator {
   }
 
   private resolveBuildVariant(): string {
+    if (process.platform === 'linux') {
+      return process.env.APPIMAGE ? 'appimage' : 'deb';
+    }
     if (process.platform !== 'win32') return 'default';
     try {
       const packageJson = JSON.parse(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -204,6 +204,7 @@ import {
   loadOpenClawSessionPolicyConfig,
   saveOpenClawSessionPolicyConfig,
 } from './openclawSessionPolicy/store';
+import { configureRendererStartup } from './rendererStartup';
 import { SkillManager } from './skillManager';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
@@ -718,11 +719,6 @@ const isWindows = process.platform === 'win32';
 const DEV_SERVER_URL = process.env.ELECTRON_START_URL || 'http://localhost:5175';
 const enableVerboseLogging =
   process.env.ELECTRON_ENABLE_LOGGING === '1' || process.env.ELECTRON_ENABLE_LOGGING === 'true';
-const disableGpu =
-  process.env.ZHIYUAN_DISABLE_GPU === '1' ||
-  process.env.ZHIYUAN_DISABLE_GPU === 'true' ||
-  process.env.ELECTRON_DISABLE_GPU === '1' ||
-  process.env.ELECTRON_DISABLE_GPU === 'true';
 const reloadOnChildProcessGone =
   process.env.ELECTRON_RELOAD_ON_CHILD_PROCESS_GONE === '1' ||
   process.env.ELECTRON_RELOAD_ON_CHILD_PROCESS_GONE === 'true';
@@ -877,20 +873,18 @@ const requestCalendarPermission = async (): Promise<boolean> => {
   return false;
 };
 
-// 配置应用
-// Linux/Windows 禁用 Chromium 沙箱：桌面应用渲染自有代码，风险可控；
-// Windows 下以管理员运行时沙箱无法降权会导致 GPU 进程启动失败 (error_code=18)
-if (isLinux || isWindows) {
-  app.commandLine.appendSwitch('no-sandbox');
-}
-if (isLinux) {
-  app.commandLine.appendSwitch('disable-dev-shm-usage');
-}
-if (disableGpu) {
-  app.commandLine.appendSwitch('disable-gpu');
-  app.commandLine.appendSwitch('disable-software-rasterizer');
-  // 禁用硬件加速
-  app.disableHardwareAcceleration();
+// Configure Chromium switches before app readiness. Linux defaults to software rendering to avoid
+// blank windows on incompatible Ubuntu GPU/Wayland combinations. This does not affect llama.cpp.
+const rendererStartup = configureRendererStartup({
+  platform: process.platform,
+  env: process.env,
+  commandLine: app.commandLine,
+  disableHardwareAcceleration: () => app.disableHardwareAcceleration(),
+});
+if (isLinux && rendererStartup.softwareRenderingEnabled) {
+  console.log(
+    '[RendererStartup] software rendering is enabled; set ZHIYUAN_ENABLE_GPU=1 to opt in to GPU acceleration',
+  );
 }
 if (enableVerboseLogging) {
   app.commandLine.appendSwitch('enable-logging');

--- a/src/main/rendererStartup.test.ts
+++ b/src/main/rendererStartup.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { configureRendererStartup } from './rendererStartup';
+
+function configure(platform: string, env: NodeJS.ProcessEnv = {}) {
+  const switches: string[] = [];
+  const disableHardwareAcceleration = vi.fn();
+
+  const result = configureRendererStartup({
+    platform,
+    env,
+    commandLine: {
+      appendSwitch(name) {
+        switches.push(name);
+      },
+    },
+    disableHardwareAcceleration,
+  });
+
+  return { ...result, switches, disableHardwareAcceleration };
+}
+
+describe('configureRendererStartup', () => {
+  test('uses software rendering by default on Linux without disabling the software rasterizer', () => {
+    const result = configure('linux');
+
+    expect(result.softwareRenderingEnabled).toBe(true);
+    expect(result.switches).toEqual(['no-sandbox', 'disable-dev-shm-usage', 'disable-gpu']);
+    expect(result.switches).not.toContain('disable-software-rasterizer');
+    expect(result.disableHardwareAcceleration).toHaveBeenCalledOnce();
+  });
+
+  test('allows Linux users to opt into hardware acceleration', () => {
+    const result = configure('linux', { ZHIYUAN_ENABLE_GPU: 'true' });
+
+    expect(result.softwareRenderingEnabled).toBe(false);
+    expect(result.switches).toEqual(['no-sandbox', 'disable-dev-shm-usage']);
+    expect(result.disableHardwareAcceleration).not.toHaveBeenCalled();
+  });
+
+  test('gives an explicit GPU disable request precedence over the Linux opt-in', () => {
+    const result = configure('linux', {
+      ZHIYUAN_DISABLE_GPU: '1',
+      ZHIYUAN_ENABLE_GPU: '1',
+    });
+
+    expect(result.softwareRenderingEnabled).toBe(true);
+    expect(result.switches).toContain('disable-gpu');
+    expect(result.disableHardwareAcceleration).toHaveBeenCalledOnce();
+  });
+
+  test('keeps hardware acceleration enabled by default on Windows', () => {
+    const result = configure('win32');
+
+    expect(result.softwareRenderingEnabled).toBe(false);
+    expect(result.switches).toEqual(['no-sandbox']);
+    expect(result.disableHardwareAcceleration).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/rendererStartup.ts
+++ b/src/main/rendererStartup.ts
@@ -1,0 +1,48 @@
+export const RendererStartupEnvironment = {
+  DisableGpu: 'ZHIYUAN_DISABLE_GPU',
+  ElectronDisableGpu: 'ELECTRON_DISABLE_GPU',
+  EnableGpu: 'ZHIYUAN_ENABLE_GPU',
+} as const;
+
+type RendererPlatform = 'darwin' | 'linux' | 'win32' | string;
+
+type ChromiumCommandLine = {
+  appendSwitch(name: string, value?: string): void;
+};
+
+type RendererStartupInput = {
+  platform: RendererPlatform;
+  env: NodeJS.ProcessEnv;
+  commandLine: ChromiumCommandLine;
+  disableHardwareAcceleration: () => void;
+};
+
+const isEnabled = (value: string | undefined): boolean => value === '1' || value === 'true';
+
+export function configureRendererStartup(input: RendererStartupInput): {
+  softwareRenderingEnabled: boolean;
+} {
+  const { platform, env, commandLine, disableHardwareAcceleration } = input;
+  const isLinux = platform === 'linux';
+  const isWindows = platform === 'win32';
+
+  if (isLinux || isWindows) {
+    commandLine.appendSwitch('no-sandbox');
+  }
+  if (isLinux) {
+    commandLine.appendSwitch('disable-dev-shm-usage');
+  }
+
+  const gpuDisabledByEnvironment =
+    isEnabled(env[RendererStartupEnvironment.DisableGpu]) ||
+    isEnabled(env[RendererStartupEnvironment.ElectronDisableGpu]);
+  const linuxGpuOptIn = isEnabled(env[RendererStartupEnvironment.EnableGpu]);
+  const softwareRenderingEnabled = gpuDisabledByEnvironment || (isLinux && !linuxGpuOptIn);
+
+  if (softwareRenderingEnabled) {
+    commandLine.appendSwitch('disable-gpu');
+    disableHardwareAcceleration();
+  }
+
+  return { softwareRenderingEnabled };
+}


### PR DESCRIPTION
## What changed

- build and publish Linux x64 `.deb` and `.AppImage` installers in the existing release workflow
- add Linux artifacts to the signed stable update manifest and desktop updater
- default Linux Electron rendering to the software path, with an explicit `ZHIYUAN_ENABLE_GPU=1` escape hatch
- add a packaged-app renderer smoke test under Xvfb that checks visible DOM content and rejects blank or near-uniform screenshots
- retain the smoke-test screenshot as a CI artifact for diagnosis

## Why

The website needs a supported Linux desktop download, with Ubuntu as the primary target. Earlier Ubuntu builds could open as an entirely white window, which is commonly associated with Electron GPU/compositor incompatibilities on Linux. The new Linux startup policy avoids that rendering path by default and the release pipeline now verifies the packaged UI before publishing.

## User impact

Ubuntu x64 users receive a native `.deb` package. Other Linux distributions can use the AppImage. Linux desktop updates are also supported through the signed release manifest.

## Validation

- `npm test -- rendererStartup appUpdateCoordinator update-manifest-lib` - 11 tests passed
- `npm run compile:electron`
- `npm run lint` - passed with one unrelated pre-existing hook-dependency warning
- `npm run build`
- workflow YAML parse and release-script syntax checks
- `git diff --check`

The Linux packaged-renderer smoke test will run in GitHub Actions on Ubuntu before release publication.
