### PR TITLE
feat: Pi steer 消息排队与注入支持

### DIFF
--- a/src/main/libs/agentEngine/piPendingMessageQueue.test.ts
+++ b/src/main/libs/agentEngine/piPendingMessageQueue.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CoworkQueueDelivery,
+  CoworkQueueItemStatus,
+} from '../../../shared/cowork/pendingMessageQueue';
+import { PiPendingMessageQueue } from './piPendingMessageQueue';
+
+describe('PiPendingMessageQueue', () => {
+  test('preserves insertion order and only drains the requested delivery', () => {
+    const queue = new PiPendingMessageQueue();
+    const first = queue.enqueue('session-1', 'first');
+    const second = queue.enqueue('session-1', 'second', CoworkQueueDelivery.Steer);
+
+    expect(queue.list('session-1').map(item => item.id)).toEqual([first.id, second.id]);
+    expect(queue.takeNext('session-1', CoworkQueueDelivery.FollowUp)).toMatchObject({
+      id: first.id,
+      status: CoworkQueueItemStatus.Sending,
+    });
+    expect(queue.takeNext('session-1', CoworkQueueDelivery.FollowUp)).toBeNull();
+    expect(queue.list('session-1')).toHaveLength(1);
+  });
+
+  test('updates and restores a failed item without affecting other items', () => {
+    const queue = new PiPendingMessageQueue();
+    const first = queue.enqueue('session-1', 'first');
+    const second = queue.enqueue('session-1', 'second');
+
+    expect(queue.update('session-1', first.id, 'edited')?.text).toBe('edited');
+    const taken = queue.take('session-1', first.id);
+    expect(taken?.id).toBe(first.id);
+    const restored = queue.restore('session-1', { ...taken!, error: 'network' });
+    expect(restored).toMatchObject({
+      id: first.id,
+      text: 'edited',
+      status: CoworkQueueItemStatus.Failed,
+      error: 'network',
+    });
+    expect(queue.list('session-1').map(item => item.id)).toEqual([first.id, second.id]);
+    expect(queue.takeNext('session-1', CoworkQueueDelivery.FollowUp)?.id).toBe(second.id);
+  });
+
+  test('does not take an item through the wrong delivery path', () => {
+    const queue = new PiPendingMessageQueue();
+    const steer = queue.enqueue('session-1', 'steer', CoworkQueueDelivery.Steer);
+
+    expect(queue.take('session-1', steer.id, CoworkQueueDelivery.FollowUp)).toBeNull();
+    expect(queue.findNextPending('session-1', CoworkQueueDelivery.Steer)?.id).toBe(steer.id);
+  });
+
+  test('isolates sessions and clears one session only', () => {
+    const queue = new PiPendingMessageQueue();
+    queue.enqueue('session-1', 'one');
+    queue.enqueue('session-2', 'two');
+
+    expect(queue.clear('session-1')).toBe(true);
+    expect(queue.list('session-1')).toEqual([]);
+    expect(queue.list('session-2')).toHaveLength(1);
+  });
+});

--- a/src/main/libs/agentEngine/piPendingMessageQueue.ts
+++ b/src/main/libs/agentEngine/piPendingMessageQueue.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from 'crypto';
+
+import {
+  CoworkQueueDelivery,
+  CoworkQueueItemStatus,
+  type CoworkPendingMessage,
+  type CoworkQueueDelivery as CoworkQueueDeliveryType,
+} from '../../../shared/cowork/pendingMessageQueue';
+
+/**
+ * Session-scoped in-memory queue for Work steer/follow-up messages.
+ *
+ * The adapter owns delivery and calls this store after each mutation so it can
+ * broadcast the authoritative queue snapshot to every renderer window.
+ */
+export class PiPendingMessageQueue {
+  private readonly itemsBySession = new Map<string, CoworkPendingMessage[]>();
+  private readonly removedPositions = new Map<string, { sessionId: string; index: number }>();
+
+  list(sessionId: string): CoworkPendingMessage[] {
+    return (this.itemsBySession.get(sessionId) ?? []).map(item => ({ ...item }));
+  }
+
+  hasPendingFollowUp(sessionId: string): boolean {
+    return this.findNextPending(sessionId, CoworkQueueDelivery.FollowUp) !== null;
+  }
+
+  findNextPending(
+    sessionId: string,
+    delivery: CoworkQueueDeliveryType,
+  ): CoworkPendingMessage | null {
+    const item = (this.itemsBySession.get(sessionId) ?? []).find(
+      candidate =>
+        candidate.status === CoworkQueueItemStatus.Pending && candidate.delivery === delivery,
+    );
+    return item ? { ...item } : null;
+  }
+
+  enqueue(
+    sessionId: string,
+    text: string,
+    delivery: CoworkQueueDeliveryType = CoworkQueueDelivery.FollowUp,
+  ): CoworkPendingMessage {
+    const item: CoworkPendingMessage = {
+      id: randomUUID(),
+      text,
+      delivery,
+      createdAt: Date.now(),
+      status: CoworkQueueItemStatus.Pending,
+    };
+    const items = this.itemsBySession.get(sessionId) ?? [];
+    items.push(item);
+    this.itemsBySession.set(sessionId, items);
+    return { ...item };
+  }
+
+  update(sessionId: string, itemId: string, text: string): CoworkPendingMessage | null {
+    const item = this.find(sessionId, itemId);
+    if (!item) return null;
+    item.text = text;
+    item.status = CoworkQueueItemStatus.Pending;
+    delete item.error;
+    return { ...item };
+  }
+
+  remove(sessionId: string, itemId: string): boolean {
+    const items = this.itemsBySession.get(sessionId);
+    if (!items) return false;
+    const index = items.findIndex(item => item.id === itemId);
+    if (index < 0) return false;
+    items.splice(index, 1);
+    if (items.length === 0) this.itemsBySession.delete(sessionId);
+    return true;
+  }
+
+  takeNext(sessionId: string, delivery: CoworkQueueDeliveryType): CoworkPendingMessage | null {
+    const items = this.itemsBySession.get(sessionId);
+    if (!items) return null;
+    const index = items.findIndex(
+      item => item.status === CoworkQueueItemStatus.Pending && item.delivery === delivery,
+    );
+    if (index < 0) return null;
+    const [item] = items.splice(index, 1);
+    this.removedPositions.set(item.id, { sessionId, index });
+    if (items.length === 0) this.itemsBySession.delete(sessionId);
+    return { ...item, status: CoworkQueueItemStatus.Sending };
+  }
+
+  take(
+    sessionId: string,
+    itemId: string,
+    delivery?: CoworkQueueDeliveryType,
+  ): CoworkPendingMessage | null {
+    const items = this.itemsBySession.get(sessionId);
+    if (!items) return null;
+    const index = items.findIndex(item => item.id === itemId);
+    if (index < 0 || (delivery && items[index].delivery !== delivery)) return null;
+    const [item] = items.splice(index, 1);
+    this.removedPositions.set(item.id, { sessionId, index });
+    if (items.length === 0) this.itemsBySession.delete(sessionId);
+    return { ...item, status: CoworkQueueItemStatus.Sending };
+  }
+
+  restore(sessionId: string, item: CoworkPendingMessage): CoworkPendingMessage {
+    const items = this.itemsBySession.get(sessionId) ?? [];
+    const existingIndex = items.findIndex(candidate => candidate.id === item.id);
+    const restored: CoworkPendingMessage = {
+      ...item,
+      status: CoworkQueueItemStatus.Failed,
+    };
+    if (existingIndex >= 0) {
+      items[existingIndex] = restored;
+    } else {
+      const removedPosition = this.removedPositions.get(item.id);
+      const index =
+        removedPosition?.sessionId === sessionId
+          ? Math.min(removedPosition.index, items.length)
+          : items.length;
+      items.splice(index, 0, restored);
+    }
+    this.removedPositions.delete(item.id);
+    this.itemsBySession.set(sessionId, items);
+    return { ...restored };
+  }
+
+  finishDelivery(itemId: string): void {
+    this.removedPositions.delete(itemId);
+  }
+
+  clear(sessionId: string): boolean {
+    for (const [itemId, position] of this.removedPositions) {
+      if (position.sessionId === sessionId) this.removedPositions.delete(itemId);
+    }
+    return this.itemsBySession.delete(sessionId);
+  }
+
+  private find(sessionId: string, itemId: string): CoworkPendingMessage | null {
+    return this.itemsBySession.get(sessionId)?.find(item => item.id === itemId) ?? null;
+  }
+}

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1813,4 +1813,48 @@ describe('PiRuntimeAdapter', () => {
       expect(mockStore.updateSession).not.toHaveBeenCalledWith('test', { status: 'completed' });
     });
   });
