### PR TITLE
fix(settings): 修复通用设置语言下拉显示

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -88,6 +88,7 @@ import ErrorMessage from './ErrorMessage';
 import { GitHubCopilotIcon } from './icons/providers';
 import IMSettings from './im/IMSettings';
 import { EmailSettingsPage } from './settings/email/EmailSettingsPage';
+import { GeneralLanguageField } from './settings/general/GeneralLanguageField';
 import { localInferenceCompactButtonClass } from './localInference/constants';
 import type { EmailSettingsHandle } from './settings/email/types';
 
@@ -3096,39 +3097,13 @@ const Settings: React.FC<SettingsProps> = ({
         return (
           <div className="space-y-8">
             {/* Language Section */}
-            <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">{i18nService.t('language')}</h4>
-              <div className="w-[140px] shrink-0">
-                <div className="flex items-center space-x-3">
-                  <Select
-                    value={language}
-                    onValueChange={v => {
-                      const nextLanguage = v as LanguageType;
-                      setLanguage(nextLanguage);
-                      i18nService.setLanguage(nextLanguage, { persist: false });
-                    }}
-                  >
-                    <SelectTrigger className="flex-1 rounded-lg bg-surface border-border text-foreground px-4 py-2.5 text-sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="bg-surface border-border">
-                      {[
-                        { value: 'zh', label: i18nService.t('chinese') },
-                        { value: 'en', label: i18nService.t('english') },
-                      ].map(option => (
-                        <SelectItem
-                          key={option.value}
-                          value={option.value}
-                          className="text-sm text-foreground"
-                        >
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </div>
+            <GeneralLanguageField
+              value={language}
+              onValueChange={nextLanguage => {
+                setLanguage(nextLanguage);
+                i18nService.setLanguage(nextLanguage, { persist: false });
+              }}
+            />
 
             {/* Auto-launch Section */}
             <SettingsToggleRow

--- a/src/renderer/components/settings/general/GeneralLanguageField.tsx
+++ b/src/renderer/components/settings/general/GeneralLanguageField.tsx
@@ -1,0 +1,55 @@
+import { Field, FieldLabel } from '@shared/components/ui/field';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@shared/components/ui/select';
+
+import { i18nService, type LanguageType } from '../../../services/i18n';
+import { GeneralLanguageOption } from './constants';
+
+const LANGUAGE_OPTIONS = [
+  { value: GeneralLanguageOption.Chinese, labelKey: 'chinese' },
+  { value: GeneralLanguageOption.English, labelKey: 'english' },
+] as const;
+
+interface GeneralLanguageFieldProps {
+  value: LanguageType;
+  onValueChange: (value: LanguageType) => void;
+}
+
+export function GeneralLanguageField({ value, onValueChange }: GeneralLanguageFieldProps) {
+  const items = LANGUAGE_OPTIONS.map(option => ({
+    value: option.value,
+    label: i18nService.t(option.labelKey),
+  }));
+
+  return (
+    <Field orientation="horizontal">
+      <FieldLabel htmlFor="settings-language-select">{i18nService.t('language')}</FieldLabel>
+      <Select
+        items={items}
+        value={value}
+        onValueChange={nextValue => {
+          if (nextValue) onValueChange(nextValue);
+        }}
+      >
+        <SelectTrigger id="settings-language-select" className="w-[140px] shrink-0">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {items.map(item => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </Field>
+  );
+}

--- a/src/renderer/components/settings/general/constants.ts
+++ b/src/renderer/components/settings/general/constants.ts
@@ -1,0 +1,6 @@
+import type { LanguageType } from '../../../services/i18n';
+
+export const GeneralLanguageOption = {
+  Chinese: 'zh',
+  English: 'en',
+} as const satisfies Record<string, LanguageType>;


### PR DESCRIPTION
## 变更说明

- 将“设置 > 通用”的语言下拉重构为符合 shadcn/Base UI 规范的独立字段组件。
- 为 Select 根节点补充本地化 `items`，中文界面下当前语言显示“中文”，不再回显原始值 `zh`。
- 使用 `Field`、`FieldLabel`、`SelectGroup` 完成标准表单与选项组合。
- 移除调用处对颜色、字体、内边距和弹层样式的覆盖，统一继承共享 Select 与 DESIGN.md 的设计 token。

## 交互与样式

- 触发器保持 140px 宽度。
- 展开菜单保留共享 Select 默认的 `alignItemWithTrigger` 行为，宽度与触发器贴合。
- 触发器和菜单均使用共享组件的 `rounded-lg`，展开、收起时圆角保持一致。
- 未修改共享 Select 或其他设置页面的下拉选单。

## 问题根因

项目使用 Base UI 版本的 Select，但原实现采用了缺少 `items` 的 Radix 风格写法。Base UI 无法将当前值 `zh` 映射到本地化标签，因此触发器直接显示原始值。

## 验证

- [x] `npm run build:tsc`
- [x] `npm run build`
- [x] `npm run lint`（仅保留 `McpManager.tsx` 中与本次无关的既有 Hook 依赖警告）
- [x] `npx oxfmt --check`（修改文件）
- [x] `git diff --check`
- [x] Electron 开发实例成功启动