### PR TITLE
feat(im): Channel/Cron 运行生命周期事件投影（#225 步骤 3 main 侧）

### DIFF
--- a/src/main/im/channelRunEvents.ts
+++ b/src/main/im/channelRunEvents.ts
@@ -1,0 +1,17 @@
+import { BrowserWindow } from 'electron';
+
+import type { ChannelRunSummary } from '../../shared/channelRun/constants';
+import { ChannelRunIpc } from '../../shared/channelRun/constants';
+
+/**
+ * Broadcasts a Channel/Cron run lifecycle event to every renderer window.
+ * The projection is read-only: renderers never drive channel runs (issue
+ * #225 — channel events stay off cowork:stream:*).
+ */
+export const emitChannelRunEvent = (summary: ChannelRunSummary): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(ChannelRunIpc.RunEvent, summary);
+    }
+  }
+};

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -9,11 +9,14 @@ import path from 'path';
 
 import { type CoworkError, CoworkErrorKind } from '../../common/coworkError';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
+import { ChannelRunStatus, ChannelRunTrigger } from '../../shared/channelRun/constants';
+import { buildChannelRunSummary } from '../../shared/channelRun/summary';
 import type { CoworkMessage, CoworkStore } from '../coworkStore';
 import { t } from '../i18n';
 import type { CoworkRuntime, PermissionRequest, PermissionResult } from '../libs/agentEngine/types';
 import { generateCorrelationId, runWithCorrelationId } from '../libs/logCorrelation';
 import { serializeForLog } from '../libs/sanitizeForLog';
