### PR TITLE
feat: 修改侧边栏的呈现动画

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -62,8 +62,8 @@ const MIN_SIDEBAR_WIDTH = 220;
 const MAX_SIDEBAR_WIDTH = 420;
 const SIDEBAR_COLLAPSE_TRANSITION_MS = 200;
 const sidebarNavItemClassName =
-  'w-full inline-flex items-center justify-start gap-2 rounded-lg px-3 py-1.5 text-left text-[14px] font-normal text-muted-foreground transition-colors hover:bg-black/3 dark:hover:bg-white/4';
-const activeSidebarNavItemClassName = `${sidebarNavItemClassName} bg-black/3 dark:bg-white/4`;
+  'sidebar-interactive-surface w-full inline-flex items-center justify-start gap-2 rounded-lg px-3 py-1.5 text-left text-[14px] font-normal text-muted-foreground transition-colors';
+const activeSidebarNavItemClassName = `${sidebarNavItemClassName} sidebar-interactive-surface-active text-foreground`;
 const sidebarCreateIconClassName = 'h-4 w-4 shrink-0';
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -414,7 +414,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           'inline-flex h-8 w-full items-center justify-start gap-2 overflow-hidden rounded-lg px-3 text-left text-[14px] font-normal text-muted-foreground',
           searchActive
             ? 'cursor-text bg-background'
-            : 'cursor-pointer transition-colors hover:bg-black/3 dark:hover:bg-white/4',
+            : 'sidebar-interactive-surface cursor-pointer transition-colors',
         )}
       >
         <Search className="h-4 w-4 shrink-0" />
@@ -464,6 +464,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       className={`relative shrink-0 overflow-hidden bg-surface-raised ${
         isResizing ? '' : 'sidebar-transition'
       }`}
