### PR TITLE
refactor(agent-engine): Pi 运行时与 CoworkRuntime 胶水层解耦（#225 步骤 2/4 切片）

### DIFF
--- a/src/main/libs/agentEngine/index.ts
+++ b/src/main/libs/agentEngine/index.ts
@@ -2,3 +2,5 @@ export { OpenClawRuntimeAdapter } from './openclawRuntimeAdapter';
 export { PiRuntimeAdapter } from './piRuntimeAdapter';
 export type { CoworkRuntime } from './types';
 export * from './types';
+export type { PiRuntime } from './piRuntimeTypes';
+export * from './piRuntimeTypes';

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1,11 +1,11 @@
 /**
  * Pi Runtime Adapter
  *
- * Implements CoworkRuntime using the Pi SDK (in-process).
+ * Implements the Pi-native PiRuntime interface using the Pi SDK (in-process).
  * Pi is an embeddable agent loop library — no subprocess, no HTTP, just import.
  *
  * Architecture:
- *   startSession    → createAgentSession() → session.subscribe() → emit CoworkRuntimeEvents
+ *   startSession    → createAgentSession() → session.subscribe() → emit PiRuntimeEvents
  *   continueSession → session.prompt()
  *   stopSession     → session.abort()
  *
@@ -22,7 +22,6 @@ import * as os from 'os';
 import path from 'path';
 
 import { classifyCoworkError, type CoworkError } from '../../../common/coworkError';
-import type { OpenClawSessionPatch } from '../../../common/openclawSession';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { CoworkToolActivityPhase } from '../../../shared/cowork/toolActivity';
 import {
@@ -71,12 +70,13 @@ import {
   toToolActivityInput,
 } from './toolActivity';
 import type {
-  CoworkContinueOptions,
-  CoworkRuntime,
-  CoworkRuntimeEvents,
-  CoworkStartOptions,
-  PermissionResult,
-} from './types';
+  PiContinueOptions,
+  PiPermissionResult,
+  PiRuntime,
+  PiRuntimeEvents,
+  PiSessionPatch,
+  PiStartOptions,
+} from './piRuntimeTypes';
 
 // ── Types ──
 
@@ -88,11 +88,13 @@ interface PiSession {
   abortBash(): void;
   reload(): Promise<void>;
   setModel(model: unknown): Promise<void>;
-  getContextUsage?(): {
-    tokens: number | null;
-    contextWindow: number;
-    percent: number | null;
-  } | undefined;
+  getContextUsage?():
+    | {
+        tokens: number | null;
+        contextWindow: number;
+        percent: number | null;
+      }
+    | undefined;
   subscribe(listener: (event: PiEvent) => void): () => void;
 }
 
@@ -309,7 +311,7 @@ const haveSameStringList = (left: string[] | undefined, right: string[] | undefi
 // tools won't emit escape sequences without this env var.
 if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '1';
 
-export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
+export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private readonly activeSessions = new Map<string, ActivePiSession>();
   private readonly approvalSessionMap = new Map<string, string>();
   private readonly pendingAskUserQuestions = new Map<
@@ -351,19 +353,13 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   >();
   private readonly pendingStoreUpdateTimer = new Map<string, ReturnType<typeof setTimeout>>();
 
-  // ── CoworkRuntime.on/off ──
+  // ── PiRuntime.on/off ──
 
-  override on<U extends keyof CoworkRuntimeEvents>(
-    event: U,
-    listener: CoworkRuntimeEvents[U],
-  ): this {
+  override on<U extends keyof PiRuntimeEvents>(event: U, listener: PiRuntimeEvents[U]): this {
     return super.on(event, listener);
   }
 
-  override off<U extends keyof CoworkRuntimeEvents>(
-    event: U,
-    listener: CoworkRuntimeEvents[U],
-  ): this {
+  override off<U extends keyof PiRuntimeEvents>(event: U, listener: PiRuntimeEvents[U]): this {
     return super.off(event, listener);
   }
 
@@ -372,7 +368,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   async startSession(
     sessionId: string,
     prompt: string,
-    options: CoworkStartOptions = {},
+    options: PiStartOptions = {},
   ): Promise<void> {
     const hasContent =
       prompt.trim() || (options.imageAttachments && options.imageAttachments.length > 0);
@@ -634,7 +630,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
   async continueSession(
     sessionId: string,
     prompt: string,
-    options: CoworkContinueOptions = {},
+    options: PiContinueOptions = {},
   ): Promise<void> {
     const active = this.activeSessions.get(sessionId);
     if (!active || active.aborted) {
@@ -771,7 +767,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     }
   }
 
-  async patchSession(sessionId: string, patch: OpenClawSessionPatch): Promise<void> {
+  async patchSession(sessionId: string, patch: PiSessionPatch): Promise<void> {
     const active = this.activeSessions.get(sessionId);
     if (!active || !patch.model) return;
 
@@ -837,7 +833,7 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
     }
   }
 
-  respondToPermission(requestId: string, result: PermissionResult): void {
+  respondToPermission(requestId: string, result: PiPermissionResult): void {
     const pendingQuestion = this.pendingAskUserQuestions.get(requestId);
     if (pendingQuestion) {
       this.finishAskUserQuestion(requestId, {
@@ -1085,7 +1081,12 @@ export class PiRuntimeAdapter extends EventEmitter implements CoworkRuntime {
             this.finalizeMessage(sessionId, active, 'answer', finalAnswer);
             active.lastCompletedAnswerMessageId = active.assistantMessageId;
             active.lastCompletedAnswerText = finalAnswer;
-            this.scheduleContextUsageSync(sessionId, active.assistantMessageId, event.message.usage, event.message.model);
+            this.scheduleContextUsageSync(
+              sessionId,
+              active.assistantMessageId,
+              event.message.usage,
+              event.message.model,
+            );
           }
 
           // Turn's segments are done; next turn starts fresh messages.

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -1,0 +1,115 @@
+import type { CoworkError } from '../../../common/coworkError';
+import type { CoworkToolActivityEvent } from '../../../shared/cowork/toolActivity';
+import type { CoworkMessage } from '../../coworkStore';
+
+/**
+ * Pi-native workbench runtime types (issue #225).
+ *
+ * Pi is the sole execution kernel for Work / Chat and owns its session,
+ * event and approval types. It must not implement or reference the
+ * OpenClaw `CoworkRuntime` glue interface — that interface stays inside
+ * the OpenClaw Channel/Cron domain (see `./types.ts`). Shared payload
+ * primitives (messages, tool activity, errors) come from the store/shared
+ * layers, not from the OpenClaw runtime abstraction.
+ */
+
+export type PiPermissionResult =
+  | {
+      behavior: 'allow';
+      updatedInput?: Record<string, unknown>;
+      updatedPermissions?: Record<string, unknown>[];
+      toolUseID?: string;
+    }
+  | {
+      behavior: 'deny';
+      message: string;
+      interrupt?: boolean;
+      toolUseID?: string;
+    };
+
+export interface PiPermissionRequest {
+  requestId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId?: string | null;
+}
+
+export interface PiRuntimeEvents {
+  message: (sessionId: string, message: CoworkMessage) => void;
+  messageUpdate: (
+    sessionId: string,
+    messageId: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ) => void;
+  toolActivity: (sessionId: string, event: CoworkToolActivityEvent) => void;
+  permissionRequest: (sessionId: string, request: PiPermissionRequest) => void;
+  permissionDismiss: (requestId: string) => void;
+  complete: (sessionId: string, claudeSessionId: string | null) => void;
+  error: (sessionId: string, error: CoworkError) => void;
+  sessionStopped: (sessionId: string) => void;
+}
+
+export type PiImageAttachment = {
+  name: string;
+  mimeType: string;
+  base64Data: string;
+};
+
+export type PiConversationHistoryMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export type PiStartOptions = {
+  skipInitialUserMessage?: boolean;
+  skillIds?: string[];
+  systemPrompt?: string;
+  autoApprove?: boolean;
+  workspaceRoot?: string;
+  confirmationMode?: 'modal' | 'text';
+  /** UI session mode, used to apply Work-only execution controls. */
+  sessionMode?: 'work' | 'chat';
+  imageAttachments?: PiImageAttachment[];
+  agentId?: string;
+  expertIds?: string[];
+  modelOverride?: string;
+  /** Previous conversation to restore (user/assistant pairs), injected into PI session state */
+  conversationHistory?: PiConversationHistoryMessage[];
+  /** Internal: override prompt text sent to PI, while UI shows original prompt */
+  _piPromptOverride?: string;
+};
+
+export type PiContinueOptions = {
+  systemPrompt?: string;
+  skillIds?: string[];
+  /** UI session mode, preserved when a skill change recreates the Pi session. */
+  sessionMode?: 'work' | 'chat';
+  imageAttachments?: PiImageAttachment[];
+  /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
+  workspaceRoot?: string;
+  agentId?: string;
+  expertIds?: string[];
+  modelOverride?: string;
+  /** Forwarded to startSession when the runtime has to recreate the session. */
+  autoApprove?: boolean;
+};
+
+/** Workbench session patch; Pi only supports switching the model. */
+export type PiSessionPatch = {
+  model?: string | null;
+};
+
+export interface PiRuntime {
+  on<U extends keyof PiRuntimeEvents>(event: U, listener: PiRuntimeEvents[U]): this;
+  off<U extends keyof PiRuntimeEvents>(event: U, listener: PiRuntimeEvents[U]): this;
+  startSession(sessionId: string, prompt: string, options?: PiStartOptions): Promise<void>;
+  continueSession(sessionId: string, prompt: string, options?: PiContinueOptions): Promise<void>;
+  patchSession?(sessionId: string, patch: PiSessionPatch): Promise<void>;
+  stopSession(sessionId: string): void;
+  stopAllSessions(): void;
+  respondToPermission(requestId: string, result: PiPermissionResult): void;
+  isSessionActive(sessionId: string): boolean;
+  getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null;
+  onSessionDeleted?(sessionId: string): void;
+}

