### PR TITLE
feat(cowork): 会话审批体验重构——审批模式与权限策略改进

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -519,6 +519,7 @@ export interface CoworkConfig {
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
   permissionMode: CoworkPermissionModeType;
+  permissionModeBySession: Record<string, CoworkPermissionModeType>;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -541,6 +542,7 @@ export type CoworkConfigUpdate = Partial<
     | 'memoryUserMemoriesMaxItems'
     | 'skipMissedJobs'
     | 'permissionMode'
+    | 'permissionModeBySession'
     | 'embeddingEnabled'
     | 'embeddingProvider'
     | 'embeddingModel'
@@ -1572,6 +1574,7 @@ export class CoworkStore {
       'memoryUserMemoriesMaxItems',
       'skipMissedJobs',
       'permissionMode',
+      'permissionModeBySession',
       'embeddingEnabled',
       'embeddingProvider',
       'embeddingModel',
@@ -1606,6 +1609,20 @@ export class CoworkStore {
       ),
       skipMissedJobs: parseBooleanConfig(cfg.get('skipMissedJobs'), true),
       permissionMode: normalizePermissionMode(cfg.get('permissionMode')),
+      permissionModeBySession: (() => {
+        try {
+          const parsed = JSON.parse(cfg.get('permissionModeBySession') || '{}');
+          if (!parsed || typeof parsed !== 'object') return {};
+          return Object.fromEntries(
+            Object.entries(parsed).filter(
+              ([, value]) =>
+                value === CoworkPermissionMode.Ask || value === CoworkPermissionMode.AllowAll,
+            ),
+          ) as Record<string, CoworkPermissionModeType>;
+        } catch {
+          return {};
+        }
+      })(),
       embeddingEnabled: parseBooleanConfig(cfg.get('embeddingEnabled'), DEFAULT_EMBEDDING_ENABLED),
       embeddingProvider: cfg.get('embeddingProvider') || DEFAULT_EMBEDDING_PROVIDER,
       embeddingModel: cfg.get('embeddingModel') || DEFAULT_EMBEDDING_MODEL,
@@ -1662,6 +1679,9 @@ export class CoworkStore {
     }
     if (config.permissionMode !== undefined) {
       this.upsertConfig('permissionMode', normalizePermissionMode(config.permissionMode), now);
+    }
+    if (config.permissionModeBySession !== undefined) {
+      this.upsertConfig('permissionModeBySession', JSON.stringify(config.permissionModeBySession), now);
     }
     if (config.embeddingEnabled !== undefined) {
       this.upsertConfig('embeddingEnabled', config.embeddingEnabled ? '1' : '0', now);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -994,6 +994,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
   }
 
+  /** Applies the global permission mode to sessions that are already running. */
+  setAutoApproveForActiveSessions(autoApprove: boolean): void {
+    for (const active of this.activeSessions.values()) {
+      active.autoApprove = autoApprove;
+    }
+  }
+
   respondToPermission(requestId: string, result: PiPermissionResult): void {
     const pendingQuestion = this.pendingAskUserQuestions.get(requestId);
     if (pendingQuestion) {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -995,10 +995,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   /** Applies the global permission mode to sessions that are already running. */
-  setAutoApproveForActiveSessions(autoApprove: boolean): void {
-    for (const active of this.activeSessions.values()) {
-      active.autoApprove = autoApprove;
-    }
+  setAutoApproveForSession(sessionId: string, autoApprove: boolean): void {
+    const active = this.activeSessions.get(sessionId);
+    if (active) active.autoApprove = autoApprove;
   }
 
   respondToPermission(requestId: string, result: PiPermissionResult): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5611,6 +5611,11 @@ if (!gotTheLock) {
         const previousConfig = getCoworkStore().getConfig();
         const previousWorkingDir = previousConfig.workingDirectory;
         getCoworkStore().setConfig(normalizedConfig);
+        if (normalizedPermissionMode !== undefined) {
+          getPiRuntimeAdapter().setAutoApproveForActiveSessions(
+            normalizedPermissionMode === CoworkPermissionMode.AllowAll,
+          );
+        }
         if (
           normalizedConfig.workingDirectory !== undefined &&
           normalizedConfig.workingDirectory !== previousWorkingDir

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5542,6 +5542,7 @@ if (!gotTheLock) {
         memoryUserMemoriesMaxItems?: number;
         skipMissedJobs?: boolean;
         permissionMode?: CoworkPermissionMode;
+        permissionModeBySession?: Record<string, CoworkPermissionMode>;
         embeddingEnabled?: boolean;
         embeddingProvider?: string;
         embeddingModel?: string;
@@ -5594,6 +5595,15 @@ if (!gotTheLock) {
           config.permissionMode === CoworkPermissionMode.AllowAll
             ? config.permissionMode
             : undefined;
+        const normalizedPermissionModeBySession =
+          config.permissionModeBySession && typeof config.permissionModeBySession === 'object'
+            ? Object.fromEntries(
+                Object.entries(config.permissionModeBySession).filter(
+                  ([, value]) =>
+                    value === CoworkPermissionMode.Ask || value === CoworkPermissionMode.AllowAll,
+                ),
+              )
+            : undefined;
         const normalizedEmbedding = normalizeEmbeddingConfig(config);
         const normalizedConfig: Parameters<CoworkStore['setConfig']>[0] = {
           ...config,
@@ -5606,15 +5616,19 @@ if (!gotTheLock) {
           memoryUserMemoriesMaxItems: normalizedMemoryUserMemoriesMaxItems,
           skipMissedJobs: normalizedSkipMissedJobs,
           permissionMode: normalizedPermissionMode,
+          permissionModeBySession: normalizedPermissionModeBySession,
           ...normalizedEmbedding,
         };
         const previousConfig = getCoworkStore().getConfig();
         const previousWorkingDir = previousConfig.workingDirectory;
         getCoworkStore().setConfig(normalizedConfig);
-        if (normalizedPermissionMode !== undefined) {
-          getPiRuntimeAdapter().setAutoApproveForActiveSessions(
-            normalizedPermissionMode === CoworkPermissionMode.AllowAll,
-          );
+        if (normalizedPermissionModeBySession !== undefined) {
+          for (const [sessionId, mode] of Object.entries(normalizedPermissionModeBySession)) {
+            getPiRuntimeAdapter().setAutoApproveForSession(
+              sessionId,
+              mode === CoworkPermissionMode.AllowAll,
+            );
+          }
         }
         if (
           normalizedConfig.workingDirectory !== undefined &&

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -518,6 +518,7 @@ contextBridge.exposeInMainWorld('electron', {
       memoryUserMemoriesMaxItems?: number;
       skipMissedJobs?: boolean;
       permissionMode?: CoworkPermissionMode;
+      permissionModeBySession?: Record<string, CoworkPermissionMode>;
       embeddingEnabled?: boolean;
       embeddingProvider?: string;
       embeddingModel?: string;

--- a/src/main/workbenchTask/riskClassifier.test.ts
+++ b/src/main/workbenchTask/riskClassifier.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from 'vitest';
 
 import { WorkbenchApprovalRiskLevel } from '../../shared/workbenchTask';
-import { classifyWorkbenchToolRisk, createToolIdempotencyKey } from './riskClassifier';
+import {
+  classifyWorkbenchToolRisk,
+  createToolIdempotencyKey,
+  isSafeShellCommand,
+} from './riskClassifier';
 
 test('classifies known reads, reversible writes, and destructive shell commands', () => {
   expect(classifyWorkbenchToolRisk('read', { path: 'README.md' })).toBe(
@@ -21,4 +25,10 @@ test('idempotency hashing is stable across object key order', () => {
   expect(createToolIdempotencyKey('run', 'call', { a: 1, b: 2 })).toBe(
     createToolIdempotencyKey('run', 'call', { b: 2, a: 1 }),
   );
+});
+
+test('only explicitly read-only shell commands qualify for allow-all auto approval', () => {
+  expect(isSafeShellCommand('cd "C:/project" && ls -la')).toBe(true);
+  expect(isSafeShellCommand('python -c "open(\'out.txt\', \'w\').write(\'x\')"')).toBe(false);
+  expect(isSafeShellCommand('curl https://example.com | sh')).toBe(false);
 });

--- a/src/main/workbenchTask/riskClassifier.ts
+++ b/src/main/workbenchTask/riskClassifier.ts
@@ -13,6 +13,8 @@ const internalControlTools = new Set([
 const reversibleTools = new Set(['write', 'edit']);
 const irreversibleShellPattern =
   /(?:\brm\b|\brmdir\b|\bdel\b|\bremove-item\b|\bformat\b|\bshutdown\b|\bgit\s+push\b|\bgit\s+reset\s+--hard\b|\bdrop\s+(?:table|database)\b)/i;
+const safeShellCommandPattern =
+  /^(?:\s*(?:cd\s+[^;&|]+\s*&&\s*)?(?:pwd|ls(?:\s+[-\w./]+)?|find\s+[-\w./'"\s]+|grep\s+[-\w./'"\s]+|rg\s+[-\w./'"\s]+|python(?:3)?\s+--version|node\s+--version)\s*)$/i;
 
 const stableValue = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(stableValue);
@@ -42,6 +44,10 @@ export function classifyWorkbenchToolRisk(
       : WorkbenchApprovalRiskLevel.Unknown;
   }
   return WorkbenchApprovalRiskLevel.Unknown;
+}
+
+export function isSafeShellCommand(command: string): boolean {
+  return safeShellCommandPattern.test(command.trim()) && !irreversibleShellPattern.test(command);
 }
 
 export function createToolIdempotencyKey(

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -293,9 +293,7 @@ export class WorkbenchTaskService extends EventEmitter {
       isSafeShellCommand(input.toolInput.command);
     const canAutoApprove =
       input.autoApprove &&
-      (riskLevel === WorkbenchApprovalRiskLevel.ReadOnly ||
-        riskLevel === WorkbenchApprovalRiskLevel.Reversible ||
-        safeShell);
+      (riskLevel === WorkbenchApprovalRiskLevel.Reversible || safeShell);
     const approval = this.repository.transaction(() => {
       const created = this.repository.createApproval({
         taskId: task.id,

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -280,7 +280,10 @@ export class WorkbenchTaskService extends EventEmitter {
     if (existing) {
       return { allow: false, reason: this.getDuplicateApprovalReason(existing) };
     }
-    const canAutoApprove = input.autoApprove && riskLevel === WorkbenchApprovalRiskLevel.Reversible;
+    // "Allow all" skips routine and unknown tool prompts, while irreversible
+    // effects still require an explicit confirmation as a safety boundary.
+    const canAutoApprove =
+      input.autoApprove && riskLevel !== WorkbenchApprovalRiskLevel.Irreversible;
     const approval = this.repository.transaction(() => {
       const created = this.repository.createApproval({
         taskId: task.id,

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -24,7 +24,11 @@ import {
 } from '../../shared/workbenchTask';
 import { collectWorkbenchArtifacts } from './artifactCollector';
 import { WorkbenchTaskRepository } from './repository';
-import { classifyWorkbenchToolRisk, createToolIdempotencyKey } from './riskClassifier';
+import {
+  classifyWorkbenchToolRisk,
+  createToolIdempotencyKey,
+  isSafeShellCommand,
+} from './riskClassifier';
 import { verifyWorkbenchRun, type WorkbenchVerificationContext } from './verification';
 
 export interface WorkbenchApprovalRequestedEvent {
@@ -282,8 +286,16 @@ export class WorkbenchTaskService extends EventEmitter {
     }
     // "Allow all" skips routine and unknown tool prompts, while irreversible
     // effects still require an explicit confirmation as a safety boundary.
+    const normalizedToolName = input.toolName.trim().toLowerCase();
+    const safeShell =
+      (normalizedToolName === 'bash' || normalizedToolName === 'shell') &&
+      typeof input.toolInput.command === 'string' &&
+      isSafeShellCommand(input.toolInput.command);
     const canAutoApprove =
-      input.autoApprove && riskLevel !== WorkbenchApprovalRiskLevel.Irreversible;
+      input.autoApprove &&
+      (riskLevel === WorkbenchApprovalRiskLevel.ReadOnly ||
+        riskLevel === WorkbenchApprovalRiskLevel.Reversible ||
+        safeShell);
     const approval = this.repository.transaction(() => {
       const created = this.repository.createApproval({
         taskId: task.id,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,13 +1,11 @@
 import { Button } from '@shared/components/ui/button';
 import { TooltipProvider } from '@shared/components/ui/tooltip';
 import { MessageCircle } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { type AppUpdateRuntimeState, AppUpdateStatus } from '../shared/appUpdate/constants';
 import { CoworkView } from './components/cowork';
-import CoworkPermissionModal from './components/cowork/CoworkPermissionModal';
-import CoworkQuestionWizard from './components/cowork/CoworkQuestionWizard';
 import {
   hasAskUserQuestions,
   isAskUserQuestionPermission,
@@ -37,7 +35,7 @@ import { themeService } from './services/theme';
 import { RootState, store } from './store';
 import {
   selectCurrentSessionId,
-  selectFirstPendingPermission,
+  selectPendingPermissions,
 } from './store/selectors/coworkSelectors';
 import { setDraftPrompt } from './store/slices/coworkSlice';
 import { setAvailableModels, setDefaultSelectedModel } from './store/slices/modelSlice';
@@ -120,7 +118,8 @@ const App: React.FC = () => {
   const dispatch = useDispatch();
   const defaultSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const currentSessionId = useSelector(selectCurrentSessionId);
-  const pendingPermission = useSelector(selectFirstPendingPermission);
+  const pendingPermissions = useSelector(selectPendingPermissions);
+  const pendingPermission = pendingPermissions.find(permission => permission.sessionId === currentSessionId) ?? null;
   const isWindows = window.electron.platform === 'win32';
 
   const waitWithTimeout = useCallback(
@@ -637,33 +636,7 @@ const App: React.FC = () => {
 
   // Update system is permanently disabled
 
-  // 根据场景选择使用哪个权限组件
-  const permissionModal = useMemo(() => {
-    if (!pendingPermission || isInlineAskUserQuestion) return null;
-
-    // 检查是否为 AskUserQuestion 且有多个问题 -> 使用向导式组件
-    const isQuestionTool = isAskUserQuestionPermission(pendingPermission);
-    if (isQuestionTool && pendingPermission.toolInput) {
-      const rawQuestions = (pendingPermission.toolInput as Record<string, unknown>).questions;
-      const hasMultipleQuestions = Array.isArray(rawQuestions) && rawQuestions.length > 1;
-
-      if (hasMultipleQuestions) {
-        return (
-          <CoworkQuestionWizard
-            permission={pendingPermission}
-            onRespond={handlePermissionResponse}
-          />
-        );
-      }
-    }
-
-    // 其他情况使用原有的权限模态框
-    return (
-      <CoworkPermissionModal permission={pendingPermission} onRespond={handlePermissionResponse} />
-    );
-  }, [pendingPermission, handlePermissionResponse, isInlineAskUserQuestion]);
-
-  const isOverlayActive = showSettings || permissionModal !== null;
+  const isOverlayActive = showSettings;
   const shouldShowUpdateBadge =
     updateInfo &&
     (appUpdateState.status === AppUpdateStatus.Ready ||
@@ -842,6 +815,15 @@ const App: React.FC = () => {
                       updateBadge={null}
                       inlineQuestionPermission={isInlineAskUserQuestion ? pendingPermission : null}
                       onRespondToInlineQuestion={handlePermissionResponse}
+                      inlinePermission={
+                        pendingPermission &&
+                        mainView === 'cowork' &&
+                        pendingPermission.sessionId === currentSessionId &&
+                        !isInlineAskUserQuestion
+                          ? pendingPermission
+                          : null
+                      }
+                      onRespondToInlinePermission={handlePermissionResponse}
                     />
                   )}
                 </React.Suspense>
@@ -863,7 +845,6 @@ const App: React.FC = () => {
             </React.Suspense>
           </LazyChunkErrorBoundary>
         )}
-        {permissionModal}
       </div>
     </TooltipProvider>
   );

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -21,6 +21,8 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { selectPendingPermissions } from '../../store/selectors/coworkSelectors';
+import { useSelector } from 'react-redux';
 import { BatchSelectionCheckbox } from './BatchSelectionCheckbox';
 import { AgentSidebarIndicator } from './constants';
 import OverflowingSessionTitle from './OverflowingSessionTitle';
@@ -100,10 +102,13 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
       : i18nService.t('myAgentSidebarUnreadResult');
   const relativeTime = formatAgentTaskRelativeTime(task.updatedAt || task.createdAt);
   const isRunning = task.indicator === AgentSidebarIndicator.Running;
-  const showRelativeTime = !isRunning;
   const pinLabel = task.pinned
     ? i18nService.t('coworkUnpinSession')
     : i18nService.t('coworkPinSession');
+  const hasPendingPermission = useSelector(selectPendingPermissions).some(
+    permission => permission.sessionId === task.id,
+  );
+  const showRelativeTime = !isRunning && !hasPendingPermission;
 
   return (
     <div
@@ -140,7 +145,14 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
           className="min-w-0 flex-1 border border-border bg-background px-1.5 py-0.5 text-[14px] font-normal"
         />
       ) : (
-        <OverflowingSessionTitle title={task.title} />
+        <>
+          <OverflowingSessionTitle title={task.title} />
+          {hasPendingPermission && (
+            <span className="inline-flex shrink-0 items-center rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+              {i18nService.t('workbenchTaskStatusWaitingApproval')}
+            </span>
+          )}
+        </>
       )}
 
       {!isBatchMode && !isRenaming && (
@@ -153,7 +165,15 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
               {relativeTime.compact}
             </span>
           )}
-          {isRunning && (
+          {hasPendingPermission && (
+            <span
+              className="absolute inset-y-0 right-0 inline-flex size-6 items-center justify-center transition-opacity group-hover:pointer-events-none group-hover:opacity-0"
+              title={i18nService.t('workbenchTaskStatusWaitingApproval')}
+            >
+              <Loader className="size-3 animate-spin text-success [animation-duration:1.8s]" />
+            </span>
+          )}
+          {!hasPendingPermission && isRunning && (
             <span
               className="absolute inset-y-0 right-0 inline-flex size-6 items-center justify-center transition-opacity group-hover:pointer-events-none group-hover:opacity-0"
               title={indicatorLabel}

--- a/src/renderer/components/cowork/CoworkPermissionModal.tsx
+++ b/src/renderer/components/cowork/CoworkPermissionModal.tsx
@@ -72,6 +72,7 @@ function detectDangerLevelFromCommand(command: string): DangerLevel {
 interface CoworkPermissionModalProps {
   permission: CoworkPermissionRequest;
   onRespond: (result: CoworkPermissionResult) => void;
+  inline?: boolean;
 }
 
 type QuestionOption = {
@@ -117,7 +118,11 @@ const resolveConfirmModeButtons = (
   return { primary: firstOption, secondary: secondOption };
 };
 
-const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({ permission, onRespond }) => {
+const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({
+  permission,
+  onRespond,
+  inline = false,
+}) => {
   const toolInput = useMemo(() => permission.toolInput ?? {}, [permission.toolInput]);
 
   const questions = useMemo<QuestionItem[]>(() => {
@@ -353,10 +358,16 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({ permissio
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
-      <div className="modal-content w-full max-w-lg mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center gap-3 px-6 py-4 border-b border-border">
+    <div className={inline ? 'w-full' : 'fixed inset-0 z-50 flex items-center justify-center modal-backdrop'}>
+      <div
+        className={
+          inline
+            ? 'w-full bg-surface-raised border border-border rounded-2xl shadow-sm overflow-hidden'
+            : 'modal-content w-full max-w-lg mx-4 bg-surface rounded-2xl shadow-modal overflow-hidden'
+        }
+      >
+        {!inline && (
+          <div className="flex items-center gap-3 px-6 py-4 border-b border-border">
           <div
             className={`p-2 rounded-full ${isQuestionTool && !isConfirmMode ? 'bg-blue-100 dark:bg-blue-900/30' : 'bg-yellow-100 dark:bg-yellow-900/30'}`}
           >
@@ -376,13 +387,16 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({ permissio
                 : i18nService.t('coworkPermissionDescription')}
             </p>
           </div>
-          <Button variant="ghost" size="icon" onClick={handleDeny} aria-label="Close">
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
+          {!inline && (
+            <Button variant="ghost" size="icon" onClick={handleDeny} aria-label="Close">
+              <X className="h-5 w-5" />
+            </Button>
+          )}
+          </div>
+        )}
 
         {/* Content */}
-        <div className="px-6 py-4 space-y-4 max-h-[60vh] overflow-y-auto">
+        <div className={inline ? 'px-5 py-4 space-y-4 max-h-[42vh] overflow-y-auto' : 'px-6 py-4 space-y-4 max-h-[60vh] overflow-y-auto'}>
           {isConfirmMode ? (
             /* Simple confirm dialog — show question text + allow/deny buttons */
             <div className="px-3 py-2 rounded-lg bg-background">
@@ -454,6 +468,22 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({ permissio
                 );
               })}
             </>
+          ) : inline ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-background border border-border">
+                  <code className="text-[11px]">&gt;_</code>
+                </span>
+                <span>{permission.toolName}</span>
+              </div>
+              <div className="rounded-xl bg-background px-3 py-2.5">
+                <pre className="text-xs text-foreground whitespace-pre-wrap wrap-break-word font-mono max-h-24 overflow-y-auto">
+                  {typeof toolInput.command === 'string'
+                    ? toolInput.command
+                    : formatToolInput(permission.toolInput)}
+                </pre>
+              </div>
+            </div>
           ) : (
             <>
               {/* Tool name */}
@@ -512,7 +542,7 @@ const CoworkPermissionModal: React.FC<CoworkPermissionModalProps> = ({ permissio
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-border">
+        <div className={inline ? 'flex items-center justify-end gap-3 px-5 py-3' : 'flex items-center justify-end gap-3 px-6 py-4 border-t border-border'}>
           <Button
             variant="ghost"
             onClick={

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -103,6 +103,7 @@ import { useConversationRailScrollSync } from './hooks/useConversationRailScroll
 import { useTodoQueueLifecycle } from './hooks/useTodoQueueLifecycle';
 import { TodoQueue } from './TodoQueue';
 import AskUserQuestionCard from './AskUserQuestionCard';
+import CoworkPermissionModal from './CoworkPermissionModal';
 import { WorkbenchTaskStatusBar } from './WorkbenchTaskStatus';
 
 // The artifact panel only mounts when the user opens it, so keep its code
@@ -133,6 +134,8 @@ interface CoworkSessionDetailProps {
   onLocalThinkingEnabledChange?: (enabled: boolean | undefined) => void;
   inlineQuestionPermission?: CoworkPermissionRequest | null;
   onRespondToInlineQuestion?: (result: CoworkPermissionResult) => void | Promise<void>;
+  inlinePermission?: CoworkPermissionRequest | null;
+  onRespondToInlinePermission?: (result: CoworkPermissionResult) => void | Promise<void>;
 }
 
 const NAV_SCROLL_LOCK_DURATION = 800;
@@ -193,6 +196,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   onLocalThinkingEnabledChange,
   inlineQuestionPermission,
   onRespondToInlineQuestion,
+  inlinePermission,
+  onRespondToInlinePermission,
 }) => {
   const dispatch = useDispatch();
   const isMac = window.electron.platform === 'darwin';
@@ -1204,7 +1209,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       <div ref={contentRowRef} className="flex-1 flex overflow-hidden">
         <div
           ref={detailRootRef}
-          className={`min-w-0 flex-1 flex flex-col bg-background h-full ${
+          className={`relative min-w-0 flex-1 flex flex-col bg-background h-full ${
             isArtifactWorkspace ? 'hidden' : ''
           }`}
           aria-hidden={isArtifactWorkspace}
@@ -1474,6 +1479,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               )}
           </div>
 
+          {inlinePermission && onRespondToInlinePermission && (
+            <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4">
+              <div className="w-full max-w-5xl mx-auto">
+                <CoworkPermissionModal
+                  permission={inlinePermission}
+                  onRespond={onRespondToInlinePermission}
+                  inline
+                />
+              </div>
+            </div>
+          )}
+
           {/* Input Area */}
           <div className="px-4 pb-4 shrink-0">
             <div className="max-w-5xl min-w-[320px] mx-auto pl-4">
@@ -1500,7 +1517,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                       ? 'chatPlaceholder'
                       : 'coworkContinuePlaceholder',
                 )}
-                disabled={remoteManaged || isAwaitingInlineQuestion}
+                disabled={remoteManaged || isAwaitingInlineQuestion || Boolean(inlinePermission)}
                 size="large"
                 remoteManaged={remoteManaged}
                 onManageSkills={remoteManaged ? undefined : onManageSkills}

--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -16,6 +16,7 @@ import type { CoworkSessionStatus, CoworkSessionSummary } from '../../types/cowo
 interface CoworkSessionItemProps {
   session: CoworkSessionSummary;
   hasUnread: boolean;
+  hasPendingPermission: boolean;
   isActive: boolean;
   isBatchMode: boolean;
   isSelected: boolean;
@@ -69,6 +70,7 @@ const formatRelativeTime = (timestamp: number): { compact: string; full: string 
 const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
   session,
   hasUnread,
+  hasPendingPermission,
   isActive,
   isBatchMode,
   isSelected,
@@ -179,8 +181,9 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
   const deleteLabel = i18nService.t('deleteSession');
   const relativeTime = formatRelativeTime(session.updatedAt);
   const showRunningIndicator = session.status === 'running';
+  const showPendingPermission = hasPendingPermission;
   const showUnreadIndicator = !showRunningIndicator && hasUnread;
-  const showStatusIndicator = showRunningIndicator || showUnreadIndicator;
+  const showStatusIndicator = showRunningIndicator || showUnreadIndicator || showPendingPermission;
   const showRelativeTime = !showStatusIndicator;
   const batchLabel = i18nService.t('batchOperations');
   const menuItems = useMemo(() => {
@@ -238,11 +241,17 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
             {/* Status indicator */}
             {showStatusIndicator && (
               <span
-                className={`block w-2 h-2 rounded-full bg-ring shrink-0 ${
-                  showRunningIndicator ? 'shadow-[0_0_6px_var(--ring)] animate-pulse' : ''
+                className={`block w-2 h-2 rounded-full shrink-0 ${
+                  showPendingPermission
+                    ? 'bg-success animate-pulse'
+                    : 'bg-ring'
                 }`}
                 title={
-                  showRunningIndicator ? i18nService.t(statusLabels[session.status]) : undefined
+                  showPendingPermission
+                    ? i18nService.t('workbenchTaskStatusWaitingApproval')
+                    : showRunningIndicator
+                      ? i18nService.t(statusLabels[session.status])
+                      : undefined
                 }
               />
             )}
@@ -264,19 +273,30 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
                 className="flex-1 min-w-0 rounded-lg border border-input bg-background px-2 py-1 text-sm font-medium text-foreground transition-colors outline-none hover:ring-1 hover:ring-ring/40 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/40"
               />
             ) : (
-              <h3 className="text-sm font-medium text-foreground truncate">{session.title}</h3>
+              <div className="flex min-w-0 items-center gap-2">
+                <h3 className="min-w-0 truncate text-sm font-medium text-foreground">
+                  {session.title}
+                </h3>
+                {showPendingPermission && (
+                  <span className="inline-flex shrink-0 items-center rounded-full bg-success/15 px-2 py-0.5 text-xs font-medium text-success">
+                    {i18nService.t('workbenchTaskStatusWaitingApproval')}
+                  </span>
+                )}
+              </div>
             )}
           </div>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {showRelativeTime && (
-              <span className="whitespace-nowrap" title={relativeTime.full}>
-                {relativeTime.compact}
+          {!showPendingPermission && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {showRelativeTime && (
+                <span className="whitespace-nowrap" title={relativeTime.full}>
+                  {relativeTime.compact}
+                </span>
+              )}
+              <span className="text-[10px] uppercase tracking-wider whitespace-nowrap">
+                {i18nService.t(statusLabels[session.status])}
               </span>
-            )}
-            <span className="text-[10px] uppercase tracking-wider whitespace-nowrap">
-              {i18nService.t(statusLabels[session.status])}
-            </span>
-          </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/renderer/components/cowork/CoworkSessionList.tsx
+++ b/src/renderer/components/cowork/CoworkSessionList.tsx
@@ -3,7 +3,10 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { i18nService } from '../../services/i18n';
-import { selectUnreadSessionIds } from '../../store/selectors/coworkSelectors';
+import {
+  selectPendingPermissions,
+  selectUnreadSessionIds,
+} from '../../store/selectors/coworkSelectors';
 import type { CoworkSessionSummary } from '../../types/cowork';
 import CoworkSessionItem from './CoworkSessionItem';
 
@@ -43,7 +46,12 @@ const CoworkSessionList: React.FC<CoworkSessionListProps> = ({
   emptyHint,
 }) => {
   const unreadSessionIds = useSelector(selectUnreadSessionIds);
+  const pendingPermissions = useSelector(selectPendingPermissions);
   const unreadSessionIdSet = useMemo(() => new Set(unreadSessionIds), [unreadSessionIds]);
+  const pendingSessionIdSet = useMemo(
+    () => new Set(pendingPermissions.map(permission => permission.sessionId)),
+    [pendingPermissions],
+  );
 
   const sortedSessions = useMemo(() => {
     const sortByPinOrder = (a: CoworkSessionSummary, b: CoworkSessionSummary) => {
@@ -113,6 +121,7 @@ const CoworkSessionList: React.FC<CoworkSessionListProps> = ({
           key={session.id}
           session={session}
           hasUnread={unreadSessionIdSet.has(session.id)}
+          hasPendingPermission={pendingSessionIdSet.has(session.id)}
           isActive={session.id === currentSessionId}
           isBatchMode={isBatchMode}
           isSelected={selectedIds.has(session.id)}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -190,6 +190,9 @@ const CoworkView: React.FC<CoworkViewProps> = ({
 
   const isStreaming = useSelector(selectIsStreaming);
   const config = useSelector(selectCoworkConfig);
+  const sessionPermissionMode = currentSession
+    ? (config.permissionModeBySession?.[currentSession.id] ?? config.permissionMode)
+    : config.permissionMode;
 
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const skills = useSelector((state: RootState) => state.skill.skills);
@@ -1268,7 +1271,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         systemPrompt: currentSession.systemPrompt || combinedSystemPrompt,
         activeSkillIds: sessionSkillIds.length > 0 ? sessionSkillIds : undefined,
         expertIds,
-        permissionMode: config.permissionMode,
+        permissionMode: sessionPermissionMode,
         imageAttachments,
       });
     } finally {
@@ -1439,9 +1442,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({
           sessionId={displayedSessionId}
           onManageSkills={() => onShowSkills?.()}
           onManageConnectors={() => onShowConnectors?.()}
-          permissionMode={config.permissionMode}
+          permissionMode={sessionPermissionMode}
           onPermissionModeChange={(mode: CoworkPermissionMode) => {
-            void coworkService.updateConfig({ permissionMode: mode });
+            if (!currentSession) return;
+            void coworkService.updateConfig({
+              permissionModeBySession: {
+                ...(config.permissionModeBySession ?? {}),
+                [currentSession.id]: mode,
+              },
+            });
           }}
           onContinue={handleContinueSession}
           onStop={handleStopSession}

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -71,6 +71,8 @@ export interface CoworkViewProps {
   updateBadge?: React.ReactNode;
   inlineQuestionPermission?: CoworkPermissionRequest | null;
   onRespondToInlineQuestion?: (result: CoworkPermissionResult) => void | Promise<void>;
+  inlinePermission?: CoworkPermissionRequest | null;
+  onRespondToInlinePermission?: (result: CoworkPermissionResult) => void | Promise<void>;
 }
 
 const DirectChatDataChunkType = {
@@ -133,6 +135,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({
   updateBadge,
   inlineQuestionPermission,
   onRespondToInlineQuestion,
+  inlinePermission,
+  onRespondToInlinePermission,
 }) => {
   const dispatch = useDispatch();
 
@@ -1451,6 +1455,8 @@ const CoworkView: React.FC<CoworkViewProps> = ({
           onLocalThinkingEnabledChange={setLocalThinkingEnabled}
           inlineQuestionPermission={inlineQuestionPermission}
           onRespondToInlineQuestion={onRespondToInlineQuestion}
+          inlinePermission={inlinePermission}
+          onRespondToInlinePermission={onRespondToInlinePermission}
         />
       </div>
     );

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -575,6 +575,11 @@ class CoworkService {
     const result = await cowork.deleteSession(sessionId);
     if (result.success) {
       store.dispatch(deleteSessionAction(sessionId));
+      const permissionModeBySession = { ...store.getState().cowork.config.permissionModeBySession };
+      if (permissionModeBySession?.[sessionId]) {
+        delete permissionModeBySession[sessionId];
+        await this.updateConfig({ permissionModeBySession });
+      }
       return true;
     }
 
@@ -589,6 +594,15 @@ class CoworkService {
     const result = await cowork.deleteSessions(sessionIds);
     if (result.success) {
       store.dispatch(deleteSessionsAction(sessionIds));
+      const permissionModeBySession = { ...store.getState().cowork.config.permissionModeBySession };
+      let changed = false;
+      for (const sessionId of sessionIds) {
+        if (permissionModeBySession?.[sessionId]) {
+          delete permissionModeBySession[sessionId];
+          changed = true;
+        }
+      }
+      if (changed) await this.updateConfig({ permissionModeBySession });
       return true;
     }
 

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -78,6 +78,7 @@ const initialState: CoworkState = {
     memoryUserMemoriesMaxItems: 12,
     skipMissedJobs: true,
     permissionMode: CoworkPermissionMode.Ask,
+    permissionModeBySession: {},
     embeddingEnabled: false,
     embeddingProvider: 'openai',
     embeddingModel: '',

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -133,6 +133,7 @@ export interface CoworkConfig {
   memoryUserMemoriesMaxItems: number;
   skipMissedJobs: boolean;
   permissionMode: CoworkPermissionMode;
+  permissionModeBySession?: Record<string, CoworkPermissionMode>;
   embeddingEnabled: boolean;
   embeddingProvider: string;
   embeddingModel: string;
@@ -156,6 +157,7 @@ export type CoworkConfigUpdate = Partial<
     | 'memoryUserMemoriesMaxItems'
     | 'skipMissedJobs'
     | 'permissionMode'
+    | 'permissionModeBySession'
     | 'embeddingEnabled'
     | 'embeddingProvider'
     | 'embeddingModel'

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -752,6 +752,7 @@ interface IElectronAPI {
       agentId?: string;
       expertIds?: string[];
       permissionMode?: CoworkPermissionMode;
+      permissionModeBySession?: Record<string, CoworkPermissionMode>;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
     }) => Promise<{
       success: boolean;


### PR DESCRIPTION
## 变更内容

- 重构会话审批体验 (a8607510)
- 权限模式变更应用到活跃会话 (5018412d)
- 常规 shell 工具 honor allow-all (a36e10c0)
- 权限模式限定到会话级 (4b3e9f23)
- 收紧 allow-all 审批策略 (1b76db36)