### PR TITLE
feat(工作主界面): 修改了聊条框相关功能得呈现方式

### DIFF
--- a/src/renderer/components/cowork/CoworkModelPicker.tsx
+++ b/src/renderer/components/cowork/CoworkModelPicker.tsx
@@ -80,7 +80,7 @@ export function CoworkModelPicker({
       />
       <PopoverContent
         className="w-72 rounded-md! border! border-border! bg-surface! p-0 shadow-md ring-0! outline-none!"
-        side="top"
+        side="bottom"
         align="start"
         sideOffset={4}
       >

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1226,7 +1226,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
         </PromptInput>
         {showFolderSelector && (
           <div className="relative mt-1.5 flex justify-start">
-            <FolderSelectorPopover onSelectFolder={handleFolderSelect} side="top" align="start">
+            <FolderSelectorPopover onSelectFolder={handleFolderSelect} side="bottom" align="start">
               <PromptInputButton
                 className={`gap-1 px-2 text-sm hover:bg-surface-raised ${showFolderRequiredWarning ? 'ring-1 ring-warning text-warning animate-shake' : ''}`}
               >

--- a/src/renderer/components/cowork/CreateProjectDialog.tsx
+++ b/src/renderer/components/cowork/CreateProjectDialog.tsx
@@ -12,6 +12,7 @@ import { FolderOpen, LoaderCircle } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { localInferenceCompactButtonClass } from '../localInference/constants';
 
 interface CreateProjectDialogProps {
   open: boolean;
@@ -141,6 +142,7 @@ const CreateProjectDialog: React.FC<CreateProjectDialogProps> = ({
               <Button
                 type="button"
                 variant="outline"
+                className={localInferenceCompactButtonClass}
                 onClick={() => void handleBrowse()}
                 disabled={isSaving}
               >
@@ -154,12 +156,19 @@ const CreateProjectDialog: React.FC<CreateProjectDialogProps> = ({
           <Button
             type="button"
             variant="outline"
+            className={localInferenceCompactButtonClass}
             onClick={() => onOpenChange(false)}
             disabled={isSaving}
           >
             {i18nService.t('cancel')}
           </Button>
-          <Button type="button" onClick={() => void handleSave()} disabled={isSaving}>
+          <Button
+            type="button"
+            variant="outline"
+            className={localInferenceCompactButtonClass}
+            onClick={() => void handleSave()}
+            disabled={isSaving}
+          >
             {isSaving && <LoaderCircle className="size-4 animate-spin" />}
             {i18nService.t('save')}
           </Button>

--- a/src/renderer/components/cowork/FolderSelectorPopover.tsx
+++ b/src/renderer/components/cowork/FolderSelectorPopover.tsx
@@ -163,7 +163,7 @@ const FolderSelectorPopover: React.FC<FolderSelectorPopoverProps> = ({
               <Clock className="h-4 w-4 text-muted-foreground" />
               <span>{i18nService.t('recentFolders')}</span>
             </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="max-h-28 overflow-y-auto">
+            <DropdownMenuSubContent sideOffset={8} className="max-h-28 overflow-y-auto">
               {isLoading ? (
                 <div className="px-2 py-1.5 text-sm text-muted-foreground">
                   {i18nService.t('loading')}

--- a/src/renderer/components/cowork/PermissionModeMenu.tsx
+++ b/src/renderer/components/cowork/PermissionModeMenu.tsx
@@ -47,7 +47,7 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
           </PromptInputButton>
         }
       />
-      <DropdownMenuContent side="top" align="start" sideOffset={4} className="w-56">
+      <DropdownMenuContent side="bottom" align="start" sideOffset={4} className="w-56">
         <DropdownMenuRadioGroup
           value={value}
           onValueChange={nextValue => onChange(nextValue as CoworkPermissionMode)}
@@ -62,7 +62,7 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
               ],
             ] as const
           ).map(([mode, labelKey, descriptionKey]) => (
-            <DropdownMenuRadioItem key={mode} value={mode} className="items-start py-1.5">
+            <DropdownMenuRadioItem key={mode} value={mode} className="items-center py-1.5">
               <div className="flex min-w-0 flex-col gap-0.5">
                 <span className="text-sm">{i18nService.t(labelKey)}</span>
                 <span className="text-xs text-muted-foreground">

--- a/src/renderer/components/cowork/PromptPlusMenu.tsx
+++ b/src/renderer/components/cowork/PromptPlusMenu.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -18,6 +19,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { i18nService } from '../../services/i18n';
 import { mcpService } from '../../services/mcp';
+import { skillService } from '../../services/skill';
 import { resolveSkillIconUrl } from '../../services/skillIcon';
 import { RootState } from '../../store';
 import { setMcpServers } from '../../store/slices/mcpSlice';
@@ -193,7 +195,7 @@ const PromptPlusMenu: React.FC<PromptPlusMenuProps> = ({
           </PromptInputButton>
         }
       />
-      <DropdownMenuContent side="top" align="start" sideOffset={4} className="w-56">
+      <DropdownMenuContent side="bottom" align="start" sideOffset={4} className="w-56">
         <DropdownMenuItem
           onClick={() => {
             onAddFile();
@@ -208,34 +210,58 @@ const PromptPlusMenu: React.FC<PromptPlusMenuProps> = ({
             <PlusMenuSkillsIcon className="size-4" />
             <span className="truncate">{i18nService.t('skills')}</span>
           </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent align="center" className="w-56">
-            {enabledSkills.length === 0 ? (
-              <DropdownMenuItem disabled>{i18nService.t('noSkillsAvailable')}</DropdownMenuItem>
-            ) : (
-              enabledSkills.map(skill => (
-                <DropdownMenuCheckboxItem
-                  key={skill.id}
-                  checked={activeSkillIds.includes(skill.id)}
-                  onCheckedChange={() => {
-                    dispatch(toggleActiveSkill(skill.id));
-                    setOpen(false);
-                  }}
-                >
-                  {skill.iconUrl ? (
-                    <img
-                      src={resolveSkillIconUrl(skill.iconUrl)}
-                      alt=""
-                      className="size-4 object-contain"
-                    />
-                  ) : (
-                    <PlusMenuSkillGlyphIcon className="size-4" />
-                  )}
-                  <span className="truncate">{skill.displayName || skill.name}</span>
-                </DropdownMenuCheckboxItem>
-              ))
-            )}
+          <DropdownMenuSubContent
+            align="center"
+            sideOffset={8}
+            className="w-[360px] max-w-[calc(100vw-16px)]"
+          >
+            <DropdownMenuGroup className="max-h-[360px] overflow-y-auto overscroll-contain">
+              {enabledSkills.length === 0 ? (
+                <DropdownMenuItem disabled>
+                  {i18nService.t('noSkillsAvailable')}
+                </DropdownMenuItem>
+              ) : (
+                enabledSkills.map(skill => {
+                  const description = skillService.getLocalizedSkillDescription(
+                    skill.id,
+                    skill.name,
+                    skill.description,
+                  );
+
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={skill.id}
+                      checked={activeSkillIds.includes(skill.id)}
+                      onCheckedChange={() => {
+                        dispatch(toggleActiveSkill(skill.id));
+                        setOpen(false);
+                      }}
+                      className="items-start gap-3 py-2.5 pr-8 pl-2"
+                    >
+                      {skill.iconUrl ? (
+                        <img
+                          src={resolveSkillIconUrl(skill.iconUrl)}
+                          alt=""
+                          className="size-10 shrink-0 rounded-md object-contain"
+                        />
+                      ) : (
+                        <PlusMenuSkillGlyphIcon className="size-10 shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm">
+                          {skill.displayName || skill.name}
+                        </span>
+                        <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                          {description}
+                        </span>
+                      </span>
+                    </DropdownMenuCheckboxItem>
+                  );
+                })
+              )}
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onManageSkills}>
+            <DropdownMenuItem onClick={onManageSkills} className="py-2.5">
               <PlusMenuManageIcon className="size-4" />
               <span className="truncate">{i18nService.t('manageSkills')}</span>
             </DropdownMenuItem>
@@ -284,7 +310,7 @@ const PromptPlusMenu: React.FC<PromptPlusMenuProps> = ({
             <Cable className="size-4" />
             <span className="truncate">{i18nService.t('connectors')}</span>
           </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent align="center" className="w-56">
+          <DropdownMenuSubContent align="center" sideOffset={8} className="w-56">
             {mcpLoading ? (
               <DropdownMenuItem disabled>{i18nService.t('loading')}</DropdownMenuItem>
             ) : mcpServers.length === 0 ? (


### PR DESCRIPTION
 ## 摘要

  优化主界面对话输入区菜单的展示位置和按钮样式，提升操作一致性与可读性。

  ## 关联问题

  请填写关联问题编号：#（issue 编号）

  ## 修改内容

  - 将文件和图片、技能、连接器菜单调整为加号按钮下方展开。
  - 将技能、连接器和最近使用子菜单向右错开。
  - 将项目工作和模型选择菜单调整为按钮下方展开。
  - 放大技能列表图标，使其占满左侧图标区域。
  - 将请求权限菜单中的选中对号调整为垂直居中。
  - 统一创建项目页面中浏览、取消、保存按钮与设置页面的样式。

  ## 修改类型

  - [ ] 程序错误修复
  - [ ] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [x] 其他：界面交互与样式优化

  ## 测试

  - [x] 已在本地执行代码检查
  - [ ] 已新增测试
  - [ ] 已更新现有测试
  - [ ] 已完成手动测试

  ## 截图

  已提供界面调整前后的参考截图。

  ## 检查清单

  - [x] 代码符合项目样式规范
  - [x] 已完成代码自查
  - [x] 无需新增注释
  - [ ] 已同步更新文档
  - [x] 未引入新的代码检查警告
  - [ ] 已新增验证功能的测试
  - [ ] 已确认全部单元测试通过

  ## Electron 特定变更

  - [ ] 修改主进程
  - [ ] 修改预加载脚本
  - [ ] 修改进程间通信
  - [ ] 修改窗口管理
  - [x] 无

  ## 其他说明

  本次修改仅涉及渲染进程中的界面布局、菜单定位和按钮样式，不改变业务逻辑及数据结构。