--- a/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
+++ b/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
@@ -9,8 +9,15 @@ const readSource = (relativePath: string): string =>
 const mainSource = readSource('../../main.ts');
 const coworkViewSource = readSource('../../../renderer/components/cowork/CoworkView.tsx');
 const coworkServiceSource = readSource('../../../renderer/services/cowork.ts');
+const piRuntimeAdapterSource = readSource('./piRuntimeAdapter.ts');
 
 describe('Work/Chat runtime isolation', () => {
+  test('Pi workbench runtime does not implement the OpenClaw CoworkRuntime glue', () => {
+    expect(piRuntimeAdapterSource).not.toContain("from './types'");
+    expect(piRuntimeAdapterSource).not.toContain('CoworkRuntime');
+    expect(piRuntimeAdapterSource).toContain('implements PiRuntime');
+  });
+
   test('projects only Pi runtime events into cowork streams', () => {
     expect(mainSource).toContain('forwardPiWorkbenchRuntimeToRenderer(getPiRuntimeAdapter())');
     expect(mainSource).not.toContain(


### PR DESCRIPTION
## 背景

#225 的剩余步骤之一：设计原则要求 **Pi 不实现、不引用 `CoworkRuntime`**——该接口是 OpenClaw Channel/Cron 域的内部胶水。当前 `PiRuntimeAdapter` 直接 `implements CoworkRuntime` 并从共享 `types.ts` 导入事件/选项/权限类型，使 Pi harness 无法独立于 OpenClaw 语义演进。

## 改动

- 新增 `piRuntimeTypes.ts`：Pi 原生的 `PiRuntime` / `PiRuntimeEvents` / `PiPermissionRequest` / `PiPermissionResult` / `PiStartOptions` / `PiContinueOptions` / `PiSessionPatch`。
  - 载荷原语（`CoworkMessage`、tool activity、error）来自 store/shared 层，不属于 OpenClaw runtime 抽象，继续复用。
  - `PiSessionPatch` 只保留 `model` 字段——`PiRuntimeAdapter.patchSession` 本就只消费 model，不再引用 `OpenClawSessionPatch`。
- `PiRuntimeAdapter` 改为 `implements PiRuntime`，不再导入 `./types`。
- `workbenchRuntimeIsolation.test.ts` 新增边界断言：`piRuntimeAdapter.ts` 不得出现 `from './types'` 与 `CoworkRuntime`。
- `types.ts` 保持不变，继续服务 OpenClaw Channel/Cron 与 IM 胶水。

## 兼容性

所有调用点（`main.ts` 的 `forwardPiWorkbenchRuntimeToRenderer`、IPC handlers）本就使用具体类 `PiRuntimeAdapter`，方法签名逐一对应，无行为变化。

## 与 #225 验收标准的对应

- ✅ “Pi 不实现、不引用 `CoworkRuntime`”
- 后续仍待办（独立 PR）：`OpenClawRuntimeAdapter` 拆分/重命名为 Channel Gateway 领域模块、Channel 运行事件 `channel:run:*` 与只读活动投影。

## 验证

- `npm test`：194 文件 / 1661 测试全部通过（含新增边界断言）
- `tsc -p electron-tsconfig.json --noEmit`、`oxlint`、`oxfmt` 通过

Refs #225