### PR TITLE
refactor(agent-engine): OpenClaw adapter 重命名为 Channel Gateway 域模块（#225 步骤 2）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Public-facing product documentation and user-visible UI copy must use the 知远
 
 - Window lifecycle management
 - SQLite storage via `better-sqlite3` (`src/main/sqliteStore.ts`)
-- Agent engine routing (`src/main/libs/agentEngine/coworkEngineRouter.ts`) - dispatches to `openclawRuntimeAdapter.ts` (OpenClaw)
+- Agent engines (`src/main/libs/agentEngine/`) - `piRuntimeAdapter.ts` is the sole Work/Chat execution runtime; `openclawChannelGateway.ts` (OpenClawChannelGateway) is the OpenClaw Channel/Cron domain glue, the only place that still implements the internal `CoworkRuntime` interface
 - llama.cpp lifecycle and local inference management (`src/main/libs/llamacppManager.ts`, `src/shared/llamacpp/`)
 - Skill management (`src/main/skillManager.ts`)
 - MCP server configuration and marketplace integration
@@ -104,8 +104,10 @@ src/main/
 ├── im/                  # IM/email gateway integrations
 └── libs/
     ├── agentEngine/
-    │   ├── coworkEngineRouter.ts    # Routes to OpenClaw runtime
-    │   └── openclawRuntimeAdapter.ts # OpenClaw gateway adapter
+    │   ├── piRuntimeAdapter.ts      # Pi runtime — sole Work/Chat execution kernel
+    │   ├── piRuntimeTypes.ts        # Pi-native runtime/event/approval types
+    │   ├── openclawChannelGateway.ts # OpenClaw Channel/Cron domain gateway
+    │   └── types.ts                 # CoworkRuntime glue (OpenClaw-internal only)
     ├── openclawEngineManager.ts # OpenClaw runtime lifecycle (install/start/status)
     ├── openclawConfigSync.ts    # Syncs cowork config → OpenClaw config files
     ├── llamacppManager.ts       # llama.cpp service lifecycle and configuration
@@ -141,8 +143,8 @@ SKILLs/                  # Custom skill definitions for cowork sessions
 ### Data Flow
 
 1. **Initialization**: `src/renderer/App.tsx` → `coworkService.init()` → loads config/sessions via IPC → sets up stream listeners
-2. **Cowork Session**: User sends prompt → `coworkService.startSession()` → IPC to main → `CoworkEngineRouter` → OpenClaw gateway (primary) → streaming events back to renderer via IPC → Redux updates
-3. **Tool Permissions**: Agent requests tool use → `CoworkEngineRouter` emits `permissionRequest` → UI shows `CoworkPermissionModal` → user approves/denies → result sent back to engine
+2. **Cowork Session**: User sends prompt → `coworkService.startSession()` → IPC to main → `PiRuntimeAdapter` → streaming events back to renderer via IPC → Redux updates
+3. **Tool Permissions**: Agent requests tool use → `PiRuntimeAdapter` emits `permissionRequest` → UI shows `CoworkPermissionModal` → user approves/denies → result sent back to engine
 4. **Persistence**: Cowork sessions stored in SQLite (`cowork_sessions`, `cowork_messages` tables)
 5. **Local Inference**: Renderer invokes llama.cpp IPC → main process manages `llama-server`, model install/list/load state, and service/model launch parameters
 
@@ -157,9 +159,10 @@ The Cowork feature provides AI-assisted coding sessions:
 
 **Agent Engine** (configured via `agentEngine` in cowork config):
 
-- `openclaw` - OpenClaw gateway (`openclawRuntimeAdapter.ts`); requires the bundled OpenClaw runtime to be running. Engine lifecycle managed by `OpenClawEngineManager` with states: `not_installed → ready → starting → running | error`
+- `pi` - Pi in-process runtime (`piRuntimeAdapter.ts`); the only engine used for Work/Chat sessions.
+- `openclaw` - OpenClaw Channel/Cron gateway (`openclawChannelGateway.ts`); requires the bundled OpenClaw runtime to be running. Engine lifecycle managed by `OpenClawEngineManager` with states: `not_installed → ready → starting → running | error`
 
-The `CoworkEngineRouter` exposes stream events to the renderer, which is engine-agnostic. Engine-specific IPC: `openclaw:engine:*` channels manage runtime lifecycle separately from `cowork:*` session channels.
+The Pi runtime forwards stream events to the renderer (`cowork:stream:*` carries Pi workbench sessions only). Engine-specific IPC: `openclaw:engine:*` channels manage the OpenClaw Channel/Cron runtime lifecycle separately from `cowork:*` session channels.
 
 **Memory System**: File-based persistent memory stored in the OpenClaw working directory:
 

