### PR TITLE
feat(skills): distill visual design workflows

### DIFF
--- a/SKILLs/frontend-design/SKILL.md
+++ b/SKILLs/frontend-design/SKILL.md
@@ -9,9 +9,17 @@ metadata:
     - https://github.com/anthropics/skills
 ---
 
-This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices. Do not begin from a remembered palette, component library, or hero layout.
 
 The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Visual direction workflow
+
+1. Read [the design brief](references/design-brief.md). Extract audience, brand cues, content density, platform, accessibility needs, and one memorable interaction or composition.
+2. Select three materially different directions from [design archetypes](references/design-archetypes.md). A direction changes composition, typography, color temperature, and motion—not only the accent color.
+3. Record the chosen direction in `design.md` before implementation: the discarded alternatives, anchor, palette roles, typography, spacing scale, component treatment, image strategy, responsive changes, motion budget, and context-specific prohibitions.
+4. When screenshots or an approved site are supplied, use [reference mode](references/reference-mode.md) before selecting a direction. Extract a design system; never copy protected logos, artwork, or a page screenshot.
+5. Build the hero and one representative dense section first. Render desktop and mobile, review with [the visual rubric](references/visual-review.md), revise the contract, then complete the site.
 
 ## Design Thinking
 
@@ -45,6 +53,10 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
 Remember: you are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+
+## Evaluation suite
+
+Before changing this skill, run the eight prompts in [the evaluation suite](examples/evaluation/README.md). For each, retain the brief, direction cards, desktop/mobile previews, build result, and rubric score. A build passing is a delivery prerequisite, not visual evidence.
 
 ## Delivery Gate
 

--- a/SKILLs/frontend-design/examples/evaluation/01-architect-portfolio.md
+++ b/SKILLs/frontend-design/examples/evaluation/01-architect-portfolio.md
@@ -1,0 +1,1 @@
+Build a portfolio for an architect documenting adaptive-reuse projects. It needs case-study navigation, image-led project pages, material notes, and an inquiry form. Avoid generic agency styling.

--- a/SKILLs/frontend-design/examples/evaluation/02-community-garden.md
+++ b/SKILLs/frontend-design/examples/evaluation/02-community-garden.md
@@ -1,0 +1,1 @@
+Build a neighbourhood garden hub with growing calendar, plot map, volunteer sign-up, harvest notes, and accessible mobile navigation.

--- a/SKILLs/frontend-design/examples/evaluation/03-museum-evenings.md
+++ b/SKILLs/frontend-design/examples/evaluation/03-museum-evenings.md
@@ -1,0 +1,1 @@
+Build an evening-membership campaign for a contemporary museum with event schedule, membership tiers, ticket CTA, and cinematic artist imagery.

--- a/SKILLs/frontend-design/examples/evaluation/04-logistics-console.md
+++ b/SKILLs/frontend-design/examples/evaluation/04-logistics-console.md
@@ -1,0 +1,1 @@
+Build an operations console for delivery exceptions with service-level trend, regional filters, delayed-shipment table, owner assignment, and clear urgency states.

--- a/SKILLs/frontend-design/examples/evaluation/05-food-maker.md
+++ b/SKILLs/frontend-design/examples/evaluation/05-food-maker.md
@@ -1,0 +1,1 @@
+Build a seasonal page for a small fermented-food maker with ingredient stories, product availability, workshops, stockists, and a preorder flow.

--- a/SKILLs/frontend-design/examples/evaluation/06-learning-lab.md
+++ b/SKILLs/frontend-design/examples/evaluation/06-learning-lab.md
@@ -1,0 +1,1 @@
+Build a mobile-first science learning lab for river ecosystems with a short lesson, interactive food-web activity, progress state, and class discussion prompt.

--- a/SKILLs/frontend-design/examples/evaluation/07-research-archive.md
+++ b/SKILLs/frontend-design/examples/evaluation/07-research-archive.md
@@ -1,0 +1,1 @@
+Build a searchable archive for oral-history recordings with filters, transcript previews, provenance, a listening queue, and an accessible high-density mobile mode.

--- a/SKILLs/frontend-design/examples/evaluation/08-mobility-service.md
+++ b/SKILLs/frontend-design/examples/evaluation/08-mobility-service.md
@@ -1,0 +1,1 @@
+Build a premium electric rail-transfer service page with route lookup, service promise, luggage guidance, an itinerary preview, and booking CTA.

--- a/SKILLs/frontend-design/examples/evaluation/README.md
+++ b/SKILLs/frontend-design/examples/evaluation/README.md
@@ -1,0 +1,14 @@
+# Visual evaluation suite
+
+For every prompt, create three direction cards, choose one, and save a desktop/mobile preview plus a build report. Compare revised output with the previous baseline blind; target at least 70% preference while preserving interaction, accessibility, responsiveness, and delivery evidence.
+
+To prepare anonymous pairs, place `baseline.json` and `candidate.json` in each task folder (each declares `{ "kind": "website", "preview": "desktop.png" }`) and run `node scripts/prepare-visual-blind-review.mjs <evaluation-root> --seed <run-id>`. Give reviewers only the generated form and artifacts; keep the review key sealed until all votes are recorded.
+
+1. `01-architect-portfolio.md` — high-end editorial portfolio.
+2. `02-community-garden.md` — civic and organic information hub.
+3. `03-museum-evenings.md` — nocturnal cultural event.
+4. `04-logistics-console.md` — dense operations control surface.
+5. `05-food-maker.md` — tactile small-business showcase.
+6. `06-learning-lab.md` — playful educational tool.
+7. `07-research-archive.md` — quiet searchable archive.
+8. `08-mobility-service.md` — precise premium service landing page.

--- a/SKILLs/frontend-design/references/design-archetypes.md
+++ b/SKILLs/frontend-design/references/design-archetypes.md
@@ -1,0 +1,18 @@
+# Design archetypes
+
+Select an archetype as a grammar, then make it specific to the task. Do not reuse an archetype's colors as a default.
+
+| Archetype | Composition and type | Color/material | Interaction cue | Best fit |
+|---|---|---|---|---|
+| editorial-field-notes | strong masthead, image captions, asymmetric columns | paper, ink, one material accent | reading-progress and image crop reveal | portfolios, culture, research |
+| swiss-signal | strict grid, oversized numerals, typographic hierarchy | high-contrast neutral with one signal color | crisp state changes, no ornamental motion | tools, data, events |
+| tactile-workshop | close crops, labels, irregular but aligned modules | natural fibers, mineral or food-derived tones | hover shifts reveal process details | makers, food, craft |
+| nocturnal-cinema | one immersive hero, sparse copy, cinematic type scale | deep low-chroma canvas with luminous restrained accents | slow parallax or light sweep | launch, invitation, culture |
+| civic-atlas | maps, routes, modular evidence blocks | calm institutional palette with geographic accent | filter and route transitions | public interest, mobility, reports |
+| precision-luxury | spacious frame, fine rules, deliberate restraint | warm neutral, graphite, metal or jewel accent | measured reveal and tactile hover | hospitality, premium services |
+| kinetic-studio | overscaled type, layered panels, editorial collisions | expressive but limited contrast | purposeful scroll sequence | agency, creator, campaign |
+| resilient-operations | exception-first data hierarchy, dense but breathable | low-noise neutral with semantic status colors | drill-down and state clarity | dashboards, administration |
+| playful-utility | bold task hierarchy, friendly geometry, clear affordances | optimistic color blocks with accessible contrast | direct feedback and small delight | learning, community, consumer tools |
+| quiet-archive | index navigation, metadata, variable image ratios | subdued paper or dark archive palette | filter, zoom, and provenance cues | collections, libraries, documentation |
+
+For a generic landing page, deliberately choose one instead of producing a gradient hero plus three cards. For data-heavy interfaces, protect task clarity before visual novelty.

--- a/SKILLs/frontend-design/references/design-brief.md
+++ b/SKILLs/frontend-design/references/design-brief.md
@@ -1,0 +1,25 @@
+# Design brief
+
+Write this before code. Keep it short and decision-oriented.
+
+```md
+## Context
+- Product, audience, primary task, and platform
+- Brand cues and constraints
+- Content density and accessibility requirements
+
+## Direction cards
+1. [archetype] — temperature, type, composition, motion, risk
+2. ...
+3. ...
+
+## Selected system
+- Why this direction fits
+- Palette roles: canvas, surface, ink, muted, primary, accent, states
+- Typography and spacing scale
+- Image/illustration and icon strategy
+- Responsive transformations and motion budget
+- Prohibited patterns
+```
+
+Derive colors from brand, subject, audience, and desired temperature. Fixed color values in a user request are constraints; an example shortcut's old colors are not. Use tokens only after their semantic role is clear.