+      data-active-view={activeView}
       style={{ width: isCollapsed ? 0 : sidebarWidth }}
     >
       <div

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -107,14 +107,14 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
 
   return (
     <div
-      className={`group relative ${
+      className={`sidebar-session-row group relative ${
         isNested ? 'ml-[-6px] w-[calc(100%+12px)]' : 'ml-0 w-full'
       } flex h-[30px] cursor-pointer items-center gap-2 rounded-md ${
         isBatchMode ? 'pl-4' : isNested ? 'pl-[38px]' : 'pl-3'
       } ${!isBatchMode && !isRenaming ? 'pr-[58px]' : 'pr-2.5'} text-[14px] font-normal transition-colors ${
         isSelected
-          ? 'bg-black/3 text-foreground dark:bg-white/4'
-          : 'text-muted-foreground hover:bg-black/3 hover:text-foreground dark:hover:bg-white/4'
+          ? 'sidebar-interactive-surface-active text-foreground'
+          : 'sidebar-interactive-surface text-muted-foreground hover:text-foreground'
       }`}
       onClick={handleRowClick}
       role="treeitem"

--- a/src/renderer/components/agentSidebar/ExpandAgentTasksRow.tsx
+++ b/src/renderer/components/agentSidebar/ExpandAgentTasksRow.tsx
@@ -16,7 +16,7 @@ const ExpandAgentTasksRow: React.FC<ExpandAgentTasksRowProps> = ({ isLoading, la
       variant="ghost"
       onClick={onClick}
       disabled={isLoading}
-      className="ml-[-6px] flex h-7 w-[calc(100%+12px)] items-center justify-start rounded-md pl-[38px] pr-2.5 text-left text-[13px] font-normal text-foreground opacity-[0.28] hover:bg-black/3 disabled:cursor-not-allowed disabled:opacity-60 dark:hover:bg-white/4"
+      className="sidebar-interactive-surface ml-[-6px] flex h-7 w-[calc(100%+12px)] items-center justify-start rounded-md pl-[38px] pr-2.5 text-left text-[13px] font-normal text-foreground opacity-[0.28] disabled:cursor-not-allowed disabled:opacity-60"
     >
       {isLoading ? i18nService.t('loading') : label}
     </Button>

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -57,8 +57,8 @@ const ChatSkillShortcuts: React.FC = () => {
               className={cn(
                 'flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-[14px] transition-colors',
                 isActive
-                  ? 'bg-black/3 font-medium text-foreground dark:bg-white/4'
-                  : 'text-muted-foreground hover:bg-black/3 hover:text-foreground dark:hover:bg-white/4',
+                  ? 'sidebar-interactive-surface-active font-medium text-foreground'
+                  : 'sidebar-interactive-surface text-muted-foreground hover:text-foreground',
                 isStreaming && 'pointer-events-none opacity-50',
               )}
             >

--- a/src/renderer/components/localInference/panels/MarketplacePanel.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.tsx
@@ -210,13 +210,6 @@ export function MarketplacePanel({
     setTokenModalOpen(false);
   };
 
-  const handleClearToken = async () => {
-    setTokenInput('');
-    await window.electron.marketplace.setToken('');
-    onTokenSaved(null);
-    setTokenModalOpen(false);
-  };
-
   const handleInstall = async (model: MarketplaceModel) => {
     setInstallingModelIds(prev => new Set(prev).add(model.id));
     try {
@@ -458,17 +451,7 @@ export function MarketplacePanel({
               </InputGroupAddon>
             </InputGroup>
           </div>
-          <div className="flex items-center justify-between pt-1">
-            <Button
-              type="button"
-              onClick={handleClearToken}
-              disabled={!savedToken}
-              className={localInferenceCompactButtonClass}
-              size="sm"
-              variant="destructive"
-            >
-              {i18nService.t('marketplaceTokenClear')}
-            </Button>
+          <div className="flex items-center justify-end pt-1">
             <div className="flex items-center gap-2">
               <Button
                 type="button"

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -518,6 +518,17 @@ select::-ms-expand {
   background-color: var(--zy-surface-raised);
 }
 
+/* Sidebar interactive surfaces follow the active application theme. */
+.sidebar-interactive-surface:hover,
+.sidebar-interactive-surface-active {
+  background-color: color-mix(in srgb, var(--zy-text-primary) 4%, transparent);
+}
+
+[data-active-view]:not([data-active-view='cowork']) .sidebar-session-row.sidebar-interactive-surface-active {
+  background-color: transparent;
+  color: var(--zy-text-secondary);
+}
+
 /* Sidebar width transition */
 .sidebar-transition {
   transition: width 200ms ease-out;


### PR DESCRIPTION
## 摘要

  优化侧边栏选中态视觉效果，并简化魔搭社区 API Token 配置弹窗。

  ## 关联问题

  Fixes #215 

  ## 修改内容

  - 删除魔搭社区 API Token 弹窗底部独立的“清除”按钮。
  - 为侧边栏导航、对话快捷技能和会话列表增加主题适配的底光效果。
  - 保持当前选中导航项的文字高亮。
  - 切换到其他工作页面时，隐藏项目会话残留的选中高亮。
  - 为展开任务行同步应用侧边栏交互样式。

  ## 变更类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 已在本地测试
  - [ ] 已新增测试
  - [ ] 已更新现有测试
  - [ ] 已完成手动测试

  已执行：

  - `npm run build:tsc`
  - `npm run lint`
  - `git diff --check`

  ## 截图

  涉及 UI 修改，请在 PR 中附上界面截图。

  ## 检查清单

  - [x] 代码符合项目编码规范
  - [x] 已完成自我检查
  - [ ] 已为复杂逻辑补充必要注释
  - [ ] 已同步更新相关文档
  - [x] 未引入新的警告
  - [ ] 已新增验证修复效果的测试
  - [ ] 新旧单元测试均已通过

  ## Electron 相关修改

  - [ ] 修改主进程（`src/main/`）
  - [ ] 修改预加载脚本（`src/main/preload.ts`）
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 无 Electron 相关修改

  ## 补充说明

  Lint 中仍存在 `src/renderer/components/mcp/McpManager.tsx` 的既有 `exhaustive-deps` 警告，本次未新增警告。