+
+  describe('pending Work messages', () => {
+    it('queues follow-ups during a running Work session and steers on demand', async () => {
+      await adapter.startSession('queue-session', 'Start work', { sessionMode: 'work' });
+
+      const queued = adapter.enqueuePendingMessage('queue-session', 'Change direction');
+      expect(queued.success).toBe(true);
+      expect(adapter.listPendingMessages('queue-session')).toHaveLength(1);
+
+      const steered = await adapter.steerPendingMessage('queue-session', queued.item!.id);
+      expect(steered.success).toBe(true);
+      expect(mockSession.steer).toHaveBeenCalledWith('Change direction');
+      expect(adapter.listPendingMessages('queue-session')).toEqual([]);
+    });
+
+    it('delivers queued follow-ups in order after Pi settles', async () => {
+      let listener: ((event: { type: string }) => void) | null = null;
+      mockSession.subscribe.mockImplementation((callback: (event: { type: string }) => void) => {
+        listener = callback;
+        return () => {};
+      });
+      await adapter.startSession('queue-session', 'Start work', { sessionMode: 'work' });
+      const first = adapter.enqueuePendingMessage('queue-session', 'First follow-up');
+      adapter.enqueuePendingMessage('queue-session', 'Second follow-up');
+
+      listener!({ type: 'agent_end' });
+      listener!({ type: 'agent_settled' });
+      await vi.waitFor(() => {
+        expect(mockSession.prompt).toHaveBeenLastCalledWith('First follow-up');
+      });
+      expect(adapter.listPendingMessages('queue-session').map(item => item.text)).toEqual([
+        'Second follow-up',
+      ]);
+      expect(first.success).toBe(true);
+    });
+
+    it('rejects queue controls for Chat sessions', async () => {
+      await adapter.startSession('chat-session', 'Hello', { sessionMode: 'chat' });
+
+      expect(adapter.enqueuePendingMessage('chat-session', 'Not allowed')).toMatchObject({
+        success: false,
+      });
+    });
+  });
 });

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1841,7 +1841,9 @@ describe('PiRuntimeAdapter', () => {
       listener!({ type: 'agent_end' });
       listener!({ type: 'agent_settled' });
       await vi.waitFor(() => {
-        expect(mockSession.prompt).toHaveBeenLastCalledWith('First follow-up');
+        expect(mockSession.prompt).toHaveBeenLastCalledWith('First follow-up', {
+          streamingBehavior: 'followUp',
+        });
       });
       expect(adapter.listPendingMessages('queue-session').map(item => item.text)).toEqual([
         'Second follow-up',

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -23,6 +23,11 @@ import path from 'path';
 
 import { classifyCoworkError, type CoworkError } from '../../../common/coworkError';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
+import {
+  CoworkQueueDelivery,
+  type CoworkPendingMessage,
+} from '../../../shared/cowork/pendingMessageQueue';
+import { CoworkSessionMode } from '../../../shared/cowork/constants';
 import { CoworkToolActivityPhase } from '../../../shared/cowork/toolActivity';
 import {
   WorkbenchContractKind,
@@ -71,6 +76,7 @@ import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool'
 import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
+import { PiPendingMessageQueue } from './piPendingMessageQueue';
 import { buildPiWorkAcceptanceTool, PiWorkExecutionController } from './piWorkExecution';
 import { createPiLargeFileWriteSystemPrompt, PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
 import {
@@ -91,7 +97,7 @@ import type {
 
 /** Minimal type for the Pi AgentSession — only the methods used by this adapter. */
 interface PiSession {
-  prompt(text: string): Promise<void>;
+  prompt(text: string, options?: { streamingBehavior?: 'steer' | 'followUp' }): Promise<void>;
   steer(text: string): Promise<void>;
   abort(): Promise<void>;
   abortBash(): void;
@@ -209,6 +215,12 @@ interface ActivePiSession {
   workbenchContract: WorkbenchTaskContract;
   workspaceRoot: string;
   autoApprove: boolean;
+  /** True while Pi is executing the current Work/Chat turn. */
+  isRunning: boolean;
+  /** True when the current turn settled with an unrecoverable Pi error. */
+  turnFailed: boolean;
+  /** Prevents duplicate queue drains when Pi emits multiple settled events. */
+  queueFlushInFlight: boolean;
 }
 
 // ── Dynamic imports ──
@@ -339,6 +351,7 @@ if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '1';
 
 export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private readonly activeSessions = new Map<string, ActivePiSession>();
+  private readonly pendingMessageQueue = new PiPendingMessageQueue();
   private readonly approvalSessionMap = new Map<string, string>();
   private readonly pendingAskUserQuestions = new Map<
     string,
@@ -673,6 +686,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workbenchContract,
         workspaceRoot,
         autoApprove: Boolean(options.autoApprove),
+        isRunning: true,
+        turnFailed: false,
+        queueFlushInFlight: false,
       };
 
       // Subscribe to Pi events before sending the prompt
@@ -742,6 +758,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     active.autoApprove = Boolean(options.autoApprove);
+    active.isRunning = true;
+    active.turnFailed = false;
 
     const requestedSystemPrompt = options.systemPrompt?.trim();
     const requestedSkillIds =
@@ -793,6 +811,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       } catch (error) {
         active.resourceState.systemPrompt = previousSystemPrompt;
         active.resourceState.skillIds = previousSkillIds;
+        active.isRunning = false;
         const message = error instanceof Error ? error.message : String(error);
         this.emit('error', sessionId, classifyCoworkError(message));
         throw error;
@@ -829,6 +848,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     if (clearActivity) this.emit('toolActivity', sessionId, clearActivity);
     active.writeTokenLimitRecovery.reset();
     active.pendingError = null;
+    active.turnFailed = false;
 
     // Emit user message (persisted to SQLite, same as startSession).
     if (!options._skipUserMessage) {
@@ -837,7 +857,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         type: 'user',
         content: prompt,
         timestamp: Date.now(),
-        metadata: options.skillIds?.length ? { skillIds: options.skillIds } : undefined,
+        metadata:
+          options.skillIds?.length || options._queueDelivery
+            ? {
+                ...(options.skillIds?.length ? { skillIds: options.skillIds } : {}),
+                ...(options._queueDelivery ? { queueDelivery: options._queueDelivery } : {}),
+              }
+            : undefined,
       };
       const persisted = this.store ? this.store.addMessage(sessionId, userMsg) : userMsg;
       this.emit('message', sessionId, persisted);
@@ -862,8 +888,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     try {
-      await active.piSession.prompt(nextPrompt);
+      await active.piSession.prompt(
+        nextPrompt,
+        options._streamingBehavior
+          ? { streamingBehavior: options._streamingBehavior }
+          : undefined,
+      );
     } catch (error) {
+      active.isRunning = false;
       if (active.abortController.signal.aborted) {
         this.emit('sessionStopped', sessionId);
         return;
@@ -912,12 +944,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     this.dismissAskUserQuestionsBySession(sessionId);
     const active = this.activeSessions.get(sessionId);
     if (!active) return;
+    const wasRunning = active.isRunning;
 
     this.finalizeActiveThinking(sessionId, active);
 
     // Mark the session as aborted so continueSession knows not to reuse the Pi
     // session object, which may be in an inconsistent state after abort.
     active.aborted = true;
+    active.isRunning = false;
+    active.turnFailed = false;
     active.agentLoop.stop();
     // Drop any deferred error without surfacing it — the user stopped the turn.
     active.pendingError = null;
@@ -933,6 +968,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     void active.piSession.abort();
     this.workbenchTaskService?.pauseRun(sessionId, 'The user stopped this run.');
     this.emit('sessionStopped', sessionId);
+
+    // A user stop ends the current turn without cancelling messages already
+    // queued in Work. Start the next follow-up from a fresh Pi session; the
+    // internal stop used during that recreation is not running and will not
+    // recursively drain the queue.
+    if (
+      wasRunning &&
+      active.workbenchContract.kind !== WorkbenchContractKind.Chat &&
+      this.pendingMessageQueue.hasPendingFollowUp(sessionId)
+    ) {
+      const next = this.pendingMessageQueue.findNextPending(
+        sessionId,
+        CoworkQueueDelivery.FollowUp,
+      );
+      if (next) void this.followUpPendingMessage(sessionId, next.id);
+    }
   }
 
   stopAllSessions(): void {
@@ -980,6 +1031,182 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     return this.activeSessions.has(sessionId);
   }
 
+  isSessionRunning(sessionId: string): boolean {
+    const active = this.activeSessions.get(sessionId);
+    return Boolean(active && active.isRunning && !active.aborted);
+  }
+
+  listPendingMessages(sessionId: string): CoworkPendingMessage[] {
+    return this.pendingMessageQueue.list(sessionId);
+  }
+
+  enqueuePendingMessage(
+    sessionId: string,
+    text: string,
+  ): { success: boolean; item?: CoworkPendingMessage; error?: string } {
+    const active = this.activeSessions.get(sessionId);
+    if (!this.isWorkSession(sessionId, active)) {
+      return { success: false, error: 'Pending message queue is only available in Work sessions.' };
+    }
+    if (!active || !this.isSessionRunning(sessionId)) {
+      return { success: false, error: 'The Work session is not running.' };
+    }
+    const normalizedText = text.trim();
+    if (!normalizedText) return { success: false, error: 'Message text is required.' };
+    const item = this.pendingMessageQueue.enqueue(
+      sessionId,
+      normalizedText,
+      CoworkQueueDelivery.FollowUp,
+    );
+    this.emitQueueUpdated(sessionId);
+    return { success: true, item };
+  }
+
+  updatePendingMessage(
+    sessionId: string,
+    itemId: string,
+    text: string,
+  ): { success: boolean; item?: CoworkPendingMessage; error?: string } {
+    if (!this.isWorkSession(sessionId, this.activeSessions.get(sessionId))) {
+      return { success: false, error: 'Pending message queue is only available in Work sessions.' };
+    }
+    const normalizedText = text.trim();
+    if (!normalizedText) return { success: false, error: 'Message text is required.' };
+    const item = this.pendingMessageQueue.update(sessionId, itemId, normalizedText);
+    if (!item) return { success: false, error: 'Pending message was not found.' };
+    this.emitQueueUpdated(sessionId);
+    return { success: true, item };
+  }
+
+  deletePendingMessage(sessionId: string, itemId: string): { success: boolean; error?: string } {
+    if (!this.isWorkSession(sessionId, this.activeSessions.get(sessionId))) {
+      return { success: false, error: 'Pending message queue is only available in Work sessions.' };
+    }
+    if (!this.pendingMessageQueue.remove(sessionId, itemId)) {
+      return { success: false, error: 'Pending message was not found.' };
+    }
+    this.emitQueueUpdated(sessionId);
+    return { success: true };
+  }
+
+  async steerPendingMessage(
+    sessionId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }> {
+    const active = this.activeSessions.get(sessionId);
+    if (!this.isWorkSession(sessionId, active)) {
+      return { success: false, error: 'Pending message queue is only available in Work sessions.' };
+    }
+    if (!active || !this.isSessionRunning(sessionId)) {
+      return { success: false, error: 'The Work session is not running.' };
+    }
+    // A queued message is initially classified as FollowUp, but the user can
+    // explicitly promote any pending item to an immediate Steer.
+    const item = this.pendingMessageQueue.take(sessionId, itemId);
+    if (!item) return { success: false, error: 'Pending message was not found.' };
+    this.emitQueueUpdated(sessionId);
+    try {
+      await active.piSession.steer(item.text);
+      this.persistQueuedUserMessage(sessionId, item.text, CoworkQueueDelivery.Steer);
+      active.isRunning = true;
+      this.pendingMessageQueue.finishDelivery(item.id);
+      return { success: true, item };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const restored = this.pendingMessageQueue.restore(sessionId, { ...item, error: message });
+      this.emitQueueUpdated(sessionId);
+      return { success: false, item: restored, error: message };
+    }
+  }
+
+  async followUpPendingMessage(
+    sessionId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }> {
+    const active = this.activeSessions.get(sessionId);
+    if (!this.isWorkSession(sessionId, active)) {
+      return { success: false, error: 'Pending message queue is only available in Work sessions.' };
+    }
+    if (!active) return { success: false, error: 'The Work session is not active.' };
+    if (this.isSessionRunning(sessionId)) {
+      return { success: false, error: 'The Work session is still running.' };
+    }
+    const item = this.pendingMessageQueue.take(sessionId, itemId, CoworkQueueDelivery.FollowUp);
+    if (!item) return { success: false, error: 'Pending message was not found.' };
+    this.emitQueueUpdated(sessionId);
+    try {
+      await this.continueSession(sessionId, item.text, {
+        sessionMode: CoworkSessionMode.Work,
+        _queueDelivery: CoworkQueueDelivery.FollowUp,
+        _streamingBehavior: 'followUp',
+      });
+      this.pendingMessageQueue.finishDelivery(item.id);
+      return { success: true, item };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const restored = this.pendingMessageQueue.restore(sessionId, { ...item, error: message });
+      this.emitQueueUpdated(sessionId);
+      return { success: false, item: restored, error: message };
+    }
+  }
+
+  private isWorkSession(sessionId: string, active: ActivePiSession | undefined): boolean {
+    if (active) return active.workbenchContract.kind !== WorkbenchContractKind.Chat;
+    return this.store?.getSession(sessionId)?.mode !== CoworkSessionMode.Chat;
+  }
+
+  private persistQueuedUserMessage(
+    sessionId: string,
+    text: string,
+    delivery: CoworkQueueDelivery,
+  ): CoworkMessage {
+    const message: CoworkMessage = {
+      id: randomUUID(),
+      type: 'user',
+      content: text,
+      timestamp: Date.now(),
+      metadata: { queueDelivery: delivery },
+    };
+    const persisted = this.store ? this.store.addMessage(sessionId, message) : message;
+    this.emit('message', sessionId, persisted);
+    if (this.store) this.store.updateSession(sessionId, { status: 'running' });
+    return persisted;
+  }
+
+  private emitQueueUpdated(sessionId: string): void {
+    this.emit('queueUpdated', sessionId, this.pendingMessageQueue.list(sessionId));
+  }
+
+  private async flushFollowUpQueue(sessionId: string, active: ActivePiSession): Promise<void> {
+    if (active.queueFlushInFlight || active.aborted || active.pendingError || active.turnFailed) return;
+    if (active.workbenchContract.kind === WorkbenchContractKind.Chat) return;
+    active.queueFlushInFlight = true;
+    let retryAfterFailure = false;
+    try {
+      if (active.aborted || active.isRunning) return;
+      const next = this.pendingMessageQueue.takeNext(sessionId, CoworkQueueDelivery.FollowUp);
+      if (!next) return;
+      this.emitQueueUpdated(sessionId);
+      try {
+        await this.continueSession(sessionId, next.text, {
+          sessionMode: CoworkSessionMode.Work,
+          _queueDelivery: CoworkQueueDelivery.FollowUp,
+          _streamingBehavior: 'followUp',
+        });
+        this.pendingMessageQueue.finishDelivery(next.id);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.pendingMessageQueue.restore(sessionId, { ...next, error: message });
+        this.emitQueueUpdated(sessionId);
+        console.error('[PiRuntime] queued follow-up failed:', error);
+        retryAfterFailure = true;
+      }
+    } finally {
+      active.queueFlushInFlight = false;
+      if (retryAfterFailure) void this.flushFollowUpQueue(sessionId, active);
+    }
+  }
+
   getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null {
     return this.activeSessions.get(sessionId)?.confirmationMode || null;
   }
@@ -987,6 +1214,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   onSessionDeleted(sessionId: string): void {
     this.stopSession(sessionId);
     this.activeSessions.delete(sessionId);
+    if (this.pendingMessageQueue.clear(sessionId)) this.emitQueueUpdated(sessionId);
     this.workbenchTaskService?.deleteSession(sessionId);
   }
 
@@ -1118,9 +1346,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
     switch (event.type) {
       case 'agent_start':
+        active.isRunning = true;
         break;
 
       case 'turn_start':
+        active.isRunning = true;
         active.preparingToolCallIdByContentIndex.clear();
         {
           const clearActivity = active.toolActivityTracker.clear();
@@ -1205,12 +1435,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             // attempt — flushPendingError surfaces the error exactly once when
             // the run settles (auto_retry_end / agent_settled).
             active.pendingError = { message: errMsg, classified: classifyCoworkError(errMsg) };
+            active.turnFailed = true;
             return;
           }
 
           // A successful assistant message after failed attempts means the retry
           // recovered — drop the deferred error so it is never surfaced.
           active.pendingError = null;
+          active.turnFailed = false;
 
           const { text, thinking } = extractStreamingSnapshot(event.message);
           const finalThinking = thinking || active.thinkingText;
@@ -1369,6 +1601,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           });
           break;
         }
+        active.isRunning = false;
+        // Pi versions differ in whether they emit agent_settled after agent_end.
+        // Drain queued Work follow-ups here so completion never leaves them stuck.
+        if (
+          active.workbenchContract.kind !== WorkbenchContractKind.Chat &&
+          this.pendingMessageQueue.hasPendingFollowUp(sessionId)
+        ) {
+          void this.flushFollowUpQueue(sessionId, active);
+          break;
+        }
         if (this.store) this.store.updateSession(sessionId, { status: 'idle' });
         if (active.workbenchRunId && this.workbenchTaskService) {
           const workflowSnapshot = active.researchRun
@@ -1405,7 +1647,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       case 'agent_settled':
         // Run settled (covers non-retryable errors with no auto-retry) —
         // surface the deferred error, if any. Idempotent after auto_retry_end.
+        active.isRunning = false;
         this.flushPendingError(sessionId, active);
+        void this.flushFollowUpQueue(sessionId, active);
         break;
 
       default:
@@ -1429,6 +1673,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     const pending = active.pendingError;
     if (!pending) return;
     active.pendingError = null;
+    active.turnFailed = true;
+    active.isRunning = false;
     this.workbenchTaskService?.failRun(sessionId, { message: pending.message });
     // Persist a system error message so the error survives session switching
     // and is visible in the message list. The classified kind lets the renderer

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -888,12 +888,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     try {
-      await active.piSession.prompt(
-        nextPrompt,
-        options._streamingBehavior
-          ? { streamingBehavior: options._streamingBehavior }
-          : undefined,
-      );
+      const promptOptions = options._streamingBehavior
+        ? { streamingBehavior: options._streamingBehavior }
+        : undefined;
+      if (promptOptions) {
+        await active.piSession.prompt(nextPrompt, promptOptions);
+      } else {
+        await active.piSession.prompt(nextPrompt);
+      }
     } catch (error) {
       active.isRunning = false;
       if (active.abortController.signal.aborted) {

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -1,6 +1,8 @@
 import type { CoworkError } from '../../../common/coworkError';
 import type { CoworkToolActivityEvent } from '../../../shared/cowork/toolActivity';
 import type { CoworkMessage } from '../../coworkStore';
+import type { CoworkPendingMessage } from '../../../shared/cowork/pendingMessageQueue';
+import type { CoworkQueueDelivery } from '../../../shared/cowork/pendingMessageQueue';
 
 /**
  * Pi-native workbench runtime types (issue #225).
@@ -48,6 +50,7 @@ export interface PiRuntimeEvents {
   complete: (sessionId: string, claudeSessionId: string | null) => void;
   error: (sessionId: string, error: CoworkError) => void;
   sessionStopped: (sessionId: string) => void;
+  queueUpdated: (sessionId: string, items: CoworkPendingMessage[]) => void;
 }
 
 export type PiImageAttachment = {
@@ -99,6 +102,10 @@ export type PiContinueOptions = {
   _workbenchRunId?: string;
   /** Internal: do not persist a synthetic Resume/Retry prompt as a user message. */
   _skipUserMessage?: boolean;
+  /** Internal: marks a queued follow-up in the persisted transcript. */
+  _queueDelivery?: CoworkQueueDelivery;
+  /** Internal: tells Pi how to queue a prompt while the agent is settling. */
+  _streamingBehavior?: 'steer' | 'followUp';
 };
 
 /** Workbench session patch; Pi only supports switching the model. */
@@ -116,6 +123,26 @@ export interface PiRuntime {
   stopAllSessions(): void;
   respondToPermission(requestId: string, result: PiPermissionResult): void;
   isSessionActive(sessionId: string): boolean;
+  isSessionRunning(sessionId: string): boolean;
+  listPendingMessages(sessionId: string): CoworkPendingMessage[];
+  enqueuePendingMessage(
+    sessionId: string,
+    text: string,
+  ): { success: boolean; item?: CoworkPendingMessage; error?: string };
+  updatePendingMessage(
+    sessionId: string,
+    itemId: string,
+    text: string,
+  ): { success: boolean; item?: CoworkPendingMessage; error?: string };
+  deletePendingMessage(sessionId: string, itemId: string): { success: boolean; error?: string };
+  steerPendingMessage(
+    sessionId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
+  followUpPendingMessage(
+    sessionId: string,
+    itemId: string,
+  ): Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
   getSessionConfirmationMode(sessionId: string): 'modal' | 'text' | null;
   onSessionDeleted?(sessionId: string): void;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -51,6 +51,7 @@ import {
   ApiIpc,
   AuthIpc,
   CoworkPermissionIpc,
+  CoworkQueueIpc,
   CoworkSessionIpc,
   CoworkStreamIpc,
   HardwareIpc,
@@ -59,6 +60,12 @@ import {
   ProjectIpc,
   SkillsIpc,
 } from '../shared/ipc/channels';
+import {
+  CoworkQueueEnqueueSchema,
+  CoworkQueueItemSchema,
+  CoworkQueueSessionSchema,
+  CoworkQueueUpdateSchema,
+} from '../shared/ipc/queueSchemas';
 import {
   ApiFetchSchema,
   ApiStreamSchema,
@@ -1774,6 +1781,18 @@ const forwardPiWorkbenchRuntimeToRenderer = (runtime: PiRuntimeAdapter): void =>
         win.webContents.send(CoworkStreamIpc.ToolActivity, { sessionId, event });
       } catch (error) {
         console.error('[CoworkForwarder] failed to forward tool activity:', error);
+      }
+    });
+  });
+
+  runtime.on('queueUpdated', (sessionId, items) => {
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach(win => {
+      if (win.isDestroyed()) return;
+      try {
+        win.webContents.send(CoworkStreamIpc.QueueUpdated, { sessionId, items });
+      } catch (error) {
+        console.error('[PiWorkbenchForwarder] failed to forward queue update:', error);
       }
     });
   });
@@ -4461,6 +4480,78 @@ if (!gotTheLock) {
       }
     },
   );
+
+  ipcMain.handle(CoworkQueueIpc.List, async (_event, rawInput: unknown) => {
+    try {
+      const sessionId = CoworkQueueSessionSchema.parse(rawInput);
+      return { success: true, items: getPiRuntimeAdapter().listPendingMessages(sessionId) };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list pending messages',
+      };
+    }
+  });
+
+  ipcMain.handle(CoworkQueueIpc.Enqueue, async (_event, rawInput: unknown) => {
+    try {
+      const input = CoworkQueueEnqueueSchema.parse(rawInput);
+      return getPiRuntimeAdapter().enqueuePendingMessage(input.sessionId, input.text);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to enqueue pending message',
+      };
+    }
+  });
+
+  ipcMain.handle(CoworkQueueIpc.Update, async (_event, rawInput: unknown) => {
+    try {
+      const input = CoworkQueueUpdateSchema.parse(rawInput);
+      return getPiRuntimeAdapter().updatePendingMessage(input.sessionId, input.itemId, input.text);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to update pending message',
+      };
+    }
+  });
+
+  ipcMain.handle(CoworkQueueIpc.Delete, async (_event, rawInput: unknown) => {
+    try {
+      const input = CoworkQueueItemSchema.parse(rawInput);
+      return getPiRuntimeAdapter().deletePendingMessage(input.sessionId, input.itemId);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to delete pending message',
+      };
+    }
+  });
+
+  ipcMain.handle(CoworkQueueIpc.Steer, async (_event, rawInput: unknown) => {
+    try {
+      const input = CoworkQueueItemSchema.parse(rawInput);
+      return await getPiRuntimeAdapter().steerPendingMessage(input.sessionId, input.itemId);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to steer pending message',
+      };
+    }
+  });
+
+  ipcMain.handle(CoworkQueueIpc.FollowUp, async (_event, rawInput: unknown) => {
+    try {
+      const input = CoworkQueueItemSchema.parse(rawInput);
+      return await getPiRuntimeAdapter().followUpPendingMessage(input.sessionId, input.itemId);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to send follow-up message',
+      };
+    }
+  });
 
   ipcMain.handle('cowork:session:stop', async (_event, sessionId: string) => {
     try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -14,6 +14,7 @@ import {
   CoworkConfigIpc,
   CoworkMemoryIpc,
   CoworkPermissionIpc,
+  CoworkQueueIpc,
   CoworkSessionIpc,
   CoworkStreamIpc,
   DialogIpc,
@@ -39,6 +40,7 @@ import {
 } from '../shared/ipc/channels';
 import type { CoworkPermissionMode, CoworkSessionMode } from '../shared/cowork/constants';
 import type { CoworkToolActivityEvent } from '../shared/cowork/toolActivity';
+import type { CoworkPendingMessage } from '../shared/cowork/pendingMessageQueue';
 import { LlamaCppIpcChannel } from '../shared/llamacpp/constants';
 import { MarketplaceIpcChannel } from '../shared/marketplace/constants';
 import { OllamaIpcChannel } from '../shared/ollama/constants';
@@ -449,6 +451,19 @@ contextBridge.exposeInMainWorld('electron', {
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
     }) => ipcRenderer.invoke(CoworkSessionIpc.Continue, options),
 
+    listPendingMessages: (sessionId: string) =>
+      ipcRenderer.invoke(CoworkQueueIpc.List, sessionId),
+    enqueuePendingMessage: (options: { sessionId: string; text: string }) =>
+      ipcRenderer.invoke(CoworkQueueIpc.Enqueue, options),
+    updatePendingMessage: (options: { sessionId: string; itemId: string; text: string }) =>
+      ipcRenderer.invoke(CoworkQueueIpc.Update, options),
+    deletePendingMessage: (options: { sessionId: string; itemId: string }) =>
+      ipcRenderer.invoke(CoworkQueueIpc.Delete, options),
+    steerPendingMessage: (options: { sessionId: string; itemId: string }) =>
+      ipcRenderer.invoke(CoworkQueueIpc.Steer, options),
+    followUpPendingMessage: (options: { sessionId: string; itemId: string }) =>
+      ipcRenderer.invoke(CoworkQueueIpc.FollowUp, options),
+
     stopSession: (sessionId: string) => ipcRenderer.invoke(CoworkSessionIpc.Stop, sessionId),
     saveSession: (session: Record<string, unknown>) =>
       ipcRenderer.invoke(CoworkSessionIpc.Save, session),
@@ -561,6 +576,9 @@ contextBridge.exposeInMainWorld('electron', {
     ) => onPush(CoworkStreamIpc.Complete, callback),
     onStreamError: (callback: (data: { sessionId: string; error: CoworkError }) => void) =>
       onPush(CoworkStreamIpc.Error, callback),
+    onStreamQueueUpdated: (
+      callback: (data: { sessionId: string; items: CoworkPendingMessage[] }) => void,
+    ) => onPush(CoworkStreamIpc.QueueUpdated, callback),
     onSessionsChanged: (callback: (data: { sessionId?: string }) => void) =>
       onPush(CoworkStreamIpc.SessionsChanged, callback),
   },

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -401,10 +401,17 @@ export class WorkbenchTaskService extends EventEmitter {
             interruptedApprovalIds.add(approval.id);
           }
           this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Paused);
-          this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Paused, run.id);
+          // A task may already require review because another interrupted run
+          // or approval effect was recovered first. Do not downgrade that
+          // stronger recovery state back to paused.
+          if (task.status === WorkbenchTaskStatus.Running) {
+            this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Paused, run.id);
+          }
         } else {
           this.repository.updateRunStatus(run.id, WorkbenchRunStatus.NeedsReview);
-          this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
+          if (task.status === WorkbenchTaskStatus.Running) {
+            this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
+          }
         }
         this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RecoveryRequired, {
           previousStatus: run.status,

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -17,7 +17,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux';
 
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
-import { CoworkPermissionMode } from '../../../shared/cowork/constants';
+import { CoworkPermissionMode, CoworkSessionMode } from '../../../shared/cowork/constants';
 import { agentService } from '../../services/agent';
 import { configService } from '../../services/config';
 import { coworkService } from '../../services/cowork';
@@ -233,6 +233,10 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
     );
     const contextUsage = contextMessage?.metadata?.contextUsage;
     const workMode = useSelector(selectWorkMode);