--- a/SKILLs/frontend-design/references/reference-mode.md
+++ b/SKILLs/frontend-design/references/reference-mode.md
@@ -1,0 +1,11 @@
+# Reference mode
+
+When the user supplies screenshots or an approved website, extract a reusable system before coding:
+
+- role-based colors and contrast, including light/dark behavior;
+- display/body type, hierarchy, line length, and numeric treatment;
+- page grid, spacing cadence, breakpoints, and image ratios;
+- buttons, inputs, cards, dividers, icons, charts, and empty states;
+- motion timing, easing, hover, and scroll behavior.
+
+Write the extraction in `design.md`, distinguish transferable grammar from protected content, and implement two compact hero variants before committing to a full page. Match the system's intent, not its pixels.

--- a/SKILLs/frontend-design/references/visual-review.md
+++ b/SKILLs/frontend-design/references/visual-review.md
@@ -1,0 +1,14 @@
+# Visual review rubric
+
+Inspect one desktop and one mobile render. Score 1–5, record defects below 4, and revise before delivery.
+
+| Dimension | Evidence |
+|---|---|
+| distinct direction | the product could not be mistaken for a generic AI landing page |
+| composition | hierarchy, rhythm, scale, and whitespace are deliberate at both sizes |
+| color/type | content-derived palette, accessible contrast, characterful but readable type |
+| component coherence | controls, cards, data, imagery, and states belong to one system |
+| interaction | motion clarifies state or creates one memorable moment without blocking use |
+| responsive quality | hierarchy and touch targets survive narrow screens |
+
+Reject a result that only changes colors while retaining the same hero, card grid, type pairing, and motion pattern as an unrelated task.

--- a/SKILLs/presentation-studio/SKILL.md
+++ b/SKILLs/presentation-studio/SKILL.md
@@ -35,9 +35,9 @@ Create an isolated project directory:
 
 1. **Audit material and audience.** Read supplied material completely. Record facts, sources, dates, assumptions, and gaps in `outline.md`. Each page must have one action title and one takeaway.
 2. **Choose a mode.** Use summary mode for complete source material, outline mode for a supplied page plan, search mode only when research is needed. Choose reference mode when the user supplied visual references; otherwise choose creative mode.
-3. **Write `design.md` before creating any page.** It must state: audience, style anchor, palette temperature and rationale, CJK/Latin font pair, type scale, grid and safe margins, image strategy, chart/table rules, page-layout families, and a deck-specific forbidden-pattern checklist. Never default to purple-blue gradients, generic rounded-card grids, or white space used as a substitute for composition.
+3. **Choose a visual direction before creating any page.** Read [Creative mode](references/creative-mode.md) and the matching scenario profile in [Profiles](references/profiles.md). For supplied visual references, read [Reference mode](references/reference-mode.md) instead. Create three concise direction cards, select one against the audience and content, then write `design.md`: profile, anchor, color rationale, font pair, type scale, grid, image strategy, chart/table treatment, layout families, and deck-specific forbidden patterns. Never default to a remembered palette, purple-blue gradients, rounded-card grids, or whitespace used as a substitute for composition.
 4. **Create three proof pages first:** cover, representative content page, and data/diagram page. Render/inspect them with the available visual capability and revise the design contract before expanding the deck.
-5. **Create `deck.json`, then pages in order.** Use only the documented DeckSpec fields. Use native `text`, `shape`, `image`, `table`, and `chart` elements; do not rasterize an entire page. Images are required where the design contract calls for visual storytelling. Use high-quality, relevant assets; never replace missing imagery with a placeholder or an unrelated gradient.
+5. **Create `deck.json`, then pages in order.** Use only the documented DeckSpec fields. Use native `text`, `shape`, `image`, `table`, and `chart` elements; do not rasterize an entire page. Declare semantic colors and explicitly style non-text elements: a mask, rule, panel, table, or chart must not silently inherit one global primary color. Images are required where the design contract calls for visual storytelling. Use high-quality, relevant assets; never replace missing imagery with a placeholder or an unrelated gradient.
 6. **Validate, fix, validate.** Run the validator in strict mode. A warning is a real presentation defect unless explicitly listed as an intentional exception in `design.md`. Do not export until validation reports zero errors and zero warnings.
 7. **Compile and inspect the final PPTX.** Confirm the file exists and is non-empty. Render the final PPTX when a renderer is available and inspect every page—not merely the source preview.
 
