### PR TITLE
feat(renderer): Channel/Cron 运行事件活动投影数据层（#225 步骤 3）

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -37,6 +37,14 @@ async function renderRoot(): Promise<void> {
   }
 
   const [{ default: App }, { store }] = await Promise.all([import('./App'), import('./store')]);
+
+  // Channel/Cron runs are projected into a read-only activity list; they
+  // never become cowork sessions (issue #225).
+  const { recordChannelRun } = await import('./store/slices/activitySlice');
+  window.electron.channelRun.onRunEvent(summary => {
+    store.dispatch(recordChannelRun(summary));
+  });
+
   root.render(
     <React.StrictMode>
       <Provider store={store}>

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import agentReducer from './slices/agentSlice';
 import artifactReducer from './slices/artifactSlice';
+import activityReducer from './slices/activitySlice';
 import authReducer from './slices/authSlice';
 import coworkReducer from './slices/coworkSlice';
 import imReducer from './slices/imSlice';
@@ -25,6 +26,7 @@ export const store = configureStore({
     agent: agentReducer,
     auth: authReducer,
     artifact: artifactReducer,
+    activity: activityReducer,
     workspace: workspaceReducer,
     workMode: workModeReducer,
   },

--- a/src/renderer/store/slices/activitySlice.test.ts
+++ b/src/renderer/store/slices/activitySlice.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest';
+
+import { ChannelRunStatus, ChannelRunTrigger } from '../../../shared/channelRun/constants';
+import type { ChannelRunSummary } from '../../../shared/channelRun/constants';
+import activityReducer, { clearChannelRuns, recordChannelRun } from './activitySlice';
+
+const summary = (overrides: Partial<ChannelRunSummary> = {}): ChannelRunSummary => ({
+  sessionId: 'session-1',
+  platform: 'feishu',
+  conversationId: 'conv-1',
+  trigger: ChannelRunTrigger.Channel,
+  status: ChannelRunStatus.Started,
+  timestamp: 1,
+  ...overrides,
+});
+
+test('records run events newest-first and keeps the latest transition', () => {
+  const started = activityReducer(undefined, recordChannelRun(summary()));
+  const completed = activityReducer(
+    started,
+    recordChannelRun(summary({ status: ChannelRunStatus.Completed, timestamp: 2 })),
+  );
+
+  expect(completed.channelRuns).toHaveLength(2);
+  expect(completed.channelRuns[0]?.status).toBe(ChannelRunStatus.Completed);
+  expect(completed.channelRuns[1]?.status).toBe(ChannelRunStatus.Started);
+});
+
+test('caps the history at 200 entries', () => {
+  let state = activityReducer(undefined, { type: 'init' });
+  for (let i = 0; i < 250; i++) {
+    state = activityReducer(state, recordChannelRun(summary({ timestamp: i })));
+  }
+
+  expect(state.channelRuns).toHaveLength(200);
+  expect(state.channelRuns[0]?.timestamp).toBe(249);
+});
+
+test('clearChannelRuns empties the projection', () => {
+  const withRuns = activityReducer(undefined, recordChannelRun(summary()));
+  const cleared = activityReducer(withRuns, clearChannelRuns());
+
+  expect(cleared.channelRuns).toEqual([]);
+});

--- a/src/renderer/store/slices/activitySlice.ts
+++ b/src/renderer/store/slices/activitySlice.ts
@@ -1,0 +1,38 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+import type { ChannelRunSummary } from '../../../shared/channelRun/constants';
+
+/** Bound on how many Channel/Cron run events stay in memory. */
+const CHANNEL_RUN_HISTORY_LIMIT = 200;
+
+export interface ActivityState {
+  /**
+   * Read-only projection of Channel/Cron run lifecycle events, newest
+   * first (issue #225). These are OpenClaw-domain runs — they never become
+   * cowork sessions; the activity feed only displays them.
+   */
+  channelRuns: ChannelRunSummary[];
+}
+
+const initialState: ActivityState = {
+  channelRuns: [],
+};
+
+const activitySlice = createSlice({
+  name: 'activity',
+  initialState,
+  reducers: {
+    recordChannelRun(state, action: PayloadAction<ChannelRunSummary>) {
+      state.channelRuns.unshift(action.payload);
+      if (state.channelRuns.length > CHANNEL_RUN_HISTORY_LIMIT) {
+        state.channelRuns.length = CHANNEL_RUN_HISTORY_LIMIT;
+      }
+    },
+    clearChannelRuns(state) {
+      state.channelRuns = [];
+    },
+  },
+});
+
+export const { recordChannelRun, clearChannelRuns } = activitySlice.actions;
+export default activitySlice.reducer;


### PR DESCRIPTION
## 背景

承接 #276（`channel:run:event` 事件接缝），落地 #225 步骤 3 的渲染端数据层：活动投影只读展示 Channel/Cron 运行，不伪装为 cowork 会话。

> 本 PR 基于 #276。

## 改动

- **`activitySlice`**：`channelRuns: ChannelRunSummary[]`，最新在前，上限 200 条（环形截断），含 3 个单测（顺序/截断/清空）。
- **`main.tsx`**：启动时订阅 `channelRun.onRunEvent` 并 dispatch 到 store；模型启动日志窗口不订阅。
- store 注册 `activity` reducer。

## 边界

- 无 UI（活动流界面的信息架构需要设计，后续 PR）；slice 只累积数据，不影响任何现有视图。
- 事件单向流入，渲染端无法经此驱动 channel 会话。

## 验证

- `npm test`：196 文件 / 1667 测试全部通过；`tsc`、`oxlint`、`oxfmt` 通过

Refs #225