### PR TITLE
fix(ci): wait for painted Linux renderer

### DIFF
--- a/scripts/verify-linux-renderer.mjs
+++ b/scripts/verify-linux-renderer.mjs
@@ -40,7 +40,15 @@ let applicationOutput = '';
 
 const application = spawn(
   'xvfb-run',
-  ['-a', executablePath, '--no-sandbox', `--remote-debugging-port=${remoteDebuggingPort}`],
+  [
+    '-a',
+    '-s',
+    '-screen 0 1280x800x24',
+    executablePath,
+    '--no-sandbox',
+    '--zhiyuan-linux-renderer-smoke',
+    `--remote-debugging-port=${remoteDebuggingPort}`,
+  ],
   {
     detached: true,
     env: {
@@ -266,6 +274,7 @@ async function stopApplication() {
 async function captureScreenshot(devTools) {
   const screenshot = await devTools.send('Page.captureScreenshot', {
     format: 'png',
+    fromSurface: true,
     captureBeyondViewport: false,
   });
   const screenshotBytes = Buffer.from(screenshot.data, 'base64');
@@ -274,11 +283,31 @@ async function captureScreenshot(devTools) {
   return screenshotBytes;
 }
 
+async function waitForNonBlankScreenshot(devTools) {
+  const deadline = Date.now() + 30_000;
+  let lastAnalysis;
+
+  while (Date.now() < deadline) {
+    const screenshotBytes = await captureScreenshot(devTools);
+    const screenshotAnalysis = analyzeScreenshot(screenshotBytes);
+    lastAnalysis = screenshotAnalysis;
+    if (screenshotAnalysis.distinctColors >= 8 && screenshotAnalysis.nonWhiteRatio >= 0.01) {
+      return screenshotAnalysis;
+    }
+    await delay(500);
+  }
+
+  throw new Error(
+    `Linux renderer screenshot appears blank after 30 seconds: ${JSON.stringify(lastAnalysis)}`,
+  );
+}
+
 let devTools;
 try {
   const page = await waitForPageTarget();
   devTools = await connectToDevTools(page.webSocketDebuggerUrl);
   await devTools.send('Page.enable');
+  await devTools.send('Page.bringToFront');
   let renderedState;
   try {
     renderedState = await waitForRenderedContent(devTools);
@@ -294,13 +323,7 @@ try {
     throw error;
   }
 
-  const screenshotBytes = await captureScreenshot(devTools);
-  const screenshotAnalysis = analyzeScreenshot(screenshotBytes);
-  if (screenshotAnalysis.distinctColors < 8 || screenshotAnalysis.nonWhiteRatio < 0.01) {
-    throw new Error(
-      `Linux renderer screenshot appears blank: ${JSON.stringify(screenshotAnalysis)}`,
-    );
-  }
+  const screenshotAnalysis = await waitForNonBlankScreenshot(devTools);
 
   console.log(
     `[LinuxRendererSmoke] rendered ${renderedState.rootChildren} root element(s) with visible text; screenshot ${screenshotAnalysis.width}x${screenshotAnalysis.height}, ${screenshotAnalysis.distinctColors} sampled colors`,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -716,6 +716,10 @@ const isDev = process.env.NODE_ENV === 'development';
 const isLinux = process.platform === 'linux';
 const isMac = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
+// The packaged Ubuntu smoke test needs an actual painted window. Production
+// startup stays hidden until ready-to-show to avoid a flash of empty content.
+const isLinuxRendererSmoke =
+  isLinux && process.argv.includes('--zhiyuan-linux-renderer-smoke');
 const DEV_SERVER_URL = process.env.ELECTRON_START_URL || 'http://localhost:5175';
 const enableVerboseLogging =
   process.env.ELECTRON_ENABLE_LOGGING === '1' || process.env.ELECTRON_ENABLE_LOGGING === 'true';
@@ -7193,7 +7197,7 @@ if (!gotTheLock) {
         navigateOnDragDrop: false,
       },
       backgroundColor: getInitialTheme() === 'dark' ? '#0F1117' : '#F8F9FB',
-      show: false,
+      show: isLinuxRendererSmoke,
       autoHideMenuBar: true,
       enableLargerThanScreen: false,
     });
@@ -7364,7 +7368,7 @@ if (!gotTheLock) {
     mainWindow.once('ready-to-show', () => {
       emitWindowState();
       // 开机自启时不显示窗口，仅显示托盘图标
-      if (!isAutoLaunched()) {
+      if (isLinuxRendererSmoke || !isAutoLaunched()) {
         mainWindow?.show();
       }
       // Initialize main-process i18n from stored language before creating UI elements.


### PR DESCRIPTION
## Summary

- Run the Linux renderer smoke check in a visible Xvfb window.
- Wait for a genuinely rendered, non-white frame instead of sampling the initial paint.
- Keep the existing blank-screen thresholds and diagnostic screenshot artifact.

## Root cause

Run 30601071969 built the Linux installers successfully, but the renderer smoke check captured an almost-white initial frame even after the DOM reported content.

## Validation

- `node --check scripts/verify-linux-renderer.mjs`
- `bun test src/main/rendererStartup.test.ts`
- `bun run lint` (passes; existing unrelated `McpManager.tsx` hooks warning remains)
- `npm run build:tsc`
