### PR TITLE
refactor(ui): 统一应用按钮组件

### DIFF
--- a/src/renderer/components/CodeBlock.tsx
+++ b/src/renderer/components/CodeBlock.tsx
@@ -34,7 +34,7 @@ import {
   rectangularSelection,
 } from '@codemirror/view';
 import { indentationMarkers } from '@replit/codemirror-indentation-markers';
-import { Button } from '@shared/components/ui/button';
+import { Button, buttonVariants } from '@shared/components/ui/button';
 // CopyIcon removed — using Copy from lucide-react instead
 import {
   Tooltip,
@@ -389,14 +389,22 @@ function buildSearchPanel(view: EditorView): Panel {
   // Prev / Next buttons
   const prevBtn = document.createElement('button');
   prevBtn.type = 'button';
-  prevBtn.className = 'cm-search-nav-btn';
+  prevBtn.className = buttonVariants({
+    variant: 'outline',
+    size: 'icon-sm',
+    className: 'cm-search-nav-btn [&_svg]:size-3.5',
+  });
   prevBtn.title = t('codeSearchPrev');
   prevBtn.innerHTML =
     '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>';
 
   const nextBtn = document.createElement('button');
   nextBtn.type = 'button';
-  nextBtn.className = 'cm-search-nav-btn';
+  nextBtn.className = buttonVariants({
+    variant: 'outline',
+    size: 'icon-sm',
+    className: 'cm-search-nav-btn [&_svg]:size-3.5',
+  });
   nextBtn.title = t('codeSearchNext');
   nextBtn.innerHTML =
     '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>';
@@ -424,7 +432,11 @@ function buildSearchPanel(view: EditorView): Panel {
   // Close button
   const closeBtn = document.createElement('button');
   closeBtn.type = 'button';
-  closeBtn.className = 'cm-search-close-btn';
+  closeBtn.className = buttonVariants({
+    variant: 'ghost',
+    size: 'icon-sm',
+    className: 'cm-search-close-btn [&_svg]:size-3.5',
+  });
   closeBtn.title = t('codeSearchClose');
   closeBtn.setAttribute('aria-label', t('codeSearchClose'));
   closeBtn.innerHTML =

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -288,7 +288,7 @@ const getProviderStatusBadge = (
       }
     : {
         labelKey: 'providerStatusOff',
-                className: 'bg-destructive/20 text-destructive',
+        className: 'bg-destructive/20 text-destructive',
       };
 };
 const normalizeBaseUrl = (baseUrl: string): string =>
@@ -2973,71 +2973,30 @@ const Settings: React.FC<SettingsProps> = ({
           {(['light', 'dark', 'system'] as const).map(mode => {
             const isSelected = theme === mode;
             return (
-              <button
+              <Button
                 key={mode}
                 type="button"
+                variant="outline"
+                size="lg"
+                aria-pressed={isSelected}
                 onClick={() => {
                   setTheme(mode);
                   themeService.setTheme(mode);
                 }}
-                className="flex flex-col items-center rounded-xl border-2 p-3 transition-colors cursor-pointer"
+                className="h-auto w-full flex-col items-center rounded-xl border-2 p-3"
                 style={{
                   borderColor: isSelected ? 'var(--zy-primary)' : 'var(--zy-border)',
-                  backgroundColor: isSelected ? 'var(--zy-primary-muted)' : undefined,
+                  backgroundColor: isSelected ? 'var(--zy-primary-muted)' : 'transparent',
                 }}
               >
-                <svg
-                  viewBox="0 0 120 80"
-                  className="w-full h-auto rounded-md mb-2 overflow-hidden"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  {mode === 'light' && (
-                    <>
-                      <rect width="120" height="80" fill="#ffffff" />
-                      <rect x="0" y="0" width="30" height="80" fill="#f4f4f5" />
-                      <rect x="4" y="8" width="22" height="4" rx="2" fill="#a1a1aa" />
-                      <rect x="4" y="16" width="18" height="3" rx="1.5" fill="#d4d4d8" />
-                      <rect x="4" y="22" width="20" height="3" rx="1.5" fill="#d4d4d8" />
-                      <rect x="4" y="28" width="16" height="3" rx="1.5" fill="#d4d4d8" />
-                      <rect x="36" y="8" width="78" height="64" rx="4" fill="#ffffff" />
-                      <rect x="42" y="16" width="50" height="4" rx="2" fill="#d4d4d8" />
-                      <rect x="42" y="24" width="66" height="3" rx="1.5" fill="#e5e5e5" />
-                      <rect x="42" y="30" width="60" height="3" rx="1.5" fill="#e5e5e5" />
-                      <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#e5e5e5" />
-                      <rect x="42" y="46" width="40" height="4" rx="2" fill="#d4d4d8" />
-                      <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#e5e5e5" />
-                      <rect x="42" y="60" width="58" height="3" rx="1.5" fill="#e5e5e5" />
-                    </>
-                  )}
-                  {mode === 'dark' && (
-                    <>
-                      <rect width="120" height="80" fill="#1a1d23" />
-                      <rect x="0" y="0" width="30" height="80" fill="#2d2d2d" />
-                      <rect x="4" y="8" width="22" height="4" rx="2" fill="#52525b" />
-                      <rect x="4" y="16" width="18" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="4" y="22" width="20" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="4" y="28" width="16" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="36" y="8" width="78" height="64" rx="4" fill="#2d2d2d" />
-                      <rect x="42" y="16" width="50" height="4" rx="2" fill="#52525b" />
-                      <rect x="42" y="24" width="66" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="42" y="30" width="60" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="42" y="46" width="40" height="4" rx="2" fill="#52525b" />
-                      <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#3f3f46" />
-                      <rect x="42" y="60" width="58" height="3" rx="1.5" fill="#3f3f46" />
-                    </>
-                  )}
-                  {mode === 'system' && (
-                    <>
-                      <defs>
-                        <clipPath id="left-half">
-                          <rect x="0" y="0" width="60" height="80" />
-                        </clipPath>
-                        <clipPath id="right-half">
-                          <rect x="60" y="0" width="60" height="80" />
-                        </clipPath>
-                      </defs>
-                      <g clipPath="url(#left-half)">
+                <span className="mb-2 block aspect-[3/2] w-full overflow-hidden rounded-md">
+                  <svg
+                    viewBox="0 0 120 80"
+                    className="size-full"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    {mode === 'light' && (
+                      <>
                         <rect width="120" height="80" fill="#ffffff" />
                         <rect x="0" y="0" width="30" height="80" fill="#f4f4f5" />
                         <rect x="4" y="8" width="22" height="4" rx="2" fill="#a1a1aa" />
@@ -3051,8 +3010,11 @@ const Settings: React.FC<SettingsProps> = ({
                         <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#e5e5e5" />
                         <rect x="42" y="46" width="40" height="4" rx="2" fill="#d4d4d8" />
                         <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#e5e5e5" />
-                      </g>
-                      <g clipPath="url(#right-half)">
+                        <rect x="42" y="60" width="58" height="3" rx="1.5" fill="#e5e5e5" />
+                      </>
+                    )}
+                    {mode === 'dark' && (
+                      <>
                         <rect width="120" height="80" fill="#1a1d23" />
                         <rect x="0" y="0" width="30" height="80" fill="#2d2d2d" />
                         <rect x="4" y="8" width="22" height="4" rx="2" fill="#52525b" />
@@ -3066,22 +3028,64 @@ const Settings: React.FC<SettingsProps> = ({
                         <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#3f3f46" />
                         <rect x="42" y="46" width="40" height="4" rx="2" fill="#52525b" />
                         <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#3f3f46" />
-                      </g>
-                      <line x1="60" y1="0" x2="60" y2="80" stroke="#71717a" strokeWidth="0.5" />
-                    </>
-                  )}
-                </svg>
+                        <rect x="42" y="60" width="58" height="3" rx="1.5" fill="#3f3f46" />
+                      </>
+                    )}
+                    {mode === 'system' && (
+                      <>
+                        <defs>
+                          <clipPath id="left-half">
+                            <rect x="0" y="0" width="60" height="80" />
+                          </clipPath>
+                          <clipPath id="right-half">
+                            <rect x="60" y="0" width="60" height="80" />
+                          </clipPath>
+                        </defs>
+                        <g clipPath="url(#left-half)">
+                          <rect width="120" height="80" fill="#ffffff" />
+                          <rect x="0" y="0" width="30" height="80" fill="#f4f4f5" />
+                          <rect x="4" y="8" width="22" height="4" rx="2" fill="#a1a1aa" />
+                          <rect x="4" y="16" width="18" height="3" rx="1.5" fill="#d4d4d8" />
+                          <rect x="4" y="22" width="20" height="3" rx="1.5" fill="#d4d4d8" />
+                          <rect x="4" y="28" width="16" height="3" rx="1.5" fill="#d4d4d8" />
+                          <rect x="36" y="8" width="78" height="64" rx="4" fill="#ffffff" />
+                          <rect x="42" y="16" width="50" height="4" rx="2" fill="#d4d4d8" />
+                          <rect x="42" y="24" width="66" height="3" rx="1.5" fill="#e5e5e5" />
+                          <rect x="42" y="30" width="60" height="3" rx="1.5" fill="#e5e5e5" />
+                          <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#e5e5e5" />
+                          <rect x="42" y="46" width="40" height="4" rx="2" fill="#d4d4d8" />
+                          <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#e5e5e5" />
+                        </g>
+                        <g clipPath="url(#right-half)">
+                          <rect width="120" height="80" fill="#1a1d23" />
+                          <rect x="0" y="0" width="30" height="80" fill="#2d2d2d" />
+                          <rect x="4" y="8" width="22" height="4" rx="2" fill="#52525b" />
+                          <rect x="4" y="16" width="18" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="4" y="22" width="20" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="4" y="28" width="16" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="36" y="8" width="78" height="64" rx="4" fill="#2d2d2d" />
+                          <rect x="42" y="16" width="50" height="4" rx="2" fill="#52525b" />
+                          <rect x="42" y="24" width="66" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="42" y="30" width="60" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="42" y="36" width="55" height="3" rx="1.5" fill="#3f3f46" />
+                          <rect x="42" y="46" width="40" height="4" rx="2" fill="#52525b" />
+                          <rect x="42" y="54" width="66" height="3" rx="1.5" fill="#3f3f46" />
+                        </g>
+                        <line x1="60" y1="0" x2="60" y2="80" stroke="#71717a" strokeWidth="0.5" />
+                      </>
+                    )}
+                  </svg>
+                </span>
                 <span
                   className="text-xs font-medium"
                   style={{ color: isSelected ? 'var(--zy-primary)' : 'var(--zy-text-primary)' }}
                 >
                   {i18nService.t(mode)}
                 </span>
-              </button>
+              </Button>
             );
           })}
         </div>
-
       </div>
     </div>
   );
@@ -4765,14 +4769,16 @@ const Settings: React.FC<SettingsProps> = ({
                       {i18nService.t('availableModels')}
                     </h3>
                     {activeProvider !== ProviderName.LlamaCpp && (
-                      <button
+                      <Button
                         type="button"
+                        variant="link"
+                        size="xs"
                         onClick={handleAddModel}
-                        className="inline-flex items-center text-xs text-primary hover:text-primary-hover"
+                        className="h-auto px-0 py-0 [&_svg]:size-3.5"
                       >
-                        <PlusCircle className="h-3.5 w-3.5 mr-1" />
+                        <PlusCircle data-icon="inline-start" />
                         {i18nService.t('addModel')}
-                      </button>
+                      </Button>
                     )}
                   </div>
 
@@ -4802,8 +4808,10 @@ const Settings: React.FC<SettingsProps> = ({
                             )}
                             {activeProvider !== ProviderName.LlamaCpp && (
                               <>
-                                <button
+                                <Button
                                   type="button"
+                                  variant="ghost"
+                                  size="icon-xs"
                                   onClick={() =>
                                     handleEditModel(
                                       model.id,
@@ -4812,17 +4820,23 @@ const Settings: React.FC<SettingsProps> = ({
                                       model.capabilities,
                                     )
                                   }
-                                  className="p-0.5 text-muted-foreground hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
+                                  aria-label={`${i18nService.t('editModel')} ${model.name}`}
+                                  title={i18nService.t('editModel')}
+                                  className="size-5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground [&_svg]:size-3.5"
                                 >
-                                  <Pencil className="h-3.5 w-3.5" />
-                                </button>
-                                <button
+                                  <Pencil />
+                                </Button>
+                                <Button
                                   type="button"
+                                  variant="ghost"
+                                  size="icon-xs"
                                   onClick={() => handleDeleteModel(model.id)}
-                                  className="p-0.5 text-muted-foreground hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                                  aria-label={`${i18nService.t('delete')} ${model.name}`}
+                                  title={i18nService.t('delete')}
+                                  className="size-5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive [&_svg]:size-3.5"
                                 >
-                                  <Trash2 className="h-3.5 w-3.5" />
-                                </button>
+                                  <Trash2 />
+                                </Button>
                               </>
                             )}
                           </div>
@@ -4837,14 +4851,16 @@ const Settings: React.FC<SettingsProps> = ({
                           {i18nService.t('noModelsAvailable')}
                         </p>
                         {activeProvider !== ProviderName.LlamaCpp && (
-                          <button
+                          <Button
                             type="button"
+                            variant="link"
+                            size="xs"
                             onClick={handleAddModel}
-                            className="mt-1.5 inline-flex items-center text-[11px] font-medium text-primary hover:text-primary-hover"
+                            className="mt-1.5 h-auto px-0 py-0"
                           >
-                            <PlusCircle className="h-3 w-3 mr-1" />
+                            <PlusCircle data-icon="inline-start" />
                             {i18nService.t('addFirstModel')}
-                          </button>
+                          </Button>
                         )}
                       </div>
                     )}
@@ -5095,8 +5111,16 @@ const Settings: React.FC<SettingsProps> = ({
         return (
           <div className="flex min-h-full flex-col items-center pt-6 pb-3">
             {/* Logo & App Name */}
-            <img src="zhiyuan-logo-light.svg" alt="知远" className="logo-light h-16 w-auto mb-3 select-none" />
-            <img src="zhiyuan-logo-dark.svg" alt="知远" className="logo-dark h-16 w-auto mb-3 select-none" />
+            <img
+              src="zhiyuan-logo-light.svg"
+              alt="知远"
+              className="logo-light h-16 w-auto mb-3 select-none"
+            />
+            <img
+              src="zhiyuan-logo-dark.svg"
+              alt="知远"
+              className="logo-dark h-16 w-auto mb-3 select-none"
+            />
             <span className="text-xs text-muted-foreground mt-1">v{appVersion}</span>
             <span className="text-xs text-muted-foreground mt-0.5">开放源码，汇聚智慧</span>
 
@@ -5402,9 +5426,7 @@ const Settings: React.FC<SettingsProps> = ({
                 </Button>
               </div>
 
-              {modelFormError && (
-                <p className="mb-3 text-xs text-destructive">{modelFormError}</p>
-              )}
+              {modelFormError && <p className="mb-3 text-xs text-destructive">{modelFormError}</p>}
 
               <div className="space-y-3">
                 {activeProvider === 'ollama' ? (

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -441,18 +441,20 @@ const Sidebar: React.FC<SidebarProps> = ({
               className="h-full min-h-0 min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-none text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
             {searchQuery && (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="icon-xs"
                 aria-label={i18nService.t('clearSearch')}
                 onClick={event => {
                   event.stopPropagation();
                   setSearchQuery('');
                   searchInputRef.current?.focus();
                 }}
-                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                className="size-4 shrink-0 text-muted-foreground hover:bg-transparent hover:text-foreground active:translate-y-0 dark:hover:bg-transparent [&_svg]:size-3.5"
               >
-                <X className="h-3.5 w-3.5" />
-              </button>
+                <X />
+              </Button>
             )}
           </>
         ) : (

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@shared/components/ui/button';
 import { cn } from '@shared/lib/utils';
 import { MotionConfig, useReducedMotion } from 'motion/react';
 import React from 'react';
@@ -104,9 +105,10 @@ const ChatSkillShortcuts: React.FC = () => {
             const selectedSkillIds = entry.skillIds || [entry.skillId];
             const isActive = selectedSkillIds.every(skillId => activeSkillIds.includes(skillId));
             return (
-              <button
+              <Button
                 key={entry.id}
                 type="button"
+                variant="ghost"
                 data-chat-skill-shortcut={entry.id}
                 disabled={isStreaming}
                 onMouseEnter={() => {
@@ -117,18 +119,17 @@ const ChatSkillShortcuts: React.FC = () => {
                 }}
                 onClick={() => handleSelect(entry)}
                 className={cn(
-                  'chat-skill-shortcut flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors',
+                  'chat-skill-shortcut w-full justify-start gap-2 px-3 text-left',
                   isActive
                     ? 'bg-surface-raised font-medium text-foreground'
                     : 'text-muted-foreground hover:bg-surface-raised hover:text-foreground',
-                  isStreaming && 'pointer-events-none opacity-50',
                 )}
               >
                 {animatedIcon?.icon ?? (
                   <Icon aria-hidden="true" className="chat-skill-shortcut-icon size-4 shrink-0" />
                 )}
                 <span className="min-w-0 truncate">{i18nService.t(entry.labelKey)}</span>
-              </button>
+              </Button>
             );
           })}
         </div>

--- a/src/renderer/components/cowork/CoworkQuestionWizard.tsx
+++ b/src/renderer/components/cowork/CoworkQuestionWizard.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/ui/button';
-import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { cn } from '@shared/lib/utils';
+import { Check, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
@@ -305,33 +306,25 @@ const CoworkQuestionWizard: React.FC<CoworkQuestionWizardProps> = ({ permission,
                     );
 
                     return (
-                      <button
+                      <Button
                         key={index}
                         type="button"
+                        variant={isActive ? 'default' : isAnswered ? 'outline' : 'secondary'}
+                        size="icon-sm"
+                        aria-current={isActive ? 'step' : undefined}
+                        aria-label={`${index + 1}. ${question.question}`}
                         onClick={() => setCurrentStep(index)}
-                        className={`relative flex items-center justify-center w-7 h-7 rounded-full text-xs font-medium transition-all ${
-                          isActive
-                            ? 'bg-primary text-white shadow-md'
-                            : isAnswered
-                              ? 'bg-green-500/20 dark:bg-green-600/20 text-green-700 dark:text-green-400 border border-green-500 dark:border-green-600 hover:scale-105'
-                              : 'bg-surface-raised text-muted-foreground hover:bg-primary/20 dark:hover:bg-primary/20 hover:scale-105'
-                        }`}
+                        className={cn(
+                          'rounded-full [&_svg]:size-3.5',
+                          isActive && 'shadow-md',
+                          isAnswered &&
+                            !isActive &&
+                            'border-success bg-success/10 text-success hover:bg-success/20',
+                        )}
                         title={question.question}
                       >
-                        {isAnswered && !isActive ? (
-                          <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none">
-                            <path
-                              d="M13 4L6 11L3 8"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                          </svg>
-                        ) : (
-                          index + 1
-                        )}
-                      </button>
+                        {isAnswered && !isActive ? <Check /> : index + 1}
+                      </Button>
                     );
                   })}
                 </div>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -4,7 +4,15 @@ import {
   ConversationScrollButton,
 } from '@shared/components/ai-elements/conversation';
 import { Button } from '@shared/components/ui/button';
-import { Download, Folder, Image as ImageIcon, MessageCirclePlus, PanelLeft } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Download,
+  Folder,
+  Image as ImageIcon,
+  MessageCirclePlus,
+  PanelLeft,
+} from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -1213,8 +1221,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 }}
               >
                 {/* Up Arrow */}
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={i18nService.t('coworkQuestionWizardPrevious')}
+                  disabled={
+                    (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
+                  }
                   onClick={() => {
                     const resolvedRail =
                       currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex;
@@ -1224,30 +1238,17 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                   onMouseEnter={() => {
                     setHoveredRailIndex(null);
                   }}
-                  className={`shrink-0 flex items-center justify-center w-5 h-5 mb-2 mr-[-5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
+                  className={`mb-2 mr-[-5px] size-5 rounded-full text-muted-foreground active:translate-y-0 [&_svg]:size-3.5
                 ${
                   !isRailHovered
-                    ? 'opacity-0 pointer-events-none'
+                    ? 'pointer-events-none opacity-0'
                     : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) <= 0
                       ? 'opacity-30 cursor-default'
-                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                      : 'cursor-pointer hover:text-foreground'
                 }`}
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2.5}
-                    stroke="currentColor"
-                    className="w-3.5 h-3.5"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M4.5 15.75l7.5-7.5 7.5 7.5"
-                    />
-                  </svg>
-                </button>
+                  <ChevronUp />
+                </Button>
 
                 {/* Message Lines */}
                 <div
@@ -1337,9 +1338,12 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                       const ratio = msg.contentLen / maxLen;
                       const lineW = Math.round(MIN_W + ratio * (MAX_W - MIN_W));
                       return (
-                        <button
+                        <Button
                           key={msg.key}
                           type="button"
+                          variant="ghost"
+                          aria-label={msg.label}
+                          aria-current={isActive ? 'true' : undefined}
                           onClick={() => {
                             navigateToRailItem(idx);
                           }}
@@ -1358,25 +1362,30 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                             });
                           }}
                           onMouseLeave={() => setRailTooltip(null)}
-                          className="flex items-center justify-end cursor-pointer w-5 py-[5px]"
+                          className="h-auto w-5 cursor-pointer justify-end rounded-none px-0 py-[5px] hover:bg-transparent active:translate-y-0 dark:hover:bg-transparent"
                         >
                           <div
                             className={`h-[2px] rounded-full transition-all ${
-                              isActive || isHovered
-                                ? 'bg-neutral-800 dark:bg-neutral-200'
-                                : 'bg-neutral-300 dark:bg-neutral-600'
+                              isActive || isHovered ? 'bg-foreground' : 'bg-border'
                             }`}
                             style={{ width: isActive || isHovered ? MAX_W : lineW }}
                           />
-                        </button>
+                        </Button>
                       );
                     });
                   })()}
                 </div>
 
                 {/* Down Arrow */}
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={i18nService.t('coworkQuestionWizardNext')}
+                  disabled={
+                    (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >=
+                    railItemCountRef.current - 1
+                  }
                   onClick={() => {
                     const maxRail = railItemCountRef.current - 1;
                     const resolvedRail = currentRailIndex < 0 ? maxRail : currentRailIndex;
@@ -1386,31 +1395,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                   onMouseEnter={() => {
                     setHoveredRailIndex(null);
                   }}
-                  className={`shrink-0 flex items-center justify-center w-5 h-5 mt-2 mr-[-5px] rounded-full transition-all text-neutral-600 dark:text-neutral-400
+                  className={`mt-2 mr-[-5px] size-5 rounded-full text-muted-foreground active:translate-y-0 [&_svg]:size-3.5
                 ${
                   !isRailHovered
-                    ? 'opacity-0 pointer-events-none'
+                    ? 'pointer-events-none opacity-0'
                     : (currentRailIndex < 0 ? railItemCountRef.current - 1 : currentRailIndex) >=
                         railItemCountRef.current - 1
                       ? 'opacity-30 cursor-default'
-                      : 'cursor-pointer hover:text-neutral-800 dark:hover:text-neutral-200 hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60'
+                      : 'cursor-pointer hover:text-foreground'
                 }`}
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={2.5}
-                    stroke="currentColor"
-                    className="w-3.5 h-3.5"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-                    />
-                  </svg>
-                </button>
+                  <ChevronDown />
+                </Button>
               </div>
             )}
 

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -45,9 +45,7 @@ import type {
 } from './types';
 import { LocalInferenceToastKind } from './types';
 import { getLocalInferenceUserFacingErrorMessage } from './utils/errors';
-import {
-  buildMarketplaceSearchParams,
-} from './utils/marketplace';
+import { buildMarketplaceSearchParams } from './utils/marketplace';
 import {
   isInstallTerminalPhase,
   isPullInProgress,
@@ -639,8 +637,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
     if (nextTab === activeTab) return;
     launchLogs.closePanel();
     setTabDirection(
-      LOCAL_INFERENCE_TAB_ORDER.indexOf(nextTab) >=
-        LOCAL_INFERENCE_TAB_ORDER.indexOf(activeTab)
+      LOCAL_INFERENCE_TAB_ORDER.indexOf(nextTab) >= LOCAL_INFERENCE_TAB_ORDER.indexOf(activeTab)
         ? 1
         : -1,
     );
@@ -654,80 +651,88 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
         onValueChange={handleTabChange}
         className="flex h-full min-h-0 flex-1 flex-col gap-0"
       >
-      <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
-        <div className="flex items-center space-x-3 h-8">
-          {isSidebarCollapsed && (
-            <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
-              <button
-                type="button"
-                onClick={onToggleSidebar}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-surface-raised hover:text-foreground"
-              >
-                <PanelLeft className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-surface-raised hover:text-foreground"
-              >
-                <Pencil className="h-4 w-4" />
-              </button>
-              {updateBadge}
-            </div>
-          )}
-          <h1 className="text-lg font-semibold text-foreground">
-            {i18nService.t('localInferenceTitle')}
-          </h1>
-        </div>
-        <WindowTitleBar inline />
-      </div>
-      <LocalInferenceTabSelector activeTab={activeTab} isVisible={isVisible} />
-      {toast && (
-        <div className="pointer-events-none absolute right-4 top-16 z-30 flex w-[min(24rem,calc(100%-2rem))] justify-end">
-          <LocalInferenceToastView toast={toast} onClose={dismissToast} />
-        </div>
-      )}
-        <div className="relative flex min-h-0 flex-1 overflow-hidden">
-        <div
-          ref={contentViewportRef}
-          className="min-w-0 flex-1 overflow-y-auto scrollbar-gutter-stable [overflow-anchor:none]"
-        >
-          <div className="w-full space-y-4 px-6 py-4">
-            {activeTab === 'models' ? (
-              <div className="flex flex-wrap items-center justify-end gap-2">
+        <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
+          <div className="flex items-center space-x-3 h-8">
+            {isSidebarCollapsed && (
+              <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
                 <Button
                   type="button"
-                  variant="outline"
-                  className={localInferenceCompactButtonClass}
-                  size="sm"
-                  onClick={openAccessSettings}
+                  variant="ghost"
+                  size="icon"
+                  onClick={onToggleSidebar}
+                  aria-label={i18nService.t('collapse')}
+                  title={i18nService.t('collapse')}
+                  className="text-foreground/70 hover:text-foreground"
                 >
-                  <Globe data-icon="inline-start" />
-                  {i18nService.t('localInferenceAccessSettings')}
+                  <PanelLeft />
                 </Button>
                 <Button
                   type="button"
-                  variant="outline"
-                  className={localInferenceCompactButtonClass}
-                  size="sm"
-                  onClick={() => {
-                    setDraftModelsDir(modelsDir);
-                    setLibrarySettingsOpen(true);
-                  }}
+                  variant="ghost"
+                  size="icon"
+                  onClick={onNewChat}
+                  aria-label={i18nService.t('newChat')}
+                  title={i18nService.t('newChat')}
+                  className="text-foreground/70 hover:text-foreground"
                 >
-                  <Settings2 data-icon="inline-start" />
-                  {i18nService.t('localInferenceLibrarySettings')}
+                  <Pencil />
                 </Button>
+                {updateBadge}
               </div>
-            ) : null}
+            )}
+            <h1 className="text-lg font-semibold text-foreground">
+              {i18nService.t('localInferenceTitle')}
+            </h1>
+          </div>
+          <WindowTitleBar inline />
+        </div>
+        <LocalInferenceTabSelector activeTab={activeTab} isVisible={isVisible} />
+        {toast && (
+          <div className="pointer-events-none absolute right-4 top-16 z-30 flex w-[min(24rem,calc(100%-2rem))] justify-end">
+            <LocalInferenceToastView toast={toast} onClose={dismissToast} />
+          </div>
+        )}
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
+          <div
+            ref={contentViewportRef}
+            className="min-w-0 flex-1 overflow-y-auto scrollbar-gutter-stable [overflow-anchor:none]"
+          >
+            <div className="w-full space-y-4 px-6 py-4">
+              {activeTab === 'models' ? (
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className={localInferenceCompactButtonClass}
+                    size="sm"
+                    onClick={openAccessSettings}
+                  >
+                    <Globe data-icon="inline-start" />
+                    {i18nService.t('localInferenceAccessSettings')}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className={localInferenceCompactButtonClass}
+                    size="sm"
+                    onClick={() => {
+                      setDraftModelsDir(modelsDir);
+                      setLibrarySettingsOpen(true);
+                    }}
+                  >
+                    <Settings2 data-icon="inline-start" />
+                    {i18nService.t('localInferenceLibrarySettings')}
+                  </Button>
+                </div>
+              ) : null}
 
-            <LayeredTabsContent
-              value="models"
-              activeValue={activeTab}
-              direction={tabDirection}
-              className="min-h-0"
-              contentClassName="min-h-0"
-            >
+              <LayeredTabsContent
+                value="models"
+                activeValue={activeTab}
+                direction={tabDirection}
+                className="min-h-0"
+                contentClassName="min-h-0"
+              >
                 <ModelsPanel
                   loading={loading}
                   loadingModelName={loadingModelName}
@@ -748,39 +753,39 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                   logPanelVisible={launchLogs.state.visible && !launchLogFullscreen}
                   logPanelModelName={launchLogFullscreen ? null : launchLogs.state.modelName}
                 />
-            </LayeredTabsContent>
-            <LayeredTabsContent
-              value="marketplace"
-              activeValue={activeTab}
-              direction={tabDirection}
-              className="min-h-0"
-              contentClassName="min-h-0"
-            >
-              <MarketplacePanel
-                loading={loading}
-                models={marketplaceModels}
-                hasSearched={marketplaceHasSearched}
-                marketplaceLoading={marketplaceLoading}
-                marketplaceError={marketplaceError}
-                query={marketplaceQuery}
-                installedModelPathMap={installedModelPathMap}
-                installProgress={pullProgress}
-                savedToken={marketplaceToken}
-                onTokenSaved={setMarketplaceToken}
-                onQueryChange={setMarketplaceQuery}
-                onSearch={handleMarketplaceSearch}
-                onInstall={handleMarketplaceInstall}
-                contentViewportRef={contentViewportRef}
-              />
-            </LayeredTabsContent>
+              </LayeredTabsContent>
+              <LayeredTabsContent
+                value="marketplace"
+                activeValue={activeTab}
+                direction={tabDirection}
+                className="min-h-0"
+                contentClassName="min-h-0"
+              >
+                <MarketplacePanel
+                  loading={loading}
+                  models={marketplaceModels}
+                  hasSearched={marketplaceHasSearched}
+                  marketplaceLoading={marketplaceLoading}
+                  marketplaceError={marketplaceError}
+                  query={marketplaceQuery}
+                  installedModelPathMap={installedModelPathMap}
+                  installProgress={pullProgress}
+                  savedToken={marketplaceToken}
+                  onTokenSaved={setMarketplaceToken}
+                  onQueryChange={setMarketplaceQuery}
+                  onSearch={handleMarketplaceSearch}
+                  onInstall={handleMarketplaceInstall}
+                  contentViewportRef={contentViewportRef}
+                />
+              </LayeredTabsContent>
+            </div>
           </div>
-        </div>
-        <ModelLaunchLogSidebar
-          state={launchLogs.state}
-          isFullscreen={launchLogFullscreen}
-          onFullscreenChange={setLaunchLogFullscreen}
-          onClose={launchLogs.closePanel}
-        />
+          <ModelLaunchLogSidebar
+            state={launchLogs.state}
+            isFullscreen={launchLogFullscreen}
+            onFullscreenChange={setLaunchLogFullscreen}
+            onClose={launchLogs.closePanel}
+          />
         </div>
       </Tabs>
 

--- a/src/renderer/components/localInference/components/Common.tsx
+++ b/src/renderer/components/localInference/components/Common.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@shared/components/ui/button';
 import { Progress } from '@shared/components/ui/progress';
 import { CheckCircle, Info, Server, TriangleAlert, X } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -50,14 +51,16 @@ export function LocalInferenceToastView({
         <div className={`min-w-0 flex-1 text-sm leading-6 ${tone.messageClass}`}>
           {toast.message}
         </div>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon-sm"
           onClick={onClose}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-foreground/70 transition-colors hover:bg-surface-raised hover:text-foreground"
+          className="shrink-0 rounded-full text-foreground/70 hover:text-foreground"
           aria-label={i18nService.t('close')}
         >
-          <X className="h-4 w-4" />
-        </button>
+          <X />
+        </Button>
       </div>
     </div>
   );

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -80,7 +80,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   // measurement may read 0 — poll with rAF until the button has a real width (with a safety
   // timeout) so the bar never stays invisible. A ResizeObserver covers later width changes
   // (e.g. the count badge appearing/disappearing).
-  const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const tabRefs = useRef<Record<string, HTMLElement | null>>({});
   const tabRowRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null);
   useLayoutEffect(() => {
@@ -266,15 +266,18 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
           {/* ── Tab list on the divider line, with a sliding underline ── */}
           <div className="relative border-b border-border">
             <div ref={tabRowRef} role="tablist" className="flex items-center gap-6">
-              {([
-                { value: AUTO_TAB.Tasks, label: i18nService.t('scheduledTasksTabTasks') },
-                { value: AUTO_TAB.Create, label: i18nService.t('scheduledTasksNewTab') },
-                { value: AUTO_TAB.History, label: i18nService.t('scheduledTasksTabHistory') },
-              ] as const).map(tab => {
+              {(
+                [
+                  { value: AUTO_TAB.Tasks, label: i18nService.t('scheduledTasksTabTasks') },
+                  { value: AUTO_TAB.Create, label: i18nService.t('scheduledTasksNewTab') },
+                  { value: AUTO_TAB.History, label: i18nService.t('scheduledTasksTabHistory') },
+                ] as const
+              ).map(tab => {
                 const active = activeTab === tab.value;
                 return (
-                  <button
+                  <Button
                     key={tab.value}
+                    variant="ghost"
                     ref={el => {
                       tabRefs.current[tab.value] = el;
                     }}
@@ -285,17 +288,15 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
                     onClick={() => setActiveTab(tab.value)}
                     onKeyDown={e => handleTabKeyDown(e, tab.value)}
                     className={cn(
-                      'relative -mb-px flex items-center gap-2 border-b-2 border-transparent pb-2.5 text-sm font-medium outline-none transition-colors focus-visible:text-foreground',
-                      active
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground',
+                      'relative -mb-px h-auto gap-2 rounded-none border-b-2 border-transparent px-0 pb-2.5 hover:bg-transparent focus-visible:text-foreground active:translate-y-0 dark:hover:bg-transparent',
+                      active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
                     )}
                   >
                     {tab.label}
                     {tab.value === AUTO_TAB.Tasks && tasks.length > 0 && (
                       <Badge variant="secondary">{tasks.length}</Badge>
                     )}
-                  </button>
+                  </Button>
                 );
               })}
             </div>

--- a/src/renderer/components/skills/ActiveSkillBadge.tsx
+++ b/src/renderer/components/skills/ActiveSkillBadge.tsx
@@ -34,25 +34,24 @@ const SkillChip: React.FC<SkillChipProps> = ({ skillId, skill, onRemove }) => {
   return (
     <span className="inline-flex h-6 items-center gap-1.5 rounded-full pl-1.5 pr-1 text-xs font-medium text-(--zy-skill-blue-foreground) transition-colors hover:bg-(--zy-skill-blue-background)">
       {skill?.iconUrl ? (
-        <img
-          src={resolveSkillIconUrl(skill.iconUrl)}
-          alt=""
-          className="size-3.5 object-contain"
-        />
+        <img src={resolveSkillIconUrl(skill.iconUrl)} alt="" className="size-3.5 object-contain" />
       ) : ShortcutIcon ? (
         <ShortcutIcon className="size-3.5" />
       ) : (
         <PlusMenuSkillsIcon className="size-3.5" />
       )}
       <span className="max-w-24 truncate">{label}</span>
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="icon-xs"
         onClick={onRemove}
+        aria-label={`${i18nService.t('clearSkill')} ${label}`}
         title={i18nService.t('clearSkill')}
-        className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-(--zy-skill-blue-foreground)/10"
+        className="ml-0.5 size-4 rounded-full hover:bg-(--zy-skill-blue-foreground)/10 aria-expanded:bg-(--zy-skill-blue-foreground)/10 dark:hover:bg-(--zy-skill-blue-foreground)/10"
       >
-        <X className="size-3" />
-      </button>
+        <X />
+      </Button>
     </span>
   );
 };

--- a/src/renderer/components/skills/InstalledSkillGrid.tsx
+++ b/src/renderer/components/skills/InstalledSkillGrid.tsx
@@ -51,10 +51,11 @@ export function InstalledSkillGrid({
             className="group relative min-h-20 flex-row items-center gap-3 border border-border bg-card p-4 ring-0 transition-colors hover:bg-muted"
           >
             {!batchMode && (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
                 aria-label={name}
-                className="absolute inset-0 z-0 rounded-[inherit] outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                className="absolute inset-0 z-0 h-auto w-auto rounded-[inherit] border-0 p-0 hover:bg-transparent active:translate-y-0 dark:hover:bg-transparent"
                 onClick={() => onSelect(skill)}
               />
             )}

--- a/src/renderer/components/skills/MarketplaceSkillGrid.tsx
+++ b/src/renderer/components/skills/MarketplaceSkillGrid.tsx
@@ -74,10 +74,12 @@ export function MarketplaceSkillGrid({
               isInstallingSkillId && !isInstalling && 'pointer-events-none opacity-50',
             )}
           >
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="lg"
               disabled={Boolean(isInstallingSkillId && !isInstalling)}
-              className="flex min-w-0 flex-1 items-center gap-2 rounded-md py-1 text-left outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              className="h-auto min-w-0 flex-1 shrink justify-start gap-2 border-0 px-0 py-1 text-left whitespace-normal hover:bg-transparent active:translate-y-0 dark:hover:bg-transparent"
               onClick={() => onSelect(skill)}
             >
               <Avatar className="size-10 shrink-0 rounded-xl bg-muted">
@@ -98,7 +100,7 @@ export function MarketplaceSkillGrid({
                   {resolveLocalizedText(skill.description)}
                 </p>
               </div>
-            </button>
+            </Button>
 
             <div className="flex shrink-0 items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
               {isInstalled ? (

--- a/src/shared/components/ai-elements/queue.tsx
+++ b/src/shared/components/ai-elements/queue.tsx
@@ -171,7 +171,7 @@ export const QueueSection = ({ className, defaultOpen = true, ...props }: QueueS
 );
 
 // QueueSectionTrigger - section header/trigger
-export type QueueSectionTriggerProps = ComponentProps<'button'>;
+export type QueueSectionTriggerProps = ComponentProps<typeof Button>;
 
 export const QueueSectionTrigger = ({
   children,
@@ -180,9 +180,10 @@ export const QueueSectionTrigger = ({
 }: QueueSectionTriggerProps) => (
   <CollapsibleTrigger
     render={
-      <button
+      <Button
+        variant="ghost"
         className={cn(
-          'group flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors hover:bg-muted',
+          'group h-auto w-full justify-between bg-muted/40 px-3 py-2 text-left text-muted-foreground hover:bg-muted',
           className,
         )}
         type="button"


### PR DESCRIPTION
## 背景

关联 Issue #149。应用内仍有部分交互直接使用原生 `button`，导致尺寸、状态、焦点样式和主题表现无法统一由共享组件维护。

## 改动内容

- 将渲染器与 AI Elements 应用层的原生按钮迁移到共享 shadcn `Button`。
- 将 CodeMirror 命令式创建的搜索按钮统一接入 `buttonVariants()`。
- 补充图标按钮的 `aria-label`、步骤状态和当前项语义。
- 保留最新主分支的快捷技能动画图标与侧边栏交互，不改变业务流程。
- 逐项校准紧凑按钮、搜索清除按钮、消息导航轨道和技能卡片的尺寸、padding、hover 与 active 行为。
- 修复主题预览 SVG 被共享按钮当作普通图标缩小的问题，恢复完整的 3:2 预览画面和选中态。

## Issue #149 解决情况

- 应用 React 组件中的业务按钮已统一使用共享 `Button`。
- 无法直接渲染 React 组件的 CodeMirror DOM 按钮已统一使用同源 `buttonVariants()`。
- 扫描中仅保留 shadcn `SidebarRail` 内部的原生按钮；它是基础组件自身的可拖拽轨道实现，不属于业务按钮。
- 独立官网、错误页和技能模板不运行在应用 React/shadcn 组件树中，不纳入本次替换。

Closes #149

## 验证

- `npm run build`
- `npm run lint`（仅保留主分支已有的 `McpManager.tsx` hooks warning）
- `npx vitest run src/renderer/components/skills/ActiveSkillBadge.test.ts src/renderer/components/localInference/LocalInferenceView.marketplace.test.ts`（15 项通过）
- 本次 13 个文件 `oxfmt --check` 通过
- `git diff --check` 通过
- 应用层原生 JSX `button` 扫描通过