--- a/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.test.ts
@@ -13,7 +13,7 @@ test('forwards gateway lifecycle events to the cron job service', () => {
   let reconnectCallback: (() => void) | null = null;
 
   initCronJobServiceManager({
-    getOpenClawRuntimeAdapter: () => ({
+    getOpenClawChannelGateway: () => ({
       getGatewayClient: () => null,
       ensureReady: async () => {},
       onGatewayDisconnect: callback => {

--- a/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.ts
+++ b/src/main/ipcHandlers/scheduledTask/cronJobServiceManager.ts
@@ -9,7 +9,7 @@ type GatewayClientLike = {
 };
 
 export interface CronJobServiceDeps {
-  getOpenClawRuntimeAdapter: () => {
+  getOpenClawChannelGateway: () => {
     getGatewayClient: () => GatewayClientLike | null;
     ensureReady: () => Promise<void>;
     onGatewayDisconnect: (callback: (reason: string) => void) => () => void;
@@ -31,7 +31,7 @@ export function getCronJobService(): CronJobService {
         'CronJobServiceManager not initialized. Call initCronJobServiceManager() first.',
       );
     }
-    const adapter = deps.getOpenClawRuntimeAdapter();
+    const adapter = deps.getOpenClawChannelGateway();
     if (!adapter) {
       throw new Error(
         'OpenClaw runtime adapter not initialized. CronJobService requires OpenClaw.',

--- a/src/main/ipcHandlers/scheduledTask/handlers.test.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.test.ts
@@ -22,7 +22,7 @@ test('task-list handler delegates to CronJobService even before a gateway client
   registerScheduledTaskHandlers({
     getCronJobService: () => ({ listJobs }) as unknown as CronJobService,
     getIMGatewayManager: () => null,
-    getOpenClawRuntimeAdapter: () => ({
+    getOpenClawChannelGateway: () => ({
       getGatewayClient: () => null,
       fetchSessionByKey: async () => null,
     }),

--- a/src/main/ipcHandlers/scheduledTask/handlers.ts
+++ b/src/main/ipcHandlers/scheduledTask/handlers.ts
@@ -41,7 +41,7 @@ export interface ScheduledTaskHandlerDeps {
       coworkSessionId: string,
     ) => Promise<void>;
   } | null;
-  getOpenClawRuntimeAdapter: () => {
+  getOpenClawChannelGateway: () => {
     getGatewayClient: () => unknown;
     fetchSessionByKey: (sessionKey: string) => Promise<unknown>;
   } | null;
@@ -100,7 +100,7 @@ async function applyAnnounceDeliveryNormalization(
 }
 
 export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): void {
-  const { getCronJobService, getIMGatewayManager, getOpenClawRuntimeAdapter } = deps;
+  const { getCronJobService, getIMGatewayManager, getOpenClawChannelGateway } = deps;
 
   ipcMain.handle(ScheduledTaskIpc.List, async () => {
     try {
@@ -262,7 +262,7 @@ export function registerScheduledTaskHandlers(deps: ScheduledTaskHandlerDeps): v
     try {
       if (!sessionKey) return { success: true, session: null };
       // Fetch session history from OpenClaw (returns transient session, not persisted)
-      const session = await getOpenClawRuntimeAdapter()?.fetchSessionByKey(sessionKey);
+      const session = await getOpenClawChannelGateway()?.fetchSessionByKey(sessionKey);
       return { success: true, session: session ?? null };
     } catch (error) {
       return {

--- a/src/main/libs/agentEngine/index.ts
+++ b/src/main/libs/agentEngine/index.ts
@@ -1,4 +1,4 @@
-export { OpenClawRuntimeAdapter } from './openclawRuntimeAdapter';
+export { OpenClawChannelGateway } from './openclawChannelGateway';
 export { PiRuntimeAdapter } from './piRuntimeAdapter';
 export type { CoworkRuntime } from './types';
 export * from './types';

--- a/src/main/libs/agentEngine/openclawChannelGateway.test.ts
+++ b/src/main/libs/agentEngine/openclawChannelGateway.test.ts
@@ -12,11 +12,11 @@ vi.mock('electron', () => ({
   },
 }));
 
-import { OpenClawRuntimeAdapter, pickPersistedAssistantSegment } from './openclawRuntimeAdapter';
+import { OpenClawChannelGateway, pickPersistedAssistantSegment } from './openclawChannelGateway';
 import { ToolActivityTracker } from './toolActivity';
 
 function setAvailabilityGuard(
-  adapter: OpenClawRuntimeAdapter,
+  adapter: OpenClawChannelGateway,
   guard: (modelRef: string) => { available: boolean; message?: string },
 ): void {
   (
@@ -107,7 +107,7 @@ function createPatchAdapter(options?: {
       clientEntryPath: '/tmp/openclaw-gateway-client.js',
     }),
   };
-  const adapter = new OpenClawRuntimeAdapter(store as never, engineManager as never);
+  const adapter = new OpenClawChannelGateway(store as never, engineManager as never);
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -260,7 +260,7 @@ function createRunTurnAdapter(
       clientEntryPath: '/tmp/openclaw-gateway-client.js',
     }),
   };
-  const adapter = new OpenClawRuntimeAdapter(store as never, engineManager as never);
+  const adapter = new OpenClawChannelGateway(store as never, engineManager as never);
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -617,7 +617,7 @@ test('reconcileWithHistory: already in sync — skips replace', async () => {
     { id: 'msg-2', type: 'assistant', content: 'Hi there', timestamp: 2, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -641,7 +641,7 @@ test('reconcileWithHistory: missing assistant message — triggers replace', asy
     // assistant message missing locally
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -669,7 +669,7 @@ test('reconcileWithHistory: carries gateway timestamps into replacement entries'
     { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -694,7 +694,7 @@ test('reconcileWithHistory: filters heartbeat prompt and ack entries', async () 
     { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -730,7 +730,7 @@ test('reconcileWithHistory: duplicate messages locally — triggers replace', as
     { id: 'msg-3', type: 'assistant', content: 'Hi there', timestamp: 3, metadata: {} }, // duplicate
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -756,7 +756,7 @@ test('reconcileWithHistory: content mismatch — triggers replace', async () => 
     { id: 'msg-2', type: 'assistant', content: 'Streaming partial...', timestamp: 2, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -803,7 +803,7 @@ test('lifecycle fallback repairs managed session assistant text from history', a
     },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -862,7 +862,7 @@ test('late lifecycle fallback event does not reopen a completed managed session'
       metadata: { isStreaming: false, isFinal: true },
     },
   ]);
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   const sessionKey = `agent:main:zhiyuan:${session.id}`;
 
   adapter.rememberSessionKey(session.id, sessionKey);
@@ -893,7 +893,7 @@ test('late event for a closed run does not recreate a managed session turn', () 
       metadata: { isStreaming: false, isFinal: true },
     },
   ]);
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   const sessionKey = `agent:main:zhiyuan:${session.id}`;
 
   adapter.rememberSessionKey(session.id, sessionKey);
@@ -925,7 +925,7 @@ test('reconcileWithHistory: preserves tool messages', async () => {
     { id: 'msg-4', type: 'assistant', content: 'Done!', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -950,7 +950,7 @@ test('reconcileWithHistory: gateway returns tail subset — preserves older loca
     { id: 'msg-4', type: 'assistant', content: 'I am fine', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -976,7 +976,7 @@ test('reconcileWithHistory: tail window starting with assistant does not rewrite
     { id: 'msg-4', type: 'assistant', content: 'Second answer', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1003,7 +1003,7 @@ test('reconcileWithHistory: tail window starting with assistant updates anchored
     { id: 'msg-4', type: 'assistant', content: 'Streaming partial...', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1042,7 +1042,7 @@ test('reconcileWithHistory: tail window repairs stale leading assistant before a
     { id: 'msg-4', type: 'assistant', content: 'Streaming partial...', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1071,7 +1071,7 @@ test('reconcileWithHistory: empty history — sets cursor to 0', async () => {
     { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1091,7 +1091,7 @@ test('reconcileWithHistory: multi-turn conversation — correct order', async ()
     // Missing second turn
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1119,7 +1119,7 @@ test('reconcileWithHistory: gateway error — does not crash', async () => {
     { id: 'msg-1', type: 'user', content: 'Hello', timestamp: 1, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1142,7 +1142,7 @@ test('reconcileWithHistory: tail content mismatch — replaces only tail, preser
     { id: 'msg-4', type: 'assistant', content: 'Streaming partial...', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1193,7 +1193,7 @@ test('reconcileWithHistory: long conversation — preserves prefix, replaces tai
   const { session, store, getReplaceCallCount, getLastReplaceArgs } =
     createReconcileStore(localMessages);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1229,7 +1229,7 @@ test('reconcileWithHistory: no overlap — full replace for dashboard consistenc
     { id: 'msg-2', type: 'assistant', content: 'Old reply 1', timestamp: 2, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1258,7 +1258,7 @@ test('reconcileWithHistory: identical user messages — aligns to latest match',
     { id: 'msg-4', type: 'assistant', content: 'Hi (second)', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1285,7 +1285,7 @@ test('reconcileWithHistory: new messages arrived — preserves old and adds new'
     { id: 'msg-4', type: 'assistant', content: 'Answer 2', timestamp: 4, metadata: {} },
   ]);
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1387,7 +1387,7 @@ test('syncFullChannelHistory seeds gateway history cursor so old reminders are n
     { role: 'system', content: 'Reminder: old reminder' },
   ];
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1424,7 +1424,7 @@ test('prefetchChannelUserMessages also consumes existing reminder history backlo
     { role: 'user', content: 'new user turn' },
   ];
 
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   adapter.gatewayClient = {
     start: () => {},
     stop: () => {},
@@ -1448,7 +1448,7 @@ test('prefetchChannelUserMessages also consumes existing reminder history backlo
 
 test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', () => {
   const { session, store } = createHistoryStore([]);
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
   const historyMessages = [
     { role: 'system', content: 'HEARTBEAT_OK' },
     { role: 'system', content: 'Reminder fired' },
@@ -1464,7 +1464,7 @@ test('syncSystemMessagesFromHistory skips pure heartbeat ack system messages', (
 
 test('collectChannelHistoryEntries skips heartbeat prompt and ack messages', () => {
   const { store } = createHistoryStore([]);
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
 
   const entries = adapter.collectChannelHistoryEntries([
     { role: 'user', content: 'regular user' },
@@ -1487,7 +1487,7 @@ If nothing needs attention, reply HEARTBEAT_OK.`,
 
 test('getSessionKeysForSession prefers channel keys before managed fallback', () => {
   const { store } = createHistoryStore([]);
-  const adapter = new OpenClawRuntimeAdapter(store, {});
+  const adapter = new OpenClawChannelGateway(store, {});
 
   adapter.rememberSessionKey(
     'session-1',

--- a/src/main/libs/agentEngine/openclawChannelGateway.ts
+++ b/src/main/libs/agentEngine/openclawChannelGateway.ts
@@ -137,7 +137,7 @@ type GatewayClientLike = {
 
 type GatewayClientCtor = new (options: Record<string, unknown>) => GatewayClientLike;
 
-type OpenClawRuntimeAdapterOptions = {
+type OpenClawChannelGatewayOptions = {
   normalizeModelRef?: (modelRef: string) => string;
   isModelAvailableForSession?: (modelRef: string) => { available: boolean; message?: string };
   getModelContextWindow?: (modelRef: string) => number | undefined;
@@ -890,10 +890,18 @@ const waitWithTimeout = async (promise: Promise<void>, timeoutMs: number): Promi
   }
 };
 
-export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntime {
+/**
+ * OpenClaw Channel/Cron domain gateway (issue #225).
+ *
+ * This class is the OpenClaw-side glue for Channel sessions, IM handlers,
+ * Cron jobs and Gateway lifecycle. `CoworkRuntime` remains its internal
+ * integration interface only — the Pi workbench never implements or
+ * references it (see piRuntimeTypes.ts).
+ */
+export class OpenClawChannelGateway extends EventEmitter implements CoworkRuntime {
   private readonly store: CoworkStore;
   private readonly engineManager: OpenClawEngineManager;
-  private readonly options: OpenClawRuntimeAdapterOptions;
+  private readonly options: OpenClawChannelGatewayOptions;
   private readonly activeTurns = new Map<string, ActiveTurn>();
   private readonly sessionIdBySessionKey = new Map<string, string>();
   private readonly sessionIdByRunId = new Map<string, string>();
@@ -1138,7 +1146,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   constructor(
     store: CoworkStore,
     engineManager: OpenClawEngineManager,
-    options: OpenClawRuntimeAdapterOptions = {},
+    options: OpenClawChannelGatewayOptions = {},
   ) {
     super();
     this.store = store;
@@ -1197,7 +1205,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         'chat.history',
         {
           sessionKey,
-          limit: OpenClawRuntimeAdapter.FULL_HISTORY_SYNC_LIMIT,
+          limit: OpenClawChannelGateway.FULL_HISTORY_SYNC_LIMIT,
         },
         { timeoutMs: 10_000 },
       );
@@ -1439,7 +1447,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     void this.pollChannelSessions();
     this.channelPollingTimer = setInterval(() => {
       void this.pollChannelSessions();
-    }, OpenClawRuntimeAdapter.CHANNEL_POLL_INTERVAL_MS);
+    }, OpenClawChannelGateway.CHANNEL_POLL_INTERVAL_MS);
   }
 
   stopChannelPolling(): void {
@@ -2592,7 +2600,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
       }
     }
 
-    while (this.recentlyClosedRunIds.size > OpenClawRuntimeAdapter.RECENTLY_CLOSED_RUN_ID_LIMIT) {
+    while (this.recentlyClosedRunIds.size > OpenClawChannelGateway.RECENTLY_CLOSED_RUN_ID_LIMIT) {
       const oldestRunId = this.recentlyClosedRunIds.keys().next().value as string | undefined;
       if (!oldestRunId) return;
       this.recentlyClosedRunIds.delete(oldestRunId);
@@ -2605,7 +2613,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const now = Date.now();
     this.recentlyClosedRunIds.set(
       normalizedRunId,
-      now + OpenClawRuntimeAdapter.RECENTLY_CLOSED_RUN_ID_TTL_MS,
+      now + OpenClawChannelGateway.RECENTLY_CLOSED_RUN_ID_TTL_MS,
     );
     this.pruneRecentlyClosedRunIds(now);
   }
@@ -2640,7 +2648,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const lastEmit = this.lastMessageUpdateEmitTime.get(messageId) ?? 0;
     const elapsed = now - lastEmit;
 
-    if (elapsed >= OpenClawRuntimeAdapter.MESSAGE_UPDATE_THROTTLE_MS) {
+    if (elapsed >= OpenClawChannelGateway.MESSAGE_UPDATE_THROTTLE_MS) {
       this.clearPendingMessageUpdate(messageId);
       this.lastMessageUpdateEmitTime.set(messageId, now);
       this.emit('messageUpdate', sessionId, messageId, content);
@@ -2655,7 +2663,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         this.pendingMessageUpdateTimer.delete(messageId);
         this.lastMessageUpdateEmitTime.set(messageId, Date.now());
         this.emit('messageUpdate', sessionId, messageId, content);
-      }, OpenClawRuntimeAdapter.MESSAGE_UPDATE_THROTTLE_MS - elapsed),
+      }, OpenClawChannelGateway.MESSAGE_UPDATE_THROTTLE_MS - elapsed),
     );
   }
 
@@ -2682,7 +2690,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const lastUpdate = this.lastStoreUpdateTime.get(messageId) ?? 0;
     const elapsed = now - lastUpdate;
 
-    if (elapsed >= OpenClawRuntimeAdapter.STORE_UPDATE_THROTTLE_MS) {
+    if (elapsed >= OpenClawChannelGateway.STORE_UPDATE_THROTTLE_MS) {
       this.clearPendingStoreUpdate(messageId);
       this.lastStoreUpdateTime.set(messageId, now);
       this.store.updateMessage(sessionId, messageId, { content, metadata });
@@ -2701,7 +2709,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
         if (activeTurn?.assistantMessageId === messageId) {
           this.store.updateMessage(sessionId, messageId, { content, metadata });
         }
-      }, OpenClawRuntimeAdapter.STORE_UPDATE_THROTTLE_MS - elapsed),
+      }, OpenClawChannelGateway.STORE_UPDATE_THROTTLE_MS - elapsed),
     );
   }
 
@@ -2734,7 +2742,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     console.log('[TickWatchdog] started');
     this.tickWatchdogTimer = setInterval(() => {
       this.checkTickHealth();
-    }, OpenClawRuntimeAdapter.TICK_WATCHDOG_INTERVAL_MS);
+    }, OpenClawChannelGateway.TICK_WATCHDOG_INTERVAL_MS);
   }
 
   private stopTickWatchdog(): void {
@@ -2747,10 +2755,10 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private checkTickHealth(): void {
     if (this.lastTickTimestamp <= 0) return;
     const elapsed = Date.now() - this.lastTickTimestamp;
-    if (elapsed <= OpenClawRuntimeAdapter.TICK_TIMEOUT_MS) return;
+    if (elapsed <= OpenClawChannelGateway.TICK_TIMEOUT_MS) return;
 
     console.warn(
-      `[TickWatchdog] no tick received for ${Math.round(elapsed / 1000)}s (threshold: ${OpenClawRuntimeAdapter.TICK_TIMEOUT_MS / 1000}s) — connection is likely dead, triggering reconnect`,
+      `[TickWatchdog] no tick received for ${Math.round(elapsed / 1000)}s (threshold: ${OpenClawChannelGateway.TICK_TIMEOUT_MS / 1000}s) — connection is likely dead, triggering reconnect`,
     );
     this.cancelGatewayReconnect();
     this.stopGatewayClient();
@@ -2783,21 +2791,21 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
    * Called from onClose when the connection drops unexpectedly after a successful handshake.
    */
   private scheduleGatewayReconnect(): void {
-    if (this.gatewayReconnectAttempt >= OpenClawRuntimeAdapter.GATEWAY_RECONNECT_MAX_ATTEMPTS) {
+    if (this.gatewayReconnectAttempt >= OpenClawChannelGateway.GATEWAY_RECONNECT_MAX_ATTEMPTS) {
       console.error(
         '[GatewayReconnect] max attempts reached (' +
-          OpenClawRuntimeAdapter.GATEWAY_RECONNECT_MAX_ATTEMPTS +
+          OpenClawChannelGateway.GATEWAY_RECONNECT_MAX_ATTEMPTS +
           '), giving up. Restart the app to reconnect.',
       );
       return;
     }
 
-    const delays = OpenClawRuntimeAdapter.GATEWAY_RECONNECT_DELAYS;
+    const delays = OpenClawChannelGateway.GATEWAY_RECONNECT_DELAYS;
     const delay = delays[Math.min(this.gatewayReconnectAttempt, delays.length - 1)];
     this.gatewayReconnectAttempt++;
 
     console.log(
-      `[GatewayReconnect] scheduling reconnect attempt ${this.gatewayReconnectAttempt}/${OpenClawRuntimeAdapter.GATEWAY_RECONNECT_MAX_ATTEMPTS} in ${delay}ms`,
+      `[GatewayReconnect] scheduling reconnect attempt ${this.gatewayReconnectAttempt}/${OpenClawChannelGateway.GATEWAY_RECONNECT_MAX_ATTEMPTS} in ${delay}ms`,
     );
 
     this.gatewayReconnectTimer = setTimeout(() => {
@@ -4917,7 +4925,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     }
 
     const limit = options?.isFullSync
-      ? OpenClawRuntimeAdapter.FULL_HISTORY_SYNC_LIMIT
+      ? OpenClawChannelGateway.FULL_HISTORY_SYNC_LIMIT
       : FINAL_HISTORY_SYNC_LIMIT;
 
     try {
@@ -5766,7 +5774,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
     const turn = this.activeTurns.get(sessionId);
     if (!turn) return;
     const timeoutMs =
-      this.agentTimeoutSeconds * 1000 + OpenClawRuntimeAdapter.CLIENT_TIMEOUT_GRACE_MS;
+      this.agentTimeoutSeconds * 1000 + OpenClawChannelGateway.CLIENT_TIMEOUT_GRACE_MS;
     turn.timeoutTimer = setTimeout(() => {
       const currentTurn = this.activeTurns.get(sessionId);
       if (!currentTurn || currentTurn.turnToken !== turn.turnToken) return;
@@ -5840,7 +5848,7 @@ export class OpenClawRuntimeAdapter extends EventEmitter implements CoworkRuntim
   private isSessionInStopCooldown(sessionId: string): boolean {
     const stoppedAt = this.stoppedSessions.get(sessionId);
     if (stoppedAt === undefined) return false;
-    if (Date.now() - stoppedAt < OpenClawRuntimeAdapter.STOP_COOLDOWN_MS) {
+    if (Date.now() - stoppedAt < OpenClawChannelGateway.STOP_COOLDOWN_MS) {
       return true;
     }
     // Cooldown expired, remove the entry

--- a/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
+++ b/src/main/libs/agentEngine/workbenchRuntimeIsolation.test.ts
@@ -14,9 +14,9 @@ describe('Work/Chat runtime isolation', () => {
   test('projects only Pi runtime events into cowork streams', () => {
     expect(mainSource).toContain('forwardPiWorkbenchRuntimeToRenderer(getPiRuntimeAdapter())');
     expect(mainSource).not.toContain(
-      'forwardPiWorkbenchRuntimeToRenderer(getOpenClawRuntimeAdapter())',
+      'forwardPiWorkbenchRuntimeToRenderer(getOpenClawChannelGateway())',
     );
-    expect(mainSource).toContain('getOpenClawRuntimeAdapter();');
+    expect(mainSource).toContain('getOpenClawChannelGateway();');
     expect(mainSource).not.toContain("webContents.send('cowork:stream:");
   });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -110,7 +110,7 @@ import {
 } from './ipcHandlers/scheduledTask';
 import { getTriageConfig, registerTriageIpcHandlers } from './ipcHandlers/triage';
 import {
-  OpenClawRuntimeAdapter,
+  OpenClawChannelGateway,
   type PermissionResult,
   PiRuntimeAdapter,
 } from './libs/agentEngine';
@@ -952,7 +952,7 @@ process.on('exit', code => {
 
 let store: SqliteStore | null = null;
 let coworkStore: CoworkStore | null = null;
-let openClawRuntimeAdapter: OpenClawRuntimeAdapter | null = null;
+let openClawChannelGateway: OpenClawChannelGateway | null = null;
 let piRuntimeAdapter: PiRuntimeAdapter | null = null;
 
 const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
@@ -1408,7 +1408,7 @@ const DEFERRED_RESTART_POLL_MS = 3_000;
 const DEFERRED_RESTART_MAX_WAIT_MS = 5 * 60_000; // 5 minutes hard cap
 
 const hasActiveGatewayWorkloads = (): boolean => {
-  if (openClawRuntimeAdapter?.hasActiveSessions()) return true;
+  if (openClawChannelGateway?.hasActiveSessions()) return true;
   try {
     if (getCronJobService()?.hasRunningJobs()) return true;
   } catch {
@@ -1696,8 +1696,8 @@ const doSyncOpenClawConfig = async (options: {
   console.log(
     `${D()} ──── HARD RESTART EXECUTING. reason=${options.reason}, phase=${gatewayStatus.phase}, port=${gatewayStatus.message?.match(/loopback:(\d+)/)?.[1] ?? 'unknown'}`,
   );
-  if (openClawRuntimeAdapter) {
-    openClawRuntimeAdapter.disconnectGatewayClient();
+  if (openClawChannelGateway) {
+    openClawChannelGateway.disconnectGatewayClient();
   }
 
   const restarted = await manager.restartGateway(`config-sync:${options.reason}`);
@@ -1832,9 +1832,9 @@ const bindPiWorkbenchRuntimeForwarder = (): void => {
   piWorkbenchRuntimeForwarderBound = true;
 };
 
-const getOpenClawRuntimeAdapter = (): OpenClawRuntimeAdapter => {
-  if (!openClawRuntimeAdapter) {
-    openClawRuntimeAdapter = new OpenClawRuntimeAdapter(
+const getOpenClawChannelGateway = (): OpenClawChannelGateway => {
+  if (!openClawChannelGateway) {
+    openClawChannelGateway = new OpenClawChannelGateway(
       getCoworkStore(),
       getOpenClawEngineManager(),
       {
@@ -1865,10 +1865,10 @@ const getOpenClawRuntimeAdapter = (): OpenClawRuntimeAdapter => {
           onBindingChanged: (sessionKey, _platform, newAgentId) => {
             const agent = getCoworkStore().getAgent(newAgentId);
             const model = agent?.model || '';
-            if (model && openClawRuntimeAdapter) {
+            if (model && openClawChannelGateway) {
               const availability = validateSessionModelAvailability(model);
               if (!availability.available) return;
-              const client = openClawRuntimeAdapter.getGatewayClient();
+              const client = openClawChannelGateway.getGatewayClient();
               if (client) {
                 void client.request('sessions.patch', { key: sessionKey, model }).catch(err => {
                   console.warn(
@@ -1880,13 +1880,13 @@ const getOpenClawRuntimeAdapter = (): OpenClawRuntimeAdapter => {
             }
           },
         });
-        openClawRuntimeAdapter.setChannelSessionSync(channelSessionSync);
+        openClawChannelGateway.setChannelSessionSync(channelSessionSync);
       }
     } catch (error) {
       console.warn('[Main] Failed to set up channel session sync:', error);
     }
   }
-  return openClawRuntimeAdapter;
+  return openClawChannelGateway;
 };
 
 const getSkillManager = () => {
@@ -2359,10 +2359,10 @@ const getIMGatewayManager = () => {
     // IM always uses OpenClaw directly, bypassing the engine router.
     // This ensures IM/Cron remain on OpenClaw regardless of the user's
     // Work/Chat engine selection (Pi / OpenClaw).
-    if (!openClawRuntimeAdapter) {
+    if (!openClawChannelGateway) {
       throw new Error('[IMGateway] OpenClaw runtime adapter not initialized');
     }
-    const runtime = openClawRuntimeAdapter;
+    const runtime = openClawChannelGateway;
     const store = getCoworkStore();
 
     imGatewayManager = new IMGatewayManager(sqliteStore.getDatabase(), {
@@ -2382,20 +2382,20 @@ const getIMGatewayManager = () => {
         });
       },
       ensureOpenClawGatewayConnected: async () => {
-        if (openClawRuntimeAdapter) {
-          await openClawRuntimeAdapter.connectGatewayIfNeeded();
+        if (openClawChannelGateway) {
+          await openClawChannelGateway.connectGatewayIfNeeded();
         }
       },
-      getOpenClawGatewayClient: () => openClawRuntimeAdapter?.getGatewayClient() ?? null,
+      getOpenClawGatewayClient: () => openClawChannelGateway?.getGatewayClient() ?? null,
       ensureOpenClawGatewayReady: async () => {
-        if (!openClawRuntimeAdapter) {
+        if (!openClawChannelGateway) {
           throw new Error('OpenClaw runtime adapter not initialized.');
         }
-        await openClawRuntimeAdapter.ensureReady();
-        await openClawRuntimeAdapter.connectGatewayIfNeeded();
+        await openClawChannelGateway.ensureReady();
+        await openClawChannelGateway.connectGatewayIfNeeded();
       },
       getOpenClawSessionKeysForCoworkSession: (sessionId: string) => {
-        return openClawRuntimeAdapter?.getSessionKeysForSession(sessionId) ?? [];
+        return openClawChannelGateway?.getSessionKeysForSession(sessionId) ?? [];
       },
       createScheduledTask: async ({ sessionId, message, request }) => {
         // if (message.platform === 'dingtalk') {
@@ -2529,11 +2529,11 @@ const getIMGatewayManager = () => {
     });
 
     // Wire gateway lifecycle notifications
-    if (openClawRuntimeAdapter) {
-      openClawRuntimeAdapter.onGatewayDisconnect(reason => {
+    if (openClawChannelGateway) {
+      openClawChannelGateway.onGatewayDisconnect(reason => {
         imGatewayManager?.onOpenClawDisconnected(reason);
       });
-      openClawRuntimeAdapter.onGatewayReconnect(() => {
+      openClawChannelGateway.onGatewayReconnect(() => {
         imGatewayManager?.onOpenClawReconnected();
       });
     }
@@ -5555,7 +5555,7 @@ if (!gotTheLock) {
   // ==================== Scheduled Task IPC Handlers (OpenClaw) ====================
 
   initCronJobServiceManager({
-    getOpenClawRuntimeAdapter: () => openClawRuntimeAdapter,
+    getOpenClawChannelGateway: () => openClawChannelGateway,
   });
   initScheduledTaskHelpers({
     getIMGatewayManager: () => ({
@@ -5590,7 +5590,7 @@ if (!gotTheLock) {
           coworkSessionId,
         ),
     }),
-    getOpenClawRuntimeAdapter: () => openClawRuntimeAdapter,
+    getOpenClawChannelGateway: () => openClawChannelGateway,
   });
 
   // ==================== Permissions IPC Handlers ====================
@@ -5678,9 +5678,9 @@ if (!gotTheLock) {
       });
       // After config sync, ensure the runtime adapter's WebSocket client
       // is connected so channel events are received.
-      if (openClawRuntimeAdapter) {
+      if (openClawChannelGateway) {
         try {
-          await openClawRuntimeAdapter.connectGatewayIfNeeded();
+          await openClawChannelGateway.connectGatewayIfNeeded();
         } catch (connectError) {
           console.error('[IM] Failed to connect gateway client after config sync:', connectError);
         }
@@ -7356,7 +7356,7 @@ if (!gotTheLock) {
     // Stop all active sessions from both kernels without blocking shutdown.
     console.log('[Main] Stopping cowork sessions...');
     if (piRuntimeAdapter) piRuntimeAdapter.stopAllSessions();
-    if (openClawRuntimeAdapter) openClawRuntimeAdapter.stopAllSessions();
+    if (openClawChannelGateway) openClawChannelGateway.stopAllSessions();
 
     await stopCoworkOpenAICompatProxy().catch(error => {
       console.error('Failed to stop OpenAI compatibility proxy:', error);
@@ -7781,7 +7781,7 @@ if (!gotTheLock) {
 
     bindPiWorkbenchRuntimeForwarder();
     // Channel/Cron own this runtime directly; it is intentionally not renderer-forwarded.
-    getOpenClawRuntimeAdapter();
+    getOpenClawChannelGateway();
     bindOpenClawStatusForwarder();
 
     const defaultAgentModelRef = resolveDefaultAgentModelRef();
@@ -7973,8 +7973,8 @@ if (!gotTheLock) {
 
     // Reconnect OpenClaw gateway WS after system wake from sleep/suspend
     powerMonitor.on('resume', () => {
-      if (openClawRuntimeAdapter) {
-        openClawRuntimeAdapter.onSystemResume();
+      if (openClawChannelGateway) {
+        openClawChannelGateway.onSystemResume();
       }
       if (Date.now() - lastSuccessfulAppUpdateCheckAt >= APP_UPDATE_POLL_INTERVAL_MS) {
         checkForAppUpdate();

--- a/src/renderer/utils/userMessageDisplay.ts
+++ b/src/renderer/utils/userMessageDisplay.ts
@@ -4,7 +4,7 @@
  * DISPLAY ONLY — does not affect what is sent to the AI model.
  *
  * NOTE: Some stripping (e.g. stripFeishuSystemHeader) already happens server-side
- * in openclawRuntimeAdapter.ts before the message is stored. This means some messages
+ * in openclawChannelGateway.ts before the message is stored. This means some messages
  * arrive here already partially stripped (e.g. Feishu messages may be just a bare path).
  */
 


### PR DESCRIPTION
## 背景

#225 迁移步骤 2：“将 `OpenClawRuntimeAdapter` 拆分/重命名为 Channel Gateway 领域模块；`CoworkRuntime` 继续作为其内部胶水，不暴露给 Pi。”

该 adapter 如今只服务 Channel 会话、IM handler、Cron 与 Gateway 生命周期（Work/Chat 已全部走 Pi），因此重命名为领域名 `OpenClawChannelGateway`，让模块边界与 #225 的目标架构一致。

## 改动

- `git mv`：`openclawRuntimeAdapter.ts` / `.test.ts` → `openclawChannelGateway.ts` / `.test.ts`（git 识别为 96–99% rename）。
- 类名 `OpenClawRuntimeAdapter` → `OpenClawChannelGateway`；`getOpenClawRuntimeAdapter` → `getOpenClawChannelGateway`，同步 `main.ts`、scheduledTask IPC handlers 及测试。
- 类注释标明域边界：`CoworkRuntime` 仅为 OpenClaw 内部集成接口，Pi workbench 不引用。
- `AGENTS.md` / `CLAUDE.md` 同步为 Pi/OpenClaw 分离的现状（原 `CoworkEngineRouter` 引用早已过期）。

纯重命名，无行为变化。

## 验证

- `npm test`：194 文件 / 1660 测试全部通过
- `tsc -p electron-tsconfig.json` 与 `tsc -p tsconfig.json` 均无错误；`oxlint`、`oxfmt` 通过

Refs #225