### PR TITLE
fix(agent): register API key for Pi built-in provider models

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -438,8 +438,52 @@ describe('PiRuntimeAdapter', () => {
           }),
         }),
       );
-      expect(mockModelRuntimeCreate).not.toHaveBeenCalled();
-      expect(mockCreateAgentSession.mock.calls[0]?.[0]).not.toHaveProperty('modelRuntime');
+      // The built-in model stays on Pi's catalog, but the user's API key must
+      // still be registered under the built-in provider id — otherwise the
+      // session fails with "No API key found for <provider>".
+      expect(mockModelRuntimeCreate).toHaveBeenCalledOnce();
+      expect(mockModelRuntime.registerProvider).not.toHaveBeenCalled();
+      expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith('openai', 'sk-openai');
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({ modelRuntime: mockModelRuntime }),
+      );
+    });
+
+    it('should register the API key under the Pi built-in provider id for MiniMax', async () => {
+      mockGetModel.mockImplementationOnce(() => ({
+        provider: 'minimax-cn',
+        id: 'MiniMax-M3',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+      }));
+      mockResolveRawApiConfigForModelRef.mockReturnValueOnce({
+        config: {
+          apiKey: 'sk-cp-minimax',
+          baseURL: 'https://api.minimaxi.com/anthropic',
+          model: 'MiniMax-M3',
+          apiType: 'anthropic' as const,
+        },
+        providerMetadata: {
+          providerName: 'minimax',
+          codingPlanEnabled: false,
+          supportsImage: false,
+          modelName: 'MiniMax-M3',
+          contextWindow: 1000000,
+          contextTokens: 1000000,
+          maxTokens: 128000,
+        },
+      });
+
+      await adapter.startSession('test', 'Hello Pi', { modelOverride: 'minimax/MiniMax-M3' });
+
+      expect(mockGetModel).toHaveBeenCalledWith('minimax-cn', 'MiniMax-M3');
+      expect(mockModelRuntime.registerProvider).not.toHaveBeenCalled();
+      expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith('minimax-cn', 'sk-cp-minimax');
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: expect.objectContaining({ provider: 'minimax-cn', id: 'MiniMax-M3' }),
+          modelRuntime: mockModelRuntime,
+        }),
+      );
     });
 
     it('should register remote custom models with their configured endpoint and API key', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1828,7 +1828,20 @@ async function resolvePiCustomModelRuntime(
   if (!config || !providerMetadata) {
     return null;
   }
-  if (canUsePiBuiltinModel(builtinModel, resolution)) return existingModelRuntime ?? null;
+  if (canUsePiBuiltinModel(builtinModel, resolution)) {
+    // Builtin model path (e.g. MiniMax M3 resolves to pi's built-in `minimax-cn`
+    // provider): the agent session authenticates via pi's model registry, which
+    // only knows provider-specific env vars (MINIMAX_CN_API_KEY) that we never
+    // set. Register the user's key under the builtin provider id so the session
+    // can authenticate — otherwise it fails with "No API key found for <id>".
+    const apiKey = config.apiKey?.trim() || '';
+    const builtinProviderId =
+      typeof builtinModel?.provider === 'string' ? builtinModel.provider : null;
+    if (!apiKey || !builtinProviderId) return existingModelRuntime ?? null;
+    const modelRuntime = existingModelRuntime ?? (await pi.ModelRuntime.create());
+    await modelRuntime.setRuntimeApiKey(builtinProviderId, apiKey);
+    return modelRuntime;
+  }
 
   const modelRuntime = existingModelRuntime ?? (await pi.ModelRuntime.create());
   const model = buildPiCustomModel(resolution);


### PR DESCRIPTION
## Problem

MiniMax sessions failed with `No API key found for minimax-cn` (see #238 for the original report context).

Root cause: when a configured model resolves to Pi's built-in model catalog — e.g. `MiniMax-M3` / `MiniMax-M2.7` via the built-in `minimax-cn` provider, whose `baseUrl` matches the configured `https://api.minimaxi.com/anthropic` — `PiRuntimeAdapter` took the built-in model path and returned no `ModelRuntime`. The user's API key was never registered anywhere. The Pi agent session then resolved credentials by the built-in provider id (`minimax-cn`), which only maps to provider-specific env vars (`MINIMAX_CN_API_KEY`) that the app never sets — so every session failed before the first request.

Models not in the built-in catalog (e.g. `MiniMax-M2.5`) took the custom-model path, which did register the key — that's why the failure only hit specific models.

## Fix

On the built-in model path, create/reuse a `ModelRuntime` and register the configured API key under the built-in provider id (`minimax-cn`). The built-in model definition itself is still used as-is (no provider re-registration). This also fixes the same latent issue for other built-in providers (e.g. `openai`).

## Verification

- Reproduced against the live MiniMax endpoint with a coding-plan key: `/anthropic` + `/v1`, all default models, streaming, tool use, and multi-turn thinking replay all return 200 — the API side was never the problem.
- Updated the test that asserted the old (buggy) no-runtime behavior, and added a MiniMax regression test (`minimax/MiniMax-M3` → key registered under `minimax-cn`).
- `piRuntimeAdapter.test.ts`: 59/59 pass; lint clean; full suite shows no new failures (remaining failures are pre-existing on `main`: sqlite backup, release manifest, xlsx smoke).

## Notes

- Fix is in the main process only; packaged apps need a rebuild to pick it up.
- No IPC, storage, or windowing changes.