### PR TITLE
refactor(cowork): 隔离 Pi 工作台运行时事件

### DIFF
--- a/src/main/ipcHandlers/openClawBridge.ts
+++ b/src/main/ipcHandlers/openClawBridge.ts
@@ -1,0 +1,49 @@
+import { ipcMain } from 'electron';
+
+import { CoworkPermissionBehavior } from '../../shared/cowork/constants';
+import { OpenClawBridgeIpc } from '../../shared/ipc/channels';
+import type { PermissionResult } from '../libs/agentEngine';
+import type { AskUserResponse, McpBridgeServer } from '../libs/mcpBridgeServer';
+
+export interface OpenClawBridgeIpcDependencies {
+  getMcpBridgeServer: () => McpBridgeServer | null;
+}
+
+const toAskUserResponse = (result: PermissionResult): AskUserResponse => ({
+  behavior: result.behavior,
+  answers:
+    result.behavior === CoworkPermissionBehavior.Allow && result.updatedInput
+      ? (result.updatedInput.answers as Record<string, string> | undefined)
+      : undefined,
+});
+
+export const registerOpenClawBridgeIpcHandlers = (
+  dependencies: OpenClawBridgeIpcDependencies,
+): void => {
+  ipcMain.handle(
+    OpenClawBridgeIpc.RespondAskUser,
+    async (
+      _event,
+      options: {
+        requestId: string;
+        result: PermissionResult;
+      },
+    ) => {
+      try {
+        const bridgeServer = dependencies.getMcpBridgeServer();
+        if (!bridgeServer) {
+          return { success: false, error: 'OpenClaw bridge server is not available' };
+        }
+
+        bridgeServer.resolveAskUser(options.requestId, toAskUserResponse(options.result));
+        return { success: true };
+      } catch (error) {
+        console.error('[OpenClawBridge] failed to respond to an AskUser request:', error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to respond to AskUser request',
+        };
+      }
+    },
+  );
+};

