### PR TITLE
feat(workbench): orchestrate persistent pi runs

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -181,6 +181,7 @@ import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
 import { PiAgentLoopAction, PiAgentLoopMode, PiAgentLoopToolName } from './piAgentLoop';
 import { CoworkErrorKind, type CoworkError } from '../../../common/coworkError';
 import type { CoworkStore } from '../../coworkStore';
+import type { WorkbenchTaskService } from '../../workbenchTask/taskService';
 import {
   PiAssistantStopReason,
   PiBuiltinFileToolName,
@@ -771,6 +772,22 @@ describe('PiRuntimeAdapter', () => {
           diagnostics: [],
         }).skills,
       ).toEqual([{ id: 'skill-b' }]);
+    });
+
+    it('creates only one workbench run when skill topology changes', async () => {
+      const beginRun = vi.fn().mockImplementation((_input: unknown) => ({
+        run: { id: `run-${beginRun.mock.calls.length}` },
+      }));
+      adapter.setWorkbenchTaskService({
+        beginRun,
+        on: vi.fn(),
+        off: vi.fn(),
+      } as unknown as WorkbenchTaskService);
+
+      await adapter.startSession('test', 'First', { skillIds: ['skill-a'] });
+      await adapter.continueSession('test', 'Second', { skillIds: ['skill-b'] });
+
+      expect(beginRun).toHaveBeenCalledTimes(2);
     });
 
     it('uses the durable acceptance loop when an arbitrary skill is added to a Work session', async () => {
@@ -1734,7 +1751,7 @@ describe('PiRuntimeAdapter', () => {
         expect.objectContaining({ status: 'error' }),
       );
       expect(completes).toEqual(['test']);
-      expect(mockStore.updateSession).toHaveBeenCalledWith('test', { status: 'completed' });
+      expect(mockStore.updateSession).toHaveBeenCalledWith('test', { status: 'idle' });
     });
 
     it('surfaces the error exactly once when auto-retries are exhausted', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -25,6 +25,11 @@ import { classifyCoworkError, type CoworkError } from '../../../common/coworkErr
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { CoworkToolActivityPhase } from '../../../shared/cowork/toolActivity';
 import {
+  WorkbenchContractKind,
+  WorkbenchRunTrigger,
+  type WorkbenchTaskContract,
+} from '../../../shared/workbenchTask';
+import {
   isLocalProviderName,
   ModelCapabilityStatus,
   ProviderModelPiApi,
@@ -33,6 +38,7 @@ import {
 } from '../../../shared/providers';
 import type { CoworkMessage } from '../../coworkStore';
 import type { CoworkStore } from '../../coworkStore';
+import type { WorkbenchTaskService } from '../../workbenchTask/taskService';
 import {
   type ApiConfigResolution,
   resolveRawApiConfig,
@@ -196,6 +202,8 @@ interface ActivePiSession {
    * agent_settled). Cleared when a retry succeeds or the turn is reset.
    */
   pendingError: { message: string; classified: CoworkError } | null;
+  workbenchRunId: string | null;
+  workbenchContract: WorkbenchTaskContract;
 }
 
 // ── Dynamic imports ──
@@ -325,9 +333,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   >();
   private store: CoworkStore | null = null;
   private mcpServerManager: McpServerManager | null = null;
+  private workbenchTaskService: WorkbenchTaskService | null = null;
 
   setCoworkStore(store: CoworkStore): void {
     this.store = store;
+  }
+  setWorkbenchTaskService(service: WorkbenchTaskService): void {
+    this.workbenchTaskService = service;
   }
   setMcpServerManager(mgr: McpServerManager): void {
     this.mcpServerManager = mgr;
@@ -399,6 +411,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     const abortController = new AbortController();
+    let workbenchRunId: string | null = null;
 
     try {
       const workspaceRoot = options.workspaceRoot || process.cwd();
@@ -415,6 +428,26 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         maxOutputTokens: DEFAULT_PI_LOCAL_MAX_TOKENS,
         fileToolsEnabled: options.confirmationMode !== 'text',
       };
+
+      const shortcutKindForContract = isAcademicResearchSkillSet(resourceState.skillIds)
+        ? null
+        : resolveShortcutWorkflowKind(resourceState.skillIds);
+      const workbenchContract = this.createWorkbenchContract(
+        options.sessionMode,
+        resourceState.skillIds,
+      );
+      if (this.workbenchTaskService) {
+        const workbench = this.workbenchTaskService.beginRun({
+          sessionId,
+          goal: prompt,
+          contract: workbenchContract,
+          trigger: options._workbenchRunId
+            ? WorkbenchRunTrigger.Resume
+            : WorkbenchRunTrigger.Message,
+          preparedRunId: options._workbenchRunId,
+        });
+        workbenchRunId = workbench.run.id;
+      }
 
       // Pi's createAgentSession does not accept a systemPrompt option. Its
       // default resource loader supplies the Pi Coding Assistant identity,
@@ -457,7 +490,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         researchRun.resumeForPrompt(prompt);
         customTools.push(buildPiResearchStateTool(researchRun));
       }
-      const shortcutKind = researchRun ? null : resolveShortcutWorkflowKind(resourceState.skillIds);
+      const shortcutKind = researchRun ? null : shortcutKindForContract;
       const shortcutWorkflow = shortcutKind
         ? new PiShortcutWorkflowController({
             sessionId,
@@ -588,6 +621,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workExecution,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
+        workbenchRunId,
+        workbenchContract,
       };
 
       // Subscribe to Pi events before sending the prompt
@@ -622,6 +657,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
+      this.workbenchTaskService?.failRun(sessionId, { message });
       this.emit('error', sessionId, classifyCoworkError(message));
       throw error;
     }
@@ -645,6 +681,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const piPrompt = buildPiConversationPrompt(history, prompt);
       return this.startSession(sessionId, prompt, {
         ...options,
+        skipInitialUserMessage: options._skipUserMessage,
         systemPrompt: options.systemPrompt ?? storedSession?.systemPrompt,
         expertIds: options.expertIds ?? storedSession?.experts.map(expert => expert.expertId),
         workspaceRoot: options.workspaceRoot ?? storedSession?.cwd,
@@ -710,6 +747,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       }
     }
 
+    if (this.workbenchTaskService) {
+      const sessionMode =
+        options.sessionMode ??
+        (active.workbenchContract.kind === WorkbenchContractKind.Chat ? 'chat' : 'work');
+      const workbenchContract = this.createWorkbenchContract(sessionMode, requestedSkillIds);
+      const workbench = this.workbenchTaskService.beginRun({
+        sessionId,
+        goal: prompt,
+        contract: workbenchContract,
+        trigger: options._workbenchRunId ? WorkbenchRunTrigger.Resume : WorkbenchRunTrigger.Message,
+        preparedRunId: options._workbenchRunId,
+      });
+      active.workbenchRunId = workbench.run.id;
+      active.workbenchContract = workbenchContract;
+    }
+
     // Reset turn state
     active.answerText = '';
     active.thinkingText = '';
@@ -726,15 +779,17 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.pendingError = null;
 
     // Emit user message (persisted to SQLite, same as startSession).
-    const userMsg: CoworkMessage = {
-      id: randomUUID(),
-      type: 'user',
-      content: prompt,
-      timestamp: Date.now(),
-      metadata: options.skillIds?.length ? { skillIds: options.skillIds } : undefined,
-    };
-    const persisted = this.store ? this.store.addMessage(sessionId, userMsg) : userMsg;
-    this.emit('message', sessionId, persisted);
+    if (!options._skipUserMessage) {
+      const userMsg: CoworkMessage = {
+        id: randomUUID(),
+        type: 'user',
+        content: prompt,
+        timestamp: Date.now(),
+        metadata: options.skillIds?.length ? { skillIds: options.skillIds } : undefined,
+      };
+      const persisted = this.store ? this.store.addMessage(sessionId, userMsg) : userMsg;
+      this.emit('message', sessionId, persisted);
+    }
 
     let nextPrompt = prompt;
     const completionWorkflow =
@@ -824,6 +879,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.abortController.abort();
     active.unsubscribe();
     void active.piSession.abort();
+    this.workbenchTaskService?.pauseRun(sessionId, 'The user stopped this run.');
     this.emit('sessionStopped', sessionId);
   }
 
@@ -870,6 +926,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   onSessionDeleted(sessionId: string): void {
     this.stopSession(sessionId);
     this.activeSessions.delete(sessionId);
+    this.workbenchTaskService?.deleteSession(sessionId);
   }
 
   // ── Chat mode: direct LLM without agent loop ──
@@ -1212,10 +1269,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           });
           break;
         }