+import { emitChannelRunEvent } from './channelRunEvents';
 import { buildIMMediaInstruction } from './imMediaInstruction';
 import { analyzeIMReply, DEFAULT_IM_EMPTY_REPLY } from './imReplyGuard';
 import {
@@ -219,6 +222,18 @@ export class IMCoworkHandler extends EventEmitter {
       }
 
       const responsePromise = this.createAccumulatorPromise(coworkSessionId);
+
+      // Project the run lifecycle to the renderer (read-only; issue #225).
+      emitChannelRunEvent(
+        buildChannelRunSummary({
+          sessionId: coworkSessionId,
+          platform: message.platform,
+          conversationId: message.conversationId,
+          trigger: ChannelRunTrigger.Channel,
+          status: ChannelRunStatus.Started,
+          input: formattedContent,
+        }),
+      );
 
       // Start or continue session
       const isActive = this.coworkRuntime.isSessionActive(coworkSessionId);
@@ -910,6 +925,22 @@ export class IMCoworkHandler extends EventEmitter {
 
     this.cleanupAccumulator(sessionId);
 
+    {
+      const conversation = this.sessionConversationMap.get(sessionId);
+      emitChannelRunEvent(
+        buildChannelRunSummary({
+          sessionId,
+          platform: conversation?.platform ?? '',
+          conversationId: conversation?.conversationId ?? '',
+          trigger: accumulator.backgroundDelivery
+            ? ChannelRunTrigger.Cron
+            : ChannelRunTrigger.Channel,
+          status: ChannelRunStatus.Completed,
+          reply: replyText,
+        }),
+      );
+    }
+
     if (accumulator.backgroundDelivery) {
       if (!this.sendAsyncReply || !replyText || replyText === '处理完成，但没有生成回复。') {
         console.warn('[IMCoworkHandler] cannot send async IM reminder reply', replyText);
@@ -959,6 +990,21 @@ export class IMCoworkHandler extends EventEmitter {
     // Generate differentiated IM reply based on error kind
     const replyText = this.formatErrorReply(error);
     this.cleanupAccumulator(sessionId);
+
+    const conversation = this.sessionConversationMap.get(sessionId);
+    emitChannelRunEvent(
+      buildChannelRunSummary({
+        sessionId,
+        platform: conversation?.platform ?? '',
+        conversationId: conversation?.conversationId ?? '',
+        trigger: accumulator.backgroundDelivery
+          ? ChannelRunTrigger.Cron
+          : ChannelRunTrigger.Channel,
+        status: ChannelRunStatus.Failed,
+        error: replyText,
+      }),
+    );
+
     accumulator.reject?.(new Error(replyText));
   }
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -4,6 +4,7 @@ import type { CoworkError } from '../common/coworkError';
 import { IpcChannel as ScheduledTaskIpc } from '../scheduledTask/constants';
 import { AgentIpcChannel } from '../shared/agent/constants';
 import { AppUpdateIpc } from '../shared/appUpdate/constants';
+import { ChannelRunIpc, type ChannelRunSummary } from '../shared/channelRun/constants';
 import {
   ApiIpc,
   AppConfigIpc,
@@ -811,5 +812,11 @@ contextBridge.exposeInMainWorld('electron', {
     cancel: () => ipcRenderer.invoke(OpenAICodexOAuthIpc.Cancel),
     logout: () => ipcRenderer.invoke(OpenAICodexOAuthIpc.Logout),
     status: () => ipcRenderer.invoke(OpenAICodexOAuthIpc.Status),
+  },
+
+  // Read-only Channel/Cron run lifecycle projection (issue #225)
+  channelRun: {
+    onRunEvent: (callback: (summary: ChannelRunSummary) => void) =>
+      onPush(ChannelRunIpc.RunEvent, callback),
   },
 });

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1,6 +1,7 @@
 import type { CoworkError } from '../../common/coworkError';
 import type { OpenClawSessionPatch } from '../../common/openclawSession';
 import type { AppUpdateCheckResult, AppUpdateRuntimeState } from '../../shared/appUpdate/constants';
+import type { ChannelRunSummary } from '../../shared/channelRun/constants';
 import type { NvidiaSmiSnapshot } from '../../shared/hardware';
 import type {
   CoworkPermissionMode,
@@ -374,7 +375,10 @@ interface IElectronAPI {
       pinned: boolean;
     }) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
     delete: (id: string) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
-      download: (source: string, options?: { iconUrl?: string; displayName?: string }) => Promise<{
+    download: (
+      source: string,
+      options?: { iconUrl?: string; displayName?: string },
+    ) => Promise<{
       success: boolean;
       skills?: Skill[];
       error?: string;
@@ -387,7 +391,9 @@ interface IElectronAPI {
       action: string,
     ) => Promise<{ success: boolean; skills?: Skill[]; error?: string }>;
     getRoot: () => Promise<{ success: boolean; path?: string; error?: string }>;
-    getContent: (skillId: string) => Promise<{ success: boolean; content?: string; error?: string }>;
+    getContent: (
+      skillId: string,
+    ) => Promise<{ success: boolean; content?: string; error?: string }>;
     autoRoutingPrompt: () => Promise<{ success: boolean; prompt?: string | null; error?: string }>;
     getConfig: (
       skillId: string,
@@ -400,15 +406,15 @@ interface IElectronAPI {
       skillId: string,
       config: Record<string, string>,
     ) => Promise<{ success: boolean; result?: EmailConnectivityTestResult; error?: string }>;
-      fetchMarketplace: (options?: {
-        pageNumber?: number;
-        pageSize?: number;
-      }) => Promise<{ success: boolean; data?: string; error?: string }>;
-      fetchMarketplaceContent: (skillId: string) => Promise<{
-        success: boolean;
-        content?: string | null;
-        error?: string;
-      }>;
+    fetchMarketplace: (options?: {
+      pageNumber?: number;
+      pageSize?: number;
+    }) => Promise<{ success: boolean; data?: string; error?: string }>;
+    fetchMarketplaceContent: (skillId: string) => Promise<{
+      success: boolean;
+      content?: string | null;
+      error?: string;
+    }>;
     onChanged: (callback: () => void) => () => void;
   };
   mcp: {
@@ -434,7 +440,9 @@ interface IElectronAPI {
       error?: string;
     }>;
     refreshBridge: () => Promise<{ success: boolean; tools: number; error?: string }>;
-    authorize: (data: any) => Promise<{ success: boolean; servers?: McpServerConfigIPC[]; error?: string }>;
+    authorize: (
+      data: any,
+    ) => Promise<{ success: boolean; servers?: McpServerConfigIPC[]; error?: string }>;
     cancelAuthorize: (requestId: string) => Promise<{ success: boolean }>;
     getFeishuCliStatus: () => Promise<{ success: boolean; installed: boolean; error?: string }>;
     prepareFeishuCli: () => Promise<{ success: boolean; error?: string }>;
@@ -505,9 +513,7 @@ interface IElectronAPI {
     listLocalModels: () => Promise<LlamaCppModel[]>;
     listRunningModels: () => Promise<LlamaCppRunningModel[]>;
     importModelFiles: (paths: string[]) => Promise<LlamaCppImportModelFilesResult>;
-    deleteModel: (
-      name: string,
-    ) => Promise<{
+    deleteModel: (name: string) => Promise<{
       success: boolean;
       deleted?: boolean;
       reason?: 'not-local-file' | 'not-app-managed';
@@ -593,9 +599,7 @@ interface IElectronAPI {
       },
     ) => Promise<Agent>;
     delete: (id: string) => Promise<boolean>;
-    importExpertPackage: (
-      expertDir: string,
-    ) => Promise<{
+    importExpertPackage: (expertDir: string) => Promise<{
       success: boolean;
       agentIds?: string[];
       expertType?: string;
@@ -619,7 +623,10 @@ interface IElectronAPI {
   api: {
     webSearch: (input: { query: string; maxResults?: number; requestId?: string }) => Promise<{
       ok: boolean;
-      data?: { query: string; results: Array<{ title: string; url: string; snippet: string; content?: string }> };
+      data?: {
+        query: string;
+        results: Array<{ title: string; url: string; snippet: string; content?: string }>;
+      };
       error?: string;
     }>;
     fetch: (options: {
@@ -712,10 +719,7 @@ interface IElectronAPI {
       workspaces?: import('../../shared/workspace').Workspace[];
       error?: string;
     }>;
-    ensureWorkspace: (options: {
-      path: string;
-      name?: string;
-    }) => Promise<{
+    ensureWorkspace: (options: { path: string; name?: string }) => Promise<{
       success: boolean;
       workspace?: import('../../shared/workspace').Workspace;
       error?: string;
@@ -728,9 +732,7 @@ interface IElectronAPI {
       workspace?: import('../../shared/workspace').Workspace;
       error?: string;
     }>;
-    deleteWorkspace: (
-      id: string,
-    ) => Promise<{
+    deleteWorkspace: (id: string) => Promise<{
       success: boolean;
       deletedSessionIds?: string[];
       error?: string;
@@ -919,10 +921,7 @@ interface IElectronAPI {
   };
   project: {
     getDefaultBaseDir: () => Promise<{ success: boolean; path: string | null; error?: string }>;
-    createDirectory: (options: {
-      name: string;
-      baseDir?: string;
-    }) => Promise<{
+    createDirectory: (options: { name: string; baseDir?: string }) => Promise<{
       success: boolean;
       path: string | null;
       code?: 'invalid-name' | 'already-exists';
@@ -1346,6 +1345,10 @@ interface IElectronAPI {
       | { loggedIn: true; email: string | null; accountId: string | null; expiresAt: number }
       | { loggedIn: false }
     >;
+  };
+
+  channelRun: {
+    onRunEvent: (callback: (summary: ChannelRunSummary) => void) => () => void;
   };
 }
 

--- a/src/shared/channelRun/constants.ts
+++ b/src/shared/channelRun/constants.ts
@@ -1,0 +1,45 @@
+/**
+ * Channel/Cron run lifecycle events (issue #225 step 3).
+ *
+ * Channel-triggered runs (IM messages) and Cron-triggered runs execute
+ * inside the OpenClaw domain and are NOT cowork workbench sessions. These
+ * events expose them to the renderer as a read-only projection for the
+ * future activity feed, on their own IPC channel instead of cowork:stream:*.
+ */
+export const ChannelRunStatus = {
+  Started: 'started',
+  Completed: 'completed',
+  Failed: 'failed',
+} as const;
+export type ChannelRunStatus = (typeof ChannelRunStatus)[keyof typeof ChannelRunStatus];
+
+export const ChannelRunTrigger = {
+  /** Inbound IM/channel message. */
+  Channel: 'channel',
+  /** Scheduled cron task delivery. */
+  Cron: 'cron',
+} as const;
+export type ChannelRunTrigger = (typeof ChannelRunTrigger)[keyof typeof ChannelRunTrigger];
+
+export const ChannelRunIpc = {
+  /** Main → renderer push of a ChannelRunSummary. */
+  RunEvent: 'channel:run:event',
+} as const;
+export type ChannelRunIpc = (typeof ChannelRunIpc)[keyof typeof ChannelRunIpc];
+
+/** Read-only summary of one Channel/Cron run lifecycle transition. */
+export type ChannelRunSummary = {
+  sessionId: string;
+  platform: string;
+  conversationId: string;
+  trigger: ChannelRunTrigger;
+  status: ChannelRunStatus;
+  /** Epoch ms when this transition happened. */
+  timestamp: number;
+  /** First characters of the inbound message (started events). */
+  inputPreview?: string;
+  /** First characters of the produced reply (completed events). */
+  replyPreview?: string;
+  /** User-facing error text (failed events). */
+  errorMessage?: string;
+};

--- a/src/shared/channelRun/summary.test.ts
+++ b/src/shared/channelRun/summary.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest';
+
+import { ChannelRunStatus, ChannelRunTrigger } from './constants';
+import { buildChannelRunSummary } from './summary';
+
+const baseInput = {
+  sessionId: 'session-1',
+  platform: 'feishu',
+  conversationId: 'conv-1',
+  trigger: ChannelRunTrigger.Channel,
+};
+
+test('builds a started summary with a collapsed input preview', () => {
+  const summary = buildChannelRunSummary({
+    ...baseInput,
+    status: ChannelRunStatus.Started,
+    input: '  hello\n\nworld   this is a message  ',
+  });
+
+  expect(summary.status).toBe(ChannelRunStatus.Started);
+  expect(summary.inputPreview).toBe('hello world this is a message');
+  expect(summary.replyPreview).toBeUndefined();
+  expect(summary.errorMessage).toBeUndefined();
+  expect(summary.timestamp).toBeGreaterThan(0);
+});
+
+test('truncates long previews at 80 characters with an ellipsis', () => {
+  const summary = buildChannelRunSummary({
+    ...baseInput,
+    status: ChannelRunStatus.Completed,
+    reply: 'x'.repeat(200),
+  });
+
+  expect(summary.replyPreview).toHaveLength(81);
+  expect(summary.replyPreview?.endsWith('…')).toBe(true);
+});
+
+test('omits previews for empty or whitespace-only text', () => {
+  const summary = buildChannelRunSummary({
+    ...baseInput,
+    status: ChannelRunStatus.Failed,
+    input: '   \n  ',
+    error: '处理超时，请稍后重试',
+  });
+
+  expect(summary.inputPreview).toBeUndefined();
+  expect(summary.errorMessage).toBe('处理超时，请稍后重试');
+});
+
+test('keeps trigger and identity fields verbatim', () => {
+  const summary = buildChannelRunSummary({
+    ...baseInput,
+    trigger: ChannelRunTrigger.Cron,
+    status: ChannelRunStatus.Completed,
+    reply: 'done',
+  });
+
+  expect(summary.trigger).toBe(ChannelRunTrigger.Cron);
+  expect(summary.sessionId).toBe('session-1');
+  expect(summary.platform).toBe('feishu');
+  expect(summary.conversationId).toBe('conv-1');
+});

--- a/src/shared/channelRun/summary.ts
+++ b/src/shared/channelRun/summary.ts
@@ -1,0 +1,36 @@
+import type { ChannelRunStatus, ChannelRunSummary, ChannelRunTrigger } from './constants';
+
+const PREVIEW_MAX_LENGTH = 80;
+
+const toPreview = (text: string | undefined): string | undefined => {
+  if (!text) return undefined;
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return undefined;
+  return collapsed.length > PREVIEW_MAX_LENGTH
+    ? `${collapsed.slice(0, PREVIEW_MAX_LENGTH)}…`
+    : collapsed;
+};
+
+export type BuildChannelRunSummaryInput = {
+  sessionId: string;
+  platform: string;
+  conversationId: string;
+  trigger: ChannelRunTrigger;
+  status: ChannelRunStatus;
+  input?: string;
+  reply?: string;
+  error?: string;
+};
+
+/** Pure summary builder for Channel/Cron run lifecycle events (issue #225). */
+export const buildChannelRunSummary = (input: BuildChannelRunSummaryInput): ChannelRunSummary => ({
+  sessionId: input.sessionId,
+  platform: input.platform,
+  conversationId: input.conversationId,
+  trigger: input.trigger,
+  status: input.status,
+  timestamp: Date.now(),
+  inputPreview: toPreview(input.input),
+  replyPreview: toPreview(input.reply),
+  errorMessage: input.error,
+});


### PR DESCRIPTION
## 背景

#225 步骤 3：“Channel 运行事件走 `channel:run:*`，不再复用 `cowork:stream:*`”“引入 Channel/Cron 的独立运行事件与只读活动投影”。本 PR 落地 main 侧事件接缝；活动流 UI 作为后续 PR（需要设计）。

## 改动

- **`shared/channelRun/constants.ts`**：`ChannelRunStatus`（started/completed/failed）、`ChannelRunTrigger`（channel/cron）、`ChannelRunIpc.RunEvent`（`channel:run:event`）、`ChannelRunSummary` 只读投影类型。
- **`shared/channelRun/summary.ts`**：纯函数 `buildChannelRunSummary`（压缩空白、预览截断 80 字符）+ 4 个单测。
- **`im/channelRunEvents.ts`**：向所有窗口广播的 helper。
- **`IMCoworkHandler`**：在既有 IM 回合生命周期点发射事件——消息受理（started，带输入预览）、回合完成（completed，带回复预览，cron 后台投递标记为 cron trigger）、会话错误（failed，带用户可读错误文本）。
- **preload + `electron.d.ts`**：`channelRun.onRunEvent` 订阅 API（带取消函数）。

## 边界

- Channel run 不进入 `cowork:stream:*`，渲染端无法通过该投影驱动 channel 会话（只读）。
- IM 投递行为本身无任何变化；无 renderer 消费方，UI 后续接。

## 验证

- `npm test`：195 文件 / 1664 测试全部通过（含新增 4 个）
- 双 tsconfig、`compile:electron`、`oxlint`、`oxfmt` 通过

Refs #225