+    const canQueueWhileStreaming =
+      workMode === WorkMode.Work &&
+      !isDirectChat &&
+      (currentSession?.mode ?? CoworkSessionMode.Work) === CoworkSessionMode.Work;
     const persistedExpertIds = useMemo(
       () => currentSession?.experts?.map(expert => expert.expertId) ?? [],
       [currentSession?.experts],
@@ -510,7 +514,12 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       }
 
       const trimmedValue = value.trim();
-      if ((!trimmedValue && attachments.length === 0) || isStreaming || disabled || isPatchingModel)
+      if (
+        (!trimmedValue && attachments.length === 0) ||
+        (isStreaming && !canQueueWhileStreaming) ||
+        disabled ||
+        isPatchingModel
+      )
         return;
       if (!isDirectChat && hasUnavailableLlamaCppModel) {
         window.dispatchEvent(
@@ -648,6 +657,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       effectiveSelectedModel?.id,
       modelSupportsImage,
       selectedExpertIds,
+      canQueueWhileStreaming,
     ]);
 
     const handleManageSkills = useCallback(() => {
@@ -697,7 +707,12 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
           break;
       }
 
-      if (isSendCombo && !isStreaming && !disabled && !isPatchingModel) {
+      if (
+        isSendCombo &&
+        (!isStreaming || canQueueWhileStreaming) &&
+        !disabled &&
+        !isPatchingModel
+      ) {
         event.preventDefault();
         handleSubmit();
       } else {
@@ -1138,7 +1153,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               {i18nService.t('coworkDropFileHint')}
             </div>
           )}
-          {isStreaming && !disabled && (
+          {isStreaming && !disabled && !canQueueWhileStreaming && (
             <div className="pointer-events-none absolute inset-0 z-10 rounded-[inherit] bg-input/50 dark:bg-input/80" />
           )}
           <PromptInputBody>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -16,7 +16,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-import type { CoworkPermissionMode } from '../../../shared/cowork/constants';
+import { CoworkSessionMode, type CoworkPermissionMode } from '../../../shared/cowork/constants';
 
 import { ArtifactDetectionService } from '../../services/artifactDetectionService';
 import {
@@ -70,6 +70,7 @@ import {
 } from './components/VirtualizedTurnList';
 import { type CoworkOpenShareOptionsEventDetail, CoworkUiEvent } from './constants';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
+import PendingMessageQueue from './PendingMessageQueue';
 import type { CaptureRect } from './helpers/exportUtils';
 import {
   composeExportCanvas,
@@ -1470,7 +1471,15 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               <CoworkPromptInput
                 ref={promptInputRef}
                 topAccessory={
-                  <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
+                  <>
+                    {workMode === CoworkSessionMode.Work && !isDirectChat && currentSession?.id && (
+                      <PendingMessageQueue
+                        sessionId={currentSession.id}
+                        isStreaming={isStreaming}
+                      />
+                    )}
+                    <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
+                  </>
                 }
                 onSubmit={onContinue}
                 onStop={onStop}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -17,6 +17,7 @@ import {
 import { resolveSkillPlaceholderKey } from '../chat/constants';
 import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import { coworkService } from '../../services/cowork';
+import { coworkQueueService } from '../../services/coworkQueue';
 import { i18nService } from '../../services/i18n';
 import { quickActionService } from '../../services/quickAction';
 import { RafMessageUpdateBatcher } from '../../services/rafMessageUpdateBatcher';
@@ -848,6 +849,27 @@ const CoworkView: React.FC<CoworkViewProps> = ({
   ) => {
     if (!currentSession) return;
     if (continuingSessionIdsRef.current.has(currentSession.id)) return;
+
+    // Work keeps the prompt editable while Pi is running. Normal input during
+    // a live turn becomes an ordered Follow-up item; Chat retains its existing
+    // direct/agent multi-turn behavior and never enters this queue.
+    if (
+      workMode === WorkMode.Work &&
+      isStreaming &&
+      (currentSession.mode ?? CoworkSessionMode.Work) === CoworkSessionMode.Work
+    ) {
+      const result = await coworkQueueService.enqueue(currentSession.id, prompt);
+      if (!result.success) {
+        window.dispatchEvent(
+          new CustomEvent('app:showToast', {
+            detail: result.error || i18nService.t('coworkQueueEnqueueFailed'),
+          }),
+        );
+        return false;
+      }
+      return true;
+    }
+
 
     // Direct chat: stream from the configured LLM via apiService. Chat
     // sessions that are agent-backed (skills attached now or persisted on the

--- a/src/renderer/components/cowork/PendingMessageQueue.tsx
+++ b/src/renderer/components/cowork/PendingMessageQueue.tsx
@@ -1,0 +1,265 @@
+import { Button } from '@shared/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@shared/components/ui/dropdown-menu';
+import { Input } from '@shared/components/ui/input';
+import { cn } from '@shared/lib/utils';
+import { Check, Compass, Ellipsis, ListTodo, Pencil, RotateCcw, Trash2, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  CoworkQueueDelivery,
+  CoworkQueueItemStatus,
+  type CoworkPendingMessage,
+} from '../../../shared/cowork/pendingMessageQueue';
+import { coworkQueueService } from '../../services/coworkQueue';
+import { i18nService } from '../../services/i18n';
+
+interface PendingMessageQueueProps {
+  sessionId: string;
+  isStreaming: boolean;
+}
+
+const showQueueToast = (message: string): void => {
+  window.dispatchEvent(new CustomEvent('app:showToast', { detail: message }));
+};
+
+const PendingMessageQueue = ({ sessionId, isStreaming }: PendingMessageQueueProps) => {
+  const [items, setItems] = useState<CoworkPendingMessage[]>([]);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    setLoading(true);
+    const unsubscribe = coworkQueueService.subscribe(sessionId, nextItems => {
+      if (!disposed) setItems(nextItems);
+    });
+    void coworkQueueService
+      .load(sessionId)
+      .catch(error => {
+        if (!disposed) {
+          showQueueToast(error instanceof Error ? error.message : String(error));
+        }
+      })
+      .finally(() => {
+        if (!disposed) setLoading(false);
+      });
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [sessionId]);
+
+  const beginEdit = (item: CoworkPendingMessage): void => {
+    setEditingId(item.id);
+    setEditingText(item.text);
+  };
+
+  const cancelEdit = (): void => {
+    setEditingId(null);
+    setEditingText('');
+  };
+
+  const saveEdit = async (itemId: string): Promise<void> => {
+    const text = editingText.trim();
+    if (!text) return;
+    const result = await coworkQueueService.update(sessionId, itemId, text);
+    if (!result.success) {
+      showQueueToast(result.error || i18nService.t('coworkQueueUpdateFailed'));
+      return;
+    }
+    cancelEdit();
+  };
+
+  const removeItem = async (itemId: string): Promise<void> => {
+    const result = await coworkQueueService.remove(sessionId, itemId);
+    if (!result.success) showQueueToast(result.error || i18nService.t('coworkQueueDeleteFailed'));
+  };
+
+  const steerItem = useCallback(
+    async (itemId: string): Promise<void> => {
+      const result = await coworkQueueService.steer(sessionId, itemId);
+      if (!result.success) {
+        showQueueToast(result.error || i18nService.t('coworkQueueSteerFailed'));
+      }
+    },
+    [sessionId],
+  );
+
+  const retryItem = useCallback(
+    async (itemId: string): Promise<void> => {
+      const item = items.find(candidate => candidate.id === itemId);
+      if (!item) return;
+      const result =
+        item.delivery === CoworkQueueDelivery.FollowUp
+          ? await coworkQueueService.followUp(sessionId, itemId)
+          : await coworkQueueService.steer(sessionId, itemId);
+      if (!result.success) {
+        showQueueToast(result.error || i18nService.t('coworkQueueRetryFailed'));
+      }
+    },
+    [items, sessionId],
+  );
+
+  useEffect(() => {
+    if (selectedItemId && items.some(item => item.id === selectedItemId)) return;
+    setSelectedItemId(items[0]?.id ?? null);
+  }, [items, selectedItemId]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      const isSteerShortcut =
+        event.key === 'Enter' && event.shiftKey && !event.altKey && (event.ctrlKey || event.metaKey);
+      if (!isSteerShortcut || !isStreaming || !selectedItemId) return;
+      const selected = items.find(item => item.id === selectedItemId);
+      if (!selected || selected.status === CoworkQueueItemStatus.Sending) return;
+      event.preventDefault();
+      void steerItem(selected.id);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isStreaming, items, selectedItemId, steerItem]);
+
+  if (loading || items.length === 0) return null;
+
+  return (
+    <div className="mb-2 overflow-hidden rounded-xl border border-border bg-card text-sm">
+      <div>
+        {items.map(item => {
+            const isEditing = editingId === item.id;
+            const isSending = item.status === CoworkQueueItemStatus.Sending;
+            const isFailed = item.status === CoworkQueueItemStatus.Failed;
+            return (
+              <div
+                key={item.id}
+                className={cn(
+                  'flex min-w-0 items-center gap-2 border-b border-border/70 px-3 py-2.5 transition-colors last:border-b-0',
+                  selectedItemId === item.id && 'bg-accent/40',
+                  isFailed && 'bg-destructive/5',
+                )}
+                onClick={() => setSelectedItemId(item.id)}
+              >
+                {isEditing ? (
+                  <Input
+                    value={editingText}
+                    autoFocus
+                    onChange={event => setEditingText(event.currentTarget.value)}
+                    onKeyDown={event => {
+                      if (event.key === 'Escape') cancelEdit();
+                      if (event.key === 'Enter' && !event.shiftKey) {
+                        event.preventDefault();
+                        void saveEdit(item.id);
+                      }
+                    }}
+                    className="h-8 min-w-0 flex-1"
+                  />
+                ) : (
+                  <>
+                    <ListTodo className="size-4 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1 truncate font-medium text-foreground" title={item.text}>
+                      {item.text}
+                    </div>
+                    {(isFailed || isSending) && (
+                      <span
+                        className={cn(
+                          'shrink-0 text-xs',
+                          isFailed ? 'text-destructive' : 'text-muted-foreground',
+                        )}
+                      >
+                        {isFailed
+                          ? i18nService.t('coworkQueueStatusFailed')
+                          : i18nService.t('coworkQueueStatusSending')}
+                      </span>
+                    )}
+                  </>
+                )}
+                <div className="flex shrink-0 items-center gap-0.5">
+                  {isEditing ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        title={i18nService.t('save')}
+                        aria-label={i18nService.t('save')}
+                        onClick={() => void saveEdit(item.id)}
+                      >
+                        <Check />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        title={i18nService.t('cancel')}
+                        aria-label={i18nService.t('cancel')}
+                        onClick={cancelEdit}
+                      >
+                        <X />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button
+                        type="button"
+                        variant={isFailed ? 'outline' : 'ghost'}
+                        size="sm"
+                        className="h-7 gap-1 px-2 text-xs"
+                        disabled={isSending || (!isFailed && !isStreaming)}
+                        onClick={() => void (isFailed ? retryItem(item.id) : steerItem(item.id))}
+                      >
+                        {isFailed ? <RotateCcw /> : <Compass />}
+                        {isFailed
+                          ? i18nService.t('coworkQueueRetry')
+                          : i18nService.t('coworkQueueSteer')}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        title={i18nService.t('delete')}
+                        aria-label={i18nService.t('delete')}
+                        disabled={isSending}
+                        onClick={() => void removeItem(item.id)}
+                      >
+                        <Trash2 />
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          render={
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              title={i18nService.t('coworkQueueMore')}
+                              aria-label={i18nService.t('coworkQueueMore')}
+                              disabled={isSending}
+                            >
+                              <Ellipsis />
+                            </Button>
+                          }
+                        />
+                        <DropdownMenuContent align="end" className="min-w-28">
+                          <DropdownMenuItem onClick={() => beginEdit(item)}>
+                            <Pencil />
+                            {i18nService.t('edit')}
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </>
+                  )}
+                </div>
+              </div>
+            );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PendingMessageQueue;

--- a/src/renderer/services/coworkQueue.ts
+++ b/src/renderer/services/coworkQueue.ts
@@ -1,0 +1,78 @@
+import type { CoworkPendingMessage } from '../../shared/cowork/pendingMessageQueue';
+
+type QueueListener = (items: CoworkPendingMessage[]) => void;
+
+class CoworkQueueService {
+  private readonly itemsBySession = new Map<string, CoworkPendingMessage[]>();
+  private readonly listenersBySession = new Map<string, Set<QueueListener>>();
+  private readonly revisionsBySession = new Map<string, number>();
+  private streamCleanup: (() => void) | null = null;
+
+  subscribe(sessionId: string, listener: QueueListener): () => void {
+    this.ensureStreamListener();
+    const listeners = this.listenersBySession.get(sessionId) ?? new Set<QueueListener>();
+    listeners.add(listener);
+    this.listenersBySession.set(sessionId, listeners);
+    listener(this.itemsBySession.get(sessionId) ?? []);
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) this.listenersBySession.delete(sessionId);
+    };
+  }
+
+  async load(sessionId: string): Promise<CoworkPendingMessage[]> {
+    this.ensureStreamListener();
+    const revisionAtRequest = this.revisionsBySession.get(sessionId) ?? 0;
+    const result = await window.electron.cowork.listPendingMessages(sessionId);
+    if (!result.success) throw new Error(result.error || 'Failed to load pending messages.');
+    if ((this.revisionsBySession.get(sessionId) ?? 0) === revisionAtRequest) {
+      this.publish(sessionId, result.items ?? []);
+      return result.items ?? [];
+    }
+    return this.itemsBySession.get(sessionId) ?? [];
+  }
+
+  enqueue(sessionId: string, text: string) {
+    return window.electron.cowork.enqueuePendingMessage({ sessionId, text });
+  }
+
+  update(sessionId: string, itemId: string, text: string) {
+    return window.electron.cowork.updatePendingMessage({ sessionId, itemId, text });
+  }
+
+  remove(sessionId: string, itemId: string) {
+    return window.electron.cowork.deletePendingMessage({ sessionId, itemId });
+  }
+
+  steer(sessionId: string, itemId: string) {
+    return window.electron.cowork.steerPendingMessage({ sessionId, itemId });
+  }
+
+  followUp(sessionId: string, itemId: string) {
+    return window.electron.cowork.followUpPendingMessage({ sessionId, itemId });
+  }
+
+  dispose(): void {
+    this.streamCleanup?.();
+    this.streamCleanup = null;
+    this.itemsBySession.clear();
+    this.revisionsBySession.clear();
+    this.listenersBySession.clear();
+  }
+
+  private ensureStreamListener(): void {
+    if (this.streamCleanup || !window.electron?.cowork?.onStreamQueueUpdated) return;
+    this.streamCleanup = window.electron.cowork.onStreamQueueUpdated(({ sessionId, items }) => {
+      this.publish(sessionId, items);
+    });
+  }
+
+  private publish(sessionId: string, items: CoworkPendingMessage[]): void {
+    const snapshot = items.map(item => ({ ...item }));
+    this.itemsBySession.set(sessionId, snapshot);
+    this.revisionsBySession.set(sessionId, (this.revisionsBySession.get(sessionId) ?? 0) + 1);
+    this.listenersBySession.get(sessionId)?.forEach(listener => listener(snapshot));
+  }
+}
+
+export const coworkQueueService = new CoworkQueueService();

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -6,6 +6,21 @@ export type LanguageType = 'zh' | 'en';
 // 语言文本映射
 const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
+    coworkQueueTitle: '\u5f85\u5904\u7406\u6d88\u606f',
+    coworkQueueCount: '{count} \u6761\u5f85\u5904\u7406\u6d88\u606f',
+    coworkQueueEmpty: '\u961f\u5217\u4e3a\u7a7a',
+    coworkQueueMore: '\u66f4\u591a\u64cd\u4f5c',
+    coworkQueueStatusPending: '\u5f85\u53d1\u9001',
+    coworkQueueStatusSending: '\u53d1\u9001\u4e2d',
+    coworkQueueStatusFollowUp: '\u4f1a\u8bdd\u7ed3\u675f\u540e\u81ea\u52a8\u53d1\u9001',
+    coworkQueueStatusFailed: '\u53d1\u9001\u5931\u8d25',
+    coworkQueueSteer: '\u5f15\u5bfc',
+    coworkQueueRetry: '\u91cd\u8bd5',
+    coworkQueueUpdateFailed: '\u66f4\u65b0\u5f85\u5904\u7406\u6d88\u606f\u5931\u8d25',
+    coworkQueueDeleteFailed: '\u5220\u9664\u5f85\u5904\u7406\u6d88\u606f\u5931\u8d25',
+    coworkQueueSteerFailed: '\u5f15\u5bfc\u6d88\u606f\u53d1\u9001\u5931\u8d25',
+    coworkQueueRetryFailed: '\u91cd\u8bd5\u5f85\u5904\u7406\u6d88\u606f\u5931\u8d25',
+    coworkQueueEnqueueFailed: '\u6dfb\u52a0\u5f85\u5904\u7406\u6d88\u606f\u5931\u8d25',
     // 通用
     save: '保存',
     cancel: '取消',
@@ -2691,6 +2706,21 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailDeleting: '删除中...',
   },
   en: {
+    coworkQueueTitle: 'Pending messages',
+    coworkQueueCount: '{count} pending',
+    coworkQueueEmpty: 'Queue is empty',
+    coworkQueueMore: 'More actions',
+    coworkQueueStatusPending: 'Pending',
+    coworkQueueStatusSending: 'Sending',
+    coworkQueueStatusFollowUp: 'Sends after the current task',
+    coworkQueueStatusFailed: 'Send failed',
+    coworkQueueSteer: 'Steer',
+    coworkQueueRetry: 'Retry',
+    coworkQueueUpdateFailed: 'Failed to update pending message',
+    coworkQueueDeleteFailed: 'Failed to delete pending message',
+    coworkQueueSteerFailed: 'Failed to steer the message',
+    coworkQueueRetryFailed: 'Failed to retry the queued message',
+    coworkQueueEnqueueFailed: 'Failed to add pending message',
     // Common
     save: 'Save',
     cancel: 'Cancel',

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -8,6 +8,7 @@ import type {
   CoworkPermissionOrigin,
   CoworkSessionMode,
 } from '../../shared/cowork/constants';
+import type { CoworkPendingMessage } from '../../shared/cowork/pendingMessageQueue';
 import type { CoworkToolActivityEvent } from '../../shared/cowork/toolActivity';
 import type { OpenClawEnginePhase } from '../../shared/openclaw/constants';
 import type {
@@ -772,6 +773,30 @@ interface IElectronAPI {
       error?: string;
       code?: string;
     }>;
+    listPendingMessages: (
+      sessionId: string,
+    ) => Promise<{ success: boolean; items?: CoworkPendingMessage[]; error?: string }>;
+    enqueuePendingMessage: (options: {
+      sessionId: string;
+      text: string;
+    }) => Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
+    updatePendingMessage: (options: {
+      sessionId: string;
+      itemId: string;
+      text: string;
+    }) => Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
+    deletePendingMessage: (options: {
+      sessionId: string;
+      itemId: string;
+    }) => Promise<{ success: boolean; error?: string }>;
+    steerPendingMessage: (options: {
+      sessionId: string;
+      itemId: string;
+    }) => Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
+    followUpPendingMessage: (options: {
+      sessionId: string;
+      itemId: string;
+    }) => Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
     stopSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
     saveSession: (session: Record<string, unknown>) => Promise<CoworkSessionResult>;
     deleteSession: (sessionId: string) => Promise<{ success: boolean; error?: string }>;
@@ -892,6 +917,9 @@ interface IElectronAPI {
     ) => () => void;
     onStreamError: (
       callback: (data: { sessionId: string; error: CoworkError }) => void,
+    ) => () => void;
+    onStreamQueueUpdated: (
+      callback: (data: { sessionId: string; items: CoworkPendingMessage[] }) => void,
     ) => () => void;
     onSessionsChanged: (callback: (data: { sessionId?: string }) => void) => () => void;
   };

--- a/src/shared/cowork/pendingMessageQueue.ts
+++ b/src/shared/cowork/pendingMessageQueue.ts
@@ -1,0 +1,32 @@
+/**
+ * Work-only pending message queue shared by the Electron main process and
+ * renderer. Queue state is intentionally in-memory and scoped to a live
+ * session; it is not part of the persisted cowork session protocol.
+ */
+
+export const CoworkQueueDelivery = {
+  Steer: 'steer',
+  FollowUp: 'followUp',
+} as const;
+
+export type CoworkQueueDelivery =
+  (typeof CoworkQueueDelivery)[keyof typeof CoworkQueueDelivery];
+
+export const CoworkQueueItemStatus = {
+  Pending: 'pending',
+  Sending: 'sending',
+  Failed: 'failed',
+} as const;
+
+export type CoworkQueueItemStatus =
+  (typeof CoworkQueueItemStatus)[keyof typeof CoworkQueueItemStatus];
+
+export interface CoworkPendingMessage {
+  id: string;
+  text: string;
+  delivery: CoworkQueueDelivery;
+  createdAt: number;
+  status: CoworkQueueItemStatus;
+  error?: string;
+}
+

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -152,6 +152,17 @@ export const CoworkSessionIpc = {
 } as const;
 export type CoworkSessionIpc = (typeof CoworkSessionIpc)[keyof typeof CoworkSessionIpc];
 
+// 鈹€鈹€鈹€ Cowork pending Work messages 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+export const CoworkQueueIpc = {
+  List: 'cowork:queue:list',
+  Enqueue: 'cowork:queue:enqueue',
+  Update: 'cowork:queue:update',
+  Delete: 'cowork:queue:delete',
+  Steer: 'cowork:queue:steer',
+  FollowUp: 'cowork:queue:followUp',
+} as const;
+export type CoworkQueueIpc = (typeof CoworkQueueIpc)[keyof typeof CoworkQueueIpc];
+
 // ─── Cowork Permission ──────────────────────────────────────────────────────
 export const CoworkPermissionIpc = {
   Respond: 'cowork:permission:respond',
@@ -191,6 +202,7 @@ export const CoworkStreamIpc = {
   PermissionDismiss: 'cowork:stream:permissionDismiss',
   Complete: 'cowork:stream:complete',
   Error: 'cowork:stream:error',
+  QueueUpdated: 'cowork:stream:queueUpdated',
   SessionsChanged: 'cowork:sessions:changed',
 } as const;
 export type CoworkStreamIpc = (typeof CoworkStreamIpc)[keyof typeof CoworkStreamIpc];

--- a/src/shared/ipc/queueSchemas.ts
+++ b/src/shared/ipc/queueSchemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const CoworkQueueSessionSchema = z.string().min(1);
+
+export const CoworkQueueEnqueueSchema = z.object({
+  sessionId: CoworkQueueSessionSchema,
+  text: z.string().trim().min(1).max(100_000),
+});
+
+export const CoworkQueueUpdateSchema = z.object({
+  sessionId: CoworkQueueSessionSchema,
+  itemId: z.string().min(1),
+  text: z.string().trim().min(1).max(100_000),
+});
+
+export const CoworkQueueItemSchema = z.object({
+  sessionId: CoworkQueueSessionSchema,
+  itemId: z.string().min(1),
+});


### PR DESCRIPTION
## 变更内容

### 队列基础设施 (ea490702)
- 新增 pending message queue 共享类型与主进程实现

### 主进程 (f20efcd0)
- piRuntimeAdapter 支持 steer 消息排队与注入
- 注册队列 IPC 通道

### 渲染进程 (1079dbcd)
- 新增 PendingMessageQueue 组件
- CoworkPromptInput 支持 steer 排队
- i18n 新增相关 key