-        // Persist completed status to SQLite so the session shows as "completed"
-        // after switching away and back (mirrors OpenClaw adapter pattern).
-        if (this.store) {
-          this.store.updateSession(sessionId, { status: 'completed' });
+        if (this.store) this.store.updateSession(sessionId, { status: 'idle' });
+        if (active.workbenchRunId && this.workbenchTaskService) {
+          this.workbenchTaskService.completeRun(active.workbenchRunId);
         }
         this.emit('complete', sessionId, null);
         break;
@@ -1257,6 +1313,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     const pending = active.pendingError;
     if (!pending) return;
     active.pendingError = null;
+    this.workbenchTaskService?.failRun(sessionId, { message: pending.message });
     // Persist a system error message so the error survives session switching
     // and is visible in the message list. The classified kind lets the renderer
     // translate it into a user-friendly i18n message; the raw message is kept
@@ -1874,6 +1931,26 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     const homedir = os.homedir();
     const configDir = process.env.PI_CODING_AGENT_DIR || path.join(homedir, '.pi', 'agent');
     return path.join(configDir, 'agents');
+  }
+
+  private createWorkbenchContract(
+    sessionMode: PiStartOptions['sessionMode'],
+    skillIds: string[] | undefined,
+  ): WorkbenchTaskContract {
+    const research = isAcademicResearchSkillSet(skillIds);
+    const shortcut = research ? null : resolveShortcutWorkflowKind(skillIds);
+    return {
+      kind:
+        sessionMode === 'chat'
+          ? WorkbenchContractKind.Chat
+          : research
+            ? WorkbenchContractKind.Research
+            : shortcut
+              ? WorkbenchContractKind.Shortcut
+              : WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: sessionMode !== 'chat' && !research && !shortcut,
+      metadata: skillIds?.length ? { skillIds } : undefined,
+    };
   }
 }
 

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -78,6 +78,8 @@ export type PiStartOptions = {
   conversationHistory?: PiConversationHistoryMessage[];
   /** Internal: override prompt text sent to PI, while UI shows original prompt */
   _piPromptOverride?: string;
+  /** Internal: run already created by an explicit Resume/Retry action. */
+  _workbenchRunId?: string;
 };
 
 export type PiContinueOptions = {
@@ -93,6 +95,10 @@ export type PiContinueOptions = {
   modelOverride?: string;
   /** Forwarded to startSession when the runtime has to recreate the session. */
   autoApprove?: boolean;
+  /** Internal: run already created by an explicit Resume/Retry action. */
+  _workbenchRunId?: string;
+  /** Internal: do not persist a synthetic Resume/Retry prompt as a user message. */
+  _skipUserMessage?: boolean;
 };
 
 /** Workbench session patch; Pi only supports switching the model. */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -110,6 +110,7 @@ import {
   registerScheduledTaskHandlers,
 } from './ipcHandlers/scheduledTask';
 import { getTriageConfig, registerTriageIpcHandlers } from './ipcHandlers/triage';
+import { WorkbenchTaskService } from './workbenchTask/taskService';
 import {
   OpenClawChannelGateway,
   type PermissionResult,
@@ -956,6 +957,14 @@ let store: SqliteStore | null = null;
 let coworkStore: CoworkStore | null = null;
 let openClawChannelGateway: OpenClawChannelGateway | null = null;
 let piRuntimeAdapter: PiRuntimeAdapter | null = null;
+let workbenchTaskService: WorkbenchTaskService | null = null;
+
+const getWorkbenchTaskService = (): WorkbenchTaskService => {
+  if (!workbenchTaskService) {
+    workbenchTaskService = new WorkbenchTaskService(getStore().getDatabase());
+  }
+  return workbenchTaskService;
+};
 
 const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
   if (!piRuntimeAdapter) {
@@ -980,6 +989,7 @@ const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
     );
     piRuntimeAdapter = new PiRuntimeAdapter();
     piRuntimeAdapter.setCoworkStore(getCoworkStore());
+    piRuntimeAdapter.setWorkbenchTaskService(getWorkbenchTaskService());
     // mcpServerManager is created async later (ensureOpenClawRunningForCowork),
     // so it is always null here. Late-injection happens on every subsequent call.
     console.log('[PiRuntime] mcpServerManager available at init:', mcpServerManager !== null);
@@ -7513,6 +7523,12 @@ if (!gotTheLock) {
     console.log('[Main] initApp: resetRunningSessions done, count:', resetCount);
     if (resetCount > 0) {
       console.log(`[Main] Reset ${resetCount} stuck cowork session(s) from running -> idle`);
+    }
+    const recoveredWorkbenchTasks = getWorkbenchTaskService().recoverInterruptedState();
+    if (recoveredWorkbenchTasks > 0) {
+      console.log(
+        `[WorkbenchTask] marked ${recoveredWorkbenchTasks} interrupted task(s) for explicit recovery`,
+      );
     }
     // Inject store getter into claudeSettings
     setStoreGetter(() => store);

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -18,6 +18,7 @@ import {
   openSqliteDatabaseWithRecovery,
   SqliteBackupManager,
 } from './libs/sqliteBackup/sqliteBackupManager';
+import { initializeWorkbenchTaskSchema } from './workbenchTask/schema';
 import { normalizeWorkspacePath, workspaceIdForPath, workspaceNameForPath } from './workspaceUtils';
 
 type ChangePayload<T = unknown> = {
@@ -155,6 +156,8 @@ export class SqliteStore {
         updated_at INTEGER NOT NULL
       );
     `);
+
+    initializeWorkbenchTaskSchema(this.db);
 
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS user_memories (

--- a/src/main/workbenchTask/repository.test.ts
+++ b/src/main/workbenchTask/repository.test.ts
@@ -1,0 +1,89 @@
+import Database from 'better-sqlite3';
+import { expect, test } from 'vitest';
+
+import {
+  WorkbenchArtifactKind,
+  WorkbenchArtifactProvenance,
+  WorkbenchArtifactVerificationStatus,
+  WorkbenchContractKind,
+  WorkbenchRunEventType,
+  WorkbenchRunTrigger,
+} from '../../shared/workbenchTask';
+import { WorkbenchTaskRepository } from './repository';
+import { initializeWorkbenchTaskSchema } from './schema';
+
+const createRepository = () => {
+  const db = new Database(':memory:');
+  initializeWorkbenchTaskSchema(db);
+  return { db, repository: new WorkbenchTaskRepository(db) };
+};
+
+const contract = {
+  kind: WorkbenchContractKind.Chat,
+  requiresUserAcceptance: false,
+};
+
+test('rolls back all repository writes when a transaction fails', () => {
+  const { db, repository } = createRepository();
+  try {
+    expect(() =>
+      repository.transaction(() => {
+        repository.createTask('session', 'goal', contract);
+        throw new Error('rollback');
+      }),
+    ).toThrow('rollback');
+    expect(repository.getLatestTaskForSession('session')).toBeNull();
+  } finally {
+    db.close();
+  }
+});
+
+test('increments attempts and run event sequences while enforcing uniqueness', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const first = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    const second = repository.createRun(task.id, WorkbenchRunTrigger.Retry);
+    repository.appendRunEvent(first.id, WorkbenchRunEventType.RunStarted);
+    repository.appendRunEvent(first.id, WorkbenchRunEventType.VerificationStarted);
+
+    expect([first.attempt, second.attempt]).toEqual([1, 2]);
+    expect(
+      repository
+        .getDetail(task.id)
+        ?.events.filter(event => event.runId === first.id)
+        .map(event => event.sequence),
+    ).toEqual([1, 2, 3]);
+    expect(() =>
+      db.prepare('UPDATE workbench_runs SET attempt = ? WHERE id = ?').run(1, second.id),
+    ).toThrow();
+  } finally {
+    db.close();
+  }
+});
+
+test('deduplicates identical artifact evidence within a run', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const run = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    const artifact = {
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'result.txt',
+      contentHash: 'hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      metadata: {},
+    };
+
+    const first = repository.addArtifact(artifact);
+    const duplicate = repository.addArtifact(artifact);
+    expect(duplicate.id).toBe(first.id);
+    expect(repository.getDetail(task.id)?.artifacts).toHaveLength(1);
+  } finally {
+    db.close();
+  }
+});

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -1,0 +1,649 @@
+import type Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+
+import {
+  WorkbenchApprovalDecision,
+  WorkbenchApprovalEffectStatus,
+  WorkbenchContractKind,
+  WorkbenchRunEventType,
+  WorkbenchRunStatus,
+  WorkbenchTaskStatus,
+  WorkbenchTerminalTaskStatuses,
+  type WorkbenchApproval,
+  type WorkbenchApprovalDecisionSource,
+  type WorkbenchApprovalRiskLevel,
+  type WorkbenchArtifact,
+  type WorkbenchArtifactKind,
+  type WorkbenchArtifactProvenance,
+  type WorkbenchArtifactVerificationStatus,
+  type WorkbenchJsonObject,
+  type WorkbenchRun,
+  type WorkbenchRunEvent,
+  type WorkbenchRunStatus as WorkbenchRunStatusType,
+  type WorkbenchRunTrigger,
+  type WorkbenchTask,
+  type WorkbenchTaskContract,
+  type WorkbenchTaskDetail,
+  type WorkbenchTaskStatus as WorkbenchTaskStatusType,
+  type WorkbenchVerificationResult,
+} from '../../shared/workbenchTask';
+import { assertRunTransition, assertTaskTransition } from './stateMachine';
+
+const terminalTaskStatuses = new Set<string>(WorkbenchTerminalTaskStatuses);
+
+const parseJson = <T>(value: string | null, fallback: T): T => {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+type TaskRow = {
+  id: string;
+  session_id: string;
+  goal: string;
+  status: WorkbenchTaskStatusType;
+  contract_json: string;
+  active_run_id: string | null;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+};
+
+type RunRow = {
+  id: string;
+  task_id: string;
+  attempt: number;
+  status: WorkbenchRunStatusType;
+  trigger: WorkbenchRunTrigger;
+  started_at: number | null;
+  ended_at: number | null;
+  verification_result_json: string | null;
+  failure_json: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+type EventRow = {
+  id: string;
+  run_id: string;
+  sequence: number;
+  type: WorkbenchRunEvent['type'];
+  payload_json: string;
+  created_at: number;
+};
+
+type ArtifactRow = {
+  id: string;
+  task_id: string;
+  run_id: string;
+  kind: WorkbenchArtifactKind;
+  mime_type: string;
+  reference: string;
+  content_hash: string;
+  provenance: WorkbenchArtifactProvenance;
+  verification_status: WorkbenchArtifactVerificationStatus;
+  metadata_json: string;
+  created_at: number;
+  updated_at: number;
+};
+
+type ApprovalRow = {
+  id: string;
+  task_id: string;
+  run_id: string;
+  tool_call_id: string;
+  tool_name: string;
+  risk_level: WorkbenchApprovalRiskLevel;
+  decision: WorkbenchApproval['decision'];
+  decision_source: WorkbenchApprovalDecisionSource | null;
+  effect_status: WorkbenchApproval['effectStatus'];
+  idempotency_key: string;
+  request_json: string;
+  result_json: string | null;
+  created_at: number;
+  updated_at: number;
+  decided_at: number | null;
+};
+
+export class WorkbenchTaskRepository {
+  constructor(private readonly db: Database.Database) {}
+
+  transaction<T>(operation: () => T): T {
+    return this.db.transaction(operation)();
+  }
+
+  createTask(sessionId: string, goal: string, contract: WorkbenchTaskContract): WorkbenchTask {
+    const now = Date.now();
+    const task: WorkbenchTask = {
+      id: randomUUID(),
+      sessionId,
+      goal,
+      status: WorkbenchTaskStatus.Planned,
+      contract,
+      activeRunId: null,
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+    };
+    this.db
+      .prepare(
+        `INSERT INTO workbench_tasks
+         (id, session_id, goal, status, contract_json, active_run_id, created_at, updated_at, completed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        task.id,
+        task.sessionId,
+        task.goal,
+        task.status,
+        JSON.stringify(task.contract),
+        task.activeRunId,
+        task.createdAt,
+        task.updatedAt,
+        task.completedAt,
+      );
+    return task;
+  }
+
+  getTask(taskId: string): WorkbenchTask | null {
+    const row = this.db.prepare('SELECT * FROM workbench_tasks WHERE id = ?').get(taskId) as
+      | TaskRow
+      | undefined;
+    return row ? this.mapTask(row) : null;
+  }
+
+  getLatestTaskForSession(sessionId: string): WorkbenchTask | null {
+    const row = this.db
+      .prepare(
+        'SELECT * FROM workbench_tasks WHERE session_id = ? ORDER BY created_at DESC LIMIT 1',
+      )
+      .get(sessionId) as TaskRow | undefined;
+    return row ? this.mapTask(row) : null;
+  }
+
+  getActiveTaskForSession(sessionId: string): WorkbenchTask | null {
+    const rows = this.db
+      .prepare('SELECT * FROM workbench_tasks WHERE session_id = ? ORDER BY created_at DESC')
+      .all(sessionId) as TaskRow[];
+    const row = rows.find(candidate => !terminalTaskStatuses.has(candidate.status));
+    return row ? this.mapTask(row) : null;
+  }
+
+  updateTaskStatus(
+    taskId: string,
+    status: WorkbenchTaskStatusType,
+    activeRunId?: string | null,
+  ): WorkbenchTask {
+    const current = this.requireTask(taskId);
+    assertTaskTransition(current.status, status);
+    const now = Date.now();
+    const completedAt =
+      status === WorkbenchTaskStatus.Completed
+        ? now
+        : status === WorkbenchTaskStatus.Running
+          ? null
+          : current.completedAt;
+    const nextActiveRunId = activeRunId === undefined ? current.activeRunId : activeRunId;
+    this.db
+      .prepare(
+        `UPDATE workbench_tasks
+         SET status = ?, active_run_id = ?, updated_at = ?, completed_at = ?
+         WHERE id = ?`,
+      )
+      .run(status, nextActiveRunId, now, completedAt, taskId);
+    return this.requireTask(taskId);
+  }
+
+  createRun(taskId: string, trigger: WorkbenchRunTrigger): WorkbenchRun {
+    const now = Date.now();
+    const attemptRow = this.db
+      .prepare(
+        'SELECT COALESCE(MAX(attempt), 0) + 1 AS attempt FROM workbench_runs WHERE task_id = ?',
+      )
+      .get(taskId) as { attempt: number };
+    const run: WorkbenchRun = {
+      id: randomUUID(),
+      taskId,
+      attempt: attemptRow.attempt,
+      status: WorkbenchRunStatus.Queued,
+      trigger,
+      startedAt: null,
+      endedAt: null,
+      verificationResult: null,
+      failure: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.db
+      .prepare(
+        `INSERT INTO workbench_runs
+         (id, task_id, attempt, status, trigger, started_at, ended_at,
+          verification_result_json, failure_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        run.id,
+        run.taskId,
+        run.attempt,
+        run.status,
+        run.trigger,
+        null,
+        null,
+        null,
+        null,
+        now,
+        now,
+      );
+    this.appendRunEvent(run.id, WorkbenchRunEventType.RunCreated, {
+      trigger,
+      attempt: run.attempt,
+    });
+    return run;
+  }
+
+  getRun(runId: string): WorkbenchRun | null {
+    const row = this.db.prepare('SELECT * FROM workbench_runs WHERE id = ?').get(runId) as
+      | RunRow
+      | undefined;
+    return row ? this.mapRun(row) : null;
+  }
+
+  updateRunStatus(
+    runId: string,
+    status: WorkbenchRunStatusType,
+    options: {
+      verificationResult?: WorkbenchVerificationResult | null;
+      failure?: WorkbenchJsonObject | null;
+    } = {},
+  ): WorkbenchRun {
+    const current = this.requireRun(runId);
+    assertRunTransition(current.status, status);
+    const now = Date.now();
+    const startedAt =
+      status === WorkbenchRunStatus.Running && current.startedAt === null ? now : current.startedAt;
+    const terminalStatuses = new Set<WorkbenchRunStatusType>([
+      WorkbenchRunStatus.Succeeded,
+      WorkbenchRunStatus.Failed,
+      WorkbenchRunStatus.Cancelled,
+      WorkbenchRunStatus.Paused,
+      WorkbenchRunStatus.NeedsReview,
+    ]);
+    const endedAt = terminalStatuses.has(status) ? now : current.endedAt;
+    const verification =
+      options.verificationResult === undefined
+        ? current.verificationResult
+        : options.verificationResult;
+    const failure = options.failure === undefined ? current.failure : options.failure;
+    this.db
+      .prepare(
+        `UPDATE workbench_runs
+         SET status = ?, started_at = ?, ended_at = ?, verification_result_json = ?,
+             failure_json = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(
+        status,
+        startedAt,
+        endedAt,
+        verification ? JSON.stringify(verification) : null,
+        failure ? JSON.stringify(failure) : null,
+        now,
+        runId,
+      );
+    return this.requireRun(runId);
+  }
+
+  appendRunEvent(
+    runId: string,
+    type: WorkbenchRunEvent['type'],
+    payload: WorkbenchJsonObject = {},
+  ): WorkbenchRunEvent {
+    const sequenceRow = this.db
+      .prepare(
+        'SELECT COALESCE(MAX(sequence), 0) + 1 AS sequence FROM workbench_run_events WHERE run_id = ?',
+      )
+      .get(runId) as { sequence: number };
+    const event: WorkbenchRunEvent = {
+      id: randomUUID(),
+      runId,
+      sequence: sequenceRow.sequence,
+      type,
+      payload,
+      createdAt: Date.now(),
+    };
+    this.db
+      .prepare(
+        `INSERT INTO workbench_run_events (id, run_id, sequence, type, payload_json, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(event.id, runId, event.sequence, event.type, JSON.stringify(payload), event.createdAt);
+    return event;
+  }
+
+  addArtifact(input: Omit<WorkbenchArtifact, 'id' | 'createdAt' | 'updatedAt'>): WorkbenchArtifact {
+    const existing = this.db
+      .prepare(
+        `SELECT * FROM workbench_artifacts
+         WHERE run_id = ? AND reference = ? AND content_hash = ?`,
+      )
+      .get(input.runId, input.reference, input.contentHash) as ArtifactRow | undefined;
+    if (existing) return this.mapArtifact(existing);
+    const now = Date.now();
+    const id = randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO workbench_artifacts
+         (id, task_id, run_id, kind, mime_type, reference, content_hash, provenance,
+          verification_status, metadata_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.taskId,
+        input.runId,
+        input.kind,
+        input.mimeType,
+        input.reference,
+        input.contentHash,
+        input.provenance,
+        input.verificationStatus,
+        JSON.stringify(input.metadata),
+        now,
+        now,
+      );
+    return this.mapArtifact(
+      this.db.prepare('SELECT * FROM workbench_artifacts WHERE id = ?').get(id) as ArtifactRow,
+    );
+  }
+
+  createApproval(
+    input: Pick<
+      WorkbenchApproval,
+      | 'taskId'
+      | 'runId'
+      | 'toolCallId'
+      | 'toolName'
+      | 'riskLevel'
+      | 'decision'
+      | 'decisionSource'
+      | 'effectStatus'
+      | 'idempotencyKey'
+      | 'request'
+    >,
+  ): WorkbenchApproval {
+    const existing = this.getApprovalByIdempotencyKey(input.idempotencyKey);
+    if (existing) return existing;
+    const now = Date.now();
+    const id = randomUUID();
+    this.db
+      .prepare(
+        `INSERT INTO workbench_approvals
+         (id, task_id, run_id, tool_call_id, tool_name, risk_level, decision,
+          decision_source, effect_status, idempotency_key, request_json, result_json,
+          created_at, updated_at, decided_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.taskId,
+        input.runId,
+        input.toolCallId,
+        input.toolName,
+        input.riskLevel,
+        input.decision,
+        input.decisionSource,
+        input.effectStatus,
+        input.idempotencyKey,
+        JSON.stringify(input.request),
+        null,
+        now,
+        now,
+        input.decision === WorkbenchApprovalDecision.Pending ? null : now,
+      );
+    return this.requireApproval(id);
+  }
+
+  getApproval(approvalId: string): WorkbenchApproval | null {
+    const row = this.db
+      .prepare('SELECT * FROM workbench_approvals WHERE id = ?')
+      .get(approvalId) as ApprovalRow | undefined;
+    return row ? this.mapApproval(row) : null;
+  }
+
+  getApprovalByIdempotencyKey(idempotencyKey: string): WorkbenchApproval | null {
+    const row = this.db
+      .prepare('SELECT * FROM workbench_approvals WHERE idempotency_key = ?')
+      .get(idempotencyKey) as ApprovalRow | undefined;
+    return row ? this.mapApproval(row) : null;
+  }
+
+  getApprovalByToolCall(runId: string, toolCallId: string): WorkbenchApproval | null {
+    const row = this.db
+      .prepare(
+        `SELECT * FROM workbench_approvals
+         WHERE run_id = ? AND tool_call_id = ? ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get(runId, toolCallId) as ApprovalRow | undefined;
+    return row ? this.mapApproval(row) : null;
+  }
+
+  listApprovalsForRun(runId: string): WorkbenchApproval[] {
+    const rows = this.db
+      .prepare('SELECT * FROM workbench_approvals WHERE run_id = ? ORDER BY created_at')
+      .all(runId) as ApprovalRow[];
+    return rows.map(row => this.mapApproval(row));
+  }
+
+  updateApproval(
+    approvalId: string,
+    patch: Partial<
+      Pick<WorkbenchApproval, 'decision' | 'decisionSource' | 'effectStatus' | 'result'>
+    >,
+  ): WorkbenchApproval {
+    const current = this.requireApproval(approvalId);
+    const decision = patch.decision ?? current.decision;
+    const decisionSource =
+      patch.decisionSource === undefined ? current.decisionSource : patch.decisionSource;
+    const effectStatus = patch.effectStatus ?? current.effectStatus;
+    const result = patch.result === undefined ? current.result : patch.result;
+    const now = Date.now();
+    const decidedAt =
+      current.decidedAt ?? (decision === WorkbenchApprovalDecision.Pending ? null : now);
+    this.db
+      .prepare(
+        `UPDATE workbench_approvals
+         SET decision = ?, decision_source = ?, effect_status = ?, result_json = ?,
+             updated_at = ?, decided_at = ?
+         WHERE id = ?`,
+      )
+      .run(
+        decision,
+        decisionSource,
+        effectStatus,
+        result ? JSON.stringify(result) : null,
+        now,
+        decidedAt,
+        approvalId,
+      );
+    return this.requireApproval(approvalId);
+  }
+
+  listRecoverableRuns(): WorkbenchRun[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM workbench_runs
+         WHERE status IN (?, ?, ?)
+         ORDER BY updated_at`,
+      )
+      .all(
+        WorkbenchRunStatus.Running,
+        WorkbenchRunStatus.Verifying,
+        WorkbenchRunStatus.WaitingApproval,
+      ) as RunRow[];
+    return rows.map(row => this.mapRun(row));
+  }
+
+  listExecutingApprovals(): WorkbenchApproval[] {
+    const rows = this.db
+      .prepare('SELECT * FROM workbench_approvals WHERE effect_status = ?')
+      .all(WorkbenchApprovalEffectStatus.Executing) as ApprovalRow[];
+    return rows.map(row => this.mapApproval(row));
+  }
+
+  getDetail(taskId: string): WorkbenchTaskDetail | null {
+    const task = this.getTask(taskId);
+    if (!task) return null;
+    const runRows = this.db
+      .prepare('SELECT * FROM workbench_runs WHERE task_id = ? ORDER BY attempt DESC')
+      .all(taskId) as RunRow[];
+    const eventRows = this.db
+      .prepare(
+        `SELECT e.* FROM workbench_run_events e
+         JOIN workbench_runs r ON r.id = e.run_id
+         WHERE r.task_id = ? ORDER BY r.attempt DESC, e.sequence`,
+      )
+      .all(taskId) as EventRow[];
+    const artifactRows = this.db
+      .prepare('SELECT * FROM workbench_artifacts WHERE task_id = ? ORDER BY created_at DESC')
+      .all(taskId) as ArtifactRow[];
+    const approvalRows = this.db
+      .prepare('SELECT * FROM workbench_approvals WHERE task_id = ? ORDER BY created_at DESC')
+      .all(taskId) as ApprovalRow[];
+    return {
+      task,
+      runs: runRows.map(row => this.mapRun(row)),
+      events: eventRows.map(row => this.mapEvent(row)),
+      artifacts: artifactRows.map(row => this.mapArtifact(row)),
+      approvals: approvalRows.map(row => this.mapApproval(row)),
+    };
+  }
+
+  deleteSessionDomainData(sessionId: string): void {
+    this.transaction(() => {
+      const taskIds = (
+        this.db
+          .prepare('SELECT id FROM workbench_tasks WHERE session_id = ?')
+          .all(sessionId) as Array<{ id: string }>
+      ).map(row => row.id);
+      for (const taskId of taskIds) {
+        const runIds = (
+          this.db.prepare('SELECT id FROM workbench_runs WHERE task_id = ?').all(taskId) as Array<{
+            id: string;
+          }>
+        ).map(row => row.id);
+        for (const runId of runIds) {
+          this.db.prepare('DELETE FROM workbench_run_events WHERE run_id = ?').run(runId);
+        }
+        this.db.prepare('DELETE FROM workbench_approvals WHERE task_id = ?').run(taskId);
+        this.db.prepare('DELETE FROM workbench_artifacts WHERE task_id = ?').run(taskId);
+        this.db.prepare('DELETE FROM workbench_runs WHERE task_id = ?').run(taskId);
+      }
+      this.db.prepare('DELETE FROM workbench_tasks WHERE session_id = ?').run(sessionId);
+    });
+  }
+
+  private requireTask(taskId: string): WorkbenchTask {
+    const task = this.getTask(taskId);
+    if (!task) throw new Error(`Workbench task not found: ${taskId}`);
+    return task;
+  }
+
+  private requireRun(runId: string): WorkbenchRun {
+    const run = this.getRun(runId);
+    if (!run) throw new Error(`Workbench run not found: ${runId}`);
+    return run;
+  }
+
+  private requireApproval(approvalId: string): WorkbenchApproval {
+    const approval = this.getApproval(approvalId);
+    if (!approval) throw new Error(`Workbench approval not found: ${approvalId}`);
+    return approval;
+  }
+
+  private mapTask(row: TaskRow): WorkbenchTask {
+    return {
+      id: row.id,
+      sessionId: row.session_id,
+      goal: row.goal,
+      status: row.status,
+      contract: parseJson<WorkbenchTaskContract>(row.contract_json, {
+        kind: WorkbenchContractKind.GenericWork,
+        requiresUserAcceptance: true,
+      }),
+      activeRunId: row.active_run_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      completedAt: row.completed_at,
+    };
+  }
+
+  private mapRun(row: RunRow): WorkbenchRun {
+    return {
+      id: row.id,
+      taskId: row.task_id,
+      attempt: row.attempt,
+      status: row.status,
+      trigger: row.trigger,
+      startedAt: row.started_at,
+      endedAt: row.ended_at,
+      verificationResult: parseJson<WorkbenchVerificationResult | null>(
+        row.verification_result_json,
+        null,
+      ),
+      failure: parseJson<WorkbenchJsonObject | null>(row.failure_json, null),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapEvent(row: EventRow): WorkbenchRunEvent {
+    return {
+      id: row.id,
+      runId: row.run_id,
+      sequence: row.sequence,
+      type: row.type,
+      payload: parseJson<WorkbenchJsonObject>(row.payload_json, {}),
+      createdAt: row.created_at,
+    };
+  }
+
+  private mapArtifact(row: ArtifactRow): WorkbenchArtifact {
+    return {
+      id: row.id,
+      taskId: row.task_id,
+      runId: row.run_id,
+      kind: row.kind,
+      mimeType: row.mime_type,
+      reference: row.reference,
+      contentHash: row.content_hash,
+      provenance: row.provenance,
+      verificationStatus: row.verification_status,
+      metadata: parseJson<WorkbenchJsonObject>(row.metadata_json, {}),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private mapApproval(row: ApprovalRow): WorkbenchApproval {
+    return {
+      id: row.id,
+      taskId: row.task_id,
+      runId: row.run_id,
+      toolCallId: row.tool_call_id,
+      toolName: row.tool_name,
+      riskLevel: row.risk_level,
+      decision: row.decision,
+      decisionSource: row.decision_source,
+      effectStatus: row.effect_status,
+      idempotencyKey: row.idempotency_key,
+      request: parseJson<WorkbenchJsonObject>(row.request_json, {}),
+      result: parseJson<WorkbenchJsonObject | null>(row.result_json, null),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      decidedAt: row.decided_at,
+    };
+  }
+}

--- a/src/main/workbenchTask/schema.ts
+++ b/src/main/workbenchTask/schema.ts
@@ -1,0 +1,103 @@
+import type Database from 'better-sqlite3';
+
+export function initializeWorkbenchTaskSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workbench_tasks (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      goal TEXT NOT NULL,
+      status TEXT NOT NULL,
+      contract_json TEXT NOT NULL,
+      active_run_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workbench_tasks_session_updated
+      ON workbench_tasks(session_id, updated_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_workbench_tasks_session_status
+      ON workbench_tasks(session_id, status);
+
+    CREATE TABLE IF NOT EXISTS workbench_runs (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      attempt INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      started_at INTEGER,
+      ended_at INTEGER,
+      verification_result_json TEXT,
+      failure_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (task_id) REFERENCES workbench_tasks(id),
+      UNIQUE(task_id, attempt)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workbench_runs_task_attempt
+      ON workbench_runs(task_id, attempt DESC);
+    CREATE INDEX IF NOT EXISTS idx_workbench_runs_status
+      ON workbench_runs(status);
+
+    CREATE TABLE IF NOT EXISTS workbench_run_events (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (run_id) REFERENCES workbench_runs(id),
+      UNIQUE(run_id, sequence)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workbench_run_events_run_sequence
+      ON workbench_run_events(run_id, sequence);
+
+    CREATE TABLE IF NOT EXISTS workbench_artifacts (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      reference TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      provenance TEXT NOT NULL,
+      verification_status TEXT NOT NULL,
+      metadata_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY (task_id) REFERENCES workbench_tasks(id),
+      FOREIGN KEY (run_id) REFERENCES workbench_runs(id),
+      UNIQUE(run_id, reference, content_hash)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workbench_artifacts_task
+      ON workbench_artifacts(task_id, created_at);
+
+    CREATE TABLE IF NOT EXISTS workbench_approvals (
+      id TEXT PRIMARY KEY,
+      task_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      tool_call_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      decision_source TEXT,
+      effect_status TEXT NOT NULL,
+      idempotency_key TEXT NOT NULL UNIQUE,
+      request_json TEXT NOT NULL,
+      result_json TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      decided_at INTEGER,
+      FOREIGN KEY (task_id) REFERENCES workbench_tasks(id),
+      FOREIGN KEY (run_id) REFERENCES workbench_runs(id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workbench_approvals_run
+      ON workbench_approvals(run_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_workbench_approvals_decision_effect
+      ON workbench_approvals(decision, effect_status);
+  `);
+}

--- a/src/main/workbenchTask/stateMachine.test.ts
+++ b/src/main/workbenchTask/stateMachine.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from 'vitest';
+
+import { WorkbenchRunStatus, WorkbenchTaskStatus } from '../../shared/workbenchTask';
+import {
+  assertRunTransition,
+  assertTaskTransition,
+  WorkbenchStateTransitionError,
+} from './stateMachine';
+
+test('allows explicit retry of a completed task while keeping completed runs terminal', () => {
+  expect(() =>
+    assertTaskTransition(WorkbenchTaskStatus.Completed, WorkbenchTaskStatus.Running),
+  ).not.toThrow();
+  expect(() =>
+    assertRunTransition(WorkbenchRunStatus.Succeeded, WorkbenchRunStatus.Running),
+  ).toThrow(WorkbenchStateTransitionError);
+});
+
+test('rejects completion before a run reaches verification', () => {
+  expect(() =>
+    assertRunTransition(WorkbenchRunStatus.Running, WorkbenchRunStatus.Succeeded),
+  ).toThrow(WorkbenchStateTransitionError);
+});
+
+test('allows user acceptance to promote a needs-review run', () => {
+  expect(() =>
+    assertRunTransition(WorkbenchRunStatus.NeedsReview, WorkbenchRunStatus.Succeeded),
+  ).not.toThrow();
+});
+
+test('guards every task status transition', () => {
+  const allowed = new Map<string, readonly string[]>([
+    [WorkbenchTaskStatus.Draft, [WorkbenchTaskStatus.Planned, WorkbenchTaskStatus.Cancelled]],
+    [WorkbenchTaskStatus.Planned, [WorkbenchTaskStatus.Running, WorkbenchTaskStatus.Cancelled]],
+    [
+      WorkbenchTaskStatus.Running,
+      [
+        WorkbenchTaskStatus.Paused,
+        WorkbenchTaskStatus.NeedsReview,
+        WorkbenchTaskStatus.Completed,
+        WorkbenchTaskStatus.Failed,
+        WorkbenchTaskStatus.Cancelled,
+      ],
+    ],
+    [WorkbenchTaskStatus.Paused, [WorkbenchTaskStatus.Running, WorkbenchTaskStatus.Cancelled]],
+    [
+      WorkbenchTaskStatus.NeedsReview,
+      [
+        WorkbenchTaskStatus.Running,
+        WorkbenchTaskStatus.Completed,
+        WorkbenchTaskStatus.Failed,
+        WorkbenchTaskStatus.Cancelled,
+      ],
+    ],
+    [WorkbenchTaskStatus.Completed, [WorkbenchTaskStatus.Running]],
+    [WorkbenchTaskStatus.Failed, [WorkbenchTaskStatus.Running]],
+    [WorkbenchTaskStatus.Cancelled, []],
+  ]);
+
+  for (const from of Object.values(WorkbenchTaskStatus)) {
+    for (const to of Object.values(WorkbenchTaskStatus)) {
+      const legal = from === to || allowed.get(from)?.includes(to);
+      if (legal) expect(() => assertTaskTransition(from, to)).not.toThrow();
+      else expect(() => assertTaskTransition(from, to)).toThrow(WorkbenchStateTransitionError);
+    }
+  }
+});
+
+test('guards every run status transition', () => {
+  const allowed = new Map<string, readonly string[]>([
+    [
+      WorkbenchRunStatus.Queued,
+      [WorkbenchRunStatus.Running, WorkbenchRunStatus.Cancelled, WorkbenchRunStatus.Failed],
+    ],
+    [
+      WorkbenchRunStatus.Running,
+      [
+        WorkbenchRunStatus.WaitingApproval,
+        WorkbenchRunStatus.Verifying,
+        WorkbenchRunStatus.Paused,
+        WorkbenchRunStatus.NeedsReview,
+        WorkbenchRunStatus.Failed,
+        WorkbenchRunStatus.Cancelled,
+      ],
+    ],
+    [
+      WorkbenchRunStatus.WaitingApproval,
+      [
+        WorkbenchRunStatus.Running,
+        WorkbenchRunStatus.Paused,
+        WorkbenchRunStatus.NeedsReview,
+        WorkbenchRunStatus.Failed,
+        WorkbenchRunStatus.Cancelled,
+      ],
+    ],
+    [
+      WorkbenchRunStatus.Verifying,
+      [WorkbenchRunStatus.Succeeded, WorkbenchRunStatus.NeedsReview, WorkbenchRunStatus.Failed],
+    ],
+    [WorkbenchRunStatus.Paused, []],
+    [WorkbenchRunStatus.NeedsReview, [WorkbenchRunStatus.Succeeded]],
+    [WorkbenchRunStatus.Succeeded, []],
+    [WorkbenchRunStatus.Failed, []],
+    [WorkbenchRunStatus.Cancelled, []],
+  ]);
+
+  for (const from of Object.values(WorkbenchRunStatus)) {
+    for (const to of Object.values(WorkbenchRunStatus)) {
+      const legal = from === to || allowed.get(from)?.includes(to);
+      if (legal) expect(() => assertRunTransition(from, to)).not.toThrow();
+      else expect(() => assertRunTransition(from, to)).toThrow(WorkbenchStateTransitionError);
+    }
+  }
+});

--- a/src/main/workbenchTask/stateMachine.ts
+++ b/src/main/workbenchTask/stateMachine.ts
@@ -1,0 +1,101 @@
+import {
+  WorkbenchRunStatus,
+  type WorkbenchRunStatus as WorkbenchRunStatusType,
+  WorkbenchTaskStatus,
+  type WorkbenchTaskStatus as WorkbenchTaskStatusType,
+} from '../../shared/workbenchTask';
+
+const taskTransitions: Record<WorkbenchTaskStatusType, ReadonlySet<WorkbenchTaskStatusType>> = {
+  [WorkbenchTaskStatus.Draft]: new Set([
+    WorkbenchTaskStatus.Planned,
+    WorkbenchTaskStatus.Cancelled,
+  ]),
+  [WorkbenchTaskStatus.Planned]: new Set([
+    WorkbenchTaskStatus.Running,
+    WorkbenchTaskStatus.Cancelled,
+  ]),
+  [WorkbenchTaskStatus.Running]: new Set([
+    WorkbenchTaskStatus.Paused,
+    WorkbenchTaskStatus.NeedsReview,
+    WorkbenchTaskStatus.Completed,
+    WorkbenchTaskStatus.Failed,
+    WorkbenchTaskStatus.Cancelled,
+  ]),
+  [WorkbenchTaskStatus.Paused]: new Set([
+    WorkbenchTaskStatus.Running,
+    WorkbenchTaskStatus.Cancelled,
+  ]),
+  [WorkbenchTaskStatus.NeedsReview]: new Set([
+    WorkbenchTaskStatus.Running,
+    WorkbenchTaskStatus.Completed,
+    WorkbenchTaskStatus.Failed,
+    WorkbenchTaskStatus.Cancelled,
+  ]),
+  [WorkbenchTaskStatus.Completed]: new Set([WorkbenchTaskStatus.Running]),
+  [WorkbenchTaskStatus.Failed]: new Set([WorkbenchTaskStatus.Running]),
+  [WorkbenchTaskStatus.Cancelled]: new Set(),
+};
+
+const runTransitions: Record<WorkbenchRunStatusType, ReadonlySet<WorkbenchRunStatusType>> = {
+  [WorkbenchRunStatus.Queued]: new Set([
+    WorkbenchRunStatus.Running,
+    WorkbenchRunStatus.Cancelled,
+    WorkbenchRunStatus.Failed,
+  ]),
+  [WorkbenchRunStatus.Running]: new Set([
+    WorkbenchRunStatus.WaitingApproval,
+    WorkbenchRunStatus.Verifying,
+    WorkbenchRunStatus.Paused,
+    WorkbenchRunStatus.NeedsReview,
+    WorkbenchRunStatus.Failed,
+    WorkbenchRunStatus.Cancelled,
+  ]),
+  [WorkbenchRunStatus.WaitingApproval]: new Set([
+    WorkbenchRunStatus.Running,
+    WorkbenchRunStatus.Paused,
+    WorkbenchRunStatus.NeedsReview,
+    WorkbenchRunStatus.Failed,
+    WorkbenchRunStatus.Cancelled,
+  ]),
+  [WorkbenchRunStatus.Verifying]: new Set([
+    WorkbenchRunStatus.Succeeded,
+    WorkbenchRunStatus.NeedsReview,
+    WorkbenchRunStatus.Failed,
+  ]),
+  [WorkbenchRunStatus.Paused]: new Set(),
+  [WorkbenchRunStatus.NeedsReview]: new Set([WorkbenchRunStatus.Succeeded]),
+  [WorkbenchRunStatus.Succeeded]: new Set(),
+  [WorkbenchRunStatus.Failed]: new Set(),
+  [WorkbenchRunStatus.Cancelled]: new Set(),
+};
+
+export class WorkbenchStateTransitionError extends Error {
+  constructor(
+    readonly entity: 'task' | 'run',
+    readonly from: string,
+    readonly to: string,
+  ) {
+    super(`Invalid workbench ${entity} transition: ${from} -> ${to}`);
+    this.name = 'WorkbenchStateTransitionError';
+  }
+}
+
+export function assertTaskTransition(
+  from: WorkbenchTaskStatusType,
+  to: WorkbenchTaskStatusType,
+): void {
+  if (from === to) return;
+  if (!taskTransitions[from].has(to)) {
+    throw new WorkbenchStateTransitionError('task', from, to);
+  }
+}
+
+export function assertRunTransition(
+  from: WorkbenchRunStatusType,
+  to: WorkbenchRunStatusType,
+): void {
+  if (from === to) return;
+  if (!runTransitions[from].has(to)) {
+    throw new WorkbenchStateTransitionError('run', from, to);
+  }
+}

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -1,0 +1,98 @@
+import Database from 'better-sqlite3';
+import { expect, test } from 'vitest';
+
+import {
+  WorkbenchContractKind,
+  WorkbenchRunStatus,
+  WorkbenchRunTrigger,
+  WorkbenchTaskStatus,
+  WorkbenchVerificationOutcome,
+} from '../../shared/workbenchTask';
+import { initializeWorkbenchTaskSchema } from './schema';
+import { WorkbenchTaskService } from './taskService';
+
+const createService = () => {
+  const db = new Database(':memory:');
+  initializeWorkbenchTaskSchema(db);
+  return { db, service: new WorkbenchTaskService(db) };
+};
+
+const chatContract = {
+  kind: WorkbenchContractKind.Chat,
+  requiresUserAcceptance: false,
+};
+
+test('reuses a non-terminal task and creates a new task after a terminal state', () => {
+  const { db, service } = createService();
+  try {
+    const first = service.beginRun({ sessionId: 'session', goal: 'first', contract: chatContract });
+    service.completeRun(first.run.id);
+    const continued = service.beginRun({
+      sessionId: 'session',
+      goal: 'continue',
+      contract: chatContract,
+    });
+    expect(continued.task.id).toBe(first.task.id);
+    service.failRun('session', { message: 'terminal' });
+    const next = service.beginRun({ sessionId: 'session', goal: 'next', contract: chatContract });
+    expect(next.task.id).not.toBe(first.task.id);
+  } finally {
+    db.close();
+  }
+});
+
+test('agent end requires verification instead of completing the task', () => {
+  const { db, service } = createService();
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'answer',
+      contract: chatContract,
+    });
+    const detail = service.completeRun(run.id);
+    expect(detail.task.id).toBe(task.id);
+    expect(detail.task.status).toBe(WorkbenchTaskStatus.NeedsReview);
+    expect(detail.runs[0].status).toBe(WorkbenchRunStatus.NeedsReview);
+    expect(detail.runs[0].verificationResult?.outcome).toBe(
+      WorkbenchVerificationOutcome.AcceptanceRequired,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test('resume and retry create incrementing immutable run attempts', () => {
+  const { db, service } = createService();
+  try {
+    const first = service.beginRun({ sessionId: 'session', goal: 'work', contract: chatContract });
+    service.pauseRun('session', 'pause');
+    const resumed = service.prepareRun(first.task.id, WorkbenchRunTrigger.Resume);
+    service.failRun('session', { message: 'failed' });
+    const retried = service.prepareRun(first.task.id, WorkbenchRunTrigger.Retry);
+    expect([first.run.attempt, resumed.run.attempt, retried.run.attempt]).toEqual([1, 2, 3]);
+    expect(service.getDetail(first.task.id)?.runs.map(run => run.status)).toEqual([
+      WorkbenchRunStatus.Queued,
+      WorkbenchRunStatus.Failed,
+      WorkbenchRunStatus.Paused,
+    ]);
+  } finally {
+    db.close();
+  }
+});
+
+test('startup recovery marks interrupted runs for explicit review', () => {
+  const { db, service } = createService();
+  try {
+    const { task } = service.beginRun({
+      sessionId: 'session',
+      goal: 'recover',
+      contract: chatContract,
+    });
+    expect(service.recoverInterruptedState()).toBe(1);
+    const detail = service.getDetail(task.id);
+    expect(detail?.task.status).toBe(WorkbenchTaskStatus.NeedsReview);
+    expect(detail?.runs[0].status).toBe(WorkbenchRunStatus.NeedsReview);
+  } finally {
+    db.close();
+  }
+});

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -1,0 +1,191 @@
+import type Database from 'better-sqlite3';
+import { EventEmitter } from 'events';
+
+import {
+  WorkbenchRunEventType,
+  WorkbenchRunStatus,
+  WorkbenchRunTrigger,
+  WorkbenchTaskStatus,
+  WorkbenchVerificationCheckStatus,
+  WorkbenchVerificationOutcome,
+  type WorkbenchJsonObject,
+  type WorkbenchRun,
+  type WorkbenchTask,
+  type WorkbenchTaskChangedEvent,
+  type WorkbenchTaskContract,
+  type WorkbenchTaskDetail,
+  type WorkbenchVerificationResult,
+} from '../../shared/workbenchTask';
+import { WorkbenchTaskRepository } from './repository';
+
+const pendingVerification: WorkbenchVerificationResult = {
+  outcome: WorkbenchVerificationOutcome.AcceptanceRequired,
+  checks: [
+    {
+      name: 'contract_verifier',
+      status: WorkbenchVerificationCheckStatus.Skipped,
+      detail: 'Contract verification is handled by the verifier registry.',
+    },
+  ],
+  evidence: [],
+  summary: 'The run ended and is waiting for contract verification.',
+};
+
+export class WorkbenchTaskService extends EventEmitter {
+  readonly repository: WorkbenchTaskRepository;
+
+  constructor(db: Database.Database) {
+    super();
+    this.repository = new WorkbenchTaskRepository(db);
+  }
+
+  getCurrent(sessionId: string): WorkbenchTaskDetail | null {
+    const task = this.repository.getLatestTaskForSession(sessionId);
+    return task ? this.repository.getDetail(task.id) : null;
+  }
+
+  getDetail(taskId: string): WorkbenchTaskDetail | null {
+    return this.repository.getDetail(taskId);
+  }
+
+  beginRun(input: {
+    sessionId: string;
+    goal: string;
+    contract: WorkbenchTaskContract;
+    trigger?: WorkbenchRunTrigger;
+    preparedRunId?: string;
+  }): { task: WorkbenchTask; run: WorkbenchRun } {
+    const result = this.repository.transaction(() => {
+      let run = input.preparedRunId ? this.repository.getRun(input.preparedRunId) : null;
+      let task = run
+        ? this.repository.getTask(run.taskId)
+        : this.repository.getActiveTaskForSession(input.sessionId);
+      if (!task) task = this.repository.createTask(input.sessionId, input.goal, input.contract);
+      if (run && run.taskId !== task.id) throw new Error('Prepared run does not belong to task.');
+      if (!run) {
+        run = this.repository.createRun(task.id, input.trigger ?? WorkbenchRunTrigger.Message);
+      }
+      task = this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Running, run.id);
+      run = this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Running);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RunStarted);
+      return { task, run };
+    });
+    this.emitChanged(result.task);
+    return result;
+  }
+
+  prepareRun(
+    taskId: string,
+    trigger: WorkbenchRunTrigger,
+  ): { task: WorkbenchTask; run: WorkbenchRun } {
+    const result = this.repository.transaction(() => {
+      let task = this.requireTask(taskId);
+      const run = this.repository.createRun(task.id, trigger);
+      task = this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Running, run.id);
+      return { task, run };
+    });
+    this.emitChanged(result.task);
+    return result;
+  }
+
+  completeRun(runId: string): WorkbenchTaskDetail {
+    const run = this.requireRun(runId);
+    const task = this.requireTask(run.taskId);
+    if (run.status !== WorkbenchRunStatus.Running) {
+      return this.requireDetail(task.id);
+    }
+    this.repository.transaction(() => {
+      this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Verifying);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationStarted);
+      this.repository.updateRunStatus(run.id, WorkbenchRunStatus.NeedsReview, {
+        verificationResult: pendingVerification,
+      });
+      this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationFinished, {
+        outcome: pendingVerification.outcome,
+      });
+    });
+    const detail = this.requireDetail(task.id);
+    this.emitChanged(detail.task);
+    return detail;
+  }
+
+  pauseRun(sessionId: string, reason: string): void {
+    const task = this.repository.getActiveTaskForSession(sessionId);
+    if (!task?.activeRunId) return;
+    const run = this.repository.getRun(task.activeRunId);
+    if (!run || !this.isRunActive(run.status)) return;
+    this.repository.transaction(() => {
+      this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Paused);
+      this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Paused, run.id);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RunPaused, { reason });
+    });
+    this.emitChanged(this.requireTask(task.id));
+  }
+
+  failRun(sessionId: string, failure: WorkbenchJsonObject): void {
+    const task = this.repository.getActiveTaskForSession(sessionId);
+    if (!task?.activeRunId) return;
+    const run = this.repository.getRun(task.activeRunId);
+    if (!run || !this.isRunActive(run.status)) return;
+    this.repository.transaction(() => {
+      this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Failed, { failure });
+      this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Failed, null);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RunFailed, failure);
+    });
+    this.emitChanged(this.requireTask(task.id));
+  }
+
+  recoverInterruptedState(): number {
+    const affectedTaskIds = new Set<string>();
+    this.repository.transaction(() => {
+      for (const run of this.repository.listRecoverableRuns()) {
+        const task = this.requireTask(run.taskId);
+        this.repository.updateRunStatus(run.id, WorkbenchRunStatus.NeedsReview);
+        this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
+        this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RecoveryRequired, {
+          previousStatus: run.status,
+        });
+        affectedTaskIds.add(task.id);
+      }
+    });
+    for (const taskId of affectedTaskIds) this.emitChanged(this.requireTask(taskId));
+    return affectedTaskIds.size;
+  }
+
+  deleteSession(sessionId: string): void {
+    this.repository.deleteSessionDomainData(sessionId);
+  }
+
+  private emitChanged(task: WorkbenchTask): void {
+    const event: WorkbenchTaskChangedEvent = { sessionId: task.sessionId, taskId: task.id };
+    this.emit('changed', event);
+  }
+
+  private requireTask(taskId: string): WorkbenchTask {
+    const task = this.repository.getTask(taskId);
+    if (!task) throw new Error(`Workbench task not found: ${taskId}`);
+    return task;
+  }
+
+  private requireRun(runId: string): WorkbenchRun {
+    const run = this.repository.getRun(runId);
+    if (!run) throw new Error(`Workbench run not found: ${runId}`);
+    return run;
+  }
+
+  private requireDetail(taskId: string): WorkbenchTaskDetail {
+    const detail = this.repository.getDetail(taskId);
+    if (!detail) throw new Error(`Workbench task detail not found: ${taskId}`);
+    return detail;
+  }
+
+  private isRunActive(status: WorkbenchRun['status']): boolean {
+    return new Set<WorkbenchRun['status']>([
+      WorkbenchRunStatus.Queued,
+      WorkbenchRunStatus.Running,
+      WorkbenchRunStatus.WaitingApproval,
+      WorkbenchRunStatus.Verifying,
+    ]).has(status);
+  }
+}

--- a/src/shared/workbenchTask/constants.ts
+++ b/src/shared/workbenchTask/constants.ts
@@ -1,0 +1,150 @@
+export const WorkbenchTaskStatus = {
+  Draft: 'draft',
+  Planned: 'planned',
+  Running: 'running',
+  Paused: 'paused',
+  NeedsReview: 'needs_review',
+  Completed: 'completed',
+  Failed: 'failed',
+  Cancelled: 'cancelled',
+} as const;
+export type WorkbenchTaskStatus = (typeof WorkbenchTaskStatus)[keyof typeof WorkbenchTaskStatus];
+
+export const WorkbenchRunStatus = {
+  Queued: 'queued',
+  Running: 'running',
+  WaitingApproval: 'waiting_approval',
+  Verifying: 'verifying',
+  Paused: 'paused',
+  NeedsReview: 'needs_review',
+  Succeeded: 'succeeded',
+  Failed: 'failed',
+  Cancelled: 'cancelled',
+} as const;
+export type WorkbenchRunStatus = (typeof WorkbenchRunStatus)[keyof typeof WorkbenchRunStatus];
+
+export const WorkbenchRunTrigger = {
+  Message: 'message',
+  Retry: 'retry',
+  Resume: 'resume',
+} as const;
+export type WorkbenchRunTrigger = (typeof WorkbenchRunTrigger)[keyof typeof WorkbenchRunTrigger];
+
+export const WorkbenchContractKind = {
+  Chat: 'chat',
+  Research: 'research',
+  Shortcut: 'shortcut',
+  GenericWork: 'generic_work',
+} as const;
+export type WorkbenchContractKind =
+  (typeof WorkbenchContractKind)[keyof typeof WorkbenchContractKind];
+
+export const WorkbenchVerificationOutcome = {
+  Passed: 'passed',
+  Failed: 'failed',
+  AcceptanceRequired: 'acceptance_required',
+} as const;
+export type WorkbenchVerificationOutcome =
+  (typeof WorkbenchVerificationOutcome)[keyof typeof WorkbenchVerificationOutcome];
+
+export const WorkbenchVerificationCheckStatus = {
+  Passed: 'passed',
+  Failed: 'failed',
+  Skipped: 'skipped',
+} as const;
+export type WorkbenchVerificationCheckStatus =
+  (typeof WorkbenchVerificationCheckStatus)[keyof typeof WorkbenchVerificationCheckStatus];
+
+export const WorkbenchApprovalRiskLevel = {
+  ReadOnly: 'read_only',
+  Reversible: 'reversible',
+  Irreversible: 'irreversible',
+  Unknown: 'unknown',
+} as const;
+export type WorkbenchApprovalRiskLevel =
+  (typeof WorkbenchApprovalRiskLevel)[keyof typeof WorkbenchApprovalRiskLevel];
+
+export const WorkbenchApprovalDecision = {
+  Pending: 'pending',
+  Approved: 'approved',
+  Denied: 'denied',
+  Expired: 'expired',
+} as const;
+export type WorkbenchApprovalDecision =
+  (typeof WorkbenchApprovalDecision)[keyof typeof WorkbenchApprovalDecision];
+
+export const WorkbenchApprovalDecisionSource = {
+  User: 'user',
+  Policy: 'policy',
+  Recovery: 'recovery',
+} as const;
+export type WorkbenchApprovalDecisionSource =
+  (typeof WorkbenchApprovalDecisionSource)[keyof typeof WorkbenchApprovalDecisionSource];
+
+export const WorkbenchApprovalEffectStatus = {
+  NotStarted: 'not_started',
+  Executing: 'executing',
+  Succeeded: 'succeeded',
+  Failed: 'failed',
+  NeedsReview: 'needs_review',
+} as const;
+export type WorkbenchApprovalEffectStatus =
+  (typeof WorkbenchApprovalEffectStatus)[keyof typeof WorkbenchApprovalEffectStatus];
+
+export const WorkbenchArtifactKind = {
+  File: 'file',
+  MessageBlock: 'message_block',
+  Evidence: 'evidence',
+} as const;
+export type WorkbenchArtifactKind =
+  (typeof WorkbenchArtifactKind)[keyof typeof WorkbenchArtifactKind];
+
+export const WorkbenchArtifactProvenance = {
+  Workspace: 'workspace',
+  Message: 'message',
+  Controller: 'controller',
+} as const;
+export type WorkbenchArtifactProvenance =
+  (typeof WorkbenchArtifactProvenance)[keyof typeof WorkbenchArtifactProvenance];
+
+export const WorkbenchArtifactVerificationStatus = {
+  Pending: 'pending',
+  Verified: 'verified',
+  Failed: 'failed',
+} as const;
+export type WorkbenchArtifactVerificationStatus =
+  (typeof WorkbenchArtifactVerificationStatus)[keyof typeof WorkbenchArtifactVerificationStatus];
+
+export const WorkbenchRunEventType = {
+  RunCreated: 'run_created',
+  RunStarted: 'run_started',
+  ToolRead: 'tool_read',
+  ApprovalRequested: 'approval_requested',
+  ApprovalResolved: 'approval_resolved',
+  ToolEffectStarted: 'tool_effect_started',
+  ToolEffectFinished: 'tool_effect_finished',
+  VerificationStarted: 'verification_started',
+  VerificationFinished: 'verification_finished',
+  RunPaused: 'run_paused',
+  RunFailed: 'run_failed',
+  RecoveryRequired: 'recovery_required',
+} as const;
+export type WorkbenchRunEventType =
+  (typeof WorkbenchRunEventType)[keyof typeof WorkbenchRunEventType];
+
+export const WorkbenchTaskIpc = {
+  GetCurrent: 'workbenchTask:getCurrent',
+  GetDetail: 'workbenchTask:getDetail',
+  Resume: 'workbenchTask:resume',
+  Retry: 'workbenchTask:retry',
+  Accept: 'workbenchTask:accept',
+  RespondToApproval: 'workbenchTask:respondToApproval',
+  Changed: 'workbenchTask:changed',
+} as const;
+export type WorkbenchTaskIpc = (typeof WorkbenchTaskIpc)[keyof typeof WorkbenchTaskIpc];
+
+export const WorkbenchTerminalTaskStatuses = [
+  WorkbenchTaskStatus.Completed,
+  WorkbenchTaskStatus.Failed,
+  WorkbenchTaskStatus.Cancelled,
+] as const;

--- a/src/shared/workbenchTask/index.ts
+++ b/src/shared/workbenchTask/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export * from './types';

--- a/src/shared/workbenchTask/types.ts
+++ b/src/shared/workbenchTask/types.ts
@@ -1,0 +1,130 @@
+import type {
+  WorkbenchApprovalDecision,
+  WorkbenchApprovalDecisionSource,
+  WorkbenchApprovalEffectStatus,
+  WorkbenchApprovalRiskLevel,
+  WorkbenchArtifactKind,
+  WorkbenchArtifactProvenance,
+  WorkbenchArtifactVerificationStatus,
+  WorkbenchContractKind,
+  WorkbenchRunEventType,
+  WorkbenchRunStatus,
+  WorkbenchRunTrigger,
+  WorkbenchTaskStatus,
+  WorkbenchVerificationCheckStatus,
+  WorkbenchVerificationOutcome,
+} from './constants';
+
+export type WorkbenchJsonObject = Record<string, unknown>;
+
+export interface WorkbenchTaskContract {
+  kind: WorkbenchContractKind;
+  requiresUserAcceptance: boolean;
+  metadata?: WorkbenchJsonObject;
+}
+
+export interface WorkbenchVerificationCheck {
+  name: string;
+  status: WorkbenchVerificationCheckStatus;
+  detail?: string;
+}
+
+export interface WorkbenchVerificationResult {
+  outcome: WorkbenchVerificationOutcome;
+  checks: WorkbenchVerificationCheck[];
+  evidence: WorkbenchJsonObject[];
+  summary: string;
+}
+
+export interface WorkbenchTask {
+  id: string;
+  sessionId: string;
+  goal: string;
+  status: WorkbenchTaskStatus;
+  contract: WorkbenchTaskContract;
+  activeRunId: string | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+}
+
+export interface WorkbenchRun {
+  id: string;
+  taskId: string;
+  attempt: number;
+  status: WorkbenchRunStatus;
+  trigger: WorkbenchRunTrigger;
+  startedAt: number | null;
+  endedAt: number | null;
+  verificationResult: WorkbenchVerificationResult | null;
+  failure: WorkbenchJsonObject | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorkbenchRunEvent {
+  id: string;
+  runId: string;
+  sequence: number;
+  type: WorkbenchRunEventType;
+  payload: WorkbenchJsonObject;
+  createdAt: number;
+}
+
+export interface WorkbenchArtifact {
+  id: string;
+  taskId: string;
+  runId: string;
+  kind: WorkbenchArtifactKind;
+  mimeType: string;
+  reference: string;
+  contentHash: string;
+  provenance: WorkbenchArtifactProvenance;
+  verificationStatus: WorkbenchArtifactVerificationStatus;
+  metadata: WorkbenchJsonObject;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface WorkbenchApproval {
+  id: string;
+  taskId: string;
+  runId: string;
+  toolCallId: string;
+  toolName: string;
+  riskLevel: WorkbenchApprovalRiskLevel;
+  decision: WorkbenchApprovalDecision;
+  decisionSource: WorkbenchApprovalDecisionSource | null;
+  effectStatus: WorkbenchApprovalEffectStatus;
+  idempotencyKey: string;
+  request: WorkbenchJsonObject;
+  result: WorkbenchJsonObject | null;
+  createdAt: number;
+  updatedAt: number;
+  decidedAt: number | null;
+}
+
+export interface WorkbenchTaskDetail {
+  task: WorkbenchTask;
+  runs: WorkbenchRun[];
+  events: WorkbenchRunEvent[];
+  artifacts: WorkbenchArtifact[];
+  approvals: WorkbenchApproval[];
+}
+
+export interface WorkbenchTaskChangedEvent {
+  sessionId: string;
+  taskId: string;
+}
+
+export interface WorkbenchTaskActionResult {
+  success: boolean;
+  detail?: WorkbenchTaskDetail;
+  error?: string;
+}
+
+export interface WorkbenchApprovalResponseInput {
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+}


### PR DESCRIPTION
## Summary

- add lazy Task creation and incrementing Run orchestration
- integrate Pi Work/Chat execution without duplicating Runs during session recreation
- decouple Cowork stream completion from domain completion
- recover interrupted Runs for explicit user review instead of automatic continuation

## Validation

- `npm test -- workbenchTask piRuntimeAdapter` (75 tests)
- renderer and Electron TypeScript checks

Stack 2/5. Base: `codex/233-domain-model`.

Previous: #284 | Next: #288

Part of #233
