### PR TITLE
perf(cowork): 流式 delta 整批单次 dispatch + summary 不随 token 更新（#141 Phase 2a）

### DIFF
--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -36,6 +36,7 @@ import {
   clearCurrentSession,
   setCurrentSession,
   updateMessageContent,
+  updateMessageContents,
   updateSessionStatus,
 } from '../../store/slices/coworkSlice';
 import { clearSelection, selectAction, setActions } from '../../store/slices/quickActionSlice';
@@ -111,9 +112,13 @@ const isDirectChatContextData = (value: unknown): value is DirectChatContextData
     outputTokens >= 0 &&
     usedTokens >= 0 &&
     (cacheReadTokens === undefined ||
-      (typeof cacheReadTokens === 'number' && Number.isFinite(cacheReadTokens) && cacheReadTokens >= 0)) &&
+      (typeof cacheReadTokens === 'number' &&
+        Number.isFinite(cacheReadTokens) &&
+        cacheReadTokens >= 0)) &&
     (cacheWriteTokens === undefined ||
-      (typeof cacheWriteTokens === 'number' && Number.isFinite(cacheWriteTokens) && cacheWriteTokens >= 0))
+      (typeof cacheWriteTokens === 'number' &&
+        Number.isFinite(cacheWriteTokens) &&
+        cacheWriteTokens >= 0))
   );
 };
 
@@ -132,8 +137,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({
 
   const contentBatcherRef = useRef<RafMessageUpdateBatcher | null>(null);
   if (!contentBatcherRef.current) {
-    contentBatcherRef.current = new RafMessageUpdateBatcher(update => {
-      dispatch(updateMessageContent(update));
+    contentBatcherRef.current = new RafMessageUpdateBatcher(updates => {
+      dispatch(updateMessageContents(updates));
     });
   }
   const contentBatcher = contentBatcherRef.current;
@@ -449,7 +454,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
                       ...(isCompleted && { isFinalAnswer: true }),
                     },
                   },
-              ]
+                ]
               : []),
           ]);
           return {
@@ -896,7 +901,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
                     ...(isCompleted && { isFinalAnswer: true }),
                   },
                 },