@@ -68,7 +68,11 @@ node "<SKILL_DIR>/scripts/compile-deck.mjs" "<deck-dir>/deck.json" "<deck-dir>/o
   "title": "Deck title",
   "canvas": { "width": 1280, "height": 720 },
   "theme": {
-    "colors": { "background": "#F3F0EA", "text": "#202124", "primary": "#4A3B32" },
+    "colors": {
+      "background": "#…", "surface": "#…", "text": "#…", "muted": "#…",
+      "primary": "#…", "secondary": "#…", "accent": "#…",
+      "series1": "#…", "series2": "#…", "series3": "#…"
+    },
     "textStyles": {
       "title": { "fontSize": 48, "fontFace": "Aptos Display", "color": "$primary", "bold": true },
       "body": { "fontSize": 20, "fontFace": "Microsoft YaHei", "color": "$text", "lineHeight": 1.35 }
@@ -78,7 +82,7 @@ node "<SKILL_DIR>/scripts/compile-deck.mjs" "<deck-dir>/deck.json" "<deck-dir>/o
 }
 ```
 
-Each page is `{ "pageType": "cover|content|chapter|final", "background": "#...", "elements": [...] }`. Elements require a unique `id`, a `type`, and `bounds: [x, y, width, height]` in canvas pixels. Supported types are `text`, `shape`, `image`, `table`, and `chart`; the compiler intentionally fails closed for unsupported element types.
+Each page is `{ "pageType": "cover|content|chapter|final", "background": "#...", "elements": [...] }`. Elements require a unique `id`, a `type`, and `bounds: [x, y, width, height]` in canvas pixels. Supported types are `text`, `shape`, `image`, `table`, and `chart`; the compiler intentionally fails closed for unsupported element types. See [DeckSpec styling](references/deckspec-styling.md) before using masks, image overlays, chart series, or tables.
 
 ### Text element
 
@@ -98,25 +102,30 @@ Each page is `{ "pageType": "cover|content|chapter|final", "background": "#...",
 ### Shape and image elements
 
 ```json
-{ "id": "rule", "type": "shape", "shape": "rect", "bounds": [96, 386, 120, 8], "fill": "$primary" }
+{ "id": "rule", "type": "shape", "shape": "rect", "bounds": [96, 386, 120, 8], "fill": "$accent" }
+{ "id": "hero-mask", "type": "shape", "shape": "rect", "bounds": [880, 0, 400, 720], "fill": "$primary", "fillTransparency": 38, "decorative": true }
 { "id": "hero", "type": "image", "src": "assets/hero.jpg", "bounds": [880, 0, 400, 720], "sizing": "cover" }
 ```
 
 ### Table and chart elements
 
 ```json
-{ "id": "metrics", "type": "table", "bounds": [96, 420, 520, 180], "rows": [["Metric", "Result"], ["Revenue", "42%"]], "fontSize": 18 }
-{ "id": "trend", "type": "chart", "chartType": "bar", "bounds": [660, 390, 520, 230], "data": [{ "name": "Growth", "labels": ["Q1", "Q2"], "values": [18, 42] }] }
+{ "id": "metrics", "type": "table", "bounds": [96, 420, 520, 180], "rows": [["Metric", "Result"], ["Revenue", "42%"]], "fontSize": 18, "headerFill": "$primary", "headerColor": "$background", "borderColor": "$muted" }
+{ "id": "trend", "type": "chart", "chartType": "bar", "bounds": [660, 390, 520, 230], "data": [{ "name": "Growth", "labels": ["Q1", "Q2"], "values": [18, 42] }], "colors": ["$primary"] }
 ```
 
 ## Non-negotiable quality gates
 
 - Use 16:9 unless the user requires another format.
 - Minimum body size is 18pt; captions may be 12pt; no text below 12pt.
-- Do not use more than three font families or three semantic colors without a design rationale.
+- Do not use more than three font families. Color count follows the selected direction; every semantic color must have an allocated role in `design.md`.
 - All non-decorative elements must remain inside the canvas and respect the declared safe margin.
 - Text overflow, text-text occlusion, unsafe margins, unintentional underfill, missing assets, invalid colors, duplicate IDs, and unsupported elements block export.
 - For decks of 20+ pages, workers may generate only assigned page files after `outline.md`, `design.md`, and `deck.json` are locked. The lead validates and exports the complete deck once.
+
+## Visual evaluation
+
+Before changing this skill, use the six prompts in [evaluation suite](examples/evaluation/README.md). Compare rendered cover, content, and data pages with the current baseline using [the visual rubric](references/visual-review.md). A clean validator result proves editability, not taste.
 
 ## Delivery
 

--- a/SKILLs/presentation-studio/examples/evaluation/01-mineral-energy-transition.md
+++ b/SKILLs/presentation-studio/examples/evaluation/01-mineral-energy-transition.md
@@ -1,0 +1,1 @@
+Prepare an executive proposal for a regional energy-transition program. Audience: public-sector and infrastructure leaders. Include the decision, investment trade-offs, a 2027–2035 pathway, and an emissions chart. Seek credible material restraint, not generic green or blue sustainability styling.

--- a/SKILLs/presentation-studio/examples/evaluation/02-night-museum-membership.md
+++ b/SKILLs/presentation-studio/examples/evaluation/02-night-museum-membership.md
@@ -1,0 +1,1 @@
+Launch a contemporary museum's evening-membership program. Include a cinematic cover, audience promise, membership tiers, a seasonal event path, and conversion metrics. The deck should feel culturally specific and image-led, not like a SaaS pitch.

--- a/SKILLs/presentation-studio/examples/evaluation/03-river-ecology-classroom.md
+++ b/SKILLs/presentation-studio/examples/evaluation/03-river-ecology-classroom.md
@@ -1,0 +1,1 @@
+Create a middle-school lesson explaining how a river ecosystem recovers after restoration. Include a food-web diagram, before/after evidence, a timeline, and a class question. Make it curious and legible without childish clip-art.

--- a/SKILLs/presentation-studio/examples/evaluation/04-healthcare-evidence-review.md
+++ b/SKILLs/presentation-studio/examples/evaluation/04-healthcare-evidence-review.md
@@ -1,0 +1,1 @@
+Prepare a clinical evidence review on reducing post-operative infection. Include study design, evidence table, effect-size chart, limitations, and recommendation. It must be scholarly, calm, and easy to audit.

--- a/SKILLs/presentation-studio/examples/evaluation/05-artisan-food-portfolio.md
+++ b/SKILLs/presentation-studio/examples/evaluation/05-artisan-food-portfolio.md
@@ -1,0 +1,1 @@
+Present an artisan food studio's seasonal work to prospective collaborators. Include origin story, three product stories, a materials/process page, and partnership offer. Aim for tactile editorial character without copying a known brand.

--- a/SKILLs/presentation-studio/examples/evaluation/06-logistics-exception-report.md
+++ b/SKILLs/presentation-studio/examples/evaluation/06-logistics-exception-report.md
@@ -1,0 +1,1 @@
+Create a monthly logistics exception report for operations leadership. Include service-level trend, delay root causes, regional comparison, owners, and next actions. Make the most important exception visually unmistakable.

--- a/SKILLs/presentation-studio/examples/evaluation/README.md
+++ b/SKILLs/presentation-studio/examples/evaluation/README.md
@@ -1,0 +1,20 @@
+# Visual evaluation suite
+
+Use each prompt for a cover, a representative content page, and a data or diagram page. Run every prompt three times when comparing a change; unrelated runs must not collapse to the same palette or layout family.
+
+1. `01-mineral-energy-transition.md` — strategic proposal, restrained and material.
+2. `02-night-museum-membership.md` — cultural brand launch, image-led.
+3. `03-river-ecology-classroom.md` — middle-school explainer, vivid but readable.
+4. `04-healthcare-evidence-review.md` — academic defense, evidence-dense.
+5. `05-artisan-food-portfolio.md` — portfolio showcase, warm editorial.
+6. `06-logistics-exception-report.md` — operations report, information-dense.
+
+For each run save `design.md`, rendered proof pages, validation output, and a rubric score. Compare against the pre-change baseline blind; target a 70% preference rate without losing validation, editability, or legibility.
+
+To prepare the render pairs for human review, put a `baseline.json` and `candidate.json` in each task folder (each declares `{ "kind": "ppt", "preview": "rendered-cover.png" }`) and run:
+
+```bash
+node scripts/prepare-visual-blind-review.mjs <evaluation-root> --seed <run-id>
+```
+
+Give reviewers only `blind-review/review-form.json` and `blind-review/artifacts/`; protect `blind-review/blind-review-key.json` until reviews are complete.

--- a/SKILLs/presentation-studio/examples/minimal/deck.json
+++ b/SKILLs/presentation-studio/examples/minimal/deck.json
@@ -3,7 +3,11 @@
   "canvas": { "width": 1280, "height": 720 },
   "safeMargin": 36,
   "theme": {
-    "colors": { "background": "#F3F0EA", "text": "#202124", "primary": "#4A3B32" },
+    "colors": {
+      "background": "#F2EFE8", "surface": "#E5E0D6", "text": "#202124", "muted": "#8B8376",
+      "primary": "#4A3B32", "secondary": "#6D7D6A", "accent": "#C96A3D",
+      "series1": "#4A3B32", "series2": "#6D7D6A", "series3": "#C96A3D"
+    },
     "textStyles": {
       "title": { "fontSize": 48, "fontFace": "Aptos Display", "color": "$primary", "bold": true },
       "body": { "fontSize": 20, "fontFace": "Microsoft YaHei", "color": "$text", "lineHeight": 1.35 }

--- a/SKILLs/presentation-studio/examples/minimal/pages/01-cover.json
+++ b/SKILLs/presentation-studio/examples/minimal/pages/01-cover.json
@@ -3,6 +3,6 @@
   "background": "$background",
   "elements": [
     { "id": "cover-title", "type": "text", "bounds": [96, 244, 860, 130], "style": "$title", "text": "A decisive action title", "wrap": true, "allowUnderfill": true },
-    { "id": "cover-rule", "type": "shape", "shape": "rect", "bounds": [96, 400, 160, 8], "fill": "$primary", "decorative": true }
+    { "id": "cover-rule", "type": "shape", "shape": "rect", "bounds": [96, 400, 160, 8], "fill": "$accent", "decorative": true }
   ]
 }

--- a/SKILLs/presentation-studio/references/creative-mode.md
+++ b/SKILLs/presentation-studio/references/creative-mode.md
@@ -1,0 +1,32 @@
+# Creative mode
+
+Use this when no visual reference is supplied. Do not start from a named hex color or a favourite layout.
+
+1. Select one profile in `profiles.md` from audience, risk, information density, and desired energy.
+2. Produce three direction cards. Each card names an anchor, color temperature, primary-color rationale, image treatment, type pairing, composition, and one risk.
+3. Choose one card. It must be recognizably different from the other two in both composition and temperature, not merely in accent color.
+4. Build `design.md` from the selected card. Allocate every semantic color to a role and declare at least three layout families.
+
+## Color decision order
+
+1. Brand color, if it exists and is usable.
+2. Conservative, balanced, or expressive risk posture.
+3. Temperature: cool, warm, neutral, paper, mineral, natural, nocturnal, or electric.
+4. Background and text contrast before decorative color.
+5. Primary, secondary, restrained accent, then chart series. Do not use blue/cyan or white merely because they are convenient.
+
+## Composition rules
+
+Use a small family of repeatable grammar, not one page template: hero crop plus mask, editorial image/text cut, framed image, asymmetric grid, timeline/path, Z/F flow, overlap, or full-page data. Keep baseline alignment rigorous even when the composition is asymmetric. Prefer hierarchy, type, image scale, and negative space to repeated cards.
+
+## Direction-card format
+
+```md
+### Direction: mineral editorial
+- Anchor: contemporary annual-report editorial
+- Audience/risk: executive, balanced
+- Temperature/palette logic: chalk, graphite, oxidised green; accent only for decisions
+- Type: restrained serif display + readable CJK sans
+- Image/composition: cropped documentary images, vertical rule, asymmetric two-column pages
+- Prohibit: dashboard-card grids, blue KPI charts, decorative gradients
+```

--- a/SKILLs/presentation-studio/references/deckspec-styling.md
+++ b/SKILLs/presentation-studio/references/deckspec-styling.md
@@ -1,0 +1,12 @@
+# DeckSpec styling
+
+Use semantic colors defined in `deck.json`; do not reuse another deck's hex values.
+
+- `shape`: require `fill`, `line`, or `gradient`. Optional `fillTransparency` and `lineTransparency` are 0–100; use a translucent rectangle over an image as an editable mask. Optional `lineWidth`, `lineDash`, and `rotate` support rules and framing. A background ornament may extend beyond the canvas only when both `decorative: true` and `allowOverflow: true` are declared; content may never use this escape hatch.
+- `gradient`: use only on a `rect`: `{ "from": "$primary", "to": "$background", "direction": "horizontal", "steps": 12 }`. It compiles to editable native rectangle bands, so use it for a deliberate cover field or image edge fade—not a default decoration.
+- `text`: optional `italic`, `charSpacing`, `margin`, and `rotate` support editorial hierarchy. Keep body text readable.
+- `image`: use `cover` or `contain`; optional `transparency` is for intentional layering only.
+- `table`: declare `headerFill`, `headerColor`, `borderColor`, `borderWidth`, and `fill` when the visual contract calls for them. A table must not inherit the primary color by accident.
+- `chart`: declare `colors` for every multi-series chart. Use `series1`, `series2`, and `series3` or more direction-specific series tokens; do not use one hue for unrelated series.
+
+All visual effects remain editable native objects. Use transparent overlays instead of rasterising masks.

--- a/SKILLs/presentation-studio/references/profiles.md
+++ b/SKILLs/presentation-studio/references/profiles.md
@@ -1,0 +1,13 @@
+# Scenario profiles
+
+Choose one baseline and adapt it; do not copy a palette from this file.
+
+| Profile | Audience and density | Suitable grammar | Avoid |
+|---|---|---|---|
+| executive-insight | decision makers, sparse claims | editorial hierarchy, decisive charts, restrained contrast | dense dashboards, decorative illustration |
+| strategic-proposal | mixed senior stakeholders, medium density | narrative chapters, bold cover, scenario diagrams | generic consulting blue |
+| academic-defense | expert reviewers, high density | clear evidence, disciplined tables, calm annotations | theatrical decoration |
+| education-explainer | learners, progressive disclosure | illustrated analogy, sequence, participatory moments | tiny labels, overfull slides |
+| brand-launch | external audience, low-to-medium density | hero imagery, dramatic scale, purposeful motion cues | commodity card grids |
+| operations-report | internal team, high density | modular rhythm, exception-focused data, clear owners | every metric equal weight |
+| portfolio-showcase | creative audience, low density | image-led pacing, strong type, varied framing | stock imagery without a visual point of view |

--- a/SKILLs/presentation-studio/references/reference-mode.md
+++ b/SKILLs/presentation-studio/references/reference-mode.md
@@ -1,0 +1,13 @@
+# Reference mode
+
+Use supplied screenshots, existing brand pages, or approved decks as evidence—not as material to screenshot into slides.
+
+Extract a short design system before writing `design.md`:
+
+- color roles and contrast, not just sampled hex values;
+- display/body typography and hierarchy;
+- margins, grids, alignment, framing, and image crops;
+- component treatment for data, tables, dividers, and annotations;
+- motion or layering cues that can be recreated with editable objects.
+
+State what is transferred, what is intentionally changed for the content, and what must not be copied (logos, proprietary illustrations, exact artwork). Render three proof pages and compare against the extracted system before producing the full deck.

--- a/SKILLs/presentation-studio/references/visual-review.md
+++ b/SKILLs/presentation-studio/references/visual-review.md
@@ -1,0 +1,14 @@
+# Visual review rubric
+
+Review rendered proof pages at normal presentation size. Score each 1–5 and record one concrete defect for any score below 4.
+
+| Dimension | Look for |
+|---|---|
+| direction | clear point of view matched to audience and content |
+| color | content-derived temperature, useful hierarchy, non-monochrome data |
+| composition | deliberate scale, alignment, visual rhythm, no unused accidental space |
+| typography | memorable display treatment and readable body hierarchy |
+| imagery/data | intentional crops, editable diagrams, data colors that communicate |
+| coherence | cover, content, and data page feel like one system without becoming clones |
+
+Do not approve merely because elements fit the canvas. Revise the design contract if two unrelated prompts converge on the same palette, font pair, or page family.

--- a/SKILLs/presentation-studio/scripts/compile-deck.mjs
+++ b/SKILLs/presentation-studio/scripts/compile-deck.mjs
@@ -31,6 +31,12 @@ const colors = deck.theme.colors;
 const styles = deck.theme.textStyles ?? {};
 const color = value => value?.startsWith('$') ? colors[value.slice(1)] : value;
 const inch = value => value / 96;
+const transparency = value => Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : undefined;
+const hexToRgb = value => {
+  const hex = value.replace(/^#/, '');
+  return [0, 2, 4].map(index => Number.parseInt(hex.slice(index, index + 2), 16));
+};
+const blend = (from, to, amount) => hexToRgb(from).map((channel, index) => Math.round(channel + (hexToRgb(to)[index] - channel) * amount).toString(16).padStart(2, '0')).join('').toUpperCase();
 const imageOptions = (imagePath, sizing, x, y, w, h) => {
   if (sizing !== 'cover' && sizing !== 'contain') return { path: imagePath, x, y, w, h };
   const { width, height } = imageSize(imagePath);
@@ -43,17 +49,36 @@ for (const pageRef of deck.pages) {
   slide.background = { color: color(page.background ?? '$background') };
   for (const element of page.elements) {
     const [x, y, w, h] = element.bounds.map(inch);
-    if (element.type === 'shape') slide.addShape(pres.ShapeType[element.shape] ?? pres.ShapeType.rect, { x, y, w, h, fill: { color: color(element.fill ?? '$primary') }, line: { color: color(element.line ?? element.fill ?? '$primary'), transparency: element.line ? 0 : 100 } });
-    if (element.type === 'image') slide.addImage(imageOptions(path.resolve(baseDir, element.src), element.sizing, x, y, w, h));
+    if (element.type === 'shape' && element.gradient) {
+      const { from, to, direction = 'horizontal', steps = 12 } = element.gradient;
+      for (let index = 0; index < steps; index += 1) {
+        const amount = steps === 1 ? 0 : index / (steps - 1);
+        const horizontal = direction === 'horizontal';
+        const band = horizontal
+          ? { x: x + (w * index) / steps, y, w: w / steps + 0.001, h }
+          : { x, y: y + (h * index) / steps, w, h: h / steps + 0.001 };
+        slide.addShape(pres.ShapeType.rect, { ...band, fill: { color: blend(color(from), color(to), amount), transparency: transparency(element.fillTransparency) }, line: { color: 'FFFFFF', transparency: 100 } });
+      }
+    }
+    if (element.type === 'shape' && !element.gradient) {
+      const fill = element.fill ? { color: color(element.fill), transparency: transparency(element.fillTransparency) } : { color: 'FFFFFF', transparency: 100 };
+      const line = element.line ? { color: color(element.line), transparency: transparency(element.lineTransparency), width: element.lineWidth, dashType: element.lineDash } : { color: 'FFFFFF', transparency: 100 };
+      slide.addShape(pres.ShapeType[element.shape] ?? pres.ShapeType.rect, { x, y, w, h, fill, line, rotate: element.rotate });
+    }
+    if (element.type === 'image') slide.addImage({ ...imageOptions(path.resolve(baseDir, element.src), element.sizing, x, y, w, h), transparency: transparency(element.transparency), rotate: element.rotate });
     if (element.type === 'text') {
       const style = element.style?.startsWith('$') ? styles[element.style.slice(1)] ?? {} : {};
-      slide.addText(element.text, { x, y, w, h, fontFace: element.fontFace ?? style.fontFace, fontSize: element.fontSize ?? style.fontSize, color: color(element.color ?? style.color ?? '$text'), bold: element.bold ?? style.bold, margin: 0, fit: 'none', align: element.align ?? 'left', valign: element.valign ?? 'top', paraSpaceAfterPt: 0 });
+      slide.addText(element.text, { x, y, w, h, fontFace: element.fontFace ?? style.fontFace, fontSize: element.fontSize ?? style.fontSize, color: color(element.color ?? style.color ?? '$text'), bold: element.bold ?? style.bold, italic: element.italic ?? style.italic, charSpacing: element.charSpacing ?? style.charSpacing, margin: element.margin ?? 0, fit: 'none', align: element.align ?? 'left', valign: element.valign ?? 'top', paraSpaceAfterPt: 0, rotate: element.rotate });
     }
     if (element.type === 'table') {
-      slide.addTable(element.rows, { x, y, w, h, fontFace: element.fontFace ?? 'Microsoft YaHei', fontSize: element.fontSize ?? 18, color: color(element.color ?? '$text'), border: { color: color(element.borderColor ?? '$primary'), pt: 1 }, fill: color(element.fill ?? '$background'), margin: 0.05, valign: 'mid' });
+      const rows = element.rows.map((row, index) => index === 0 && (element.headerFill || element.headerColor)
+        ? row.map(text => ({ text, options: { bold: true, color: color(element.headerColor ?? '$text'), fill: color(element.headerFill ?? '$surface') } }))
+        : row);
+      slide.addTable(rows, { x, y, w, h, fontFace: element.fontFace ?? 'Microsoft YaHei', fontSize: element.fontSize ?? 18, color: color(element.color ?? '$text'), border: { color: color(element.borderColor ?? '$muted'), pt: element.borderWidth ?? 1 }, fill: color(element.fill ?? '$surface'), margin: 0.05, valign: 'mid' });
     }
     if (element.type === 'chart') {
-      slide.addChart(pres.ChartType[element.chartType], element.data, { x, y, w, h, showLegend: element.showLegend ?? false, showTitle: false, chartColors: element.colors?.map(color) ?? [colors.primary] });
+      const chartColors = element.colors?.map(color) ?? (element.data.length === 1 ? [colors.primary] : []);
+      slide.addChart(pres.ChartType[element.chartType], element.data, { x, y, w, h, showLegend: element.showLegend ?? false, showTitle: false, showValue: element.showValue ?? false, chartColors });
     }
   }
 }

--- a/SKILLs/presentation-studio/scripts/test-validator.mjs
+++ b/SKILLs/presentation-studio/scripts/test-validator.mjs
@@ -28,7 +28,7 @@ try {
 
   page.elements = [
     { id: 'cover-title', type: 'text', bounds: [96, 96, 860, 100], style: '$title', text: 'Metrics at a glance', wrap: true },
-    { id: 'metrics', type: 'table', bounds: [96, 240, 500, 180], rows: [['Metric', 'Result'], ['Revenue', '42%']], fontSize: 18 },
+    { id: 'metrics', type: 'table', bounds: [96, 240, 500, 180], rows: [['Metric', 'Result'], ['Revenue', '42%']], fontSize: 18, headerFill: '$primary', headerColor: '$background', borderColor: '$muted' },
     { id: 'trend', type: 'chart', chartType: 'bar', bounds: [640, 240, 500, 220], data: [{ name: 'Growth', labels: ['Q1', 'Q2'], values: [18, 42] }] },
   ];
   fs.writeFileSync(pagePath, `${JSON.stringify(page, null, 2)}\n`);
@@ -38,6 +38,38 @@ try {
   const compiled = spawnSync(process.execPath, [compiler, path.join(workspace, 'deck.json'), outputPath], { encoding: 'utf8' });
   assert.equal(compiled.status, 0, compiled.stdout + compiled.stderr);
   assert.ok(fs.statSync(outputPath).size > 0, 'compiler must create a non-empty PPTX for tables and charts');
+
+  page.elements = [
+    { id: 'mask', type: 'shape', shape: 'rect', bounds: [96, 96, 500, 280], fill: '$primary', fillTransparency: 35, decorative: true },
+    { id: 'gradient', type: 'shape', shape: 'rect', bounds: [96, 96, 500, 280], gradient: { from: '$primary', to: '$secondary', direction: 'horizontal', steps: 8 }, decorative: true },
+    { id: 'divider', type: 'shape', shape: 'line', bounds: [96, 410, 500, 1], line: '$accent', lineWidth: 1.5, decorative: true },
+    { id: 'table-style', type: 'table', bounds: [96, 440, 500, 180], rows: [['Metric', 'Result'], ['Revenue', '42%']], fontSize: 18, headerFill: '$secondary', headerColor: '$background', borderColor: '$muted' },
+    { id: 'comparison', type: 'chart', chartType: 'bar', bounds: [640, 240, 500, 220], data: [{ name: 'Plan', labels: ['Q1', 'Q2'], values: [18, 42] }, { name: 'Actual', labels: ['Q1', 'Q2'], values: [12, 36] }], colors: ['$series1', '$series2'] },
+  ];
+  fs.writeFileSync(pagePath, `${JSON.stringify(page, null, 2)}\n`);
+  const validVisualPrimitives = run();
+  assert.equal(validVisualPrimitives.status, 0, validVisualPrimitives.stdout + validVisualPrimitives.stderr);
+  const visualOutputPath = path.join(workspace, 'output', 'visual-primitives.pptx');
+  const visualCompiled = spawnSync(process.execPath, [compiler, path.join(workspace, 'deck.json'), visualOutputPath], { encoding: 'utf8' });
+  assert.equal(visualCompiled.status, 0, visualCompiled.stdout + visualCompiled.stderr);
+  assert.ok(fs.statSync(visualOutputPath).size > 0, 'compiler must preserve visual primitives as editable PowerPoint elements');
+
+  delete page.elements[4].colors;
+  fs.writeFileSync(pagePath, `${JSON.stringify(page, null, 2)}\n`);
+  const invalidMultiSeriesChart = run();
+  assert.equal(invalidMultiSeriesChart.status, 1, 'multi-series charts must not silently become monochrome');
+  assert.match(invalidMultiSeriesChart.stdout, /one explicit color per series/);
+
+  page.elements = [{ id: 'edge-ornament', type: 'shape', shape: 'ellipse', bounds: [-40, 60, 180, 180], fill: '$accent', decorative: true, allowOverflow: true }];
+  fs.writeFileSync(pagePath, `${JSON.stringify(page, null, 2)}\n`);
+  const validOverflowOrnament = run();
+  assert.equal(validOverflowOrnament.status, 0, validOverflowOrnament.stdout + validOverflowOrnament.stderr);
+
+  delete page.elements[0].allowOverflow;
+  fs.writeFileSync(pagePath, `${JSON.stringify(page, null, 2)}\n`);
+  const invalidOverflowOrnament = run();
+  assert.equal(invalidOverflowOrnament.status, 1, 'decorative overflow requires an explicit opt-in');
+  assert.match(invalidOverflowOrnament.stdout, /element exceeds canvas bounds/);
   console.log('Presentation Studio validator tests passed');
 } finally {
   fs.rmSync(workspace, { recursive: true, force: true });

--- a/SKILLs/presentation-studio/scripts/validate-deck.mjs
+++ b/SKILLs/presentation-studio/scripts/validate-deck.mjs
@@ -6,6 +6,7 @@ const HEX = /^#[0-9a-fA-F]{6}$/;
 const ALLOWED_TYPES = new Set(['text', 'shape', 'image', 'table', 'chart']);
 const ALLOWED_SIZING = new Set(['cover', 'contain']);
 const ALLOWED_CHART_TYPES = new Set(['area', 'bar', 'doughnut', 'line', 'pie', 'radar']);
+const ALLOWED_GRADIENT_DIRECTIONS = new Set(['horizontal', 'vertical']);
 
 function fail(message) {
   throw new Error(message);
@@ -31,6 +32,10 @@ function resolveColor(value, colors) {
   if (typeof value !== 'string') return null;
   if (value.startsWith('$')) return colors[value.slice(1)] ?? null;
   return value;
+}
+
+function isTransparency(value) {
+  return value === undefined || (Number.isFinite(value) && value >= 0 && value <= 100);
 }
 
 function textMetrics(text, fontSize, width, lineHeight, wrap) {
@@ -78,14 +83,30 @@ function validateDeck(deckPath) {
       if (!isBounds(element.bounds) || element.bounds[2] <= 0 || element.bounds[3] <= 0) { add('error', 'bounds must be [x, y, width, height] with positive size', label); continue; }
       const [x, y, width, height] = element.bounds;
       if (!element.decorative && (x < safeMargin || y < safeMargin || x + width > canvas.width - safeMargin || y + height > canvas.height - safeMargin)) add('warning', `element breaches ${safeMargin}px safe margin`, label);
-      if (x < 0 || y < 0 || x + width > canvas.width || y + height > canvas.height) add('error', 'element exceeds canvas bounds', label);
+      const exceedsCanvas = x < 0 || y < 0 || x + width > canvas.width || y + height > canvas.height;
+      if (exceedsCanvas && !(element.decorative && element.allowOverflow)) add('error', 'element exceeds canvas bounds', label);
       if (element.type === 'image') {
         if (typeof element.src !== 'string' || !element.src) add('error', 'image src is required', label);
         else if (/^https?:\/\//.test(element.src)) add('error', 'remote image URLs are not allowed; download the verified asset into assets/', label);
         else if (!fs.existsSync(path.resolve(baseDir, element.src))) add('error', `image asset not found: ${element.src}`, label);
         if (element.sizing !== undefined && !ALLOWED_SIZING.has(element.sizing)) add('error', 'image sizing must be cover or contain', label);
+        if (!isTransparency(element.transparency)) add('error', 'image transparency must be between 0 and 100', label);
       }
-      if (element.type === 'shape' && !HEX.test(resolveColor(element.fill ?? '$background', colors) ?? '')) add('error', 'shape fill must resolve to #RRGGBB', label);
+      if (element.type === 'shape') {
+        if (!element.fill && !element.line && !element.gradient) add('error', 'shape requires fill, line, or gradient; do not inherit a default primary color', label);
+        if (element.fill && !HEX.test(resolveColor(element.fill, colors) ?? '')) add('error', 'shape fill must resolve to #RRGGBB', label);
+        if (element.line && !HEX.test(resolveColor(element.line, colors) ?? '')) add('error', 'shape line must resolve to #RRGGBB', label);
+        if (!isTransparency(element.fillTransparency) || !isTransparency(element.lineTransparency)) add('error', 'shape transparency must be between 0 and 100', label);
+        if (element.gradient) {
+          if (element.shape && element.shape !== 'rect') add('error', 'gradient shapes must use rect', label);
+          if (!element.gradient || typeof element.gradient !== 'object') add('error', 'gradient must be an object', label);
+          else {
+            if (!HEX.test(resolveColor(element.gradient.from, colors) ?? '') || !HEX.test(resolveColor(element.gradient.to, colors) ?? '')) add('error', 'gradient from and to must resolve to #RRGGBB', label);
+            if (element.gradient.direction !== undefined && !ALLOWED_GRADIENT_DIRECTIONS.has(element.gradient.direction)) add('error', 'gradient direction must be horizontal or vertical', label);
+            if (element.gradient.steps !== undefined && (!Number.isInteger(element.gradient.steps) || element.gradient.steps < 2 || element.gradient.steps > 32)) add('error', 'gradient steps must be an integer between 2 and 32', label);
+          }
+        }
+      }
       if (element.type === 'text') {
         if (typeof element.text !== 'string') add('error', 'text content must be a string', label);
         const style = element.style?.startsWith('$') ? styles[element.style.slice(1)] ?? {} : {};
@@ -108,6 +129,9 @@ function validateDeck(deckPath) {
         else if (element.rows.some(row => row.some(cell => typeof cell !== 'string' && typeof cell !== 'number'))) add('error', 'table cells must be strings or numbers', label);
         const tableFontSize = element.fontSize ?? 18;
         if (!Number.isFinite(tableFontSize) || tableFontSize < 12) add('error', 'table font size must be at least 12pt', label);
+        for (const field of ['fill', 'borderColor', 'headerFill', 'headerColor']) {
+          if (element[field] !== undefined && !HEX.test(resolveColor(element[field], colors) ?? '')) add('error', `table ${field} must resolve to #RRGGBB`, label);
+        }
       }
       if (element.type === 'chart') {
         if (!ALLOWED_CHART_TYPES.has(element.chartType)) add('error', `unsupported chart type ${element.chartType}`, label);
@@ -116,6 +140,8 @@ function validateDeck(deckPath) {
           if (!series || typeof series.name !== 'string' || !Array.isArray(series.labels) || !Array.isArray(series.values)) add('error', 'chart series requires name, labels, and values', label);
           else if (series.labels.length === 0 || series.labels.length !== series.values.length || series.values.some(value => !Number.isFinite(value))) add('error', 'chart labels and numeric values must have matching non-zero lengths', label);
         }
+        if (Array.isArray(element.data) && element.data.length > 1 && (!Array.isArray(element.colors) || element.colors.length < element.data.length)) add('error', 'multi-series chart requires one explicit color per series', label);
+        if (element.colors !== undefined && (!Array.isArray(element.colors) || element.colors.some(value => !HEX.test(resolveColor(value, colors) ?? '')))) add('error', 'chart colors must resolve to #RRGGBB', label);
       }
     }
     for (let i = 0; i < textElements.length; i += 1) for (let j = i + 1; j < textElements.length; j += 1) {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "format:check": "oxfmt --check .",
     "prepare": "husky",
     "test": "node scripts/test-with-native-restore.cjs",
+    "test:visual-blind-review": "node tests/visualBlindReview.test.mjs",
     "test:sqlite-backup:seed": "node tests/sqlite-backup/generate-large-db.cjs",
     "preview": "vite preview",
     "compile:electron": "tsc --project electron-tsconfig.json",

--- a/public/quick-actions-i18n.json
+++ b/public/quick-actions-i18n.json
@@ -81,22 +81,22 @@
         "web-resume": {
           "label": "个人简历",
           "description": "在线简历与作品集页面",
-          "prompt": "帮我制作一个精美的在线个人简历页面。\n\n基本信息:\n- 姓名:张小明;\n- 职位:产品经理(5年经验);\n- 联系方式:邮箱、手机、微信二维码占位区。\n\n页面内容:\n- 个人简介:一段简短的自我介绍,突出核心优势;\n- 工作经历:3段工作经历,含公司名、职位、时间、主要成果;\n- 专业技能:以进度条形式展示产品设计、数据分析、项目管理等技能;\n- 项目案例:展示3个代表项目的卡片,含项目名称和简短描述;\n- 教育背景与证书。\n\n设计风格:\n简洁专业、左右分栏布局、深色侧边栏搭配白色主内容区。适合直接分享给面试官或合作伙伴。"
+          "prompt": "帮我制作一个精美的在线个人简历页面。\n\n基本信息:\n- 姓名:张小明;\n- 职位:产品经理(5年经验);\n- 联系方式:邮箱、手机、微信二维码占位区。\n\n页面内容:\n- 个人简介:一段简短的自我介绍,突出核心优势;\n- 工作经历:3段工作经历,含公司名、职位、时间、主要成果;\n- 专业技能:以进度条形式展示产品设计、数据分析、项目管理等技能;\n- 项目案例:展示3个代表项目的卡片,含项目名称和简短描述;\n- 教育背景与证书。\n\n设计目标:\n面向面试官或合作伙伴，传达可信、清晰且有个人辨识度的专业感。请从内容和受众推导视觉方向、配色、字体和版式；不要默认套用侧栏或固定颜色。"
         },
         "web-store": {
           "label": "店铺主页",
           "description": "小型商铺或工作室展示页",
-          "prompt": "帮我做一个烘焙工作室的展示网页,工作室名叫「麦田烘焙」。\n\n页面内容:\n- 首屏大图:工作室名称、一句口号「用心烘焙,温暖每一天」、\"查看菜单\"按钮;\n- 招牌产品:展示6款人气产品卡片(含图片占位、名称、价格、简短描述);\n- 关于我们:工作室的故事,创始人理念,配一张店内环境图占位;\n- 顾客好评:3条用户评价,带头像和星级评分;\n- 联系与地址:营业时间、地址、电话,嵌入地图占位区域;\n\n设计风格:\n温馨文艺、奶油色和棕色为主色调、圆角卡片、手写风格标题字体。整体氛围温暖亲切。"
+          "prompt": "帮我做一个烘焙工作室的展示网页,工作室名叫「麦田烘焙」。\n\n页面内容:\n- 首屏大图:工作室名称、一句口号「用心烘焙,温暖每一天」、\"查看菜单\"按钮;\n- 招牌产品:展示6款人气产品卡片(含图片占位、名称、价格、简短描述);\n- 关于我们:工作室的故事,创始人理念,配一张店内环境图占位;\n- 顾客好评:3条用户评价,带头像和星级评分;\n- 联系与地址:营业时间、地址、电话,嵌入地图占位区域;\n\n设计目标:\n传达食物、手作与社区感，但请根据品牌故事选择有辨识度的材质、色温、字体和构图；不要默认使用奶油棕、圆角卡片或手写字体。"
         },
         "web-event": {
           "label": "活动邀请函",
           "description": "聚会、婚礼或活动的在线邀请页",
-          "prompt": "帮我制作一个生日派对的在线邀请函网页。\n\n活动信息:\n- 主题:「Leo的30岁生日派对」;\n- 时间:2025年8月15日 周六 晚上7:00;\n- 地点:星光花园餐厅 三楼露台;\n\n页面内容:\n- 开场动画:标题渐入,彩色纸屑飘落效果;\n- 邀请语:一段温馨的邀请文字;\n- 活动安排:时间轴展示派对流程(签到、晚宴、游戏、蛋糕、自由交流);\n- 着装建议:休闲正装,配色参考图占位;\n- 交通指引:地址信息和停车提示;\n- RSVP确认:\"我会参加\"和\"很遗憾不能到\"两个按钮;\n\n设计风格:\n浪漫活泼、深蓝色星空背景、金色点缀文字、充满庆祝氛围。页面要适合手机浏览。"
+          "prompt": "帮我制作一个生日派对的在线邀请函网页。\n\n活动信息:\n- 主题:「Leo的30岁生日派对」;\n- 时间:2025年8月15日 周六 晚上7:00;\n- 地点:星光花园餐厅 三楼露台;\n\n页面内容:\n- 开场动画:标题渐入,彩色纸屑飘落效果;\n- 邀请语:一段温馨的邀请文字;\n- 活动安排:时间轴展示派对流程(签到、晚宴、游戏、蛋糕、自由交流);\n- 着装建议:休闲正装,配色参考图占位;\n- 交通指引:地址信息和停车提示;\n- RSVP确认:\"我会参加\"和\"很遗憾不能到\"两个按钮;\n\n设计目标:\n营造成年生日庆典的记忆点与仪式感，并优先适配手机。请独立选择色温、字体、动效和空间节奏；不要默认使用星空、深蓝金色或固定庆典模板。"
         },
         "web-survey": {
           "label": "调查问卷",
           "description": "在线表单与问卷收集页",
-          "prompt": "帮我做一个客户满意度调查问卷网页。\n\n问卷标题:「您的反馈对我们很重要」\n\n问卷内容:\n- 基本信息:姓名(选填)、联系方式(选填);\n- 单选题:整体满意度(非常满意/满意/一般/不满意/非常不满意);\n- 单选题:您是否愿意推荐给朋友(1-10分评分滑块);\n- 多选题:您最看重的方面(产品质量/服务态度/响应速度/性价比/售后保障);\n- 单选题:使用频率(每天/每周/每月/偶尔);\n- 文本题:您的建议或意见(大文本框);\n- 提交按钮,提交后显示感谢页面。\n\n设计风格:\n清爽简洁、白色背景、蓝绿色主色调、每道题之间有足够间距、带进度条显示填写进度。适合手机端操作。"
+          "prompt": "帮我做一个客户满意度调查问卷网页。\n\n问卷标题:「您的反馈对我们很重要」\n\n问卷内容:\n- 基本信息:姓名(选填)、联系方式(选填);\n- 单选题:整体满意度(非常满意/满意/一般/不满意/非常不满意);\n- 单选题:您是否愿意推荐给朋友(1-10分评分滑块);\n- 多选题:您最看重的方面(产品质量/服务态度/响应速度/性价比/售后保障);\n- 单选题:使用频率(每天/每周/每月/偶尔);\n- 文本题:您的建议或意见(大文本框);\n- 提交按钮,提交后显示感谢页面。\n\n设计目标:\n让填写过程轻松、可信且适合手机操作，清晰呈现进度和反馈状态。请根据这一任务选择克制而有辨识度的设计系统；不要默认使用白底蓝绿色问卷模板。"
         }
       }
     }
@@ -183,25 +183,24 @@
         "web-resume": {
           "label": "Personal Resume",
           "description": "Online resume and portfolio page",
-          "prompt": "Help me create a beautiful online personal resume page.\n\nBasic information:\n- Name: John Smith\n- Position: Product Manager (5 years experience)\n- Contact: Email, phone, WeChat QR code placeholder\n\nPage content:\n- Personal introduction: A brief self-introduction highlighting core strengths\n- Work experience: 3 work experiences, including company name, position, time, main achievements\n- Professional skills: Display product design, data analysis, project management and other skills in progress bar format\n- Project cases: Display 3 representative project cards with project name and brief description\n- Educational background and certificates\n\nDesign style:\nClean and professional, left-right column layout, dark sidebar with white main content area. Suitable for sharing directly with interviewers or partners."
+          "prompt": "Help me create a beautiful online personal resume page.\n\nBasic information:\n- Name: John Smith\n- Position: Product Manager (5 years experience)\n- Contact: Email, phone, WeChat QR code placeholder\n\nPage content:\n- Personal introduction: A brief self-introduction highlighting core strengths\n- Work experience: 3 work experiences, including company name, position, time, main achievements\n- Professional skills: Display product design, data analysis, project management and other skills in progress bar format\n- Project cases: Display 3 representative project cards with project name and brief description\n- Educational background and certificates\n\nDesign goal:\nCommunicate credibility, clarity, and a personal point of view to interviewers or partners. Derive the visual direction, palette, typography, and composition from the content and audience; do not default to a sidebar or fixed colors."
         },
         "web-store": {
           "label": "Store Homepage",
           "description": "Small shop or studio showcase page",
-          "prompt": "Help me create a showcase webpage for a bakery studio called \"Wheat Field Bakery\".\n\nPage content:\n- Hero image: Studio name, a slogan \"Baking with heart, warming every day\", \"View Menu\" button\n- Signature products: Display 6 popular product cards (including image placeholder, name, price, brief description)\n- About us: Studio story, founder philosophy, with a store environment image placeholder\n- Customer reviews: 3 user reviews with avatars and star ratings\n- Contact and address: Business hours, address, phone, embedded map placeholder area\n\nDesign style:\nWarm and artistic, cream and brown as main colors, rounded cards, handwritten style title fonts. Overall atmosphere warm and friendly."
+          "prompt": "Help me create a showcase webpage for a bakery studio called \"Wheat Field Bakery\".\n\nPage content:\n- Hero image: Studio name, a slogan \"Baking with heart, warming every day\", \"View Menu\" button\n- Signature products: Display 6 popular product cards (including image placeholder, name, price, brief description)\n- About us: Studio story, founder philosophy, with a store environment image placeholder\n- Customer reviews: 3 user reviews with avatars and star ratings\n- Contact and address: Business hours, address, phone, embedded map placeholder area\n\nDesign goal:\nCommunicate food, craft, and community. Select distinctive material, temperature, typography, and composition from the brand story; do not default to cream-brown, rounded cards, or handwritten type."
         },
         "web-event": {
           "label": "Event Invitation",
           "description": "Online invitation page for parties, weddings or events",
-          "prompt": "Help me create an online invitation webpage for a birthday party.\n\nEvent information:\n- Theme: \"Leo's 30th Birthday Party\"\n- Time: Saturday, August 15, 2025, 7:00 PM\n- Location: Starlight Garden Restaurant, 3rd Floor Terrace\n\nPage content:\n- Opening animation: Title fade-in, colorful confetti falling effect\n- Invitation message: A warm invitation text\n- Event schedule: Timeline showing party flow (check-in, dinner, games, cake, free socializing)\n- Dress code: Business casual, color reference image placeholder\n- Transportation guide: Address information and parking tips\n- RSVP confirmation: \"I will attend\" and \"Regrettably cannot attend\" two buttons\n\nDesign style:\nRomantic and lively, dark blue starry background, gold accent text, full of celebration atmosphere. Page should be mobile-friendly."
+          "prompt": "Help me create an online invitation webpage for a birthday party.\n\nEvent information:\n- Theme: \"Leo's 30th Birthday Party\"\n- Time: Saturday, August 15, 2025, 7:00 PM\n- Location: Starlight Garden Restaurant, 3rd Floor Terrace\n\nPage content:\n- Opening animation: Title fade-in, colorful confetti falling effect\n- Invitation message: A warm invitation text\n- Event schedule: Timeline showing party flow (check-in, dinner, games, cake, free socializing)\n- Dress code: Business casual, color reference image placeholder\n- Transportation guide: Address information and parking tips\n- RSVP confirmation: \"I will attend\" and \"Regrettably cannot attend\" two buttons\n\nDesign goal:\nCreate a memorable, ceremonial adult birthday experience with mobile-first RSVP. Independently select temperature, typography, motion, and spatial rhythm; do not default to stars, navy-and-gold, or a fixed celebration template."
         },
         "web-survey": {
           "label": "Survey Questionnaire",
           "description": "Online form and questionnaire collection page",
-          "prompt": "Help me create a customer satisfaction survey questionnaire webpage.\n\nQuestionnaire title: \"Your Feedback is Important to Us\"\n\nQuestionnaire content:\n- Basic information: Name (optional), Contact (optional)\n- Single choice: Overall satisfaction (Very satisfied/Satisfied/Neutral/Dissatisfied/Very dissatisfied)\n- Single choice: Would you recommend to friends (1-10 rating slider)\n- Multiple choice: What aspects do you value most (Product quality/Service attitude/Response speed/Value for money/After-sales support)\n- Single choice: Usage frequency (Daily/Weekly/Monthly/Occasionally)\n- Text question: Your suggestions or opinions (large text box)\n- Submit button, show thank you page after submission\n\nDesign style:\nFresh and simple, white background, blue-green main color, sufficient spacing between questions, with progress bar showing completion. Suitable for mobile operation."
+          "prompt": "Help me create a customer satisfaction survey questionnaire webpage.\n\nQuestionnaire title: \"Your Feedback is Important to Us\"\n\nQuestionnaire content:\n- Basic information: Name (optional), Contact (optional)\n- Single choice: Overall satisfaction (Very satisfied/Satisfied/Neutral/Dissatisfied/Very dissatisfied)\n- Single choice: Would you recommend to friends (1-10 rating slider)\n- Multiple choice: What aspects do you value most (Product quality/Service attitude/Response speed/Value for money/After-sales support)\n- Single choice: Usage frequency (Daily/Weekly/Monthly/Occasionally)\n- Text question: Your suggestions or opinions (large text box)\n- Submit button, show thank you page after submission\n\nDesign goal:\nMake completion easy, trustworthy, and mobile-friendly with clear progress and feedback states. Choose a restrained but distinctive system for this task; do not default to a white-and-teal survey template."
         }
       }
     }
   }
 }
-

--- a/scripts/prepare-visual-blind-review.mjs
+++ b/scripts/prepare-visual-blind-review.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    fail(`Cannot read ${file}: ${error.message}`);
+  }
+}
+
+function parseArgs(args) {
+  const [root, ...rest] = args;
+  if (!root) fail('Usage: prepare-visual-blind-review.mjs <evaluation-root> [--seed <seed>] [--output <dir>]');
+  const seedIndex = rest.indexOf('--seed');
+  const outputIndex = rest.indexOf('--output');
+  const seed = seedIndex >= 0 ? rest[seedIndex + 1] : 'visual-review-v1';
+  const output = outputIndex >= 0 ? rest[outputIndex + 1] : path.join(root, 'blind-review');
+  if (!seed || !output) fail('--seed and --output require values');
+  return { root: path.resolve(root), seed, output: path.resolve(output) };
+}
+
+function loadVariant(taskDir, name) {
+  const file = path.join(taskDir, `${name}.json`);
+  const data = readJson(file);
+  if (!data || typeof data !== 'object' || typeof data.preview !== 'string' || !data.preview) fail(`${file} requires a preview path`);
+  if (typeof data.kind !== 'string' || !data.kind) fail(`${file} requires kind`);
+  const preview = path.resolve(taskDir, data.preview);
+  if (!fs.existsSync(preview)) fail(`${file} preview does not exist: ${data.preview}`);
+  const extension = path.extname(preview).toLowerCase();
+  if (!IMAGE_EXTENSIONS.has(extension)) fail(`${file} preview must be a rendered PNG, JPG, JPEG, or WebP`);
+  return { kind: data.kind, preview, extension };
+}
+
+function chooseOrder(seed, taskId) {
+  const byte = crypto.createHash('sha256').update(`${seed}:${taskId}`).digest()[0];
+  return byte % 2 === 0 ? ['baseline', 'candidate'] : ['candidate', 'baseline'];
+}
+
+const { root, seed, output } = parseArgs(process.argv.slice(2));
+if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) fail(`Evaluation root does not exist: ${root}`);
+const taskNames = fs.readdirSync(root, { withFileTypes: true })
+  .filter(entry => entry.isDirectory() && entry.name !== path.basename(output))
+  .map(entry => entry.name)
+  .sort();
+if (taskNames.length === 0) fail('Evaluation root must contain task directories');
+if (fs.existsSync(output) && fs.readdirSync(output).length > 0) fail(`Refusing to overwrite non-empty output directory: ${output}`);
+
+fs.mkdirSync(path.join(output, 'artifacts'), { recursive: true });
+const reviewerTasks = [];
+const keyTasks = [];
+
+for (const taskId of taskNames) {
+  const taskDir = path.join(root, taskId);
+  const variants = { baseline: loadVariant(taskDir, 'baseline'), candidate: loadVariant(taskDir, 'candidate') };
+  if (variants.baseline.kind !== variants.candidate.kind) fail(`${taskId} baseline and candidate must use the same kind`);
+  const orderedSources = chooseOrder(seed, taskId);
+  const choices = orderedSources.map((source, index) => {
+    const label = index === 0 ? 'A' : 'B';
+    const sourceVariant = variants[source];
+    const destination = path.join(output, 'artifacts', `${taskId}-${label}${sourceVariant.extension}`);
+    fs.copyFileSync(sourceVariant.preview, destination);
+    return { label, preview: path.relative(output, destination) };
+  });
+  reviewerTasks.push({ taskId, kind: variants.baseline.kind, choices, rubric: ['direction', 'composition', 'color-and-type', 'coherence', 'legibility-or-responsiveness'], winner: null, notes: '' });
+  keyTasks.push({ taskId, A: orderedSources[0], B: orderedSources[1] });
+}
+
+fs.writeFileSync(path.join(output, 'review-form.json'), `${JSON.stringify({ schemaVersion: 1, instructions: 'Review each A/B pair without opening the source task directory. Pick one winner or tie, then score the listed dimensions 1–5 and explain any score below 4.', tasks: reviewerTasks }, null, 2)}\n`);
+fs.writeFileSync(path.join(output, 'blind-review-key.json'), `${JSON.stringify({ schemaVersion: 1, seed, tasks: keyTasks }, null, 2)}\n`);
+console.log(`Prepared ${taskNames.length} blinded visual review pair(s) in ${output}`);

--- a/tests/visualBlindReview.test.mjs
+++ b/tests/visualBlindReview.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repo = path.resolve(import.meta.dirname, '..');
+const script = path.join(repo, 'scripts', 'prepare-visual-blind-review.mjs');
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-blind-review-'));
+
+try {
+  for (const taskId of ['ppt-mineral', 'web-field-culture']) {
+    const task = path.join(root, taskId);
+    fs.mkdirSync(task, { recursive: true });
+    fs.writeFileSync(path.join(task, 'baseline.png'), 'baseline');
+    fs.writeFileSync(path.join(task, 'candidate.png'), 'candidate');
+    fs.writeFileSync(path.join(task, 'baseline.json'), JSON.stringify({ kind: taskId.startsWith('ppt') ? 'ppt' : 'website', preview: 'baseline.png' }));
+    fs.writeFileSync(path.join(task, 'candidate.json'), JSON.stringify({ kind: taskId.startsWith('ppt') ? 'ppt' : 'website', preview: 'candidate.png' }));
+  }
+  const output = path.join(root, 'review');
+  const result = spawnSync(process.execPath, [script, root, '--seed', 'test-seed', '--output', output], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const form = JSON.parse(fs.readFileSync(path.join(output, 'review-form.json'), 'utf8'));
+  const key = JSON.parse(fs.readFileSync(path.join(output, 'blind-review-key.json'), 'utf8'));
+  assert.equal(form.tasks.length, 2);
+  assert.equal(key.tasks.length, 2);
+  assert.deepEqual(Object.keys(form.tasks[0].choices[0]).sort(), ['label', 'preview']);
+  assert.ok(fs.existsSync(path.join(output, form.tasks[0].choices[0].preview)));
+  assert.ok(!JSON.stringify(form).includes('baseline'));
+  assert.ok(!JSON.stringify(form).includes('candidate'));
+  console.log('Visual blind review tests passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- distill visual-direction workflows for Presentation Studio and Website generation
- remove PPT primary-color fallbacks and add editable masks, lines, richer text/table styling, and explicit multi-series chart colors
- replace Website shortcut color/layout prescriptions with audience and brand-oriented design goals
- add PPT and Website evaluation suites, visual rubrics, reference mode, and reusable design grammar

## Why

PPT and Website outputs repeatedly converged on fixed colors and generic layouts. This changes the decision process and render surface rather than adding another template.

Closes #244.

## Validation

- `npm test --prefix SKILLs/presentation-studio`
- `npm run validate:skills`
- `npm run build:tsc`
- JSON parse check for `public/quick-actions-i18n.json`
- `git diff --check`

## Follow-up

The evaluation suites define the blind-render test corpus. Their actual model runs and preference results should be captured under #244 and fed into #237 paired evaluation.