### PR TITLE
feat(ui): 替换 Switch 组件并优化深色主题可见性

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -601,16 +601,24 @@ select::-ms-expand {
   background-color: var(--zy-surface-raised);
   box-shadow: var(--shadow-inset);
 }
-[data-slot='switch'][data-checked] {
-  background-color: var(--zy-primary);
+[data-fluid-switch][data-slot='switch'][data-unchecked]:hover {
+  background-color: color-mix(in oklab, var(--zy-surface-raised), var(--zy-text-primary) 8%);
 }
-[data-slot='switch-thumb'] {
-  background-color: var(--zy-primary-foreground) !important;
+[data-slot='switch'][data-checked] {
+  background-color: var(--zy-switch-track-checked);
+}
+[data-fluid-switch][data-slot='switch'][data-checked]:hover {
+  background-color: var(--zy-switch-track-checked-hover);
+}
+[data-fluid-switch] [data-slot='switch-thumb'] {
+  background-color: var(--color-white) !important;
   transition: translate 200ms ease !important;
 }
-/* v4 component classes handle thumb positioning via translate-x-* utilities.
-   Do not override here — let items-center on the track handle vertical
-   centering, and component translate-x handle horizontal positioning. */
+[data-mode='work-chat'] [data-slot='switch-thumb'] {
+  background-color: var(--zy-primary-foreground) !important;
+}
+/* Normal thumbs are positioned by Motion; the Work/Chat variant below keeps
+   its existing translate utility classes and dedicated left-position rules. */
 
 /* Slider: zhiyuan theme tokens are hex values, so shadcn's hsl() utility colors are invalid. */
 [data-slot='slider-track'] {

--- a/src/renderer/index.test.ts
+++ b/src/renderer/index.test.ts
@@ -1,11 +1,41 @@
 import fs from 'fs';
 import path from 'path';
 import { expect, test } from 'vitest';
+import { classicDark } from './theme/themes/classic-dark';
+import { classicLight } from './theme/themes/classic-light';
 
-test('switch thumbs use the primary foreground token in every theme state', () => {
+test('fluid switch thumbs stay pure white across interaction states', () => {
   const css = fs.readFileSync(path.join(process.cwd(), 'src', 'renderer', 'index.css'), 'utf-8');
 
   expect(css).toMatch(
-    /\[data-slot='switch-thumb'\]\s*\{\s*background-color: var\(--zy-primary-foreground\) !important;/,
+    /\[data-fluid-switch\] \[data-slot='switch-thumb'\]\s*\{\s*background-color: var\(--color-white\) !important;/,
   );
+  expect(css).not.toMatch(
+    /\[data-fluid-switch\][^{]*:hover[^{]*\[data-slot='switch-thumb'\][^{]*\{[^}]*background-color:/,
+  );
+});
+
+test('work chat switch keeps its existing thumb token', () => {
+  const css = fs.readFileSync(path.join(process.cwd(), 'src', 'renderer', 'index.css'), 'utf-8');
+
+  expect(css).toMatch(
+    /\[data-mode='work-chat'\] \[data-slot='switch-thumb'\]\s*\{\s*background-color: var\(--zy-primary-foreground\) !important;/,
+  );
+});
+
+test('checked switch tracks use theme-specific contrast tokens', () => {
+  const css = fs.readFileSync(path.join(process.cwd(), 'src', 'renderer', 'index.css'), 'utf-8');
+  const themeCss = fs.readFileSync(
+    path.join(process.cwd(), 'src', 'renderer', 'theme', 'css', 'themes.css'),
+    'utf-8',
+  );
+
+  expect(css).toContain('background-color: var(--zy-switch-track-checked);');
+  expect(css).toContain('background-color: var(--zy-switch-track-checked-hover);');
+  expect(classicLight.tokens['switch-track-checked']).toBe('var(--zy-primary)');
+  expect(classicLight.tokens['switch-track-checked-hover']).toBe('var(--zy-primary-hover)');
+  expect(classicDark.tokens['switch-track-checked']).toBe('var(--zy-gray-5)');
+  expect(classicDark.tokens['switch-track-checked-hover']).toBe('var(--zy-gray-6)');
+  expect(themeCss).toContain('--zy-switch-track-checked: var(--zy-gray-5);');
+  expect(themeCss).toContain('--zy-switch-track-checked-hover: var(--zy-gray-6);');
 });

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -8,6 +8,8 @@
   --zy-primary-foreground: oklch(0.985 0.001 106.423);
   --zy-primary-hover: oklch(0.147 0.004 49.25);
   --zy-primary-muted: oklch(0.97 0.001 106.424);
+  --zy-switch-track-checked: var(--zy-primary);
+  --zy-switch-track-checked-hover: var(--zy-primary-hover);
   --zy-accent: oklch(0.97 0.001 106.424);
   --zy-accent-foreground: oklch(0.216 0.006 56.043);
   --zy-background: oklch(1 0 0);
@@ -70,6 +72,8 @@
   --zy-primary-foreground: oklch(0.216 0.006 56.043);
   --zy-primary-hover: oklch(1 0 0);
   --zy-primary-muted: oklch(0.268 0.007 34.298);
+  --zy-switch-track-checked: var(--zy-gray-5);
+  --zy-switch-track-checked-hover: var(--zy-gray-6);
   --zy-accent: oklch(0.268 0.007 34.298);
   --zy-accent-foreground: oklch(0.985 0.001 106.423);
   --zy-background: oklch(0.147 0.004 49.25);

--- a/src/renderer/theme/themes/classic-dark.ts
+++ b/src/renderer/theme/themes/classic-dark.ts
@@ -14,6 +14,8 @@ export const classicDark: ThemeDefinition = {
     'primary-foreground': 'oklch(0.216 0.006 56.043)',
     'primary-hover': 'oklch(1 0 0)',
     'primary-muted': 'oklch(0.268 0.007 34.298)',
+    'switch-track-checked': 'var(--zy-gray-5)',
+    'switch-track-checked-hover': 'var(--zy-gray-6)',
     accent: 'oklch(0.268 0.007 34.298)',
     'accent-foreground': 'oklch(0.985 0.001 106.423)',
     background: 'oklch(0.147 0.004 49.25)',

--- a/src/renderer/theme/themes/classic-light.ts
+++ b/src/renderer/theme/themes/classic-light.ts
@@ -14,6 +14,8 @@ export const classicLight: ThemeDefinition = {
     'primary-foreground': 'oklch(0.985 0.001 106.423)',
     'primary-hover': 'oklch(0.147 0.004 49.25)',
     'primary-muted': 'oklch(0.97 0.001 106.424)',
+    'switch-track-checked': 'var(--zy-primary)',
+    'switch-track-checked-hover': 'var(--zy-primary-hover)',
     accent: 'oklch(0.97 0.001 106.424)',
     'accent-foreground': 'oklch(0.216 0.006 56.043)',
     background: 'oklch(1 0 0)',

--- a/src/renderer/theme/tokens/contract.ts
+++ b/src/renderer/theme/tokens/contract.ts
@@ -12,6 +12,8 @@ export const TOKEN_CONTRACT = {
   'primary-foreground': '--zy-primary-foreground',
   'primary-hover': '--zy-primary-hover',
   'primary-muted': '--zy-primary-muted',
+  'switch-track-checked': '--zy-switch-track-checked',
+  'switch-track-checked-hover': '--zy-switch-track-checked-hover',
 
   // ── Accent ──
   accent: '--zy-accent',

--- a/src/shared/components/ui/switch.tsx
+++ b/src/shared/components/ui/switch.tsx
@@ -1,29 +1,332 @@
 import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
 import { cn } from '@shared/lib/utils';
+import { animate, motion, useMotionValue, useReducedMotion, type Transition } from 'motion/react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+} from 'react';
+
+type SwitchSize = 'sm' | 'default';
+
+const SwitchMode = {
+  WorkChat: 'work-chat',
+} as const;
+
+interface SwitchGeometry {
+  trackWidth: number;
+  trackHeight: number;
+  thumbSize: number;
+  thumbOffset: number;
+}
+
+const SWITCH_GEOMETRY: Record<SwitchSize, SwitchGeometry> = {
+  default: {
+    trackWidth: 34,
+    trackHeight: 20,
+    thumbSize: 16,
+    thumbOffset: 1,
+  },
+  sm: {
+    trackWidth: 24,
+    trackHeight: 14,
+    thumbSize: 12,
+    thumbOffset: 1,
+  },
+};
+
+const TRACK_BORDER_WIDTH = 1;
+const PILL_EXTEND = 2;
+const PRESS_EXTEND = 4;
+const PRESS_SHRINK = 4;
+const DRAG_DEAD_ZONE = 2;
+const DEFAULT_THUMB_TRANSITION: Transition = {
+  type: 'spring',
+  duration: 0.16,
+  bounce: 0,
+};
+
+type SwitchProps = SwitchPrimitive.Root.Props & {
+  'data-mode'?: (typeof SwitchMode)[keyof typeof SwitchMode];
+  size?: SwitchSize;
+  thumbTransition?: Transition;
+};
 
 function Switch({
+  checked,
   className,
+  'data-mode': dataMode,
+  defaultChecked,
+  disabled = false,
+  onCheckedChange,
+  onClick,
+  onPointerCancel,
+  onPointerDown,
+  onPointerEnter,
+  onPointerLeave,
+  onPointerMove,
+  onPointerUp,
+  readOnly = false,
   size = 'default',
+  thumbTransition,
   ...props
-}: SwitchPrimitive.Root.Props & {
-  size?: 'sm' | 'default';
-}) {
+}: SwitchProps) {
+  const isWorkChat = dataMode === SwitchMode.WorkChat;
+  const geometry = SWITCH_GEOMETRY[size];
+  const trackContentWidth = geometry.trackWidth - TRACK_BORDER_WIDTH * 2;
+  const prefersReducedMotion = useReducedMotion();
+  const transition = useMemo<Transition>(
+    () => (prefersReducedMotion ? { duration: 0 } : (thumbTransition ?? DEFAULT_THUMB_TRANSITION)),
+    [prefersReducedMotion, thumbTransition],
+  );
+  const [uncontrolledChecked, setUncontrolledChecked] = useState(defaultChecked ?? false);
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const currentChecked = checked ?? uncontrolledChecked;
+  const currentCheckedRef = useRef(currentChecked);
+  const hasMounted = useRef(false);
+  const dragging = useRef(false);
+  const didDrag = useRef(false);
+  const dispatchingDragClick = useRef(false);
+  const pointerStart = useRef<{ clientX: number; originX: number } | null>(null);
+  const motionX = useMotionValue(
+    currentChecked
+      ? trackContentWidth - geometry.thumbOffset - geometry.thumbSize
+      : geometry.thumbOffset,
+  );
+
+  currentCheckedRef.current = currentChecked;
+
+  useEffect(() => {
+    hasMounted.current = true;
+  }, []);
+
+  const thumbWidth = prefersReducedMotion
+    ? geometry.thumbSize
+    : pressed
+      ? geometry.thumbSize + PRESS_EXTEND
+      : hovered
+        ? geometry.thumbSize + PILL_EXTEND
+        : geometry.thumbSize;
+  const thumbHeight =
+    prefersReducedMotion || !pressed ? geometry.thumbSize : geometry.thumbSize - PRESS_SHRINK;
+  const thumbY =
+    (geometry.trackHeight - TRACK_BORDER_WIDTH * 2 - geometry.thumbSize) / 2 +
+    (geometry.thumbSize - thumbHeight) / 2;
+  const thumbX = currentChecked
+    ? trackContentWidth - geometry.thumbOffset - thumbWidth
+    : geometry.thumbOffset;
+
+  useEffect(() => {
+    if (isWorkChat || dragging.current) return;
+    if (!hasMounted.current || prefersReducedMotion) {
+      motionX.set(thumbX);
+      return;
+    }
+    const controls = animate(motionX, thumbX, transition);
+    return () => controls.stop();
+  }, [isWorkChat, motionX, prefersReducedMotion, thumbX, transition]);
+
+  const handleCheckedChange = useCallback<
+    NonNullable<SwitchPrimitive.Root.Props['onCheckedChange']>
+  >(
+    (nextChecked, eventDetails) => {
+      onCheckedChange?.(nextChecked, eventDetails);
+      if (checked === undefined && !eventDetails.isCanceled) {
+        setUncontrolledChecked(nextChecked);
+      }
+    },
+    [checked, onCheckedChange],
+  );
+
+  const resetPointerInteraction = useCallback(() => {
+    setPressed(false);
+    dragging.current = false;
+    pointerStart.current = null;
+  }, []);
+
+  const handlePointerDown: NonNullable<SwitchPrimitive.Root.Props['onPointerDown']> = useCallback(
+    event => {
+      onPointerDown?.(event);
+      if (event.defaultPrevented || disabled || readOnly) return;
+      if (event.pointerType === 'mouse' && event.button !== 0) return;
+
+      setPressed(true);
+      dragging.current = false;
+      didDrag.current = false;
+      pointerStart.current = {
+        clientX: event.clientX,
+        originX: motionX.get(),
+      };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [disabled, motionX, onPointerDown, readOnly],
+  );
+
+  const handlePointerMove: NonNullable<SwitchPrimitive.Root.Props['onPointerMove']> = useCallback(
+    event => {
+      onPointerMove?.(event);
+      if (event.defaultPrevented || !pointerStart.current) return;
+
+      const delta = event.clientX - pointerStart.current.clientX;
+      if (!dragging.current) {
+        if (Math.abs(delta) < DRAG_DEAD_ZONE) return;
+        dragging.current = true;
+      }
+
+      const dragMin = geometry.thumbOffset;
+      const pressedThumbWidth = geometry.thumbSize + PRESS_EXTEND;
+      const dragMax = trackContentWidth - geometry.thumbOffset - pressedThumbWidth;
+      const rawX = pointerStart.current.originX + delta;
+      motionX.set(Math.max(dragMin, Math.min(dragMax, rawX)));
+    },
+    [geometry, motionX, onPointerMove, trackContentWidth],
+  );
+
+  const handlePointerUp: NonNullable<SwitchPrimitive.Root.Props['onPointerUp']> = useCallback(
+    event => {
+      onPointerUp?.(event);
+      if (!pointerStart.current) return;
+
+      if (dragging.current) {
+        didDrag.current = true;
+        const dragMin = geometry.thumbOffset;
+        const pressedThumbWidth = geometry.thumbSize + PRESS_EXTEND;
+        const dragMax = trackContentWidth - geometry.thumbOffset - pressedThumbWidth;
+        const shouldBeChecked = motionX.get() > (dragMin + dragMax) / 2;
+
+        if (shouldBeChecked !== currentCheckedRef.current) {
+          dispatchingDragClick.current = true;
+          event.currentTarget.click();
+          dispatchingDragClick.current = false;
+        } else {
+          const snapTarget = shouldBeChecked
+            ? trackContentWidth - geometry.thumbOffset - geometry.thumbSize
+            : geometry.thumbOffset;
+          animate(motionX, snapTarget, transition);
+        }
+
+        requestAnimationFrame(() => {
+          didDrag.current = false;
+        });
+      }
+
+      resetPointerInteraction();
+    },
+    [geometry, motionX, onPointerUp, resetPointerInteraction, trackContentWidth, transition],
+  );
+
+  const handlePointerCancel: NonNullable<SwitchPrimitive.Root.Props['onPointerCancel']> =
+    useCallback(
+      event => {
+        onPointerCancel?.(event);
+        if (!pointerStart.current) return;
+
+        const snapTarget = currentCheckedRef.current
+          ? trackContentWidth - geometry.thumbOffset - geometry.thumbSize
+          : geometry.thumbOffset;
+        animate(motionX, snapTarget, transition);
+        resetPointerInteraction();
+      },
+      [geometry, motionX, onPointerCancel, resetPointerInteraction, trackContentWidth, transition],
+    );
+
+  const handleClick: NonNullable<SwitchPrimitive.Root.Props['onClick']> = useCallback(
+    event => {
+      if (didDrag.current && !dispatchingDragClick.current) {
+        event.preventBaseUIHandler();
+        return;
+      }
+      onClick?.(event);
+    },
+    [onClick],
+  );
+
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
+      data-mode={dataMode}
+      data-fluid-switch={isWorkChat ? undefined : ''}
+      checked={checked}
+      defaultChecked={defaultChecked}
+      disabled={disabled}
+      readOnly={readOnly}
+      onCheckedChange={handleCheckedChange}
+      onClick={isWorkChat ? onClick : handleClick}
+      onPointerCancel={isWorkChat ? onPointerCancel : handlePointerCancel}
+      onPointerDown={isWorkChat ? onPointerDown : handlePointerDown}
+      onPointerEnter={
+        isWorkChat
+          ? onPointerEnter
+          : event => {
+              onPointerEnter?.(event);
+              if (!event.defaultPrevented && event.pointerType === 'mouse') setHovered(true);
+            }
+      }
+      onPointerLeave={
+        isWorkChat
+          ? onPointerLeave
+          : event => {
+              onPointerLeave?.(event);
+              setHovered(false);
+            }
+      }
+      onPointerMove={isWorkChat ? onPointerMove : handlePointerMove}
+      onPointerUp={isWorkChat ? onPointerUp : handlePointerUp}
       className={cn(
-        'peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:opacity-50',
+        'peer group/switch relative inline-flex shrink-0 cursor-pointer touch-none items-center rounded-full border border-transparent outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-[34px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:pointer-events-none data-disabled:cursor-not-allowed data-disabled:opacity-50',
         className,
       )}
       {...props}
     >
-      <SwitchPrimitive.Thumb
-        data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
-      />
+      {isWorkChat ? (
+        <SwitchPrimitive.Thumb
+          data-slot="switch-thumb"
+          className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        />
+      ) : (
+        <SwitchPrimitive.Thumb
+          data-slot="switch-thumb"
+          render={thumbProps => {
+            const {
+              style: baseStyle,
+              onDrag: _onDrag,
+              onDragStart: _onDragStart,
+              onDragEnd: _onDragEnd,
+              onAnimationStart: _onAnimationStart,
+              onAnimationEnd: _onAnimationEnd,
+              onAnimationIteration: _onAnimationIteration,
+              ...rest
+            } = thumbProps as HTMLAttributes<HTMLSpanElement>;
+
+            return (
+              <motion.span
+                {...rest}
+                className="pointer-events-none absolute top-0 left-0 block rounded-full ring-0"
+                initial={false}
+                style={{
+                  ...(baseStyle as CSSProperties | undefined),
+                  x: motionX,
+                }}
+                animate={{
+                  y: thumbY,
+                  width: thumbWidth,
+                  height: thumbHeight,
+                }}
+                transition={hasMounted.current ? transition : { duration: 0 }}
+              />
+            );
+          }}
+        />
+      )}
     </SwitchPrimitive.Root>
   );
 }
 
 export { Switch };
+export type { SwitchProps };


### PR DESCRIPTION
## 变更概述

- 将除侧边栏顶部“工作 / 对话”之外的 Switch 替换为 Fluid Functionalism 风格交互
- 保留 shadcn/Base UI 的受控与非受控语义，并支持键盘操作、拖拽吸附和减少动态效果设置
- 统一默认尺寸为 `34 x 20`、Thumb 为 `16 x 16`；小尺寸保持 `24 x 14`、Thumb 为 `12 x 12`
- 保留 hover / press 时 Thumb 延展效果，hover 仅加深轨道颜色
- Thumb 使用纯白语义 token，避免 hover 时变色
- 新增启用态轨道主题 token，修复深色主题下轨道与白色 Thumb 对比不足、状态近乎不可见的问题
- 侧边栏顶部“工作 / 对话”Switch 继续使用原有实现与样式，不受本次替换影响

## 验证

- `npm run build` 通过
- `npm run lint` 通过（仅保留现有 `McpManager.tsx` exhaustive-deps warning）
- `npx vitest run src/renderer/index.test.ts` 通过（3/3）
- `git diff --check` 通过
- 已在深色主题下核对启用态、hover 启用态及 Thumb 尺寸和颜色

## 备注

本次再次执行 `npm test -- src/renderer/index.test.ts` 时，测试包装脚本在恢复 Electron 原生模块阶段因运行中的进程占用 `better_sqlite3.node` 而失败；测试断言已通过直接运行 Vitest 完成验证。