-            ]
+              ]
             : []),
         ]);
         return {

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -30,7 +30,7 @@ import {
   setHasMoreSessions,
   setRemoteManaged,
   setSessions,
-  updateMessageContent,
+  updateMessageContents,
   updateToolActivity,
   updateSessionPinned,
   updateSessionStatus,
@@ -167,8 +167,8 @@ class CoworkService {
 
     // Keep the latest update per message for the next frame. Thinking and answer
     // messages can be finalized back-to-back, so a single pending slot loses one.
-    const updateBatcher = new RafMessageUpdateBatcher(update => {
-      store.dispatch(updateMessageContent(update));
+    const updateBatcher = new RafMessageUpdateBatcher(updates => {
+      store.dispatch(updateMessageContents(updates));
     });
     const messageUpdateCleanup = cowork.onStreamMessageUpdate(update => {
       updateBatcher.enqueue(update);

--- a/src/renderer/services/rafMessageUpdateBatcher.test.ts
+++ b/src/renderer/services/rafMessageUpdateBatcher.test.ts
@@ -34,28 +34,28 @@ const update = (messageId: string, content: string): StreamMessageUpdate => ({
 });
 
 test('keeps the latest update for each message in the same frame', () => {
-  const applied: StreamMessageUpdate[] = [];
+  const applied: StreamMessageUpdate[][] = [];
   const frame = createScheduler();
-  const batcher = new RafMessageUpdateBatcher(item => applied.push(item), frame.scheduler);
+  const batcher = new RafMessageUpdateBatcher(batch => applied.push(batch), frame.scheduler);
 
   batcher.enqueue(update('thinking', 'partial'));
   batcher.enqueue(update('answer', 'answer'));
   batcher.enqueue(update('thinking', 'complete reasoning'));
   frame.runFrame();
 
-  expect(applied).toEqual([update('thinking', 'complete reasoning'), update('answer', 'answer')]);
+  expect(applied).toEqual([[update('thinking', 'complete reasoning'), update('answer', 'answer')]]);
 });
 
 test('discards a finalised message without dropping other pending messages', () => {
-  const applied: StreamMessageUpdate[] = [];
+  const applied: StreamMessageUpdate[][] = [];
   const frame = createScheduler();
-  const batcher = new RafMessageUpdateBatcher(item => applied.push(item), frame.scheduler);
+  const batcher = new RafMessageUpdateBatcher(batch => applied.push(batch), frame.scheduler);
 
   batcher.enqueue(update('thinking', 'stale'));
   batcher.enqueue(update('answer', 'current'));
   batcher.discard('session-1', 'thinking');
   frame.runFrame();
 
-  expect(applied).toEqual([update('answer', 'current')]);
+  expect(applied).toEqual([[update('answer', 'current')]]);
   expect(frame.wasCanceled()).toBe(false);
 });

--- a/src/renderer/services/rafMessageUpdateBatcher.ts
+++ b/src/renderer/services/rafMessageUpdateBatcher.ts
@@ -27,7 +27,7 @@ export class RafMessageUpdateBatcher {
   private readonly pending = new Map<string, StreamMessageUpdate>();
 
   constructor(
-    private readonly applyUpdate: (update: StreamMessageUpdate) => void,
+    private readonly applyUpdates: (updates: StreamMessageUpdate[]) => void,
     private readonly scheduler: AnimationFrameScheduler = browserAnimationFrameScheduler,
   ) {}
 
@@ -53,7 +53,9 @@ export class RafMessageUpdateBatcher {
     }
     const updates = Array.from(this.pending.values());
     this.pending.clear();
-    updates.forEach(this.applyUpdate);
+    if (updates.length > 0) {
+      this.applyUpdates(updates);
+    }
   }
 
   dispose(): void {

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -18,6 +18,7 @@ import coworkReducer, {
   setChatSessions,
   setSessions,
   updateCurrentSessionModelOverride,
+  updateMessageContents,
   updateToolActivity,
   updateSessionStatus,
 } from './coworkSlice';
@@ -147,10 +148,7 @@ test('chat sessions use the chat cache without invalidating work sessions', () =
 });
 
 test('refreshing chat sessions keeps the work session array stable', () => {
-  const workState = coworkReducer(
-    undefined,
-    setSessions([makeSession({ id: 'work-session-1' })]),
-  );
+  const workState = coworkReducer(undefined, setSessions([makeSession({ id: 'work-session-1' })]));
   const chatState = coworkReducer(
     workState,
     setChatSessions([makeSession({ id: 'chat-session-1', mode: 'chat' })]),
@@ -414,4 +412,34 @@ test('clears transient tool activities when a session stops running', () => {
   );
 
   expect(completedState.toolActivitiesBySession['session-1']).toBeUndefined();
+});
+
+test('applies a batched stream frame without touching summaries or unread state', () => {
+  const session = makeSession({
+    id: 'session-1',
+    status: CoworkSessionStatusValue.Running,
+    updatedAt: 5,
+    messages: [
+      { id: 'thinking', type: 'assistant', content: 'partial thinking', timestamp: 2 },
+      { id: 'answer', type: 'assistant', content: 'partial answer', timestamp: 3 },
+    ],
+  });
+  const withSession = coworkReducer(undefined, addSession(session));
+  const unreadBefore = withSession.unreadSessionIds;
+
+  const updated = coworkReducer(
+    withSession,
+    updateMessageContents([
+      { sessionId: 'session-1', messageId: 'thinking', content: 'full thinking' },
+      { sessionId: 'session-1', messageId: 'answer', content: 'full answer' },
+    ]),
+  );
+
+  expect(updated.currentSession?.messages.map(message => message.content)).toEqual([
+    'full thinking',
+    'full answer',
+  ]);
+  // Token-frequency deltas must not invalidate the sidebar summary list (issue #141).
+  expect(updated.sessions[0]?.updatedAt).toBe(5);
+  expect(updated.unreadSessionIds).toBe(unreadBefore);
 });

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -158,6 +158,53 @@ const updateSessionSummary = (
   if (session) update(session);
 };
 
+type MessageContentUpdate = {
+  sessionId: string;
+  messageId: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Applies a streaming content delta to the streaming cache and the current
+ * session. Session summaries and unread state intentionally stay untouched:
+ * token-frequency updates must not invalidate the sidebar list (issue #141)
+ * — summaries refresh on message add / status change / completion instead.
+ */
+const applyMessageContentUpdate = (state: CoworkState, update: MessageContentUpdate): void => {
+  const { sessionId, messageId, content, metadata } = update;
+  const updatedAt = Date.now();
+
+  const streamingSession = state.streamingSessions[sessionId];
+  if (streamingSession) {
+    const messageIndex = streamingSession.messages.findIndex(m => m.id === messageId);
+    if (messageIndex !== -1) {
+      streamingSession.messages[messageIndex].content = content;
+      if (metadata) {
+        streamingSession.messages[messageIndex].metadata = {
+          ...streamingSession.messages[messageIndex].metadata,
+          ...metadata,
+        };
+      }
+      streamingSession.updatedAt = updatedAt;
+    }
+  }
+
+  if (state.currentSession?.id === sessionId) {
+    const messageIndex = state.currentSession.messages.findIndex(m => m.id === messageId);
+    if (messageIndex !== -1) {
+      state.currentSession.messages[messageIndex].content = content;
+      if (metadata) {
+        state.currentSession.messages[messageIndex].metadata = {
+          ...state.currentSession.messages[messageIndex].metadata,
+          ...metadata,
+        };
+      }
+      state.currentSession.updatedAt = updatedAt;
+    }
+  }
+};
+
 const retainUnreadSessionIds = (state: CoworkState): void => {
   const validSessionIds = new Set([
     ...state.sessions.map(session => session.id),
@@ -410,55 +457,18 @@ const coworkSlice = createSlice({
       state.currentSession.messagesOffset = newOffset;
     },
 
-    updateMessageContent(
-      state,
-      action: PayloadAction<{
-        sessionId: string;
-        messageId: string;
-        content: string;
-        metadata?: Record<string, unknown>;
-      }>,
-    ) {
-      const { sessionId, messageId, content, metadata } = action.payload;
-      const updatedAt = Date.now();
+    updateMessageContent(state, action: PayloadAction<MessageContentUpdate>) {
+      applyMessageContentUpdate(state, action.payload);
+    },
 
-      const streamingSession = state.streamingSessions[sessionId];
-      if (streamingSession) {
-        const messageIndex = streamingSession.messages.findIndex(m => m.id === messageId);
-        if (messageIndex !== -1) {
-          streamingSession.messages[messageIndex].content = content;
-          if (metadata) {
-            streamingSession.messages[messageIndex].metadata = {
-              ...streamingSession.messages[messageIndex].metadata,
-              ...metadata,
-            };
-          }
-          streamingSession.updatedAt = updatedAt;
-        }
+    /**
+     * Applies one RAF frame of stream deltas with a single store
+     * notification, instead of one reducer pass per message (issue #141).
+     */
+    updateMessageContents(state, action: PayloadAction<MessageContentUpdate[]>) {
+      for (const update of action.payload) {
+        applyMessageContentUpdate(state, update);
       }
-
-      if (state.currentSession?.id === sessionId) {
-        const messageIndex = state.currentSession.messages.findIndex(m => m.id === messageId);
-        if (messageIndex !== -1) {
-          state.currentSession.messages[messageIndex].content = content;
-          if (metadata) {
-            state.currentSession.messages[messageIndex].metadata = {
-              ...state.currentSession.messages[messageIndex].metadata,
-              ...metadata,
-            };
-          }
-          state.currentSession.updatedAt = updatedAt;
-        }
-      }
-
-      updateSessionSummary(state.sessions, sessionId, session => {
-        session.updatedAt = updatedAt;
-      });
-      updateSessionSummary(state.chatSessions, sessionId, session => {
-        session.updatedAt = updatedAt;
-      });
-
-      markSessionUnread(state, sessionId);
     },
 
     updateToolActivity(
@@ -624,6 +634,7 @@ export const {
   addMessage,
   prependMessages,
   updateMessageContent,
+  updateMessageContents,
   updateToolActivity,
   setRemoteManaged,
   updateSessionPinned,


### PR DESCRIPTION
## 背景

#141 Phase 2 的第一个安全切片。此前每个 animation frame 内，RAF batcher 对每条脏消息各 dispatch 一次 `updateMessageContent`；且每次 token delta 还会改写 `sessions`/`chatSessions` 摘要的 `updatedAt` 与 unread 状态——Immer 每次产生新的 summary 引用，Sidebar 在消息流期间以 token 频率失效、过滤和重排。

## 改动

- `RafMessageUpdateBatcher` 回调签名改为整批数组：一帧内每条消息保留最新 delta，flush 时一次性交给回调。
- 新增 `updateMessageContents` reducer：同一帧的多条 delta 在一次 store notification 内应用；两个流式接线点（`services/cowork.ts`、`CoworkView.tsx`）改为每帧单次 dispatch。
- token delta 不再触碰 session 摘要与 unread 状态；摘要改在新增消息 / 状态变化 / 完成时刷新（这些地方原本就在做）。
- 单条 `updateMessageContent` 保留，供 finalize 等即时路径使用。

## 兼容性

- 会话状态机、消息内容、权限语义完全不变；Sidebar 的活跃时间从“每 token 刷新”变为“每消息刷新”，与 issue 验收标准一致（token delta 不触发 sidebar 重排或 summary 更新）。
- 新增 slice 测试覆盖：批量 delta 应用 + 摘要/unread 不被触碰。

## 验证

- `npm test`：194 文件 / 1661 测试全部通过（含新增用例）
- `tsc --noEmit`、`oxlint`、`oxfmt` 通过

Refs #141