--- a/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
+++ b/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+const readSource = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8');
+
+const mainSource = readSource('../../main.ts');
+const coworkViewSource = readSource('../../../renderer/components/cowork/CoworkView.tsx');
+const coworkServiceSource = readSource('../../../renderer/services/cowork.ts');
+
+describe('Work/Chat runtime isolation', () => {
+  test('projects only Pi runtime events into cowork streams', () => {
+    expect(mainSource).toContain('forwardPiWorkbenchRuntimeToRenderer(getPiRuntimeAdapter())');
+    expect(mainSource).not.toContain(
+      'forwardPiWorkbenchRuntimeToRenderer(getOpenClawRuntimeAdapter())',
+    );
+    expect(mainSource).toContain('getOpenClawRuntimeAdapter();');
+    expect(mainSource).not.toContain("webContents.send('cowork:stream:");
+  });
+
+  test('keeps OpenClaw AskUser traffic on its dedicated bridge', () => {
+    expect(mainSource).toContain('win.webContents.send(OpenClawBridgeIpc.AskUser');
+    expect(mainSource).toContain('OpenClawBridgeIpc.AskUserDismiss');
+    expect(mainSource).toContain('registerOpenClawBridgeIpcHandlers');
+  });
+
+  test('does not couple CoworkView initialization to OpenClaw Gateway state', () => {
+    expect(coworkViewSource).not.toContain('getOpenClawEngineStatus');
+    expect(coworkViewSource).not.toContain('onOpenClawEngineStatus');
+    expect(coworkViewSource).not.toContain('engineStatusBanner');
+
+    const initStart = coworkServiceSource.indexOf('async init(): Promise<void>');
+    const streamSetupStart = coworkServiceSource.indexOf('private setupStreamListeners');
+    const initSource = coworkServiceSource.slice(initStart, streamSetupStart);
+    expect(initSource).not.toContain('loadOpenClawEngineStatus');
+    expect(initSource).not.toContain('setupOpenClawEngineListeners');
+  });
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,6 +38,8 @@ import {
   COWORK_MESSAGE_PAGE_SIZE,
   COWORK_SESSION_PAGE_SIZE,
   CoworkPermissionMode,
+  CoworkPermissionSessionId,
+  CoworkPermissionToolName,
   CoworkSessionMode,
 } from '../shared/cowork/constants';
 import {
@@ -45,7 +47,17 @@ import {
   type CoworkSessionExpertSnapshot,
   CoworkSessionExpertSource,
 } from '../shared/cowork/sessionExperts';
-import { ApiIpc, CoworkStreamIpc, McpIpc, ProjectIpc, SkillsIpc } from '../shared/ipc/channels';
+import {
+  ApiIpc,
+  AuthIpc,
+  CoworkPermissionIpc,
+  CoworkSessionIpc,
+  CoworkStreamIpc,
+  McpIpc,
+  OpenClawBridgeIpc,
+  ProjectIpc,
+  SkillsIpc,
+} from '../shared/ipc/channels';
 import {
   ApiFetchSchema,
   ApiStreamSchema,
@@ -89,6 +101,7 @@ import type {
 import { getLlamaCppServiceConfig, registerLlamaCppIpcHandlers } from './ipcHandlers/llamacpp';
 import { registerMarketplaceIpcHandlers } from './ipcHandlers/marketplace';
 import { getOllamaServiceConfig, registerOllamaIpcHandlers } from './ipcHandlers/ollama';
+import { registerOpenClawBridgeIpcHandlers } from './ipcHandlers/openClawBridge';
 import {
   getCronJobService,
   initCronJobServiceManager,
@@ -97,7 +110,6 @@ import {
 } from './ipcHandlers/scheduledTask';
 import { getTriageConfig, registerTriageIpcHandlers } from './ipcHandlers/triage';
 import {
-  type CoworkRuntime,
   OpenClawRuntimeAdapter,
   type PermissionResult,
   PiRuntimeAdapter,
@@ -1000,7 +1012,7 @@ let ollamaManager: OllamaManager | null = null;
 let openClawConfigSync: OpenClawConfigSync | null = null;
 let openClawBootstrapPromise: Promise<OpenClawEngineStatus> | null = null;
 let openClawStatusForwarderBound = false;
-let coworkRuntimeForwarderBound = false;
+let piWorkbenchRuntimeForwarderBound = false;
 let memoryMigrationDone = false;
 let preventSleepBlockerId: number | null = null;
 let appUpdateCoordinator: AppUpdateCoordinator | null = null;
@@ -1108,16 +1120,6 @@ const bindOpenClawStatusForwarder = (): void => {
   });
   openClawStatusForwarderBound = true;
   forwardOpenClawStatus(manager.getStatus());
-};
-
-const getEngineNotReadyResponse = (status: OpenClawEngineStatus) => {
-  const fallbackMessage = 'AI engine is initializing. Please try again in a moment.';
-  return {
-    success: false,
-    code: ENGINE_NOT_READY_CODE,
-    error: status.message || fallbackMessage,
-    engineStatus: status,
-  };
 };
 
 const bootstrapOpenClawEngine = async (
@@ -1714,29 +1716,17 @@ const doSyncOpenClawConfig = async (options: {
   };
 };
 
-/** Forward events from a single runtime to all renderer windows via IPC. */
-const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
+/** Project Pi Work/Chat events to renderer-owned cowork streams. */
+const forwardPiWorkbenchRuntimeToRenderer = (runtime: PiRuntimeAdapter): void => {
   runtime.on('message', (sessionId: string, message: unknown) => {
     const safeMessage = sanitizeCoworkMessageForIpc(message);
     const windows = BrowserWindow.getAllWindows();
-    const messageType =
-      typeof message === 'object' && message && 'type' in message
-        ? (message as { type?: unknown }).type
-        : undefined;
-    console.log(
-      '[CoworkForwarder] forwarding message: sessionId=',
-      sessionId,
-      'type=',
-      messageType,
-      'windowCount=',
-      windows.length,
-    );
     windows.forEach(win => {
       if (win.isDestroyed()) return;
       try {
-        win.webContents.send('cowork:stream:message', { sessionId, message: safeMessage });
+        win.webContents.send(CoworkStreamIpc.Message, { sessionId, message: safeMessage });
       } catch (error) {
-        console.error('Failed to forward cowork message:', error);
+        console.error('[PiWorkbenchForwarder] failed to forward a message:', error);
       }
     });
   });
@@ -1749,14 +1739,14 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
       windows.forEach(win => {
         if (win.isDestroyed()) return;
         try {
-          win.webContents.send('cowork:stream:messageUpdate', {
+          win.webContents.send(CoworkStreamIpc.MessageUpdate, {
             sessionId,
             messageId,
             content: safeContent,
             metadata,
           });
         } catch (error) {
-          console.error('Failed to forward cowork message update:', error);
+          console.error('[PiWorkbenchForwarder] failed to forward a message update:', error);
         }
       });
     },
@@ -1771,9 +1761,9 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
     windows.forEach(win => {
       if (win.isDestroyed()) return;
       try {
-        win.webContents.send('cowork:stream:permission', { sessionId, request: safeRequest });
+        win.webContents.send(CoworkStreamIpc.Permission, { sessionId, request: safeRequest });
       } catch (error) {
-        console.error('Failed to forward cowork permission request:', error);
+        console.error('[PiWorkbenchForwarder] failed to forward a permission request:', error);
       }
     });
   });
@@ -1783,9 +1773,9 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
     windows.forEach(win => {
       if (win.isDestroyed()) return;
       try {
-        win.webContents.send('cowork:stream:permissionDismiss', { requestId });
+        win.webContents.send(CoworkStreamIpc.PermissionDismiss, { requestId });
       } catch (error) {
-        console.error('Failed to forward cowork permission dismissal:', error);
+        console.error('[PiWorkbenchForwarder] failed to dismiss a permission request:', error);
       }
     });
   });
@@ -1794,14 +1784,14 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach(win => {
       if (win.isDestroyed()) return;
-      win.webContents.send('cowork:stream:complete', { sessionId, claudeSessionId });
+      win.webContents.send(CoworkStreamIpc.Complete, { sessionId, claudeSessionId });
     });
     try {
       if (shouldRefreshServerQuotaForSession(sessionId)) {
         const windows = BrowserWindow.getAllWindows();
         windows.forEach(win => {
           if (win.isDestroyed()) return;
-          win.webContents.send('auth:quotaChanged');
+          win.webContents.send(AuthIpc.QuotaChanged);
         });
       }
     } catch {
@@ -1818,21 +1808,16 @@ const forwardRuntimeToRenderer = (runtime: CoworkRuntime): void => {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach(win => {
       if (win.isDestroyed()) return;
-      win.webContents.send('cowork:stream:error', { sessionId, error });
+      win.webContents.send(CoworkStreamIpc.Error, { sessionId, error });
     });
   });
 };
 
-const bindCoworkRuntimeForwarder = (): void => {
-  if (coworkRuntimeForwarderBound) return;
+const bindPiWorkbenchRuntimeForwarder = (): void => {
+  if (piWorkbenchRuntimeForwarderBound) return;
 
-  // Dual-kernel: bind both Pi (Work sessions) and OpenClaw (IM sessions).
-  // Both feed into the same cowork:stream:* IPC channels so the UI shows
-  // messages from both sources.
-  forwardRuntimeToRenderer(getPiRuntimeAdapter()); // Work → Pi
-  forwardRuntimeToRenderer(getOpenClawRuntimeAdapter()); // IM → OpenClaw
-
-  coworkRuntimeForwarderBound = true;
+  forwardPiWorkbenchRuntimeToRenderer(getPiRuntimeAdapter());
+  piWorkbenchRuntimeForwarderBound = true;
 };
 
 const getOpenClawRuntimeAdapter = (): OpenClawRuntimeAdapter => {
@@ -2199,35 +2184,32 @@ const startMcpBridge = (): Promise<McpBridgeConfig | null> => {
         await mcpBridgeServer.start();
       }
 
-      // Register AskUserQuestion callback — shows a permission modal when the
-      // ask-user-question OpenClaw plugin sends a request via HTTP.
+      // Forward OpenClaw AskUser requests through their own renderer bridge.
       mcpBridgeServer.onAskUser(request => {
         const windows = BrowserWindow.getAllWindows();
         windows.forEach(win => {
           if (win.isDestroyed()) return;
           try {
-            win.webContents.send('cowork:stream:permission', {
-              sessionId: '__askuser__',
+            win.webContents.send(OpenClawBridgeIpc.AskUser, {
+              sessionId: CoworkPermissionSessionId.OpenClawBridge,
               request: {
                 requestId: request.requestId,
-                toolName: 'AskUserQuestion',
+                toolName: CoworkPermissionToolName.AskUserQuestion,
                 toolInput: { questions: request.questions },
               },
             });
           } catch (error) {
-            console.error('[AskUser] failed to send permission request to window:', error);
+            console.error('[OpenClawBridge] failed to forward an AskUser request:', error);
           }
         });
       });
 
-      // Dismiss the AskUser modal when timeout or resolved from server side.
-      // Simulate a deny response to remove it from the renderer's pending queue.
       mcpBridgeServer.onAskUserDismiss(requestId => {
         const windows = BrowserWindow.getAllWindows();
         windows.forEach(win => {
           if (win.isDestroyed()) return;
           try {
-            win.webContents.send('cowork:stream:permissionDismiss', { requestId });
+            win.webContents.send(OpenClawBridgeIpc.AskUserDismiss, { requestId });
           } catch {
             // ignore
           }
@@ -4147,7 +4129,7 @@ if (!gotTheLock) {
   });
 
   // Cowork IPC handlers
-  ipcMain.handle('cowork:session:start', async (_event, rawOptions: unknown) => {
+  ipcMain.handle(CoworkSessionIpc.Start, async (_event, rawOptions: unknown) => {
     const cid = generateCorrelationId();
     const log = createLogger('CoworkSession').withContext({ cid });
     const options = CoworkSessionStartSchema.input.parse(rawOptions);
@@ -4160,23 +4142,6 @@ if (!gotTheLock) {
       try {
         // Work sessions use Pi (SDK mode, instant availability). No need to wait
         // for OpenClaw — that gate is only for IM/Cron paths.
-        const engineStatus: {
-          phase: 'running' | 'error';
-          version: null;
-          message: string;
-          canRetry: boolean;
-        } = getPiRuntimeAdapter()
-          ? { phase: 'running', version: null, message: 'Pi SDK ready', canRetry: false }
-          : {
-              phase: 'error',
-              version: null,
-              message: 'Pi runtime not initialized',
-              canRetry: true,
-            };
-        if (engineStatus.phase !== 'running') {
-          return getEngineNotReadyResponse(engineStatus);
-        }
-
         const coworkStoreInstance = getCoworkStore();
         const config = coworkStoreInstance.getConfig();
         const selectedAgent = getAgentManager().getAgent(options.agentId || 'main');
@@ -4308,7 +4273,7 @@ if (!gotTheLock) {
               const windows = BrowserWindow.getAllWindows();
               windows.forEach(win => {
                 if (win.isDestroyed()) return;
-                win.webContents.send('cowork:stream:error', {
+                win.webContents.send(CoworkStreamIpc.Error, {
                   sessionId: session.id,
                   error: errorMessage,
                 });
@@ -4336,7 +4301,7 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle(
-    'cowork:session:continue',
+    CoworkSessionIpc.Continue,
     async (
       _event,
       options: {
@@ -4351,23 +4316,6 @@ if (!gotTheLock) {
     ) => {
       try {
         // Work sessions use Pi (SDK mode, instant availability).
-        const engineStatus: {
-          phase: 'running' | 'error';
-          version: null;
-          message: string;
-          canRetry: boolean;
-        } = getPiRuntimeAdapter()
-          ? { phase: 'running', version: null, message: 'Pi SDK ready', canRetry: false }
-          : {
-              phase: 'error',
-              version: null,
-              message: 'Pi runtime not initialized',
-              canRetry: true,
-            };
-        if (engineStatus.phase !== 'running') {
-          return getEngineNotReadyResponse(engineStatus);
-        }
-
         const runtime = getPiRuntimeAdapter();
         const store = getCoworkStore();
         let existingSession = store.getSession(options.sessionId);
@@ -4463,7 +4411,7 @@ if (!gotTheLock) {
               const windows = BrowserWindow.getAllWindows();
               windows.forEach(win => {
                 if (win.isDestroyed()) return;
-                win.webContents.send('cowork:stream:error', {
+                win.webContents.send(CoworkStreamIpc.Error, {
                   sessionId: options.sessionId,
                   error: errorMessage,
                 });
@@ -5105,8 +5053,12 @@ if (!gotTheLock) {
     },
   );
 
+  registerOpenClawBridgeIpcHandlers({
+    getMcpBridgeServer: () => mcpBridgeServer,
+  });
+
   ipcMain.handle(
-    'cowork:permission:respond',
+    CoworkPermissionIpc.Respond,
     async (
       _event,
       options: {
@@ -5115,36 +5067,6 @@ if (!gotTheLock) {
       },
     ) => {
       try {
-        // Dual-dispatch pattern: permission responses arrive through one IPC channel
-        // but may target either of two independent subsystems.
-        //
-        // - resolveAskUser() handles AskUserQuestion plugin requests routed through
-        //   the McpBridgeServer HTTP callback. It is a no-op when the requestId does
-        //   not match a pending bridge request (i.e. for normal SDK permission requests).
-        //
-        // - respondToPermission() handles standard Claude Agent SDK permission requests
-        //   managed by the CoworkEngineRouter. It is a no-op when the requestId does
-        //   not match a pending SDK permission (i.e. for bridge plugin requests).
-        //
-        // Both calls are safe to invoke unconditionally; exactly one will match.
-
-        // AskUserQuestion plugin responses go to the bridge server, not the runtime
-        if (mcpBridgeServer && options.requestId) {
-          const result = options.result;
-          const askUserResponse: import('./libs/mcpBridgeServer').AskUserResponse = {
-            behavior: result.behavior === 'allow' ? 'allow' : 'deny',
-            answers:
-              result.behavior === 'allow' &&
-              result.updatedInput &&
-              typeof result.updatedInput === 'object'
-                ? ((result.updatedInput as Record<string, unknown>).answers as
-                    | Record<string, string>
-                    | undefined)
-                : undefined,
-          };
-          mcpBridgeServer.resolveAskUser(options.requestId, askUserResponse);
-        }
-
         const runtime = getPiRuntimeAdapter();
         runtime.respondToPermission(options.requestId, options.result);
         return { success: true };
@@ -7845,7 +7767,9 @@ if (!gotTheLock) {
     const mcpTools = await initMcpServers();
     console.log(`[Main] initApp: MCP init done, ${mcpTools.length} tools available`);
 
-    bindCoworkRuntimeForwarder();
+    bindPiWorkbenchRuntimeForwarder();
+    // Channel/Cron own this runtime directly; it is intentionally not renderer-forwarded.
+    getOpenClawRuntimeAdapter();
     bindOpenClawStatusForwarder();
 
     const defaultAgentModelRef = resolveDefaultAgentModelRef();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -27,6 +27,7 @@ import {
   McpIpc,
   NetworkIpc,
   OpenAICodexOAuthIpc,
+  OpenClawBridgeIpc,
   OpenClawEngineIpc,
   PermissionsIpc,
   ProjectIpc,
@@ -319,6 +320,14 @@ contextBridge.exposeInMainWorld('electron', {
   getRecentCwds: (limit?: number) => ipcRenderer.invoke(AppConfigIpc.GetRecentCwds, limit),
 
   openclaw: {
+    bridge: {
+      respondToAskUser: (options: { requestId: string; result: unknown }) =>
+        ipcRenderer.invoke(OpenClawBridgeIpc.RespondAskUser, options),
+      onAskUser: (callback: (data: { sessionId: string; request: unknown }) => void) =>
+        onPush(OpenClawBridgeIpc.AskUser, callback),
+      onAskUserDismiss: (callback: (data: { requestId: string }) => void) =>
+        onPush(OpenClawBridgeIpc.AskUserDismiss, callback),
+    },
     engine: {
       getStatus: () => ipcRenderer.invoke(OpenClawEngineIpc.GetStatus),
       install: () => ipcRenderer.invoke(OpenClawEngineIpc.Install),

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -219,7 +219,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
     const currentAgentId = useSelector((state: RootState) => state.agent.currentAgentId);
     const agents = useSelector((state: RootState) => state.agent.agents);
     const currentAgent = agents.find(agent => agent.id === currentAgentId);
-    const coworkAgentEngine = useSelector((state: RootState) => state.cowork.config.agentEngine);
     const availableModels = useSelector((state: RootState) => state.model.availableModels);
     const defaultSelectedModel = useSelector(
       (state: RootState) => state.model.defaultSelectedModel,
@@ -325,7 +324,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       agentModel: currentAgent?.model ?? '',
       availableModels,
       fallbackModel: currentAgentSelectedModel,
-      engine: coworkAgentEngine,
     });
 
     const handleModelSelect = useCallback(

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -7,11 +7,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { buildSessionTitleFromInput } from '../../../common/sessionTitle';
 import { CoworkPermissionMode, CoworkSessionMode } from '../../../shared/cowork/constants';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
-import { OpenClawEnginePhase } from '../../../shared/openclaw/constants';
-import {
-  isOpenClawEngineTransitioning,
-  isOpenClawGatewayRunning,
-} from '../../../shared/openclaw/status';
 import { agentService } from '../../services/agent';
 import { ChatChatTransport } from '../../services/chatChatTransport';
 import {
@@ -52,7 +47,6 @@ import {
   type CoworkPermissionRequest,
   type CoworkPermissionResult,
   type CoworkSession,
-  type OpenClawEngineStatus,
 } from '../../types/cowork';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
 import { PromptPanel, QuickActionBar } from '../quick-actions';
@@ -63,7 +57,6 @@ import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInpu
 import CoworkSessionViewport from './CoworkSessionViewport';
 import { mergeDirectChatSnapshotMessages } from './directChatSnapshot';
 import SecurityStatusIndicator from './SecurityStatusIndicator';
-import { useDelayedVisibility } from './useDelayedVisibility';
 import { shouldClearQuickActionSelection } from '../quick-actions/quickActionSelection';
 
 export interface CoworkViewProps {
@@ -148,16 +141,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({
   useEffect(() => () => contentBatcher.dispose(), [contentBatcher]);
   const isMac = window.electron.platform === 'darwin';
   const [isInitialized, setIsInitialized] = useState(false);
-  const [openClawStatus, setOpenClawStatus] = useState<OpenClawEngineStatus | null>(null);
-  const [isRestartingGateway, setIsRestartingGateway] = useState(false);
-  const shouldShowEngineStatus = useDelayedVisibility(
-    Boolean(
-      openClawStatus &&
-      !isOpenClawGatewayRunning(openClawStatus.phase) &&
-      !isOpenClawEngineTransitioning(openClawStatus.phase) &&
-      openClawStatus.phase !== OpenClawEnginePhase.Error,
-    ),
-  );
   // Track in-flight direct-chat operations per session so switching to another
   // chat window does not block submission on a global boolean ref.
   const startingSessionIdsRef = useRef(new Set<string>());
@@ -241,46 +224,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     return { noticeI18nKey: key, noticeExtra: error };
   };
 
-  const resolveEngineStatusText = (status: OpenClawEngineStatus): string => {
-    switch (status.phase) {
-      case OpenClawEnginePhase.NotInstalled:
-        return i18nService.t('coworkOpenClawNotInstalledNotice');
-      case OpenClawEnginePhase.Installing:
-        return i18nService.t('coworkOpenClawInstalling');
-      case OpenClawEnginePhase.Ready:
-        return i18nService.t('coworkOpenClawReadyNotice');
-      case OpenClawEnginePhase.Starting:
-      case OpenClawEnginePhase.Compiling:
-      case OpenClawEnginePhase.Restarting:
-        return status.message || i18nService.t('coworkOpenClawStarting');
-      case OpenClawEnginePhase.Error:
-        return i18nService.t('coworkOpenClawError');
-      case OpenClawEnginePhase.Running:
-      default:
-        return i18nService.t('coworkOpenClawRunning');
-    }
-  };
-
-  const handleRestartGateway = async () => {
-    if (isRestartingGateway) return;
-    setIsRestartingGateway(true);
-    try {
-      await coworkService.restartOpenClawGateway();
-    } catch (error) {
-      console.error('[CoworkView] Failed to restart gateway:', error);
-    } finally {
-      setIsRestartingGateway(false);
-    }
-  };
-
   useEffect(() => {
     const init = async () => {
       await coworkService.init();
       await agentService.loadAgents();
-      const initialEngineStatus = await coworkService.getOpenClawEngineStatus();
-      if (initialEngineStatus) {
-        setOpenClawStatus(initialEngineStatus);
-      }
       // Load quick actions with localization
       try {
         quickActionService.initialize();
@@ -304,10 +251,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     };
     init();
 
-    const unsubscribeOpenClawStatus = coworkService.onOpenClawEngineStatus(status => {
-      setOpenClawStatus(status);
-    });
-
     // Subscribe to language changes to reload quick actions
     const unsubscribe = quickActionService.subscribe(async () => {
       try {
@@ -320,7 +263,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({
 
     return () => {
       unsubscribe();
-      unsubscribeOpenClawStatus();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
@@ -1392,8 +1334,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     );
   }
 
-  const isEngineError = openClawStatus?.phase === OpenClawEnginePhase.Error;
-
   const homeHeader = (
     <div className="draggable flex h-12 items-center justify-between px-4 border-b border-border shrink-0">
       <div className="non-draggable h-8 flex items-center">
@@ -1426,37 +1366,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     </div>
   );
 
-  // Engine status banner for error/non-running states (starting overlay is now global in App.tsx)
-  const engineStatusBanner =
-    shouldShowEngineStatus && openClawStatus ? (
-      <div
-        className={`shrink-0 flex items-center justify-between px-4 py-2 text-xs ${
-          isEngineError
-            ? 'bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-300'
-            : 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'
-        }`}
-      >
-        <div className="flex items-center gap-2">
-          <span>{resolveEngineStatusText(openClawStatus)}</span>
-          {typeof openClawStatus.progressPercent === 'number' && (
-            <span className="opacity-70">({Math.round(openClawStatus.progressPercent)}%)</span>
-          )}
-        </div>
-        <Button
-          variant={isEngineError ? 'destructive' : 'default'}
-          size="xs"
-          onClick={handleRestartGateway}
-          disabled={isRestartingGateway}
-        >
-          {i18nService.t('coworkOpenClawRestartGateway')}
-        </Button>
-      </div>
-    ) : null;
-
   if (displayedSessionId) {
     return (
       <div className="flex-1 flex flex-col h-full">
-        {engineStatusBanner}
         <CoworkSessionViewport
           sessionId={displayedSessionId}
           onManageSkills={() => onShowSkills?.()}
@@ -1485,9 +1397,6 @@ const CoworkView: React.FC<CoworkViewProps> = ({
   // Home view - no current session
   return (
     <div className="flex-1 flex flex-col bg-background h-full">
-      {/* Engine status banner for error states */}
-      {engineStatusBanner}
-
       {/* Header */}
       {homeHeader}
 

--- a/src/renderer/components/cowork/agentModelSelection.test.ts
+++ b/src/renderer/components/cowork/agentModelSelection.test.ts
@@ -35,7 +35,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'anthropic/claude-sonnet-4',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('claude-sonnet-4');
@@ -49,7 +48,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'anthropic/claude-sonnet-4',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
@@ -62,7 +60,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: '',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
@@ -75,7 +72,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'anthropic/claude-sonnet-4',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('claude-sonnet-4');
@@ -88,7 +84,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'deleted-model',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
@@ -101,7 +96,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'deepseek-v3.2',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
@@ -115,7 +109,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: 'anthropic/claude-sonnet-4',
       availableModels: models,
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('gpt-4o');
@@ -128,7 +121,6 @@ describe('resolveAgentModelSelection', () => {
       agentModel: `${OpenClawProviderId.LlamaCpp}/qwen-local`,
       availableModels: [...models, ineligibleLlamaCppModel],
       fallbackModel: models[0],
-      engine: 'openclaw',
     });
 
     expect(result.selectedModel?.id).toBe('qwen-local');

--- a/src/renderer/components/cowork/agentModelSelection.ts
+++ b/src/renderer/components/cowork/agentModelSelection.ts
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { OpenClawProviderId } from '../../../shared/providers';
 import type { RootState } from '../../store';
 import { type Model, selectAgentSelectedModel } from '../../store/slices/modelSlice';
-import type { CoworkAgentEngine } from '../../types/cowork';
 import { resolveOpenClawModelRef } from '../../utils/openclawModelRef';
 
 type ResolveAgentModelSelectionInput = {
@@ -12,7 +11,6 @@ type ResolveAgentModelSelectionInput = {
   agentModel: string;
   availableModels: Model[];
   fallbackModel: Model | null;
-  engine: CoworkAgentEngine;
 };
 
 type ResolveAgentModelSelectionResult = {

--- a/src/renderer/components/cowork/askUserQuestion.test.ts
+++ b/src/renderer/components/cowork/askUserQuestion.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 
+import { CoworkPermissionOrigin } from '../../../shared/cowork/constants';
 import type { CoworkPermissionRequest } from '../../types/cowork';
 import {
   buildAskUserQuestionAllowResult,
@@ -10,6 +11,7 @@ import {
 } from './askUserQuestion';
 
 const makePermission = (toolInput: Record<string, unknown>): CoworkPermissionRequest => ({
+  origin: CoworkPermissionOrigin.PiWorkbench,
   sessionId: 'session-1',
   requestId: 'request-1',
   toolName: CoworkPermissionToolName.AskUserQuestion,

--- a/src/renderer/components/cowork/askUserQuestion.ts
+++ b/src/renderer/components/cowork/askUserQuestion.ts
@@ -1,13 +1,10 @@
+import {
+  CoworkPermissionBehavior,
+  CoworkPermissionToolName,
+} from '../../../shared/cowork/constants';
 import type { CoworkPermissionRequest, CoworkPermissionResult } from '../../types/cowork';
 
-export const CoworkPermissionToolName = {
-  AskUserQuestion: 'AskUserQuestion',
-} as const;
-
-export const CoworkPermissionBehavior = {
-  Allow: 'allow',
-  Deny: 'deny',
-} as const;
+export { CoworkPermissionBehavior, CoworkPermissionToolName };
 
 export const AskUserQuestionAnswerDelimiter = '|||';
 

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -6,7 +6,11 @@ import {
 } from '../../common/coworkError';
 import { classifyErrorKey } from '../../common/coworkErrorClassify';
 import type { OpenClawSessionPatch } from '../../common/openclawSession';
-import { COWORK_SESSION_PAGE_SIZE, CoworkSessionMode } from '../../shared/cowork/constants';
+import {
+  COWORK_SESSION_PAGE_SIZE,
+  CoworkPermissionOrigin,
+  CoworkSessionMode,
+} from '../../shared/cowork/constants';
 import { store } from '../store';
 import { setCurrentAgentId } from '../store/slices/agentSlice';
 import {
@@ -37,6 +41,7 @@ import type {
   CoworkConfigUpdate,
   CoworkContinueOptions,
   CoworkMemoryStats,
+  CoworkPermissionRequest,
   CoworkPermissionResult,
   CoworkSession,
   CoworkSessionListResult,
@@ -47,6 +52,7 @@ import type {
   OpenClawSessionPolicyConfig,
 } from '../types/cowork';
 import { i18nService } from './i18n';
+import { respondToPermissionByOrigin } from './coworkPermissionRouting';
 import { RafMessageUpdateBatcher } from './rafMessageUpdateBatcher';
 import { workspaceService } from './workspace';
 
@@ -84,10 +90,7 @@ class CoworkService {
 
     // Set up stream listeners
     this.setupStreamListeners();
-    this.setupOpenClawEngineListeners();
-
-    // Load OpenClaw status
-    await this.loadOpenClawEngineStatus();
+    this.setupOpenClawBridgeListeners();
 
     this.initialized = true;
   }
@@ -179,6 +182,7 @@ class CoworkService {
     const permissionCleanup = cowork.onStreamPermission(({ sessionId, request }) => {
       store.dispatch(
         enqueuePendingPermission({
+          origin: CoworkPermissionOrigin.PiWorkbench,
           sessionId,
           toolName: request.toolName,
           toolInput: request.toolInput,
@@ -270,6 +274,29 @@ class CoworkService {
         });
     });
     this.streamListenerCleanups.push(sessionsChangedCleanup);
+  }
+
+  private setupOpenClawBridgeListeners(): void {
+    const bridge = window.electron?.openclaw?.bridge;
+    if (!bridge) return;
+
+    const askUserCleanup = bridge.onAskUser(({ sessionId, request }) => {
+      store.dispatch(
+        enqueuePendingPermission({
+          origin: CoworkPermissionOrigin.OpenClawBridge,
+          sessionId,
+          toolName: request.toolName,
+          toolInput: request.toolInput,
+          requestId: request.requestId,
+          toolUseId: request.toolUseId ?? null,
+        }),
+      );
+    });
+    const askUserDismissCleanup = bridge.onAskUserDismiss(({ requestId }) => {
+      store.dispatch(dequeuePendingPermission({ requestId }));
+    });
+
+    this.streamListenerCleanups.push(askUserCleanup, askUserDismissCleanup);
   }
 
   private setupOpenClawEngineListeners(): void {
@@ -435,10 +462,6 @@ class CoworkService {
       return { session: result.session };
     }
 
-    if (result.engineStatus) {
-      this.notifyOpenClawStatus(result.engineStatus);
-    }
-
     // Show a user-visible error when session start fails
     if (result.error) {
       const errorContent =
@@ -471,10 +494,7 @@ class CoworkService {
       imageAttachments: options.imageAttachments,
     });
     if (!result.success) {
-      if (result.engineStatus) {
-        this.notifyOpenClawStatus(result.engineStatus);
-      }
-      if (result.code !== 'ENGINE_NOT_READY') {
+      if (result.code !== ENGINE_NOT_READY_CODE) {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
         if (result.error) {
           store.dispatch(
@@ -762,10 +782,17 @@ class CoworkService {
   }
 
   async respondToPermission(requestId: string, result: CoworkPermissionResult): Promise<boolean> {
-    const cowork = window.electron?.cowork;
-    if (!cowork) return false;
+    const permission = store
+      .getState()
+      .cowork.pendingPermissions.find(
+        (pending: CoworkPermissionRequest) => pending.requestId === requestId,
+      );
+    if (!permission) return false;
 
-    const response = await cowork.respondToPermission({ requestId, result });
+    const response = await respondToPermissionByOrigin(permission, result, {
+      respondToPi: window.electron?.cowork?.respondToPermission,
+      respondToOpenClaw: window.electron?.openclaw?.bridge?.respondToAskUser,
+    });
     if (response.success) {
       store.dispatch(dequeuePendingPermission({ requestId }));
       return true;

--- a/src/renderer/services/coworkPermissionRouting.test.ts
+++ b/src/renderer/services/coworkPermissionRouting.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { CoworkPermissionBehavior, CoworkPermissionOrigin } from '../../shared/cowork/constants';
+import type { CoworkPermissionRequest, CoworkPermissionResult } from '../types/cowork';
+import { respondToPermissionByOrigin } from './coworkPermissionRouting';
+
+const result: CoworkPermissionResult = {
+  behavior: CoworkPermissionBehavior.Allow,
+  updatedInput: { answers: { Continue: 'Yes' } },
+};
+
+const createPermission = (origin: CoworkPermissionRequest['origin']): CoworkPermissionRequest => ({
+  origin,
+  sessionId: 'session-1',
+  requestId: 'request-1',
+  toolName: 'test-tool',
+  toolInput: {},
+});
+
+describe('respondToPermissionByOrigin', () => {
+  test('routes Pi workbench permissions to the cowork responder', async () => {
+    const respondToPi = vi.fn().mockResolvedValue({ success: true });
+    const respondToOpenClaw = vi.fn().mockResolvedValue({ success: true });
+
+    await respondToPermissionByOrigin(
+      createPermission(CoworkPermissionOrigin.PiWorkbench),
+      result,
+      { respondToPi, respondToOpenClaw },
+    );
+
+    expect(respondToPi).toHaveBeenCalledWith({ requestId: 'request-1', result });
+    expect(respondToOpenClaw).not.toHaveBeenCalled();
+  });
+
+  test('routes OpenClaw AskUser permissions to the dedicated bridge responder', async () => {
+    const respondToPi = vi.fn().mockResolvedValue({ success: true });
+    const respondToOpenClaw = vi.fn().mockResolvedValue({ success: true });
+
+    await respondToPermissionByOrigin(
+      createPermission(CoworkPermissionOrigin.OpenClawBridge),
+      result,
+      { respondToPi, respondToOpenClaw },
+    );
+
+    expect(respondToOpenClaw).toHaveBeenCalledWith({ requestId: 'request-1', result });
+    expect(respondToPi).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/services/coworkPermissionRouting.ts
+++ b/src/renderer/services/coworkPermissionRouting.ts
@@ -1,0 +1,35 @@
+import { CoworkPermissionOrigin } from '../../shared/cowork/constants';
+import type { CoworkPermissionRequest, CoworkPermissionResult } from '../types/cowork';
+
+export interface PermissionResponseResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface CoworkPermissionResponders {
+  respondToPi?: (options: {
+    requestId: string;
+    result: CoworkPermissionResult;
+  }) => Promise<PermissionResponseResult>;
+  respondToOpenClaw?: (options: {
+    requestId: string;
+    result: CoworkPermissionResult;
+  }) => Promise<PermissionResponseResult>;
+}
+
+export const respondToPermissionByOrigin = async (
+  permission: CoworkPermissionRequest,
+  result: CoworkPermissionResult,
+  responders: CoworkPermissionResponders,
+): Promise<PermissionResponseResult> => {
+  const respond =
+    permission.origin === CoworkPermissionOrigin.OpenClawBridge
+      ? responders.respondToOpenClaw
+      : responders.respondToPi;
+
+  if (!respond) {
+    return { success: false, error: 'Permission response API is not available' };
+  }
+
+  return respond({ requestId: permission.requestId, result });
+};

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -1,5 +1,9 @@
 // Cowork image attachment for vision-capable models
-import type { CoworkPermissionMode, CoworkSessionMode } from '../../shared/cowork/constants';
+import type {
+  CoworkPermissionMode,
+  CoworkPermissionOrigin,
+  CoworkSessionMode,
+} from '../../shared/cowork/constants';
 import type { CoworkSessionExpertSnapshot } from '../../shared/cowork/sessionExperts';
 import type { OpenClawEnginePhase } from '../../shared/openclaw/constants';
 
@@ -195,6 +199,7 @@ export interface CoworkMemoryStats {
 
 // Cowork pending permission request
 export interface CoworkPermissionRequest {
+  origin: CoworkPermissionOrigin;
   sessionId: string;
   toolName: string;
   toolInput: Record<string, unknown>;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -2,7 +2,11 @@ import type { CoworkError } from '../../common/coworkError';
 import type { OpenClawSessionPatch } from '../../common/openclawSession';
 import type { AppUpdateCheckResult, AppUpdateRuntimeState } from '../../shared/appUpdate/constants';
 import type { NvidiaSmiSnapshot } from '../../shared/hardware';
-import type { CoworkPermissionMode, CoworkSessionMode } from '../../shared/cowork/constants';
+import type {
+  CoworkPermissionMode,
+  CoworkPermissionOrigin,
+  CoworkSessionMode,
+} from '../../shared/cowork/constants';
 import type { OpenClawEnginePhase } from '../../shared/openclaw/constants';
 import type {
   LlamaCppCancelInstallResult,
@@ -172,6 +176,7 @@ interface CoworkMemoryStats {
 }
 
 interface CoworkPermissionRequest {
+  origin: CoworkPermissionOrigin;
   sessionId: string;
   toolName: string;
   toolInput: Record<string, unknown>;
@@ -643,6 +648,19 @@ interface IElectronAPI {
   generateSessionTitle: (userInput: string | null) => Promise<string>;
   getRecentCwds: (limit?: number) => Promise<string[]>;
   openclaw: {
+    bridge: {
+      respondToAskUser: (options: {
+        requestId: string;
+        result: CoworkPermissionResult;
+      }) => Promise<{ success: boolean; error?: string }>;
+      onAskUser: (
+        callback: (data: {
+          sessionId: string;
+          request: Omit<CoworkPermissionRequest, 'origin'>;
+        }) => void,
+      ) => () => void;
+      onAskUserDismiss: (callback: (data: { requestId: string }) => void) => () => void;
+    };
     engine: {
       getStatus: () => Promise<{ success: boolean; status?: OpenClawEngineStatus; error?: string }>;
       install: () => Promise<{ success: boolean; status?: OpenClawEngineStatus; error?: string }>;
@@ -732,7 +750,6 @@ interface IElectronAPI {
       session?: CoworkSession;
       error?: string;
       code?: string;
-      engineStatus?: OpenClawEngineStatus;
     }>;
     continueSession: (options: {
       sessionId: string;
@@ -747,7 +764,6 @@ interface IElectronAPI {
       session?: CoworkSession;
       error?: string;
       code?: string;
-      engineStatus?: OpenClawEngineStatus;
     }>;
     stopSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     saveSession: (session: Record<string, unknown>) => Promise<CoworkSessionResult>;
@@ -855,7 +871,10 @@ interface IElectronAPI {
       }) => void,
     ) => () => void;
     onStreamPermission: (
-      callback: (data: { sessionId: string; request: CoworkPermissionRequest }) => void,
+      callback: (data: {
+        sessionId: string;
+        request: Omit<CoworkPermissionRequest, 'origin'>;
+      }) => void,
     ) => () => void;
     onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) => () => void;
     onStreamComplete: (

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -22,3 +22,30 @@ export const CoworkPermissionMode = {
 } as const;
 
 export type CoworkPermissionMode = (typeof CoworkPermissionMode)[keyof typeof CoworkPermissionMode];
+
+export const CoworkPermissionBehavior = {
+  Allow: 'allow',
+  Deny: 'deny',
+} as const;
+
+export type CoworkPermissionBehavior =
+  (typeof CoworkPermissionBehavior)[keyof typeof CoworkPermissionBehavior];
+
+export const CoworkPermissionOrigin = {
+  PiWorkbench: 'pi-workbench',
+  OpenClawBridge: 'openclaw-bridge',
+} as const;
+
+export type CoworkPermissionOrigin =
+  (typeof CoworkPermissionOrigin)[keyof typeof CoworkPermissionOrigin];
+
+export const CoworkPermissionToolName = {
+  AskUserQuestion: 'AskUserQuestion',
+} as const;
+
+export type CoworkPermissionToolName =
+  (typeof CoworkPermissionToolName)[keyof typeof CoworkPermissionToolName];
+
+export const CoworkPermissionSessionId = {
+  OpenClawBridge: 'openclaw-bridge',
+} as const;

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -121,6 +121,14 @@ export const OpenClawEngineIpc = {
 } as const;
 export type OpenClawEngineIpc = (typeof OpenClawEngineIpc)[keyof typeof OpenClawEngineIpc];
 
+// ─── OpenClaw renderer bridge ───────────────────────────────────────────────
+export const OpenClawBridgeIpc = {
+  AskUser: 'openclaw:bridge:askUser',
+  AskUserDismiss: 'openclaw:bridge:askUserDismiss',
+  RespondAskUser: 'openclaw:bridge:respondAskUser',
+} as const;
+export type OpenClawBridgeIpc = (typeof OpenClawBridgeIpc)[keyof typeof OpenClawBridgeIpc];
+
 // ─── Cowork Session ─────────────────────────────────────────────────────────
 export const CoworkSessionIpc = {
   Start: 'cowork:session:start',


### PR DESCRIPTION
## 背景

Work / Chat 已经直接使用 Pi 执行，但渲染进程仍同时接收 Pi 与 OpenClaw 的 `cowork:stream:*` 事件，工作台也仍订阅并展示 OpenClaw Gateway 状态。这会让两个运行时的会话、审批和生命周期继续互相污染，并阻碍后续 Task / Run 领域模型落地。

Refs #225

## 本次改动

- 将 Work / Chat 的流式事件绑定收敛到 Pi
- 停止将 OpenClaw Channel/Cron 运行事件转发到 `cowork:stream:*`
- 保留并显式初始化 OpenClaw Channel/Cron 运行时
- 将 OpenClaw AskUser 桥接迁移到独立 IPC 命名空间
- 按权限来源分别回传 Pi 与 OpenClaw 响应
- 移除工作台对 OpenClaw Gateway 状态的依赖
- 清理模型选择中的遗留运行时参数
- 补充运行时边界和权限路由测试

## 范围说明

本 PR 只完成 #225 中 Task / Run 建模所需的前置隔离，不重构 OpenClaw Channel/Cron 内部实现，也不引入 Task / Run / Artifact / Approval 模型。

## 验证

- [x] 定向测试：22 个用例通过
- [x] Channel/Cron 核心测试：23 个通过，1 个跳过
- [x] `npm run lint`（仅保留 1 个既有 Hook 依赖警告）
- [x] `npm run build`
- [x] `npm run compile:electron`
- [x] Vite renderer、Electron main/preload 开发构建启动
- [ ] Electron 窗口交互验证：当前机器已有同应用实例持有单实例锁，未终止用户现有实例

## 全量测试说明

`npm test` 中 188/192 个测试文件通过。剩余 6 个失败来自 Windows 环境与既有跨平台断言：缺少 `python3`、发布脚本盘符解析，以及路径分隔符断言，均不在本次改动路径。