### PR TITLE
fix: make Windows Skill runtime independent of host shell

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -91,6 +91,12 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify Windows package runtimes with a clean PATH
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/windows-runtime-smoke.ps1
+          -ProjectRoot ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with:
           name: windows-build

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -78,6 +78,12 @@ jobs:
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify Windows package runtimes with a clean PATH
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/windows-runtime-smoke.ps1
+          -ProjectRoot ${{ github.workspace }}
       - uses: actions/upload-artifact@v4
         with: { name: win32-x64-lite, path: "release/*.exe" }
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ resources/uv-mac/
 resources/python-mac/
 resources/uv-linux/
 resources/python-linux/
+resources/skill-python/
 resources/modelscope.tokens.local.json
 
 # SKILLs runtime files

--- a/SKILLs/docx/SKILL.md
+++ b/SKILLs/docx/SKILL.md
@@ -27,7 +27,26 @@ Create, edit, and format DOCX documents via CLI tools or direct C# scripts built
 
 ## Setup
 
-**First time:** `bash scripts/setup.sh` (or `powershell scripts/setup.ps1` on Windows, `--minimal` to skip optional deps).
+## ZhiYuan/Pi execution
+
+When this skill is run inside ZhiYuan, use the `run_skill_script` tool for every bundled
+`.sh`, `.py`, `.mjs`, or `.ps1` script. Do not invoke `bash`, `python3`, `node`, or `pandoc`
+through a hand-built shell command. The application resolves the packaged Git Bash,
+Pandoc, Python, and Node runtimes and reports the exact unavailable runtime when one is missing.
+Markdown remains the source/intermediate format: create or edit the `.md` with Pi's file tools,
+then run the conversion script through the same tool.
+
+Example:
+
+```json
+{
+  "skillId": "docx",
+  "script": "scripts/markdown_to_docx.sh",
+  "args": ["content.md", "output.docx"]
+}
+```
+
+**First time (CLI reference):** `bash scripts/setup.sh` (or `powershell scripts/setup.ps1` on Windows, `--minimal` to skip optional deps). Inside ZhiYuan, run the corresponding setup script with `run_skill_script`.
 
 **First operation in session:** `bash scripts/env_check.sh`. Do not proceed if `NOT READY`. Packaged Windows and macOS builds provide a private Pandoc binary through `PANDOC_BIN`; never ask an end user to install it. `LIMITED` means that bundled Pandoc can create a simple DOCX from Markdown, but structural editing, template operations, and OpenXML validation still require .NET 8+. (Skip on subsequent operations within the same session.)
 

--- a/SKILLs/docx/SKILL.md
+++ b/SKILLs/docx/SKILL.md
@@ -2,7 +2,7 @@
 name: minimax-docx
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   category: document-processing
   author: MiniMaxAI
   sources:

--- a/SKILLs/pdf/SKILL.md
+++ b/SKILLs/pdf/SKILL.md
@@ -14,7 +14,7 @@ description: >
   Prefer this skill when appearance matters, not just when any PDF output is needed.
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.0.1"
   category: document-generation
 ---
 

--- a/SKILLs/pdf/SKILL.md
+++ b/SKILLs/pdf/SKILL.md
@@ -24,6 +24,23 @@ Three tasks. One skill.
 
 ## Read `design/design.md` before any CREATE or REFORMAT work.
 
+## ZhiYuan/Pi execution
+
+When this skill is run inside ZhiYuan, call `run_skill_script` for the bundled `.py`, `.js`,
+and `.sh` pipeline steps. Pass each argument separately in `args`; do not call `python3`,
+`uv`, or `bash` directly. The application chooses the managed Python/uv/Node/Git Bash runtime
+and returns a structured runtime error instead of misreporting the input PDF as missing.
+
+Example:
+
+```json
+{
+  "skillId": "pdf",
+  "script": "scripts/fill_inspect.py",
+  "args": ["--input", "form.pdf"]
+}
+```
+
 ---
 
 ## Route table

--- a/SKILLs/pdf/requirements.txt
+++ b/SKILLs/pdf/requirements.txt
@@ -1,0 +1,5 @@
+reportlab>=4,<5
+pypdf>=5,<7
+matplotlib>=3.9,<4
+pypdfium2>=4,<5
+pillow>=10,<12

--- a/SKILLs/pdf/scripts/make.sh
+++ b/SKILLs/pdf/scripts/make.sh
@@ -28,7 +28,10 @@
 
 set -euo pipefail
 SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PY="${ZHIYUAN_PYTHON_BIN:-python3}"
+# ZhiYuan supplies a prebuilt, Skill-specific environment when available. Keep
+# the base runtime as the CLI fallback, and only use uv for legacy standalone
+# runs where that private environment has not been prepared.
+PY="${ZHIYUAN_SKILL_PYTHON_BIN:-${ZHIYUAN_PYTHON_BIN:-python3}}"
 NODE="node"
 UV="${ZHIYUAN_UV_BIN:-$(command -v uv || true)}"
 PYTHON_DEPS=(reportlab pypdf matplotlib pypdfium2 pillow)
@@ -42,7 +45,9 @@ bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
 # Packaged builds provide uv plus an externally-managed CPython. Run all PDF
 # helpers in an isolated uv environment instead of mutating that base runtime.
 run_python() {
-  if [[ -n "$UV" ]]; then
+  if [[ -n "${ZHIYUAN_SKILL_PYTHON_BIN:-}" ]]; then
+    "$PY" "$@"
+  elif [[ -n "$UV" ]]; then
     # Do not discover a caller's project/.venv: a Skill must use its own
     # isolated dependency context and never delete or mutate project state.
     local uv_args=(run --quiet --no-project --python "$PY")

--- a/SKILLs/presentation-studio/SKILL.md
+++ b/SKILLs/presentation-studio/SKILL.md
@@ -3,7 +3,7 @@ name: presentation-studio
 description: "The only skill for creating a new PowerPoint deck. Builds a source-backed story and visual system, writes a native editable DeckSpec, blocks export on layout warnings, and compiles a verified PPTX. Triggers: create, generate, design, or lay out a new PPT, PPTX, PowerPoint, presentation, slide deck, pitch deck, report deck, training deck, or slides. Do not use to read or modify an existing PPTX."
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.0.1"
   category: productivity
 ---
 

--- a/SKILLs/presentation-studio/SKILL.md
+++ b/SKILLs/presentation-studio/SKILL.md
@@ -43,22 +43,34 @@ Create an isolated project directory:
 
 ## Tooling
 
+Inside ZhiYuan/Pi, use `run_skill_script` for the validator and compiler so PowerPoint export
+does not depend on a user-installed Node.js. The skill's local `node_modules` remains the
+dependency boundary; the app supplies the Node-compatible runtime.
+
 Install the compiler dependency once per bundled skill copy:
 
 ```bash
-npm install --prefix "<SKILL_DIR>"
+npm install --prefix "<SKILL_DIR>" # packaging/runtime setup only
 ```
 
 Validate before every export:
 
-```bash
-node "<SKILL_DIR>/scripts/validate-deck.mjs" "<deck-dir>/deck.json" --strict --json "<deck-dir>/output/validation.json"
+```json
+{
+  "skillId": "presentation-studio",
+  "script": "scripts/validate-deck.mjs",
+  "args": ["<deck-dir>/deck.json", "--strict", "--json", "<deck-dir>/output/validation.json"]
+}
 ```
 
 Compile only after a clean validation:
 
-```bash
-node "<SKILL_DIR>/scripts/compile-deck.mjs" "<deck-dir>/deck.json" "<deck-dir>/output/presentation.pptx"
+```json
+{
+  "skillId": "presentation-studio",
+  "script": "scripts/compile-deck.mjs",
+  "args": ["<deck-dir>/deck.json", "<deck-dir>/output/presentation.pptx"]
+}
 ```
 
 ## DeckSpec minimum schema

--- a/SKILLs/web-search/SKILL.md
+++ b/SKILLs/web-search/SKILL.md
@@ -47,6 +47,20 @@ Use the web-search skill when you need:
 4. **Search Engine Layer** - Google primary, Bing fallback
 5. **Chrome Browser** - Headless by default; automatically retries once with a visible browser when headless search appears blocked
 
+## ZhiYuan/Pi execution
+
+Inside ZhiYuan, invoke the bundled search script with `run_skill_script` and pass the query as
+an argv item. Do not build a Bash command string. The app starts the service through the managed
+runtime and reports Git Bash/runtime failures separately from search failures.
+
+```json
+{
+  "skillId": "web-search",
+  "script": "scripts/search.sh",
+  "args": ["React Server Components guide", "5"]
+}
+```
+
 ## Basic Usage
 
 ### Simple Search (Recommended)

--- a/SKILLs/web-search/SKILL.md
+++ b/SKILLs/web-search/SKILL.md
@@ -2,7 +2,7 @@
 name: web-search
 description: Real-time web search using Playwright-controlled browser. Use this skill when you need current information, latest documentation, recent news, or any data beyond your knowledge cutoff (January 2025).
 metadata:
-  version: 1.0.2
+  version: 1.0.3
 ---
 
 # Web Search Skill

--- a/SKILLs/xlsx/SKILL.md
+++ b/SKILLs/xlsx/SKILL.md
@@ -3,7 +3,7 @@ name: minimax-xlsx
 description: "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format."
 license: MIT
 metadata:
-  version: '1.0'
+  version: '1.0.1'
   category: productivity
   sources:
     - ECMA-376 Office Open XML File Formats

--- a/SKILLs/xlsx/SKILL.md
+++ b/SKILLs/xlsx/SKILL.md
@@ -3,7 +3,7 @@ name: minimax-xlsx
 description: "Open, create, read, analyze, edit, or validate Excel/spreadsheet files (.xlsx, .xlsm, .csv, .tsv). Use when the user asks to create, build, modify, analyze, read, validate, or format any Excel spreadsheet, financial model, pivot table, or tabular data file. Covers: creating new xlsx from scratch, reading and analyzing existing files, editing existing xlsx with zero format loss, formula recalculation and validation, and applying professional financial formatting standards. Triggers on 'spreadsheet', 'Excel', '.xlsx', '.csv', 'pivot table', 'financial model', 'formula', or any request to produce tabular data in Excel format."
 license: MIT
 metadata:
-  version: "1.0"
+  version: '1.0'
   category: productivity
   sources:
     - ECMA-376 Office Open XML File Formats
@@ -14,15 +14,34 @@ metadata:
 
 Handle the request directly. Do NOT spawn sub-agents. Always write the output file the user requests.
 
+## ZhiYuan/Pi execution
+
+When this skill is run inside ZhiYuan, invoke bundled scripts with the `run_skill_script` tool.
+Pass script arguments as an array; never construct a shell command or call `python3` directly.
+The direct `python3` commands later in this document are CLI-reference examples only; inside
+ZhiYuan, translate each such invocation to `run_skill_script` so the packaged XLSX runtime is used.
+The application supplies its managed Python/uv runtime and the skill's `requirements.txt`, then
+returns distinct errors for a missing script, a missing runtime, and a non-zero script exit.
+
+Example:
+
+```json
+{
+  "skillId": "xlsx",
+  "script": "scripts/xlsx_reader.py",
+  "args": ["input.xlsx", "--json"]
+}
+```
+
 ## Task Routing
 
-| Task | Method | Guide |
-|------|--------|-------|
-| **READ** — analyze existing data | `xlsx_reader.py` + pandas | `references/read-analyze.md` |
-| **CREATE** — new xlsx from scratch | XML template | `references/create.md` + `references/format.md` |
-| **EDIT** — modify existing xlsx | XML unpack→edit→pack | `references/edit.md` (+ `format.md` if styling needed) |
-| **FIX** — repair broken formulas in existing xlsx | XML unpack→fix `<f>` nodes→pack | `references/fix.md` |
-| **VALIDATE** — check formulas | `formula_check.py` | `references/validate.md` |
+| Task                                              | Method                          | Guide                                                  |
+| ------------------------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| **READ** — analyze existing data                  | `xlsx_reader.py` + pandas       | `references/read-analyze.md`                           |
+| **CREATE** — new xlsx from scratch                | XML template                    | `references/create.md` + `references/format.md`        |
+| **EDIT** — modify existing xlsx                   | XML unpack→edit→pack            | `references/edit.md` (+ `format.md` if styling needed) |
+| **FIX** — repair broken formulas in existing xlsx | XML unpack→fix `<f>` nodes→pack | `references/fix.md`                                    |
+| **VALIDATE** — check formulas                     | `formula_check.py`              | `references/validate.md`                               |
 
 ## READ — Analyze data (read `references/read-analyze.md` first)
 
@@ -39,6 +58,7 @@ Copy `templates/minimal_xlsx/` → edit XML directly → pack with `xlsx_pack.py
 ## EDIT — XML direct-edit (read `references/edit.md` first)
 
 **CRITICAL — EDIT INTEGRITY RULES:**
+
 1. **NEVER create a new `Workbook()`** for edit tasks. Always load the original file.
 2. The output MUST contain the **same sheets** as the input (same names, same data).
 3. Only modify the specific cells the task asks for — everything else must be untouched.
@@ -47,6 +67,7 @@ Copy `templates/minimal_xlsx/` → edit XML directly → pack with `xlsx_pack.py
 Never use openpyxl round-trip on existing files (corrupts VBA, pivots, sparklines). Instead: unpack → use helper scripts → repack.
 
 **"Fill cells" / "Add formulas to existing cells" = EDIT task.** If the input file already exists and you are told to fill, update, or add formulas to specific cells, you MUST use the XML edit path. Never create a new `Workbook()`. Example — fill B3 with a cross-sheet SUM formula:
+
 ```bash
 python3 SKILL_DIR/scripts/xlsx_unpack.py input.xlsx /tmp/xlsx_work/
 # Find the target sheet's XML via xl/workbook.xml → xl/_rels/workbook.xml.rels
@@ -56,6 +77,7 @@ python3 SKILL_DIR/scripts/xlsx_pack.py /tmp/xlsx_work/ output.xlsx
 ```
 
 **Add a column** (formulas, numfmt, styles auto-copied from adjacent column):
+
 ```bash
 python3 SKILL_DIR/scripts/xlsx_unpack.py input.xlsx /tmp/xlsx_work/
 python3 SKILL_DIR/scripts/xlsx_add_column.py /tmp/xlsx_work/ --col G \
@@ -65,9 +87,11 @@ python3 SKILL_DIR/scripts/xlsx_add_column.py /tmp/xlsx_work/ --col G \
     --border-row 10 --border-style medium
 python3 SKILL_DIR/scripts/xlsx_pack.py /tmp/xlsx_work/ output.xlsx
 ```
+
 The `--border-row` flag applies a top border to ALL cells in that row (not just the new column). Use it when the task requires accounting-style borders on total rows.
 
 **Insert a row** (shifts existing rows, updates SUM formulas, fixes circular refs):
+
 ```bash
 python3 SKILL_DIR/scripts/xlsx_unpack.py input.xlsx /tmp/xlsx_work/
 # IMPORTANT: Find the correct --at row by searching for the label text
@@ -80,10 +104,12 @@ python3 SKILL_DIR/scripts/xlsx_insert_row.py /tmp/xlsx_work/ --at 5 \
     --formula 'F=SUM(B{row}:E{row})' --copy-style-from 4
 python3 SKILL_DIR/scripts/xlsx_pack.py /tmp/xlsx_work/ output.xlsx
 ```
+
 **Row lookup rule**: When the task says "after row N (Label)", always find the row by searching for "Label" in the worksheet XML (`grep -n "Label" /tmp/xlsx_work/xl/worksheets/sheet*.xml` or check sharedStrings.xml). Use the actual row number + 1 for `--at`. Do NOT call `xlsx_shift_rows.py` separately — `xlsx_insert_row.py` calls it internally.
 
 **Apply row-wide borders** (e.g. accounting line on a TOTAL row):
 After running helper scripts, apply borders to ALL cells in the target row, not just newly added cells. In `xl/styles.xml`, append a new `<border>` with the desired style, then append a new `<xf>` in `<cellXfs>` that clones each cell's existing `<xf>` but sets the new `borderId`. Apply the new style index to every `<c>` in the row via the `s` attribute:
+
 ```xml
 <!-- In xl/styles.xml, append to <borders>: -->
 <border>
@@ -91,9 +117,11 @@ After running helper scripts, apply borders to ALL cells in the target row, not 
 </border>
 <!-- Then append to <cellXfs> an xf clone with the new borderId for each existing style -->
 ```
+
 **Key rule**: When a task says "add a border to row N", iterate over ALL cells A through the last column, not just newly added cells.
 
 **Manual XML edit** (for anything the helper scripts don't cover):
+
 ```bash
 python3 SKILL_DIR/scripts/xlsx_unpack.py input.xlsx /tmp/xlsx_work/
 # ... edit XML with the Edit tool ...
@@ -110,11 +138,11 @@ Run `formula_check.py` for static validation. Use `libreoffice_recalc.py` for dy
 
 ## Financial Color Standard
 
-| Cell Role | Font Color | Hex Code |
-|-----------|-----------|----------|
-| Hard-coded input / assumption | Blue | `0000FF` |
-| Formula / computed result | Black | `000000` |
-| Cross-sheet reference formula | Green | `00B050` |
+| Cell Role                     | Font Color | Hex Code |
+| ----------------------------- | ---------- | -------- |
+| Hard-coded input / assumption | Blue       | `0000FF` |
+| Formula / computed result     | Black      | `000000` |
+| Cross-sheet reference formula | Green      | `00B050` |
 
 ## Key Rules
 

--- a/SKILLs/xlsx/requirements.txt
+++ b/SKILLs/xlsx/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.2,<3
+openpyxl>=3.1,<4

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -137,6 +137,11 @@
         "filter": ["**/*"]
       },
       {
+        "from": "resources/skill-python",
+        "to": "skill-python",
+        "filter": ["**/*"]
+      },
+      {
         "from": "vendor/openclaw-runtime/current",
         "to": "cfmind",
         "filter": [
@@ -204,6 +209,11 @@
       {
         "from": "resources/python-linux",
         "to": "python-linux",
+        "filter": ["**/*"]
+      },
+      {
+        "from": "resources/skill-python",
+        "to": "skill-python",
         "filter": ["**/*"]
       },
       {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "setup:uv-runtime": "node scripts/setup-uv-runtime.js",
     "setup:posix-uv-runtime": "node scripts/setup-mac-uv-runtime.js",
     "setup:posix-python-runtime": "node scripts/setup-mac-python-runtime.js",
+    "setup:skill-python-runtime": "node scripts/setup-skill-python-runtime.js",
     "setup:pandoc-runtime": "node scripts/setup-pandoc-runtime.js",
     "validate:skills": "node scripts/validate-skill-frontmatter.cjs",
     "openclaw:ensure": "node scripts/ensure-openclaw-version.cjs",

--- a/scripts/ci/package-windows.ps1
+++ b/scripts/ci/package-windows.ps1
@@ -208,6 +208,16 @@ if ($builderExit -ne 0) {
   Write-Error "electron-builder/npm run $distWinCommand exited with code $builderExit"
 }
 
+if ($builderExit -eq 0) {
+  Write-Host '=== Verifying bundled runtimes with a clean PATH ==='
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'windows-runtime-smoke.ps1') -ProjectRoot (Get-Location).Path
+  $smokeExit = $LASTEXITCODE
+  if ($smokeExit -ne 0) {
+    Write-Error "Windows runtime smoke gate failed with exit code $smokeExit"
+    exit $smokeExit
+  }
+}
+
 # 无论上传是否成功，都打印 release 目录内容，方便排查 CI 构建问题。
 Write-Host '=== Release directory contents ==='
 if (Test-Path 'release') {

--- a/scripts/ci/windows-runtime-smoke.ps1
+++ b/scripts/ci/windows-runtime-smoke.ps1
@@ -74,8 +74,10 @@ try {
   }
 
   Invoke-Checked $python @('--version') 'bundled application Python version probe'
-  Invoke-Checked $skillPython @('-c', 'import pandas, openpyxl; print("xlsx-dependencies-ok")') 'bundled XLSX dependency probe'
-  Invoke-Checked $pdfPython @('-c', 'import reportlab, pypdfium2, PIL; print("pdf-dependencies-ok")') 'bundled PDF dependency probe'
+  # Windows PowerShell 5.1 strips nested quotes from native process arguments.
+  # Keep these probes quote-free so the Python code is identical on clean CI hosts.
+  Invoke-Checked $skillPython @('-c', 'import pandas, openpyxl; print(1)') 'bundled XLSX dependency probe'
+  Invoke-Checked $pdfPython @('-c', 'import reportlab, pypdfium2, PIL; print(1)') 'bundled PDF dependency probe'
   Invoke-Checked $bash @('-lc', 'printf "portable-git-bash-ok\n"') 'bundled Bash probe'
   Invoke-Checked $pandoc @('--version') 'bundled Pandoc version probe'
 

--- a/scripts/ci/windows-runtime-smoke.ps1
+++ b/scripts/ci/windows-runtime-smoke.ps1
@@ -1,0 +1,100 @@
+param(
+  [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [string]$TarPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Path {
+  param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)][string]$Label)
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Missing ${Label}: $Path"
+  }
+}
+
+function Invoke-Checked {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [string]$Label = $FilePath
+  )
+  & $FilePath @ArgumentList
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE"
+  }
+}
+
+$osVersion = [Environment]::OSVersion.Version
+if ($osVersion.Major -ne 10) {
+  throw "This gate requires a Windows 10/11-compatible host; detected $osVersion"
+}
+
+if (-not $TarPath) {
+  $TarPath = Join-Path $ProjectRoot 'build-tar\win-resources.tar'
+}
+Assert-Path $TarPath 'Windows resource tar'
+
+$systemTar = Join-Path $env:SystemRoot 'System32\tar.exe'
+Assert-Path $systemTar 'Windows system tar.exe'
+
+$smokeRoot = Join-Path $env:TEMP ("zhiyuan-runtime-smoke-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N'))
+$oldPath = $env:PATH
+try {
+  New-Item -ItemType Directory -Path $smokeRoot -Force | Out-Null
+  Invoke-Checked $systemTar @('-xf', $TarPath, '-C', $smokeRoot) 'Windows resource tar extraction'
+
+  $resourcesRoot = $smokeRoot
+  $bash = Join-Path $resourcesRoot 'mingit\usr\bin\bash.exe'
+  if (-not (Test-Path -LiteralPath $bash)) {
+    $bash = Join-Path $resourcesRoot 'mingit\bin\bash.exe'
+  }
+  $python = Join-Path $resourcesRoot 'python-win\python.exe'
+  $skillPython = Join-Path $resourcesRoot 'skill-python\xlsx\Scripts\python.exe'
+  $pdfPython = Join-Path $resourcesRoot 'skill-python\pdf\Scripts\python.exe'
+  $pandoc = Join-Path $resourcesRoot 'pandoc\pandoc.exe'
+  $skillsRoot = Join-Path $resourcesRoot 'SKILLs'
+
+  Assert-Path $bash 'bundled PortableGit Bash'
+  Assert-Path $python 'bundled application Python'
+  Assert-Path $skillPython 'bundled XLSX Skill Python'
+  Assert-Path $pdfPython 'bundled PDF Skill Python'
+  Assert-Path (Join-Path $resourcesRoot 'uv-win\uv.exe') 'bundled uv'
+  Assert-Path $pandoc 'bundled Pandoc'
+  Assert-Path (Join-Path $skillsRoot 'xlsx\scripts\xlsx_reader.py') 'XLSX Skill reader'
+  Assert-Path (Join-Path $skillsRoot 'docx\scripts\markdown_to_docx.sh') 'DOCX Markdown converter'
+
+  # Remove Git, Python, Node, and user-installed tool directories from PATH.
+  # The smoke test invokes only explicit package paths below.
+  $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+  $env:UV_OFFLINE = '1'
+  foreach ($externalCommand in @('git.exe', 'python.exe', 'python3.exe', 'node.exe')) {
+    if (Get-Command $externalCommand -ErrorAction SilentlyContinue) {
+      throw "External command unexpectedly remains discoverable on the clean PATH: $externalCommand"
+    }
+  }
+
+  Invoke-Checked $python @('--version') 'bundled application Python version probe'
+  Invoke-Checked $skillPython @('-c', 'import pandas, openpyxl; print("xlsx-dependencies-ok")') 'bundled XLSX dependency probe'
+  Invoke-Checked $pdfPython @('-c', 'import reportlab, pypdfium2, PIL; print("pdf-dependencies-ok")') 'bundled PDF dependency probe'
+  Invoke-Checked $bash @('-lc', 'printf "portable-git-bash-ok\n"') 'bundled Bash probe'
+  Invoke-Checked $pandoc @('--version') 'bundled Pandoc version probe'
+
+  $markdown = Join-Path $smokeRoot 'smoke.md'
+  $docx = Join-Path $smokeRoot 'smoke.docx'
+  Set-Content -LiteralPath $markdown -Value "# Windows runtime smoke`n`nManaged DOCX conversion works.`n" -Encoding UTF8
+  Invoke-Checked $pandoc @('--from', 'markdown', '--to', 'docx', '--output', $docx, $markdown) 'DOCX Markdown conversion'
+  Assert-Path $docx 'generated DOCX'
+
+  $fixture = Join-Path $smokeRoot 'smoke.xlsx'
+  $createFixture = "from openpyxl import Workbook; w=Workbook(); s=w.active; s.title='Smoke'; s.append(['Name','Score']); s.append(['Windows',100]); w.save(r'$fixture')"
+  Invoke-Checked $skillPython @('-c', $createFixture) 'XLSX fixture creation'
+  $reader = Join-Path $skillsRoot 'xlsx\scripts\xlsx_reader.py'
+  Invoke-Checked $skillPython @($reader, $fixture, '--json') 'XLSX Skill reader'
+
+  Write-Host "Windows runtime smoke passed on Windows $osVersion"
+} finally {
+  $env:PATH = $oldPath
+  if (Test-Path -LiteralPath $smokeRoot) {
+    Remove-Item -LiteralPath $smokeRoot -Recurse -Force
+  }
+}

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -32,6 +32,11 @@ const {
   ensurePortablePandocRuntime,
   checkRuntimeHealth: checkPandocRuntimeHealth,
 } = require('./setup-pandoc-runtime.js');
+const { ensurePortableGit } = require('./setup-mingit.js');
+const {
+  ensureSkillPythonRuntimes,
+  checkSkillPythonRuntimeHealth,
+} = require('./setup-skill-python-runtime.js');
 const { syncLocalOpenClawExtensions } = require('./sync-local-openclaw-extensions.cjs');
 const { packMultipleSources } = require('./pack-openclaw-tar.cjs');
 const {
@@ -914,6 +919,19 @@ async function beforePack(context) {
 
   if (isWindowsTarget(context)) {
     console.log(
+      '[electron-builder-hooks] Windows target detected, ensuring bundled PortableGit...',
+    );
+    await ensurePortableGit({ required: true });
+    const portableGitRoot = path.join(__dirname, '..', 'resources', 'mingit');
+    const portableGitBash = [
+      path.join(portableGitRoot, 'bin', 'bash.exe'),
+      path.join(portableGitRoot, 'usr', 'bin', 'bash.exe'),
+    ].find(candidate => existsSync(candidate));
+    if (!portableGitBash) {
+      throw new Error('Bundled PortableGit health check failed before pack: bash.exe is missing.');
+    }
+
+    console.log(
       '[electron-builder-hooks] Windows target detected, ensuring portable uv runtime is prepared...',
     );
     await ensurePortableUvRuntime({ required: true });
@@ -944,22 +962,72 @@ async function beforePack(context) {
     const targetArch = resolveTargetArch(context);
     const targetPlatform = context.electronPlatformName;
     const resourceSuffix = targetPlatform === 'darwin' ? 'mac' : 'linux';
-    console.log(`[electron-builder-hooks] ${targetPlatform} target detected, ensuring bundled uv and uv-managed Python 3.14.6...`);
+    console.log(
+      `[electron-builder-hooks] ${targetPlatform} target detected, ensuring bundled uv and uv-managed Python 3.14.6...`,
+    );
     await ensurePosixUvRuntime({ required: true, platform: targetPlatform, arch: targetArch });
-    const uvHealth = checkMacUvRuntimeHealth(path.join(__dirname, '..', 'resources', `uv-${resourceSuffix}`), targetArch, targetPlatform);
-    if (!uvHealth.ok) throw new Error(`Bundled ${targetPlatform} uv health check failed: ${uvHealth.missing.join(', ')}`);
+    const uvHealth = checkMacUvRuntimeHealth(
+      path.join(__dirname, '..', 'resources', `uv-${resourceSuffix}`),
+      targetArch,
+      targetPlatform,
+    );
+    if (!uvHealth.ok)
+      throw new Error(
+        `Bundled ${targetPlatform} uv health check failed: ${uvHealth.missing.join(', ')}`,
+      );
     await ensurePosixPythonRuntime({ required: true, platform: targetPlatform, arch: targetArch });
-    const pythonHealth = checkMacPythonRuntimeHealth(path.join(__dirname, '..', 'resources', `python-${resourceSuffix}`), targetArch, targetPlatform);
-    if (!pythonHealth.ok) throw new Error(`Bundled ${targetPlatform} Python health check failed: ${pythonHealth.missing.join(', ')}`);
+    const pythonHealth = checkMacPythonRuntimeHealth(
+      path.join(__dirname, '..', 'resources', `python-${resourceSuffix}`),
+      targetArch,
+      targetPlatform,
+    );
+    if (!pythonHealth.ok)
+      throw new Error(
+        `Bundled ${targetPlatform} Python health check failed: ${pythonHealth.missing.join(', ')}`,
+      );
+  }
+
+  if (isWindowsTarget(context) || isMacTarget(context) || isLinuxTarget(context)) {
+    const targetPlatform = context.electronPlatformName;
+    const targetArch = resolveTargetArch(context);
+    console.log(
+      `[electron-builder-hooks] Preparing bundled Python environments for Skills (${targetPlatform}-${targetArch})...`,
+    );
+    const skillPythonResult = await ensureSkillPythonRuntimes({
+      platform: targetPlatform,
+      arch: targetArch,
+      required: true,
+    });
+    const skillPythonHealth = checkSkillPythonRuntimeHealth({
+      platform: targetPlatform,
+      arch: targetArch,
+    });
+    if (!skillPythonHealth.ok) {
+      throw new Error(
+        'Bundled Skill Python runtime health check failed before pack. Missing: ' +
+          skillPythonHealth.missing.join(', '),
+      );
+    }
+    console.log(
+      `[electron-builder-hooks] Bundled Python environments ready: ${skillPythonResult.environments.length}`,
+    );
   }
 
   if (isWindowsTarget(context) || isMacTarget(context) || isLinuxTarget(context)) {
     console.log('[electron-builder-hooks] Ensuring bundled Pandoc runtime is prepared...');
     const targetPlatform = context.electronPlatformName;
     const targetArch = resolveTargetArch(context);
-    await ensurePortablePandocRuntime({ required: true, platform: targetPlatform, arch: targetArch });
+    await ensurePortablePandocRuntime({
+      required: true,
+      platform: targetPlatform,
+      arch: targetArch,
+    });
     const pandocRuntimeRoot = path.join(__dirname, '..', 'resources', 'pandoc');
-    const pandocRuntimeHealth = checkPandocRuntimeHealth(pandocRuntimeRoot, targetPlatform, targetArch);
+    const pandocRuntimeHealth = checkPandocRuntimeHealth(
+      pandocRuntimeRoot,
+      targetPlatform,
+      targetArch,
+    );
     if (!pandocRuntimeHealth.ok) {
       throw new Error(
         'Bundled Pandoc runtime health check failed before pack. Missing files: ' +
@@ -1004,9 +1072,19 @@ async function beforePack(context) {
         prefix: 'MCPs',
       },
       {
+        label: 'PortableGit runtime',
+        dir: path.join(__dirname, '..', 'resources', 'mingit'),
+        prefix: 'mingit',
+      },
+      {
         label: 'Python runtime',
         dir: path.join(__dirname, '..', 'resources', 'python-win'),
         prefix: 'python-win',
+      },
+      {
+        label: 'Skill Python runtimes',
+        dir: path.join(__dirname, '..', 'resources', 'skill-python'),
+        prefix: 'skill-python',
       },
       {
         label: 'uv runtime',

--- a/scripts/setup-skill-python-runtime.js
+++ b/scripts/setup-skill-python-runtime.js
@@ -1,0 +1,412 @@
+#!/usr/bin/env node
+/**
+ * Build isolated, relocatable Python environments for Skills that declare
+ * requirements.txt. These environments are shipped with the desktop package,
+ * so end users do not need Python, pip, uv, or network access for the common
+ * document workflows.
+ */
+
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const SKILLS_ROOT = path.join(PROJECT_ROOT, 'SKILLs');
+const RUNTIME_ROOT = path.join(PROJECT_ROOT, 'resources', 'skill-python');
+const MANIFEST_VERSION = 1;
+
+const IMPORT_NAME_OVERRIDES = {
+  pillow: 'PIL',
+  'scikit-learn': 'sklearn',
+  pypdfium2: 'pypdfium2',
+};
+
+function normalizePlatform(value = process.platform) {
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === 'win' || normalized === 'windows' || normalized === 'win32') return 'win32';
+  if (normalized === 'mac' || normalized === 'macos' || normalized === 'darwin') return 'darwin';
+  if (normalized === 'linux') return 'linux';
+  throw new Error(`Unsupported Skill Python target platform: ${value}`);
+}
+
+function listRequirementFiles(skillsRoot = SKILLS_ROOT) {
+  if (!fs.existsSync(skillsRoot)) return [];
+  return fs
+    .readdirSync(skillsRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => {
+      const skillId = entry.name;
+      const requirementsPath = path.join(skillsRoot, skillId, 'requirements.txt');
+      return fs.existsSync(requirementsPath) ? { skillId, requirementsPath } : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.skillId.localeCompare(right.skillId));
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function parseImportNames(requirementsPath) {
+  const names = [];
+  const seen = new Set();
+  for (const line of fs.readFileSync(requirementsPath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('-')) continue;
+    const match = trimmed.match(/^([A-Za-z0-9_.-]+)/);
+    if (!match) continue;
+    const packageName = match[1].toLowerCase();
+    const importName = IMPORT_NAME_OVERRIDES[packageName] || packageName.replaceAll('-', '_');
+    if (!seen.has(importName)) {
+      seen.add(importName);
+      names.push(importName);
+    }
+  }
+  return names;
+}
+
+function pythonExecutableForEnvironment(environmentRoot, platform) {
+  const candidates =
+    platform === 'win32'
+      ? [
+          path.join(environmentRoot, 'Scripts', 'python.exe'),
+          path.join(environmentRoot, 'python.exe'),
+        ]
+      : [path.join(environmentRoot, 'bin', 'python3'), path.join(environmentRoot, 'bin', 'python')];
+  return candidates.find(candidate => fs.existsSync(candidate)) || null;
+}
+
+function walkSymlinks(root) {
+  const links = [];
+  const visit = current => {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      let stat;
+      try {
+        stat = fs.lstatSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (stat.isSymbolicLink()) {
+        links.push(fullPath);
+      } else if (stat.isDirectory()) {
+        visit(fullPath);
+      }
+    }
+  };
+  visit(root);
+  return links;
+}
+
+function rebaseEnvironmentSymlinks(environmentRoot, basePythonPath) {
+  const baseRuntimeRoot = path.dirname(path.dirname(basePythonPath));
+  for (const linkPath of walkSymlinks(environmentRoot)) {
+    const linkTarget = fs.readlinkSync(linkPath);
+    if (!path.isAbsolute(linkTarget)) continue;
+    const resolvedTarget = path.resolve(linkTarget);
+    if (
+      resolvedTarget !== basePythonPath &&
+      !resolvedTarget.startsWith(`${baseRuntimeRoot}${path.sep}`)
+    ) {
+      continue;
+    }
+    const targetRelativeToBase = path.relative(baseRuntimeRoot, resolvedTarget);
+    const packageBaseRoot = path.dirname(path.dirname(environmentRoot));
+    const packagedBaseRoot = path.join(packageBaseRoot, path.basename(baseRuntimeRoot));
+    const packagedTarget = path.join(packagedBaseRoot, targetRelativeToBase);
+    const relativeTarget = path.relative(path.dirname(linkPath), packagedTarget);
+    fs.unlinkSync(linkPath);
+    fs.symlinkSync(relativeTarget, linkPath);
+  }
+}
+
+function isEnvironmentRelocatable(environmentRoot) {
+  return walkSymlinks(environmentRoot).every(
+    linkPath => !path.isAbsolute(fs.readlinkSync(linkPath)),
+  );
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || PROJECT_ROOT,
+    env: { ...process.env, ...(options.env || {}) },
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: options.timeout || 20 * 60 * 1000,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const detail = `${result.stderr || result.stdout || ''}`.trim();
+    throw new Error(
+      `${command} ${args.join(' ')} failed with exit code ${result.status}: ${detail}`,
+    );
+  }
+  return result;
+}
+
+function probePython(pythonPath, importNames) {
+  const code = [
+    'import importlib',
+    ...importNames.map(name => `importlib.import_module(${JSON.stringify(name)})`),
+    'print("skill-python-health-ok")',
+  ].join('\n');
+  const result = spawnSync(pythonPath, ['-c', code], {
+    cwd: PROJECT_ROOT,
+    env: { ...process.env, PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8' },
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 60_000,
+    windowsHide: true,
+  });
+  return {
+    ok: result.status === 0,
+    detail: `${result.stderr || result.stdout || ''}`.trim(),
+  };
+}
+
+function readManifest(environmentRoot) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path.join(environmentRoot, 'runtime.json'), 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPythonVersion(pythonPath) {
+  const result = run(pythonPath, ['--version'], { timeout: 60_000 });
+  return `${result.stdout || result.stderr || ''}`.trim();
+}
+
+function getUvVersion(uvPath) {
+  const result = run(uvPath, ['--version'], { timeout: 60_000 });
+  return `${result.stdout || result.stderr || ''}`.trim();
+}
+
+function expectedManifest(entry, platform, arch, pythonVersion, uvVersion) {
+  return {
+    version: MANIFEST_VERSION,
+    skillId: entry.skillId,
+    platform,
+    arch,
+    requirementsSha256: sha256File(entry.requirementsPath),
+    pythonVersion,
+    uvVersion,
+  };
+}
+
+function manifestMatches(manifest, expected) {
+  return Boolean(
+    manifest &&
+    manifest.version === expected.version &&
+    manifest.skillId === expected.skillId &&
+    manifest.platform === expected.platform &&
+    manifest.arch === expected.arch &&
+    manifest.requirementsSha256 === expected.requirementsSha256 &&
+    manifest.pythonVersion === expected.pythonVersion &&
+    manifest.uvVersion === expected.uvVersion,
+  );
+}
+
+function checkSkillPythonRuntimeHealth(options = {}) {
+  const platform = normalizePlatform(options.platform);
+  const arch = options.arch || process.arch;
+  const requirements = listRequirementFiles(options.skillsRoot || SKILLS_ROOT);
+  const environments = [];
+  const missing = [];
+
+  for (const entry of requirements) {
+    const environmentRoot = path.join(options.runtimeRoot || RUNTIME_ROOT, entry.skillId);
+    const pythonPath = pythonExecutableForEnvironment(environmentRoot, platform);
+    const importNames = parseImportNames(entry.requirementsPath);
+    const manifest = readManifest(environmentRoot);
+    const requirementsSha256 = sha256File(entry.requirementsPath);
+    const entryMissing = [];
+    if (!pythonPath) entryMissing.push('python executable');
+    if (
+      !manifest ||
+      manifest.version !== MANIFEST_VERSION ||
+      manifest.skillId !== entry.skillId ||
+      manifest.platform !== platform ||
+      manifest.arch !== arch ||
+      manifest.requirementsSha256 !== requirementsSha256
+    ) {
+      entryMissing.push('matching runtime.json');
+    }
+    if (!isEnvironmentRelocatable(environmentRoot)) {
+      entryMissing.push('relocatable symlinks');
+    }
+    if (pythonPath) {
+      const probe = probePython(pythonPath, importNames);
+      if (!probe.ok) entryMissing.push(`imports (${probe.detail || 'probe failed'})`);
+    }
+    if (entryMissing.length > 0) {
+      missing.push(`${entry.skillId}: ${entryMissing.join(', ')}`);
+    }
+    environments.push({
+      skillId: entry.skillId,
+      environmentRoot,
+      pythonPath,
+      missing: entryMissing,
+    });
+  }
+
+  return { ok: missing.length === 0, missing, environments };
+}
+
+async function resolveBaseRuntime(platform, arch) {
+  if (platform === 'win32') {
+    const [
+      { ensurePortableUvRuntime, findPortableUvExecutables },
+      { ensurePortablePythonRuntime, findPortablePythonExecutable },
+    ] = await Promise.all([
+      Promise.resolve(require('./setup-uv-runtime.js')),
+      Promise.resolve(require('./setup-python-runtime.js')),
+    ]);
+    await ensurePortableUvRuntime({ required: true });
+    await ensurePortablePythonRuntime({ required: true });
+    return {
+      uvPath: findPortableUvExecutables().uv,
+      pythonPath: findPortablePythonExecutable(),
+    };
+  }
+
+  const { ensurePosixUvRuntime } = require('./setup-mac-uv-runtime.js');
+  const { ensurePosixPythonRuntime } = require('./setup-mac-python-runtime.js');
+  const uv = await ensurePosixUvRuntime({ required: true, platform, arch });
+  const python = await ensurePosixPythonRuntime({ required: true, platform, arch });
+  return { uvPath: uv.uvPath, pythonPath: python.pythonPath };
+}
+
+async function ensureSkillPythonRuntimes(options = {}) {
+  const platform = normalizePlatform(options.platform);
+  const arch = options.arch || process.arch;
+  const skillsRoot = options.skillsRoot || SKILLS_ROOT;
+  const runtimeRoot = options.runtimeRoot || RUNTIME_ROOT;
+  const requirements = listRequirementFiles(skillsRoot);
+  if (requirements.length === 0) {
+    return { ok: true, skipped: true, environments: [] };
+  }
+
+  const base = await resolveBaseRuntime(platform, arch);
+  if (!base.uvPath || !base.pythonPath) {
+    throw new Error('Bundled uv and Python are required before building Skill Python runtimes.');
+  }
+
+  const pythonVersion = getPythonVersion(base.pythonPath);
+  const uvVersion = getUvVersion(base.uvPath);
+  fs.mkdirSync(runtimeRoot, { recursive: true });
+
+  for (const entry of requirements) {
+    const environmentRoot = path.join(runtimeRoot, entry.skillId);
+    const expected = expectedManifest(entry, platform, arch, pythonVersion, uvVersion);
+    const existingPython = pythonExecutableForEnvironment(environmentRoot, platform);
+    if (
+      existingPython &&
+      isEnvironmentRelocatable(environmentRoot) &&
+      manifestMatches(readManifest(environmentRoot), expected)
+    ) {
+      const probe = probePython(existingPython, parseImportNames(entry.requirementsPath));
+      if (probe.ok) {
+        console.log(
+          `[setup-skill-python-runtime] ${entry.skillId}: existing environment is healthy`,
+        );
+        continue;
+      }
+    }
+
+    fs.rmSync(environmentRoot, { recursive: true, force: true });
+    fs.mkdirSync(environmentRoot, { recursive: true });
+    console.log(`[setup-skill-python-runtime] ${entry.skillId}: creating relocatable environment`);
+    run(
+      base.uvPath,
+      [
+        'venv',
+        '--no-project',
+        '--relocatable',
+        '--link-mode',
+        'copy',
+        '--no-managed-python',
+        '--no-python-downloads',
+        '--python',
+        base.pythonPath,
+        environmentRoot,
+      ],
+      { env: { UV_NO_PROGRESS: '1', UV_PYTHON: base.pythonPath } },
+    );
+    const environmentPython = pythonExecutableForEnvironment(environmentRoot, platform);
+    if (!environmentPython)
+      throw new Error(`${entry.skillId}: uv did not create a Python executable.`);
+    rebaseEnvironmentSymlinks(environmentRoot, base.pythonPath);
+    run(
+      base.uvPath,
+      [
+        'pip',
+        'install',
+        '--python',
+        environmentPython,
+        '--requirement',
+        entry.requirementsPath,
+        '--link-mode',
+        'copy',
+        '--no-managed-python',
+        '--no-python-downloads',
+      ],
+      { env: { UV_NO_PROGRESS: '1', UV_PYTHON: base.pythonPath } },
+    );
+    rebaseEnvironmentSymlinks(environmentRoot, base.pythonPath);
+    const probe = probePython(environmentPython, parseImportNames(entry.requirementsPath));
+    if (!probe.ok)
+      throw new Error(`${entry.skillId}: dependency health check failed: ${probe.detail}`);
+    fs.writeFileSync(
+      path.join(environmentRoot, 'runtime.json'),
+      `${JSON.stringify(expected, null, 2)}\n`,
+      'utf8',
+    );
+    console.log(`[setup-skill-python-runtime] ${entry.skillId}: ready`);
+  }
+
+  const health = checkSkillPythonRuntimeHealth({ platform, arch, skillsRoot, runtimeRoot });
+  if (!health.ok)
+    throw new Error(`Skill Python runtime health check failed: ${health.missing.join('; ')}`);
+  return { ok: true, skipped: false, environments: health.environments };
+}
+
+async function main() {
+  const platformIndex = process.argv.indexOf('--platform');
+  const archIndex = process.argv.indexOf('--arch');
+  await ensureSkillPythonRuntimes({
+    platform: platformIndex >= 0 ? process.argv[platformIndex + 1] : process.platform,
+    arch: archIndex >= 0 ? process.argv[archIndex + 1] : process.arch,
+  });
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(
+      '[setup-skill-python-runtime] ERROR:',
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  RUNTIME_ROOT,
+  checkSkillPythonRuntimeHealth,
+  listRequirementFiles,
+  normalizePlatform,
+  parseImportNames,
+  pythonExecutableForEnvironment,
+  ensureSkillPythonRuntimes,
+};

--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -18,6 +18,12 @@ declare module '@earendil-works/pi-coding-agent' {
     reload(): Promise<void>;
   }
 
+  export class SettingsManager {
+    static create(cwd: string, agentDir?: string): SettingsManager;
+    applyOverrides(overrides: { shellPath?: string }): void;
+    getShellPath(): string | undefined;
+  }
+
   export function getAgentDir(): string;
 
   export const ModelRuntime: {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -31,8 +31,16 @@ const hoisted = vi.hoisted(() => {
     subscribe: vi.fn().mockReturnValue(() => {}),
   };
 
+  const mockSettingsManagerCreate = vi.fn((cwd: string, agentDir?: string) => ({
+    cwd,
+    agentDir,
+    applyOverrides: vi.fn(),
+    getShellPath: vi.fn(),
+  }));
+
   return {
     mockSession,
+    mockSettingsManagerCreate,
     mockCreateAgentSession: vi.fn().mockResolvedValue({ session: mockSession }),
     mockDefaultResourceLoader: vi.fn(function (this: { reload: () => Promise<void> }) {
       this.reload = vi.fn().mockResolvedValue(undefined);
@@ -148,6 +156,7 @@ const hoisted = vi.hoisted(() => {
 const mockSession = hoisted.mockSession;
 const mockCreateAgentSession = hoisted.mockCreateAgentSession;
 const mockDefaultResourceLoader = hoisted.mockDefaultResourceLoader;
+const mockSettingsManagerCreate = hoisted.mockSettingsManagerCreate;
 const mockGetModel = hoisted.mockGetModel;
 const mockModelRuntime = hoisted.mockModelRuntime;
 const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
@@ -158,6 +167,7 @@ const mockRegisterPiOpenAICompatUpstream = hoisted.mockRegisterPiOpenAICompatUps
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: hoisted.mockCreateAgentSession,
   DefaultResourceLoader: hoisted.mockDefaultResourceLoader,
+  SettingsManager: { create: hoisted.mockSettingsManagerCreate },
   getAgentDir: hoisted.mockGetAgentDir,
   ModelRuntime: {
     create: hoisted.mockModelRuntimeCreate,
@@ -312,8 +322,12 @@ describe('PiRuntimeAdapter', () => {
       const acceptanceTool = sessionOptions.customTools.find(
         tool => tool.name === 'work_acceptance',
       );
+      const skillScriptTool = sessionOptions.customTools.find(
+        tool => tool.name === 'run_skill_script',
+      );
       expect(loopTool).toBeDefined();
       expect(acceptanceTool).toBeDefined();
+      expect(skillScriptTool).toBeDefined();
 
       const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
         type: string;
@@ -414,6 +428,19 @@ describe('PiRuntimeAdapter', () => {
         }),
       );
       expect(mockCreateAgentSession.mock.calls[0]?.[0]).not.toHaveProperty('systemPrompt');
+    });
+
+    it('shares one Pi SettingsManager with resource loading and the agent session', async () => {
+      await adapter.startSession('settings-manager', 'Hello Pi');
+
+      expect(mockSettingsManagerCreate).toHaveBeenCalledWith(process.cwd(), '/tmp/pi-agent');
+      const settingsManager = mockSettingsManagerCreate.mock.results[0]?.value;
+      expect(mockDefaultResourceLoader.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({ settingsManager }),
+      );
+      expect(mockCreateAgentSession.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({ settingsManager }),
+      );
     });
 
     it('should resolve the explicit model override for a new session', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -54,7 +54,7 @@ import {
   resolveRawApiConfig,
   resolveRawApiConfigForModelRef,
 } from '../claudeSettings';
-import { getSkillsRoot } from '../coworkUtil';
+import { getSkillsRoot, resolveGitBashPathForPi } from '../coworkUtil';
 import type { McpServerManager } from '../mcpServerManager';
 import { isRasterPreviewDecodable, renderOfficePreview } from '../officePreviewRenderer';
 import {
@@ -77,6 +77,8 @@ import {
 import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool';
 import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
+import { buildPiSkillScriptTool } from './piSkillScriptTool';
+import { buildPiSkillRuntimeCapabilitiesTool } from './piSkillRuntimeCapabilitiesTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { PiPendingMessageQueue } from './piPendingMessageQueue';
 import { buildPiWorkAcceptanceTool, PiWorkExecutionController } from './piWorkExecution';
@@ -218,6 +220,7 @@ interface ActivePiSession {
   workbenchRunId: string | null;
   workbenchContract: WorkbenchTaskContract;
   workspaceRoot: string;
+  settingsManager: PiSettingsManager | null;
   autoApprove: boolean;
   /** True while Pi is executing the current Work/Chat turn. */
   isRunning: boolean;
@@ -232,6 +235,9 @@ interface ActivePiSession {
 interface PiModules {
   createAgentSession: (options: Record<string, unknown>) => Promise<{ session: PiSession }>;
   DefaultResourceLoader: new (options: Record<string, unknown>) => PiResourceLoader;
+  SettingsManager?: {
+    create(cwd: string, agentDir?: string): PiSettingsManager;
+  };
   getAgentDir: () => string;
   getModel: (provider: string, modelId: string) => unknown;
   ModelRuntime: {
@@ -246,6 +252,12 @@ interface PiModules {
 
 interface PiResourceLoader {
   reload(): Promise<void>;
+  settingsManager?: PiSettingsManager | null;
+}
+
+interface PiSettingsManager {
+  applyOverrides(overrides: { shellPath?: string }): void;
+  getShellPath?(): string | undefined;
 }
 
 interface PiToolCallEvent {
@@ -303,6 +315,10 @@ async function getPiModules(): Promise<PiModules> {
         createAgentSession: codingAgent.createAgentSession as PiModules['createAgentSession'],
         DefaultResourceLoader:
           codingAgent.DefaultResourceLoader as PiModules['DefaultResourceLoader'],
+        SettingsManager: Object.prototype.hasOwnProperty.call(codingAgent, 'SettingsManager')
+          ? ((codingAgent as typeof codingAgent & { SettingsManager?: unknown })
+              .SettingsManager as PiModules['SettingsManager'])
+          : undefined,
         getAgentDir: codingAgent.getAgentDir as PiModules['getAgentDir'],
         ModelRuntime: codingAgent.ModelRuntime as PiModules['ModelRuntime'],
         // getModel is the current API (deprecated but functional); will migrate to createModels() later
@@ -523,13 +539,18 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionOptions.modelRuntime = resolvedModel.modelRuntime;
       }
 
+      const settingsManager = this.createPiSettingsManager(pi, workspaceRoot);
       const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState, {
         sessionId,
         runId: workbenchRunId,
+        settingsManager,
         getAutoApprove: () =>
           this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
       });
       sessionOptions.resourceLoader = resourceLoader;
+      if (settingsManager) {
+        sessionOptions.settingsManager = settingsManager;
+      }
 
       // Build custom tools: MCP proxy + optional subagent for Team Leads.
       // Each call creates a distinct tool instance for this Pi session, so its
@@ -572,6 +593,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       if (shortcutWorkflow) {
         shortcutWorkflow.resumeForPrompt(prompt);
         customTools.push(buildPiShortcutWorkflowStateTool(shortcutWorkflow));
+      }
+
+      if (options.sessionMode === 'work' && resourceState.skillIds?.length) {
+        customTools.push(buildPiSkillRuntimeCapabilitiesTool());
+        customTools.push(
+          buildPiSkillScriptTool({
+            workspaceRoot,
+            allowedSkillIds: resourceState.skillIds,
+          }),
+        );
       }
       // A selected skill in Work mode is an execution request, not a one-turn
       // chat hint. Run it through Pi's durable loop by default; completion
@@ -705,6 +736,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workbenchRunId,
         workbenchContract,
         workspaceRoot,
+        settingsManager,
         autoApprove: Boolean(options.autoApprove),
         isRunning: true,
         turnFailed: false,
@@ -830,6 +862,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         // Pi reloads the existing ResourceLoader without replacing transcript
         // state, model, MCP tools, or custom expert tools.
         await active.piSession.reload();
+        // AgentSession.reload() reloads SettingsManager from disk, so restore
+        // the per-process bundled PortableGit override after every reload.
+        this.applyPiShellOverride(active.settingsManager);
         active.requestedSystemPrompt = nextSystemPrompt;
         active.requestedSkillIds = requestedSkillIds;
         console.debug('[PiRuntime] reloaded session resources after prompt change');
@@ -960,6 +995,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       if (active.resourceState.maxOutputTokens !== resolvedModel.maxOutputTokens) {
         active.resourceState.maxOutputTokens = resolvedModel.maxOutputTokens;
         await active.piSession.reload();
+        this.applyPiShellOverride(active.settingsManager);
       }
       console.log('[PiRuntime] Model updated via patchSession:', patch.model);
     } catch (err) {
@@ -1224,7 +1260,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   private async flushFollowUpQueue(sessionId: string, active: ActivePiSession): Promise<void> {
-    if (active.queueFlushInFlight || active.aborted || active.pendingError || active.turnFailed) return;
+    if (active.queueFlushInFlight || active.aborted || active.pendingError || active.turnFailed)
+      return;
     if (active.workbenchContract.kind === WorkbenchContractKind.Chat) return;
     active.queueFlushInFlight = true;
     let retryAfterFailure = false;
@@ -1266,6 +1303,19 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   // ── Chat mode: direct LLM without agent loop ──
 
+  private createPiSettingsManager(pi: PiModules, cwd: string): PiSettingsManager | null {
+    if (!pi.SettingsManager) return null;
+    return pi.SettingsManager.create(cwd, pi.getAgentDir());
+  }
+
+  private applyPiShellOverride(settingsManager: PiSettingsManager | null): void {
+    if (!settingsManager || process.platform !== 'win32') return;
+    const bashPath = resolveGitBashPathForPi();
+    if (bashPath) {
+      settingsManager.applyOverrides({ shellPath: bashPath });
+    }
+  }
+
   private async createPiResourceLoader(
     pi: PiModules,
     cwd: string,
@@ -1273,12 +1323,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     approvalContext?: {
       sessionId: string;
       runId: string | null;
+      settingsManager?: PiSettingsManager | null;
       getAutoApprove: () => boolean;
     },
   ): Promise<PiResourceLoader> {
+    const settingsManager =
+      approvalContext?.settingsManager ?? this.createPiSettingsManager(pi, cwd);
     const resourceLoader = new pi.DefaultResourceLoader({
       cwd,
       agentDir: pi.getAgentDir(),
+      ...(settingsManager ? { settingsManager } : {}),
       // ZhiYuanAgent skills come exclusively from the app-managed SKILLs dirs —
       // never from the developer's global ~/.agents/skills (which would leak
       // dev-only tooling skills like ai-sdk/shadcn into user sessions).
@@ -1335,6 +1389,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         : [],
     });
     await resourceLoader.reload();
+    // Pi's resource reload refreshes settings from disk, so apply the resolved
+    // per-process shell override after reload and share the same manager with
+    // createAgentSession. This makes bundled PortableGit usable by every Pi
+    // session without changing the user's global Pi settings file.
+    this.applyPiShellOverride(settingsManager);
+    resourceLoader.settingsManager = settingsManager;
     return resourceLoader;
   }
 

--- a/src/main/libs/agentEngine/piSkillRuntimeCapabilitiesTool.ts
+++ b/src/main/libs/agentEngine/piSkillRuntimeCapabilitiesTool.ts
@@ -1,0 +1,32 @@
+import {
+  probeSkillRuntimeCapabilities,
+  type SkillRuntimeCapabilities,
+} from '../skillRuntimeCapabilities';
+
+export const PiSkillRuntimeCapabilitiesToolName = 'skill_runtime_capabilities';
+
+type SkillRuntimeCapabilitiesToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  details: SkillRuntimeCapabilities;
+};
+
+export function buildPiSkillRuntimeCapabilitiesTool(): Record<string, unknown> {
+  return {
+    name: PiSkillRuntimeCapabilitiesToolName,
+    label: 'Inspect Skill Runtimes',
+    description:
+      'Read-only probe of application-managed Python, uv, Node, Bash, PowerShell, Pandoc, and prebuilt Skill Python environments.',
+    parameters: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    execute: async (): Promise<SkillRuntimeCapabilitiesToolResult> => {
+      const details = probeSkillRuntimeCapabilities();
+      return {
+        content: [{ type: 'text', text: JSON.stringify(details, null, 2) }],
+        details,
+      };
+    },
+  };
+}

--- a/src/main/libs/agentEngine/piSkillRuntimeCapabilitiesTool.ts
+++ b/src/main/libs/agentEngine/piSkillRuntimeCapabilitiesTool.ts
@@ -22,7 +22,7 @@ export function buildPiSkillRuntimeCapabilitiesTool(): Record<string, unknown> {
       additionalProperties: false,
     },
     execute: async (): Promise<SkillRuntimeCapabilitiesToolResult> => {
-      const details = probeSkillRuntimeCapabilities();
+      const details = await probeSkillRuntimeCapabilities();
       return {
         content: [{ type: 'text', text: JSON.stringify(details, null, 2) }],
         details,

--- a/src/main/libs/agentEngine/piSkillScriptTool.ts
+++ b/src/main/libs/agentEngine/piSkillScriptTool.ts
@@ -1,0 +1,101 @@
+import { runManagedSkillScript, type SkillScriptRunResult } from '../skillRuntimeRunner';
+
+export const PiSkillScriptToolName = 'run_skill_script';
+
+type SkillScriptToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+};
+
+const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const resultText = (result: SkillScriptRunResult): string => {
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+  if (result.ok) {
+    return output || `Skill script completed successfully (${result.runtime}).`;
+  }
+  return [
+    `Skill script failed [${result.errorCode || 'SKILL_SCRIPT_FAILED'}].`,
+    result.error,
+    output,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
+
+export function buildPiSkillScriptTool(options: {
+  workspaceRoot: string;
+  allowedSkillIds: string[];
+}): Record<string, unknown> {
+  const allowedSkillIds = new Set(
+    options.allowedSkillIds.map(value => value.trim()).filter(Boolean),
+  );
+
+  return {
+    name: PiSkillScriptToolName,
+    label: 'Run Skill Script',
+    description:
+      'Run a bundled Skill script with the application-managed runtime. ' +
+      'Use this for Python, Node, PowerShell, or Bash scripts from a selected Skill; ' +
+      'do not invoke python3, node, npm, or bash directly for a bundled Skill script. ' +
+      'The script path must be relative to the selected Skill directory.',
+    parameters: {
+      type: 'object',
+      properties: {
+        skillId: {
+          type: 'string',
+          description: 'The selected Skill id, such as xlsx, docx, pdf, or presentation-studio.',
+        },
+        script: {
+          type: 'string',
+          description: 'A relative script path inside that Skill, such as scripts/xlsx_reader.py.',
+        },
+        args: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Arguments passed as an argv array; do not build a shell command string.',
+        },
+        timeoutMs: { type: 'number', minimum: 1000, maximum: 900000 },
+      },
+      required: ['skillId', 'script'],
+      additionalProperties: false,
+    },
+    execute: async (
+      _toolCallId: string,
+      params: Record<string, unknown>,
+      signal?: AbortSignal,
+    ): Promise<SkillScriptToolResult> => {
+      const skillId = text(params.skillId);
+      const script = text(params.script);
+      const args = Array.isArray(params.args)
+        ? params.args.filter((value): value is string => typeof value === 'string')
+        : [];
+      if (!allowedSkillIds.has(skillId)) {
+        const denied: SkillScriptToolResult = {
+          content: [
+            { type: 'text', text: `Skill script denied: ${skillId || '(missing skillId)'}.` },
+          ],
+          details: { errorCode: 'SKILL_NOT_SELECTED', skillId, script },
+        };
+        return denied;
+      }
+
+      const result = await runManagedSkillScript({
+        skillId,
+        script,
+        args,
+        workspaceRoot: options.workspaceRoot,
+        timeoutMs: typeof params.timeoutMs === 'number' ? params.timeoutMs : undefined,
+        signal,
+      });
+      return {
+        content: [{ type: 'text', text: resultText(result) }],
+        details: {
+          ...result,
+          command: result.command,
+          args: result.args,
+        },
+      };
+    },
+  };
+}

--- a/src/main/libs/agentEngine/piSkillScriptTool.ts
+++ b/src/main/libs/agentEngine/piSkillScriptTool.ts
@@ -11,13 +11,20 @@ const text = (value: unknown): string => (typeof value === 'string' ? value.trim
 
 const resultText = (result: SkillScriptRunResult): string => {
   const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+  const truncationWarning =
+    result.stdoutTruncated || result.stderrTruncated
+      ? 'Skill script output was truncated at 1 MiB per stream.'
+      : '';
   if (result.ok) {
-    return output || `Skill script completed successfully (${result.runtime}).`;
+    return [output || `Skill script completed successfully (${result.runtime}).`, truncationWarning]
+      .filter(Boolean)
+      .join('\n');
   }
   return [
     `Skill script failed [${result.errorCode || 'SKILL_SCRIPT_FAILED'}].`,
     result.error,
     output,
+    truncationWarning,
   ]
     .filter(Boolean)
     .join('\n');

--- a/src/main/libs/agentEngine/piSubagentTool.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.ts
@@ -255,11 +255,20 @@ async function runSubagent(
         `bash "${path.join(deps.webSearchSkillPath || '', 'scripts/search.sh')}" "<query>" 10\n` +
         'Open the returned primary sources where possible. Never substitute model memory for a retrieved citation.'
       : profile.systemPrompt;
-    subOptions.resourceLoader = researcherUsesWebSearch
+    const resourceLoader = researcherUsesWebSearch
       ? await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens, [
           CoreSkillId.WebSearch,
         ])
       : await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens);
+    subOptions.resourceLoader = resourceLoader;
+    if (
+      resourceLoader &&
+      typeof resourceLoader === 'object' &&
+      'settingsManager' in resourceLoader &&
+      (resourceLoader as { settingsManager?: unknown }).settingsManager
+    ) {
+      subOptions.settingsManager = (resourceLoader as { settingsManager: unknown }).settingsManager;
+    }
     if (deps.resolvedModel.modelRuntime) {
       subOptions.modelRuntime = deps.resolvedModel.modelRuntime;
     }

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -674,6 +674,14 @@ export function ensureElectronNodeShim(electronPath: string, npmBinDir?: string)
  * Priority: env var override > bundled PortableGit > installed Git > PATH lookup.
  * Every candidate must pass a health check (`cygpath -u`) before use.
  */
+export function resolveGitBashPathForPi(): string | null {
+  return resolveWindowsGitBashPath();
+}
+
+export function getGitBashResolutionErrorForPi(): string | null {
+  return cachedGitBashResolutionError;
+}
+
 function resolveWindowsGitBashPath(): string | null {
   if (cachedGitBashPath !== undefined) return cachedGitBashPath;
 

--- a/src/main/libs/skillPythonRuntime.ts
+++ b/src/main/libs/skillPythonRuntime.ts
@@ -1,0 +1,94 @@
+import crypto from 'crypto';
+import { app } from 'electron';
+import fs from 'fs';
+import path from 'path';
+
+const RUNTIME_DIR_NAME = 'skill-python';
+
+function resolveBundledCandidates(): string[] {
+  if (app.isPackaged) {
+    const candidates: string[] = [];
+    if (typeof process.resourcesPath === 'string' && process.resourcesPath) {
+      candidates.push(path.join(process.resourcesPath, RUNTIME_DIR_NAME));
+    }
+    try {
+      candidates.push(path.join(app.getAppPath(), RUNTIME_DIR_NAME));
+    } catch {
+      // Some Node-only test harnesses mark Electron as packaged without an app path.
+    }
+    const projectRoot = path.resolve(__dirname, '..', '..', '..');
+    candidates.push(path.join(projectRoot, 'resources', RUNTIME_DIR_NAME));
+    return candidates;
+  }
+
+  const projectRoot = path.resolve(__dirname, '..', '..', '..');
+  return [
+    path.join(projectRoot, 'resources', RUNTIME_DIR_NAME),
+    path.join(process.cwd(), 'resources', RUNTIME_DIR_NAME),
+    path.join(app.getAppPath(), 'resources', RUNTIME_DIR_NAME),
+  ];
+}
+
+function findPythonExecutable(environmentRoot: string): string | null {
+  const candidates =
+    process.platform === 'win32'
+      ? [
+          path.join(environmentRoot, 'Scripts', 'python.exe'),
+          path.join(environmentRoot, 'python.exe'),
+        ]
+      : [path.join(environmentRoot, 'bin', 'python3'), path.join(environmentRoot, 'bin', 'python')];
+  return candidates.find(candidate => fs.existsSync(candidate)) || null;
+}
+
+function readManifest(environmentRoot: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(path.join(environmentRoot, 'runtime.json'), 'utf8'),
+    );
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function requirementsHash(requirementsPath: string): string | null {
+  try {
+    return crypto.createHash('sha256').update(fs.readFileSync(requirementsPath)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function candidateRoots(): string[] {
+  const userRoot = path.join(app.getPath('userData'), 'runtimes', RUNTIME_DIR_NAME);
+  return [userRoot, ...resolveBundledCandidates()].filter(
+    (candidate, index, candidates) =>
+      candidates.indexOf(candidate) === index && fs.existsSync(candidate),
+  );
+}
+
+/**
+ * Resolve a prebuilt Skill environment only when its requirements manifest
+ * matches the active Skill copy. This prevents a stale user Skill update from
+ * silently using incompatible packaged dependencies.
+ */
+export function findSkillPythonExecutable(
+  skillId: string,
+  requirementsPath: string,
+): string | null {
+  const expectedHash = requirementsHash(requirementsPath);
+  if (!expectedHash) return null;
+
+  for (const root of candidateRoots()) {
+    const environmentRoot = path.join(root, skillId);
+    const manifest = readManifest(environmentRoot);
+    if (manifest?.requirementsSha256 !== expectedHash || manifest?.skillId !== skillId) continue;
+    const executable = findPythonExecutable(environmentRoot);
+    if (executable) return executable;
+  }
+  return null;
+}
+
+export function getSkillPythonRuntimeRoot(): string | null {
+  return candidateRoots()[0] || null;
+}

--- a/src/main/libs/skillRuntimeCapabilities.test.ts
+++ b/src/main/libs/skillRuntimeCapabilities.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { probeSkillRuntimeCapabilities } from './skillRuntimeCapabilities';
 
 describe('skill runtime capabilities', () => {
-  it('returns a structured report for every application-managed runtime', () => {
-    const report = probeSkillRuntimeCapabilities();
+  it('returns a structured report for every application-managed runtime', async () => {
+    const report = await probeSkillRuntimeCapabilities();
 
     expect(report.platform).toBe(process.platform);
     expect(report.arch).toBe(process.arch);

--- a/src/main/libs/skillRuntimeCapabilities.test.ts
+++ b/src/main/libs/skillRuntimeCapabilities.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { probeSkillRuntimeCapabilities } from './skillRuntimeCapabilities';
+
+describe('skill runtime capabilities', () => {
+  it('returns a structured report for every application-managed runtime', () => {
+    const report = probeSkillRuntimeCapabilities();
+
+    expect(report.platform).toBe(process.platform);
+    expect(report.arch).toBe(process.arch);
+    for (const capability of [
+      report.python,
+      report.uv,
+      report.node,
+      report.bash,
+      report.powershell,
+      report.pandoc,
+    ]) {
+      expect(typeof capability.available).toBe('boolean');
+      expect(capability.executable === null || typeof capability.executable === 'string').toBe(
+        true,
+      );
+      expect(capability.version === null || typeof capability.version === 'string').toBe(true);
+    }
+
+    expect(report.skillPython).toEqual(expect.any(Object));
+    expect(report.skillPython.xlsx).toEqual(
+      expect.objectContaining({ available: expect.any(Boolean) }),
+    );
+  });
+});

--- a/src/main/libs/skillRuntimeCapabilities.ts
+++ b/src/main/libs/skillRuntimeCapabilities.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import {
+  getElectronNodeRuntimePath,
+  getGitBashResolutionErrorForPi,
+  getSkillsRoot,
+  resolveGitBashPathForPi,
+} from './coworkUtil';
+import { findBundledPandocExecutable } from './pandocRuntime';
+import { getManagedPythonExecutable } from './pythonRuntime';
+import { findSkillPythonExecutable } from './skillPythonRuntime';
+import { findBundledUvExecutable } from './uvRuntime';
+
+export type SkillRuntimeCapability = {
+  available: boolean;
+  executable: string | null;
+  version: string | null;
+  error?: string;
+};
+
+export type SkillRuntimeCapabilities = {
+  platform: NodeJS.Platform;
+  arch: string;
+  python: SkillRuntimeCapability;
+  uv: SkillRuntimeCapability;
+  node: SkillRuntimeCapability;
+  bash: SkillRuntimeCapability;
+  powershell: SkillRuntimeCapability;
+  pandoc: SkillRuntimeCapability;
+  skillPython: Record<string, SkillRuntimeCapability>;
+};
+
+function resolveOptional<T>(resolver: () => T): T | null {
+  try {
+    return resolver();
+  } catch {
+    return null;
+  }
+}
+
+function probe(
+  executable: string | null,
+  args: string[],
+  versionArgs = args,
+): SkillRuntimeCapability {
+  if (!executable) {
+    return { available: false, executable: null, version: null, error: 'executable not found' };
+  }
+  const result = spawnSync(executable, versionArgs, {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: 30_000,
+    shell: false,
+    windowsHide: true,
+  });
+  const output = `${result.stdout || result.stderr || ''}`.trim();
+  if (result.status === 0) return { available: true, executable, version: output || 'available' };
+  return {
+    available: false,
+    executable,
+    version: null,
+    error: `${output || result.error?.message || `exit code ${result.status}`}`.trim(),
+  };
+}
+
+function skillPythonCapabilities(): Record<string, SkillRuntimeCapability> {
+  const root = resolveOptional(() => getSkillsRoot());
+  const result: Record<string, SkillRuntimeCapability> = {};
+  const skillIds = ['xlsx', 'pdf', 'programming-tutor'];
+  if (!root) {
+    for (const skillId of skillIds) {
+      result[skillId] = probe(null, ['--version']);
+    }
+    return result;
+  }
+  for (const skillId of skillIds) {
+    const requirementsPath = path.join(root, skillId, 'requirements.txt');
+    const executable = resolveOptional(() => findSkillPythonExecutable(skillId, requirementsPath));
+    result[skillId] = probe(executable, ['--version']);
+  }
+  return result;
+}
+
+/** Probe only application-owned runtimes used by Skill execution. */
+export function probeSkillRuntimeCapabilities(): SkillRuntimeCapabilities {
+  const python = resolveOptional(() => getManagedPythonExecutable());
+  const uv = resolveOptional(() =>
+    findBundledUvExecutable(process.platform === 'win32' ? 'uv.exe' : 'uv'),
+  );
+  const node = resolveOptional(() => getElectronNodeRuntimePath());
+  const bash =
+    process.platform === 'win32' ? resolveOptional(() => resolveGitBashPathForPi()) : '/bin/bash';
+  const powershell = process.platform === 'win32' ? 'powershell.exe' : null;
+  const pandoc = resolveOptional(() => findBundledPandocExecutable());
+
+  const bashCapability = probe(bash, ['--version']);
+  if (!bashCapability.available && process.platform === 'win32') {
+    const resolutionError = getGitBashResolutionErrorForPi();
+    if (resolutionError) bashCapability.error = resolutionError;
+  }
+
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    python: probe(python, ['--version']),
+    uv: probe(uv, ['--version']),
+    node: probe(node, ['--version'], ['--version']),
+    bash: bashCapability,
+    powershell: probe(powershell, [
+      '-NoProfile',
+      '-Command',
+      '$PSVersionTable.PSVersion.ToString()',
+    ]),
+    pandoc: probe(pandoc, ['--version']),
+    skillPython: skillPythonCapabilities(),
+  };
+}

--- a/src/main/libs/skillRuntimeCapabilities.ts
+++ b/src/main/libs/skillRuntimeCapabilities.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import path from 'path';
 
 import {
@@ -39,51 +39,137 @@ function resolveOptional<T>(resolver: () => T): T | null {
   }
 }
 
+const PROBE_TIMEOUT_MS = 30_000;
+const MAX_PROBE_OUTPUT_BYTES = 64 * 1024;
+
 function probe(
   executable: string | null,
   args: string[],
   versionArgs = args,
-): SkillRuntimeCapability {
+): Promise<SkillRuntimeCapability> {
   if (!executable) {
-    return { available: false, executable: null, version: null, error: 'executable not found' };
+    return Promise.resolve({
+      available: false,
+      executable: null,
+      version: null,
+      error: 'executable not found',
+    });
   }
-  const result = spawnSync(executable, versionArgs, {
-    encoding: 'utf8',
-    stdio: 'pipe',
-    timeout: 30_000,
-    shell: false,
-    windowsHide: true,
+
+  return new Promise(resolve => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+    let timeout: NodeJS.Timeout | null = null;
+    let forceKillTimeout: NodeJS.Timeout | null = null;
+
+    const append = (current: string, chunk: Buffer | string): string => {
+      const remaining = MAX_PROBE_OUTPUT_BYTES - Buffer.byteLength(current, 'utf8');
+      if (remaining <= 0) return current;
+      const bytes = Buffer.from(chunk);
+      return current + bytes.subarray(0, remaining).toString('utf8');
+    };
+
+    const finish = (capability: SkillRuntimeCapability): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
+      resolve(capability);
+    };
+
+    let child: ChildProcess;
+    try {
+      child = spawn(executable, versionArgs, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: false,
+        windowsHide: true,
+      });
+    } catch (error) {
+      finish({
+        available: false,
+        executable,
+        version: null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    child.stdout?.on('data', chunk => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr?.on('data', chunk => {
+      stderr = append(stderr, chunk);
+    });
+    child.once('error', error => {
+      finish({
+        available: false,
+        executable,
+        version: null,
+        error: `${stderr || stdout || error.message}`.trim(),
+      });
+    });
+    child.once('close', code => {
+      const output = `${stdout || stderr}`.trim();
+      if (code === 0 && !timedOut) {
+        finish({ available: true, executable, version: output || 'available' });
+        return;
+      }
+      finish({
+        available: false,
+        executable,
+        version: null,
+        error: timedOut
+          ? `runtime probe timed out after ${PROBE_TIMEOUT_MS}ms`
+          : `${output || `exit code ${code}`}`.trim(),
+      });
+    });
+    timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      forceKillTimeout = setTimeout(() => {
+        if (settled) return;
+        child.kill();
+        finish({
+          available: false,
+          executable,
+          version: null,
+          error: `runtime probe timed out after ${PROBE_TIMEOUT_MS}ms`,
+        });
+      }, 2_000);
+    }, PROBE_TIMEOUT_MS);
   });
-  const output = `${result.stdout || result.stderr || ''}`.trim();
-  if (result.status === 0) return { available: true, executable, version: output || 'available' };
-  return {
-    available: false,
-    executable,
-    version: null,
-    error: `${output || result.error?.message || `exit code ${result.status}`}`.trim(),
-  };
 }
 
-function skillPythonCapabilities(): Record<string, SkillRuntimeCapability> {
+async function skillPythonCapabilities(): Promise<Record<string, SkillRuntimeCapability>> {
   const root = resolveOptional(() => getSkillsRoot());
   const result: Record<string, SkillRuntimeCapability> = {};
   const skillIds = ['xlsx', 'pdf', 'programming-tutor'];
   if (!root) {
-    for (const skillId of skillIds) {
-      result[skillId] = probe(null, ['--version']);
-    }
+    const capabilities = await Promise.all(skillIds.map(() => probe(null, ['--version'])));
+    skillIds.forEach((skillId, index) => {
+      result[skillId] = capabilities[index];
+    });
     return result;
   }
-  for (const skillId of skillIds) {
-    const requirementsPath = path.join(root, skillId, 'requirements.txt');
-    const executable = resolveOptional(() => findSkillPythonExecutable(skillId, requirementsPath));
-    result[skillId] = probe(executable, ['--version']);
-  }
+  const capabilities = await Promise.all(
+    skillIds.map(skillId => {
+      const requirementsPath = path.join(root, skillId, 'requirements.txt');
+      const executable = resolveOptional(() =>
+        findSkillPythonExecutable(skillId, requirementsPath),
+      );
+      return probe(executable, ['--version']);
+    }),
+  );
+  skillIds.forEach((skillId, index) => {
+    result[skillId] = capabilities[index];
+  });
   return result;
 }
 
 /** Probe only application-owned runtimes used by Skill execution. */
-export function probeSkillRuntimeCapabilities(): SkillRuntimeCapabilities {
+export async function probeSkillRuntimeCapabilities(): Promise<SkillRuntimeCapabilities> {
   const python = resolveOptional(() => getManagedPythonExecutable());
   const uv = resolveOptional(() =>
     findBundledUvExecutable(process.platform === 'win32' ? 'uv.exe' : 'uv'),
@@ -94,7 +180,23 @@ export function probeSkillRuntimeCapabilities(): SkillRuntimeCapabilities {
   const powershell = process.platform === 'win32' ? 'powershell.exe' : null;
   const pandoc = resolveOptional(() => findBundledPandocExecutable());
 
-  const bashCapability = probe(bash, ['--version']);
+  const [
+    bashCapability,
+    pythonCapability,
+    uvCapability,
+    nodeCapability,
+    powershellCapability,
+    pandocCapability,
+    skillPython,
+  ] = await Promise.all([
+    probe(bash, ['--version']),
+    probe(python, ['--version']),
+    probe(uv, ['--version']),
+    probe(node, ['--version'], ['--version']),
+    probe(powershell, ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()']),
+    probe(pandoc, ['--version']),
+    skillPythonCapabilities(),
+  ]);
   if (!bashCapability.available && process.platform === 'win32') {
     const resolutionError = getGitBashResolutionErrorForPi();
     if (resolutionError) bashCapability.error = resolutionError;
@@ -103,16 +205,12 @@ export function probeSkillRuntimeCapabilities(): SkillRuntimeCapabilities {
   return {
     platform: process.platform,
     arch: process.arch,
-    python: probe(python, ['--version']),
-    uv: probe(uv, ['--version']),
-    node: probe(node, ['--version'], ['--version']),
+    python: pythonCapability,
+    uv: uvCapability,
+    node: nodeCapability,
     bash: bashCapability,
-    powershell: probe(powershell, [
-      '-NoProfile',
-      '-Command',
-      '$PSVersionTable.PSVersion.ToString()',
-    ]),
-    pandoc: probe(pandoc, ['--version']),
-    skillPython: skillPythonCapabilities(),
+    powershell: powershellCapability,
+    pandoc: pandocCapability,
+    skillPython,
   };
 }

--- a/src/main/libs/skillRuntimeRunner.test.ts
+++ b/src/main/libs/skillRuntimeRunner.test.ts
@@ -1,0 +1,266 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as XLSX from 'xlsx';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveSkillScriptPath, runManagedSkillScript } from './skillRuntimeRunner';
+
+describe('skillRuntimeRunner', () => {
+  const roots: string[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps script execution inside the selected skill directory', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-'));
+    roots.push(root);
+    const skillDir = path.join(root, 'xlsx', 'scripts');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'reader.py'), 'print("ok")\n');
+
+    const valid = resolveSkillScriptPath(root, 'xlsx', 'scripts/reader.py');
+    const realRoot = fs.realpathSync(root);
+    expect(valid).toEqual({
+      scriptPath: path.join(realRoot, 'xlsx', 'scripts', 'reader.py'),
+      skillDir: path.join(realRoot, 'xlsx'),
+    });
+
+    const escaped = resolveSkillScriptPath(root, 'xlsx', '../outside.py');
+    expect('errorCode' in escaped && escaped.errorCode).toBe('SKILL_SCRIPT_OUTSIDE_ROOT');
+  });
+
+  it('reports a missing script distinctly from a missing runtime', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'pdf'), { recursive: true });
+
+    const result = resolveSkillScriptPath(root, 'pdf', 'scripts/inspect.py');
+    expect('errorCode' in result && result.errorCode).toBe('SKILL_SCRIPT_NOT_FOUND');
+    expect('error' in result && result.error).toContain('Skill script not found');
+  });
+
+  it('returns the script failure and stderr instead of relabeling it as a missing file', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'xlsx', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'xlsx', 'scripts', 'reader.mjs'),
+      'process.stderr.write("input file is not readable\\n"); process.exit(3);\n',
+    );
+
+    const result = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'xlsx',
+      script: 'scripts/reader.mjs',
+      workspaceRoot: root,
+      timeoutMs: 10_000,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe('SKILL_SCRIPT_FAILED');
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain('input file is not readable');
+  });
+
+  it('runs a Node Skill script without a shell command string', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'presentation-studio', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'presentation-studio', 'scripts', 'probe.mjs'),
+      'process.stdout.write(process.argv.slice(2).join("|"));\n',
+    );
+
+    const result = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'presentation-studio',
+      script: 'scripts/probe.mjs',
+      args: ['a b', 'c'],
+      workspaceRoot: root,
+      timeoutMs: 10_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.runtime).toBe('node');
+    expect(result.stdout).toBe('a b|c');
+  });
+
+  it('reads an XLSX file through the packaged Skill Python environment', async () => {
+    const skillsRoot = path.resolve(process.cwd(), 'SKILLs');
+    const packagedEnvironment = path.resolve(process.cwd(), 'resources', 'skill-python', 'xlsx');
+    if (!fs.existsSync(packagedEnvironment)) return;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-xlsx-'));
+    roots.push(root);
+    const inputPath = path.join(root, 'sample.xlsx');
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.aoa_to_sheet([
+        ['Name', 'Score'],
+        ['Alice', 98],
+      ]),
+      'Scores',
+    );
+    XLSX.writeFile(workbook, inputPath);
+
+    const result = await runManagedSkillScript({
+      skillsRoot,
+      skillId: 'xlsx',
+      script: 'scripts/xlsx_reader.py',
+      args: [inputPath, '--json'],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.runtime).toBe('python');
+    expect(result.stdout).toContain('Scores');
+    expect(result.stdout).toContain('Alice');
+  });
+
+  it('creates a simple DOCX through the managed Bash and Pandoc path', async () => {
+    const skillsRoot = path.resolve(process.cwd(), 'SKILLs');
+    const pandocPath = path.resolve(process.cwd(), 'resources', 'pandoc', 'pandoc');
+    if (!fs.existsSync(pandocPath)) return;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-docx-'));
+    roots.push(root);
+    const inputPath = path.join(root, 'content.md');
+    const outputPath = path.join(root, 'content.docx');
+    fs.writeFileSync(inputPath, '# Managed DOCX\n\nCreated through the Pi Skill runner.\n');
+
+    const result = await runManagedSkillScript({
+      skillsRoot,
+      skillId: 'docx',
+      script: 'scripts/markdown_to_docx.sh',
+      args: [inputPath, outputPath],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.runtime).toBe('bash');
+    expect(fs.statSync(outputPath).size).toBeGreaterThan(0);
+  });
+
+  it('runs the PDF inspection pipeline with the packaged PDF Skill environment', async () => {
+    const sourceRoot = path.resolve(process.cwd(), 'SKILLs', 'pdf');
+    const requirementsPath = path.join(sourceRoot, 'requirements.txt');
+    const packagedEnvironment = path.resolve(process.cwd(), 'resources', 'skill-python', 'pdf');
+    if (!fs.existsSync(requirementsPath) || !fs.existsSync(packagedEnvironment)) return;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-pdf-'));
+    roots.push(root);
+    const skillDir = path.join(root, 'pdf');
+    const scriptDir = path.join(skillDir, 'scripts');
+    fs.mkdirSync(scriptDir, { recursive: true });
+    fs.copyFileSync(requirementsPath, path.join(skillDir, 'requirements.txt'));
+    fs.copyFileSync(
+      path.join(sourceRoot, 'scripts', 'pdf_inspect.py'),
+      path.join(scriptDir, 'pdf_inspect.py'),
+    );
+    fs.writeFileSync(
+      path.join(scriptDir, 'create_pdf.py'),
+      [
+        'import sys',
+        'from reportlab.pdfgen import canvas',
+        'document = canvas.Canvas(sys.argv[1])',
+        'document.drawString(72, 720, "Managed PDF")',
+        'document.save()',
+      ].join('\n'),
+    );
+    const inputPath = path.join(root, 'input.pdf');
+    const outputDir = path.join(root, 'inspection');
+
+    const create = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'pdf',
+      script: 'scripts/create_pdf.py',
+      args: [inputPath],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(create.ok).toBe(true);
+
+    const inspect = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'pdf',
+      script: 'scripts/pdf_inspect.py',
+      args: [inputPath, '--output', outputDir],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(inspect.ok).toBe(true);
+    expect(inspect.runtime).toBe('python');
+    expect(fs.existsSync(path.join(outputDir, 'inspection.json'))).toBe(true);
+  });
+
+  it('validates and compiles a PowerPoint deck through the managed Electron Node path', async () => {
+    const skillsRoot = path.resolve(process.cwd(), 'SKILLs');
+    const presentationRoot = path.join(skillsRoot, 'presentation-studio');
+    if (!fs.existsSync(path.join(presentationRoot, 'node_modules', 'pptxgenjs'))) return;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-ppt-'));
+    roots.push(root);
+    const pagesDir = path.join(root, 'pages');
+    const outputDir = path.join(root, 'output');
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'deck.json'),
+      JSON.stringify({
+        title: 'Managed deck',
+        canvas: { width: 1280, height: 720 },
+        theme: {
+          colors: { background: '#101820', text: '#FFFFFF', accent: '#F2AA4C' },
+          textStyles: { title: { fontSize: 34, fontFace: 'Arial', color: '$text', bold: true } },
+        },
+        pages: ['pages/01-cover.json'],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, '01-cover.json'),
+      JSON.stringify({
+        pageType: 'cover',
+        background: '$background',
+        elements: [
+          {
+            id: 'title',
+            type: 'text',
+            bounds: [96, 240, 720, 80],
+            style: '$title',
+            text: 'Managed deck',
+          },
+        ],
+      }),
+    );
+
+    const validation = await runManagedSkillScript({
+      skillsRoot,
+      skillId: 'presentation-studio',
+      script: 'scripts/validate-deck.mjs',
+      args: [
+        path.join(root, 'deck.json'),
+        '--strict',
+        '--json',
+        path.join(outputDir, 'validation.json'),
+      ],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(validation.ok).toBe(true);
+
+    const compile = await runManagedSkillScript({
+      skillsRoot,
+      skillId: 'presentation-studio',
+      script: 'scripts/compile-deck.mjs',
+      args: [path.join(root, 'deck.json'), path.join(outputDir, 'presentation.pptx')],
+      workspaceRoot: root,
+      timeoutMs: 30_000,
+    });
+    expect(compile.ok).toBe(true);
+    expect(fs.statSync(path.join(outputDir, 'presentation.pptx')).size).toBeGreaterThan(0);
+  });
+});

--- a/src/main/libs/skillRuntimeRunner.test.ts
+++ b/src/main/libs/skillRuntimeRunner.test.ts
@@ -94,7 +94,7 @@ describe('skillRuntimeRunner', () => {
     fs.mkdirSync(path.join(root, 'xlsx', 'scripts'), { recursive: true });
     fs.writeFileSync(
       path.join(root, 'xlsx', 'scripts', 'noisy.mjs'),
-      'process.stdout.write("x".repeat(2 * 1024 * 1024));\n',
+      'process.stdout.write("😀".repeat(400_000));\n',
     );
 
     const result = await runManagedSkillScript({
@@ -107,6 +107,7 @@ describe('skillRuntimeRunner', () => {
     expect(result.ok).toBe(true);
     expect(Buffer.byteLength(result.stdout, 'utf8')).toBeLessThanOrEqual(1024 * 1024);
     expect(result.stdoutTruncated).toBe(true);
+    expect(result.stdout).not.toContain('\uFFFD');
   });
 
   it('reads an XLSX file through the packaged Skill Python environment', async () => {

--- a/src/main/libs/skillRuntimeRunner.test.ts
+++ b/src/main/libs/skillRuntimeRunner.test.ts
@@ -88,6 +88,27 @@ describe('skillRuntimeRunner', () => {
     expect(result.stdout).toBe('a b|c');
   });
 
+  it('bounds captured stdout and reports truncation', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-output-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'xlsx', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'xlsx', 'scripts', 'noisy.mjs'),
+      'process.stdout.write("x".repeat(2 * 1024 * 1024));\n',
+    );
+
+    const result = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'xlsx',
+      script: 'scripts/noisy.mjs',
+      workspaceRoot: root,
+      timeoutMs: 10_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBeLessThanOrEqual(1024 * 1024);
+    expect(result.stdoutTruncated).toBe(true);
+  });
+
   it('reads an XLSX file through the packaged Skill Python environment', async () => {
     const skillsRoot = path.resolve(process.cwd(), 'SKILLs');
     const packagedEnvironment = path.resolve(process.cwd(), 'resources', 'skill-python', 'xlsx');

--- a/src/main/libs/skillRuntimeRunner.test.ts
+++ b/src/main/libs/skillRuntimeRunner.test.ts
@@ -110,6 +110,27 @@ describe('skillRuntimeRunner', () => {
     expect(result.stdout).not.toContain('\uFFFD');
   });
 
+  it('does not report truncation when stdout exactly reaches the capture limit', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-runtime-output-limit-'));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, 'xlsx', 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'xlsx', 'scripts', 'exact-limit.mjs'),
+      'process.stdout.write("x".repeat(1024 * 1024));\n',
+    );
+
+    const result = await runManagedSkillScript({
+      skillsRoot: root,
+      skillId: 'xlsx',
+      script: 'scripts/exact-limit.mjs',
+      workspaceRoot: root,
+      timeoutMs: 10_000,
+    });
+    expect(result.ok).toBe(true);
+    expect(Buffer.byteLength(result.stdout, 'utf8')).toBe(1024 * 1024);
+    expect(result.stdoutTruncated).toBe(false);
+  });
+
   it('reads an XLSX file through the packaged Skill Python environment', async () => {
     const skillsRoot = path.resolve(process.cwd(), 'SKILLs');
     const packagedEnvironment = path.resolve(process.cwd(), 'resources', 'skill-python', 'xlsx');

--- a/src/main/libs/skillRuntimeRunner.ts
+++ b/src/main/libs/skillRuntimeRunner.ts
@@ -96,7 +96,6 @@ const appendCapturedOutput = (current: CapturedOutput, chunk: Buffer | string): 
   current.parts.push(current.decoder.write(captured));
   current.capturedBytes += captured.byteLength;
   if (captured.byteLength < bytes.byteLength) current.truncated = true;
-  if (current.capturedBytes >= MAX_CAPTURED_OUTPUT_BYTES) current.truncated = true;
 };
 
 const finalizeCapturedOutput = (current: CapturedOutput): string => {

--- a/src/main/libs/skillRuntimeRunner.ts
+++ b/src/main/libs/skillRuntimeRunner.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { StringDecoder } from 'string_decoder';
 
 import {
   getElectronNodeRuntimePath,
@@ -65,20 +66,50 @@ const MAX_CAPTURED_OUTPUT_BYTES = 1 * 1024 * 1024;
 
 const trimOutput = (value: string): string => value.trim();
 
-const appendCapturedOutput = (
-  current: string,
-  chunk: Buffer | string,
-): { value: string; truncated: boolean } => {
-  const remaining = MAX_CAPTURED_OUTPUT_BYTES - Buffer.byteLength(current, 'utf8');
-  if (remaining <= 0) return { value: current, truncated: true };
-  const bytes = Buffer.from(chunk);
-  if (bytes.byteLength <= remaining) {
-    return { value: current + bytes.toString('utf8'), truncated: false };
+type CapturedOutput = {
+  decoder: StringDecoder;
+  parts: string[];
+  capturedBytes: number;
+  truncated: boolean;
+  finalized: boolean;
+  value: string;
+};
+
+const createCapturedOutput = (): CapturedOutput => ({
+  decoder: new StringDecoder('utf8'),
+  parts: [],
+  capturedBytes: 0,
+  truncated: false,
+  finalized: false,
+  value: '',
+});
+
+const appendCapturedOutput = (current: CapturedOutput, chunk: Buffer | string): void => {
+  if (current.truncated) return;
+  const remaining = MAX_CAPTURED_OUTPUT_BYTES - current.capturedBytes;
+  if (remaining <= 0) {
+    current.truncated = true;
+    return;
   }
-  return {
-    value: current + bytes.subarray(0, remaining).toString('utf8'),
-    truncated: true,
-  };
+  const bytes = Buffer.from(chunk);
+  const captured = bytes.byteLength <= remaining ? bytes : bytes.subarray(0, remaining);
+  current.parts.push(current.decoder.write(captured));
+  current.capturedBytes += captured.byteLength;
+  if (captured.byteLength < bytes.byteLength) current.truncated = true;
+  if (current.capturedBytes >= MAX_CAPTURED_OUTPUT_BYTES) current.truncated = true;
+};
+
+const finalizeCapturedOutput = (current: CapturedOutput): string => {
+  if (current.finalized) return current.value;
+  if (!current.truncated) {
+    current.parts.push(current.decoder.end());
+  } else {
+    // The byte cap may have ended in the middle of a UTF-8 sequence. Do not
+    // flush the decoder because that would return a replacement character.
+  }
+  current.value = current.parts.join('');
+  current.finalized = true;
+  return current.value;
 };
 
 const isWithin = (root: string, candidate: string): boolean => {
@@ -388,10 +419,8 @@ export async function runManagedSkillScript(
   }
 
   return await new Promise<SkillScriptRunResult>(resolve => {
-    let stdout = '';
-    let stderr = '';
-    let stdoutTruncated = false;
-    let stderrTruncated = false;
+    const stdout = createCapturedOutput();
+    const stderr = createCapturedOutput();
     let settled = false;
     let timedOut = false;
     let aborted = false;
@@ -429,15 +458,26 @@ export async function runManagedSkillScript(
     options.signal?.addEventListener('abort', onAbort, { once: true });
 
     child.stdout.on('data', chunk => {
-      const captured = appendCapturedOutput(stdout, chunk);
-      stdout = captured.value;
-      stdoutTruncated ||= captured.truncated;
+      appendCapturedOutput(stdout, chunk);
     });
     child.stderr.on('data', chunk => {
-      const captured = appendCapturedOutput(stderr, chunk);
-      stderr = captured.value;
-      stderrTruncated ||= captured.truncated;
+      appendCapturedOutput(stderr, chunk);
     });
+    const capturedResult = (): {
+      stdout: string;
+      stderr: string;
+      stdoutTruncated: boolean;
+      stderrTruncated: boolean;
+    } => {
+      const stdoutText = finalizeCapturedOutput(stdout);
+      const stderrText = finalizeCapturedOutput(stderr);
+      return {
+        stdout: trimOutput(stdoutText),
+        stderr: trimOutput(stderrText),
+        stdoutTruncated: stdout.truncated,
+        stderrTruncated: stderr.truncated,
+      };
+    };
     child.on('error', (error: NodeJS.ErrnoException) => {
       clearTimeout(timeoutTimer);
       if (forceKillTimer) clearTimeout(forceKillTimer);
@@ -449,6 +489,7 @@ export async function runManagedSkillScript(
           : error.code === 'ENOENT'
             ? 'SKILL_RUNTIME_UNAVAILABLE'
             : 'SKILL_SCRIPT_FAILED';
+      const output = capturedResult();
       finish({
         ok: false,
         status: timedOut ? 'timed-out' : aborted ? 'aborted' : 'failed',
@@ -459,12 +500,12 @@ export async function runManagedSkillScript(
         args: commandArgs,
         scriptPath: resolved.scriptPath,
         exitCode: null,
-        stdout: trimOutput(stdout),
-        stderr: trimOutput(stderr),
+        stdout: output.stdout,
+        stderr: output.stderr,
         durationMs: Date.now() - startedAt,
         timedOut,
-        stdoutTruncated,
-        stderrTruncated,
+        stdoutTruncated: output.stdoutTruncated,
+        stderrTruncated: output.stderrTruncated,
       });
     });
     child.on('close', exitCode => {
@@ -472,6 +513,7 @@ export async function runManagedSkillScript(
       if (forceKillTimer) clearTimeout(forceKillTimer);
       options.signal?.removeEventListener('abort', onAbort);
       const failed = timedOut || aborted || exitCode !== 0;
+      const output = capturedResult();
       finish({
         ok: !failed,
         status: timedOut ? 'timed-out' : aborted ? 'aborted' : failed ? 'failed' : 'completed',
@@ -494,12 +536,12 @@ export async function runManagedSkillScript(
         args: commandArgs,
         scriptPath: resolved.scriptPath,
         exitCode,
-        stdout: trimOutput(stdout),
-        stderr: trimOutput(stderr),
+        stdout: output.stdout,
+        stderr: output.stderr,
         durationMs: Date.now() - startedAt,
         timedOut,
-        stdoutTruncated,
-        stderrTruncated,
+        stdoutTruncated: output.stdoutTruncated,
+        stderrTruncated: output.stderrTruncated,
       });
     });
   });

--- a/src/main/libs/skillRuntimeRunner.ts
+++ b/src/main/libs/skillRuntimeRunner.ts
@@ -42,6 +42,8 @@ export type SkillScriptRunResult = {
   stderr: string;
   durationMs: number;
   timedOut: boolean;
+  stdoutTruncated?: boolean;
+  stderrTruncated?: boolean;
 };
 
 export type RunSkillScriptOptions = {
@@ -59,8 +61,25 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 15 * 60_000;
 const MAX_ARGUMENTS = 128;
 const MAX_ARGUMENT_LENGTH = 16_384;
+const MAX_CAPTURED_OUTPUT_BYTES = 1 * 1024 * 1024;
 
 const trimOutput = (value: string): string => value.trim();
+
+const appendCapturedOutput = (
+  current: string,
+  chunk: Buffer | string,
+): { value: string; truncated: boolean } => {
+  const remaining = MAX_CAPTURED_OUTPUT_BYTES - Buffer.byteLength(current, 'utf8');
+  if (remaining <= 0) return { value: current, truncated: true };
+  const bytes = Buffer.from(chunk);
+  if (bytes.byteLength <= remaining) {
+    return { value: current + bytes.toString('utf8'), truncated: false };
+  }
+  return {
+    value: current + bytes.subarray(0, remaining).toString('utf8'),
+    truncated: true,
+  };
+};
 
 const isWithin = (root: string, candidate: string): boolean => {
   const relative = path.relative(root, candidate);
@@ -371,6 +390,8 @@ export async function runManagedSkillScript(
   return await new Promise<SkillScriptRunResult>(resolve => {
     let stdout = '';
     let stderr = '';
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
     let settled = false;
     let timedOut = false;
     let aborted = false;
@@ -408,10 +429,14 @@ export async function runManagedSkillScript(
     options.signal?.addEventListener('abort', onAbort, { once: true });
 
     child.stdout.on('data', chunk => {
-      stdout += chunk.toString();
+      const captured = appendCapturedOutput(stdout, chunk);
+      stdout = captured.value;
+      stdoutTruncated ||= captured.truncated;
     });
     child.stderr.on('data', chunk => {
-      stderr += chunk.toString();
+      const captured = appendCapturedOutput(stderr, chunk);
+      stderr = captured.value;
+      stderrTruncated ||= captured.truncated;
     });
     child.on('error', (error: NodeJS.ErrnoException) => {
       clearTimeout(timeoutTimer);
@@ -438,6 +463,8 @@ export async function runManagedSkillScript(
         stderr: trimOutput(stderr),
         durationMs: Date.now() - startedAt,
         timedOut,
+        stdoutTruncated,
+        stderrTruncated,
       });
     });
     child.on('close', exitCode => {
@@ -471,6 +498,8 @@ export async function runManagedSkillScript(
         stderr: trimOutput(stderr),
         durationMs: Date.now() - startedAt,
         timedOut,
+        stdoutTruncated,
+        stderrTruncated,
       });
     });
   });

--- a/src/main/libs/skillRuntimeRunner.ts
+++ b/src/main/libs/skillRuntimeRunner.ts
@@ -1,0 +1,477 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  getElectronNodeRuntimePath,
+  getEnhancedEnv,
+  getSkillsRoot,
+  getGitBashResolutionErrorForPi,
+  resolveGitBashPathForPi,
+} from './coworkUtil';
+import { appendPandocRuntimeToEnv } from './pandocRuntime';
+import { appendPythonRuntimeToEnv, getManagedPythonExecutable } from './pythonRuntime';
+import { findSkillPythonExecutable } from './skillPythonRuntime';
+import {
+  appendUvRuntimeToEnv,
+  configureUvForManagedPython,
+  findBundledUvExecutable,
+} from './uvRuntime';
+
+export type SkillScriptErrorCode =
+  | 'SKILL_SCRIPT_NOT_FOUND'
+  | 'SKILL_SCRIPT_OUTSIDE_ROOT'
+  | 'SKILL_RUNTIME_UNAVAILABLE'
+  | 'SKILL_SCRIPT_FAILED'
+  | 'SKILL_SCRIPT_TIMEOUT'
+  | 'SKILL_SCRIPT_ABORTED';
+
+export type SkillScriptRuntime = 'python' | 'node' | 'bash' | 'powershell';
+
+export type SkillScriptRunResult = {
+  ok: boolean;
+  status: 'completed' | 'failed' | 'runtime-unavailable' | 'not-found' | 'timed-out' | 'aborted';
+  errorCode?: SkillScriptErrorCode;
+  error?: string;
+  runtime: SkillScriptRuntime | null;
+  command: string | null;
+  args: string[];
+  scriptPath: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  timedOut: boolean;
+};
+
+export type RunSkillScriptOptions = {
+  skillId: string;
+  script: string;
+  args?: string[];
+  workspaceRoot: string;
+  skillsRoot?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  envOverrides?: Record<string, string | undefined>;
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TIMEOUT_MS = 15 * 60_000;
+const MAX_ARGUMENTS = 128;
+const MAX_ARGUMENT_LENGTH = 16_384;
+
+const trimOutput = (value: string): string => value.trim();
+
+const isWithin = (root: string, candidate: string): boolean => {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === '' ||
+    (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+};
+
+const resolveRealPathIfPossible = (value: string): string => {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return path.resolve(value);
+  }
+};
+
+export function resolveSkillScriptPath(
+  skillsRoot: string,
+  skillId: string,
+  script: string,
+): { scriptPath: string; skillDir: string } | { errorCode: SkillScriptErrorCode; error: string } {
+  const root = resolveRealPathIfPossible(path.resolve(skillsRoot));
+  const normalizedSkillId = skillId.trim();
+  const normalizedScript = script.trim();
+  const skillDir = path.resolve(root, normalizedSkillId);
+  const scriptPath = path.resolve(skillDir, normalizedScript);
+
+  if (
+    !normalizedSkillId ||
+    !normalizedScript ||
+    !isWithin(root, skillDir) ||
+    !isWithin(skillDir, scriptPath)
+  ) {
+    return {
+      errorCode: 'SKILL_SCRIPT_OUTSIDE_ROOT',
+      error: 'Skill script must remain inside its selected skill directory.',
+    };
+  }
+
+  const realSkillDir = resolveRealPathIfPossible(skillDir);
+  const realScriptPath = resolveRealPathIfPossible(scriptPath);
+  if (!isWithin(root, realSkillDir) || !isWithin(realSkillDir, realScriptPath)) {
+    return {
+      errorCode: 'SKILL_SCRIPT_OUTSIDE_ROOT',
+      error: 'Skill script must remain inside its selected skill directory.',
+    };
+  }
+
+  if (!fs.existsSync(scriptPath) || !fs.statSync(scriptPath).isFile()) {
+    return {
+      errorCode: 'SKILL_SCRIPT_NOT_FOUND',
+      error: `Skill script not found: ${scriptPath}`,
+    };
+  }
+
+  return { scriptPath, skillDir };
+}
+
+function resolveRuntime(
+  scriptPath: string,
+  skillDir: string,
+):
+  | {
+      runtime: SkillScriptRuntime;
+      command: string;
+      prefixArgs: string[];
+      env: Record<string, string>;
+    }
+  | { errorCode: SkillScriptErrorCode; error: string } {
+  const extension = path.extname(scriptPath).toLowerCase();
+
+  if (extension === '.py') {
+    let executable: string | null = null;
+    try {
+      executable = getManagedPythonExecutable();
+    } catch {
+      executable = null;
+    }
+    const requirementsPath = path.join(skillDir, 'requirements.txt');
+    const skillPythonExecutable = fs.existsSync(requirementsPath)
+      ? findSkillPythonExecutable(path.basename(skillDir), requirementsPath)
+      : null;
+    executable = skillPythonExecutable || executable;
+    if (!executable) {
+      return {
+        errorCode: 'SKILL_RUNTIME_UNAVAILABLE',
+        error: 'The application-managed Python runtime is unavailable for this Skill.',
+      };
+    }
+    if (fs.existsSync(requirementsPath) && !skillPythonExecutable) {
+      let uvExecutable: string | null = null;
+      try {
+        uvExecutable = findBundledUvExecutable(process.platform === 'win32' ? 'uv.exe' : 'uv');
+      } catch {
+        uvExecutable = null;
+      }
+      if (!uvExecutable) {
+        return {
+          errorCode: 'SKILL_RUNTIME_UNAVAILABLE',
+          error: 'The application-managed uv runtime is unavailable for this Skill dependency set.',
+        };
+      }
+      return {
+        runtime: 'python',
+        command: uvExecutable,
+        prefixArgs: [
+          'run',
+          '--no-project',
+          '--with-requirements',
+          requirementsPath,
+          '--python',
+          executable,
+        ],
+        env: { PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8' },
+      };
+    }
+    return {
+      runtime: 'python',
+      command: executable,
+      prefixArgs: [],
+      env: { PYTHONUTF8: '1', PYTHONIOENCODING: 'utf-8' },
+    };
+  }
+
+  if (extension === '.js' || extension === '.mjs' || extension === '.cjs') {
+    return {
+      runtime: 'node',
+      command: getElectronNodeRuntimePath(),
+      prefixArgs: [],
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    };
+  }
+
+  if (extension === '.sh') {
+    const command =
+      process.platform === 'win32'
+        ? resolveGitBashPathForPi()
+        : fs.existsSync('/bin/bash')
+          ? '/bin/bash'
+          : process.env.SHELL || 'bash';
+    if (!command) {
+      return {
+        errorCode: 'SKILL_RUNTIME_UNAVAILABLE',
+        error:
+          'No healthy Git Bash runtime is available for this Skill script.' +
+          (getGitBashResolutionErrorForPi() ? ` ${getGitBashResolutionErrorForPi()}` : ''),
+      };
+    }
+    const requirementsPath = path.join(skillDir, 'requirements.txt');
+    const skillPythonExecutable = fs.existsSync(requirementsPath)
+      ? findSkillPythonExecutable(path.basename(skillDir), requirementsPath)
+      : null;
+    return {
+      runtime: 'bash',
+      command,
+      prefixArgs: [],
+      env: skillPythonExecutable ? { ZHIYUAN_SKILL_PYTHON_BIN: skillPythonExecutable } : {},
+    };
+  }
+
+  if (extension === '.ps1') {
+    if (process.platform !== 'win32') {
+      return {
+        errorCode: 'SKILL_RUNTIME_UNAVAILABLE',
+        error: 'PowerShell Skill scripts are supported only on Windows.',
+      };
+    }
+    return {
+      runtime: 'powershell',
+      command: 'powershell.exe',
+      prefixArgs: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File'],
+      env: {},
+    };
+  }
+
+  return {
+    errorCode: 'SKILL_RUNTIME_UNAVAILABLE',
+    error: `Unsupported Skill script type: ${extension || '(no extension)'}.`,
+  };
+}
+
+function invalidInputResult(
+  scriptPath: string,
+  errorCode: SkillScriptErrorCode,
+  error: string,
+): SkillScriptRunResult {
+  return {
+    ok: false,
+    status:
+      errorCode === 'SKILL_SCRIPT_NOT_FOUND' || errorCode === 'SKILL_SCRIPT_OUTSIDE_ROOT'
+        ? 'not-found'
+        : errorCode === 'SKILL_RUNTIME_UNAVAILABLE'
+          ? 'runtime-unavailable'
+          : 'failed',
+    errorCode,
+    error,
+    runtime: null,
+    command: null,
+    args: [],
+    scriptPath,
+    exitCode: null,
+    stdout: '',
+    stderr: '',
+    durationMs: 0,
+    timedOut: false,
+  };
+}
+
+export async function runManagedSkillScript(
+  options: RunSkillScriptOptions,
+): Promise<SkillScriptRunResult> {
+  const skillsRoot = options.skillsRoot || getSkillsRoot();
+  const resolved = resolveSkillScriptPath(skillsRoot, options.skillId, options.script);
+  if ('errorCode' in resolved) {
+    return invalidInputResult(
+      path.resolve(skillsRoot, options.skillId, options.script),
+      resolved.errorCode,
+      resolved.error,
+    );
+  }
+
+  const args = options.args || [];
+  if (
+    args.length > MAX_ARGUMENTS ||
+    args.some(value => typeof value !== 'string' || value.length > MAX_ARGUMENT_LENGTH)
+  ) {
+    return invalidInputResult(
+      resolved.scriptPath,
+      'SKILL_SCRIPT_FAILED',
+      `Skill script arguments exceed the supported limit (${MAX_ARGUMENTS} arguments, ${MAX_ARGUMENT_LENGTH} characters each).`,
+    );
+  }
+
+  const runtime = resolveRuntime(resolved.scriptPath, resolved.skillDir);
+  if ('errorCode' in runtime) {
+    return invalidInputResult(resolved.scriptPath, runtime.errorCode, runtime.error);
+  }
+
+  const timeoutMs = Math.min(
+    Math.max(options.timeoutMs || DEFAULT_TIMEOUT_MS, 1_000),
+    MAX_TIMEOUT_MS,
+  );
+  let env: Record<string, string | undefined>;
+  try {
+    env = await getEnhancedEnv('local');
+  } catch (error) {
+    // Keep the direct runner usable in test harnesses and unusual embedded
+    // launches where Electron has not populated resourcesPath yet. The
+    // managed runtimes are still appended below; this fallback is not a
+    // request to use user-installed Python or Node binaries.
+    console.warn(
+      '[skill-runtime] Falling back to process environment:',
+      error instanceof Error ? error.message : String(error),
+    );
+    env = { ...process.env };
+  }
+  try {
+    appendPythonRuntimeToEnv(env);
+  } catch (error) {
+    console.warn(
+      '[skill-runtime] Managed Python environment was not appended:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  try {
+    appendPandocRuntimeToEnv(env);
+  } catch (error) {
+    console.warn(
+      '[skill-runtime] Managed Pandoc environment was not appended:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  try {
+    appendUvRuntimeToEnv(env);
+    configureUvForManagedPython(env);
+  } catch (error) {
+    console.warn(
+      '[skill-runtime] Managed uv environment was not appended:',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  Object.assign(env, runtime.env, options.envOverrides || {});
+  env.SKILLS_ROOT = skillsRoot;
+  env.ZHIYUAN_SKILLS_ROOT = skillsRoot;
+
+  const commandArgs = [...runtime.prefixArgs, resolved.scriptPath, ...args];
+  const startedAt = Date.now();
+
+  if (options.signal?.aborted) {
+    return {
+      ok: false,
+      status: 'aborted',
+      errorCode: 'SKILL_SCRIPT_ABORTED',
+      error: 'Skill script was aborted before it started.',
+      runtime: runtime.runtime,
+      command: runtime.command,
+      args: commandArgs,
+      scriptPath: resolved.scriptPath,
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      durationMs: 0,
+      timedOut: false,
+    };
+  }
+
+  return await new Promise<SkillScriptRunResult>(resolve => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timedOut = false;
+    let aborted = false;
+    let forceKillTimer: NodeJS.Timeout | null = null;
+
+    const child = spawn(runtime.command, commandArgs, {
+      cwd: path.resolve(options.workspaceRoot),
+      env: env as NodeJS.ProcessEnv,
+      shell: false,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const finish = (result: SkillScriptRunResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    const stopChild = (): void => {
+      child.kill('SIGTERM');
+      forceKillTimer = setTimeout(() => child.kill('SIGKILL'), 2_000);
+    };
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      stopChild();
+    }, timeoutMs);
+
+    const onAbort = (): void => {
+      if (settled) return;
+      aborted = true;
+      stopChild();
+    };
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      clearTimeout(timeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      options.signal?.removeEventListener('abort', onAbort);
+      const errorCode = timedOut
+        ? 'SKILL_SCRIPT_TIMEOUT'
+        : aborted
+          ? 'SKILL_SCRIPT_ABORTED'
+          : error.code === 'ENOENT'
+            ? 'SKILL_RUNTIME_UNAVAILABLE'
+            : 'SKILL_SCRIPT_FAILED';
+      finish({
+        ok: false,
+        status: timedOut ? 'timed-out' : aborted ? 'aborted' : 'failed',
+        errorCode,
+        error: error.message,
+        runtime: runtime.runtime,
+        command: runtime.command,
+        args: commandArgs,
+        scriptPath: resolved.scriptPath,
+        exitCode: null,
+        stdout: trimOutput(stdout),
+        stderr: trimOutput(stderr),
+        durationMs: Date.now() - startedAt,
+        timedOut,
+      });
+    });
+    child.on('close', exitCode => {
+      clearTimeout(timeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      options.signal?.removeEventListener('abort', onAbort);
+      const failed = timedOut || aborted || exitCode !== 0;
+      finish({
+        ok: !failed,
+        status: timedOut ? 'timed-out' : aborted ? 'aborted' : failed ? 'failed' : 'completed',
+        errorCode: timedOut
+          ? 'SKILL_SCRIPT_TIMEOUT'
+          : aborted
+            ? 'SKILL_SCRIPT_ABORTED'
+            : failed
+              ? 'SKILL_SCRIPT_FAILED'
+              : undefined,
+        error: timedOut
+          ? `Skill script timed out after ${timeoutMs}ms.`
+          : aborted
+            ? 'Skill script was aborted.'
+            : failed
+              ? `Skill script exited with code ${exitCode ?? 'unknown'}.`
+              : undefined,
+        runtime: runtime.runtime,
+        command: runtime.command,
+        args: commandArgs,
+        scriptPath: resolved.scriptPath,
+        exitCode,
+        stdout: trimOutput(stdout),
+        stderr: trimOutput(stderr),
+        durationMs: Date.now() - startedAt,
+        timedOut,
+      });
+    });
+  });
+}

--- a/src/main/skillManager.test.ts
+++ b/src/main/skillManager.test.ts
@@ -1,8 +1,39 @@
-import { expect, test } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, expect, test } from 'vitest';
 
 import { __skillManagerTestUtils } from './skillManager';
 
-const { parseFrontmatter, isTruthy, extractDescription } = __skillManagerTestUtils;
+const { parseFrontmatter, isTruthy, extractDescription, hasMatchingBundledRequirements } =
+  __skillManagerTestUtils;
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('bundled Skill requirements trigger repair for an older userData copy', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-manager-runtime-sync-'));
+  tempRoots.push(root);
+  const bundledDir = path.join(root, 'bundled', 'xlsx');
+  const targetDir = path.join(root, 'userData', 'xlsx');
+  fs.mkdirSync(bundledDir, { recursive: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(bundledDir, 'requirements.txt'), 'pandas>=2.2,<3\n');
+
+  expect(hasMatchingBundledRequirements(targetDir, bundledDir)).toBe(false);
+
+  fs.writeFileSync(path.join(targetDir, 'requirements.txt'), 'pandas>=2.2,<3\n');
+  expect(hasMatchingBundledRequirements(targetDir, bundledDir)).toBe(true);
+
+  fs.writeFileSync(path.join(targetDir, 'requirements.txt'), 'pandas>=2.1,<3\n');
+  expect(hasMatchingBundledRequirements(targetDir, bundledDir)).toBe(false);
+});
 
 // ==================== parseFrontmatter ====================
 

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -480,6 +480,25 @@ const compareVersions = (a: string, b: string): number => {
   return 0;
 };
 
+/**
+ * Requirements are part of a bundled Skill's runtime contract. Existing
+ * userData copies must be repaired when a newly bundled requirements file is
+ * added or changed, even if an older Skill used the same metadata version.
+ */
+const hasMatchingBundledRequirements = (targetDir: string, bundledDir: string): boolean => {
+  const bundledRequirements = path.join(bundledDir, 'requirements.txt');
+  if (!fs.existsSync(bundledRequirements)) return true;
+
+  const targetRequirements = path.join(targetDir, 'requirements.txt');
+  if (!fs.existsSync(targetRequirements)) return false;
+
+  try {
+    return fs.readFileSync(targetRequirements).equals(fs.readFileSync(bundledRequirements));
+  } catch {
+    return false;
+  }
+};
+
 const resolveWithin = (root: string, target: string): string => {
   const resolvedRoot = path.resolve(root);
   const resolvedTarget = path.resolve(root, target);
@@ -1564,6 +1583,10 @@ export class SkillManager {
    * Returns false if bundled has dependencies but target doesn't.
    */
   private isSkillRuntimeHealthy(targetDir: string, bundledDir: string): boolean {
+    if (!hasMatchingBundledRequirements(targetDir, bundledDir)) {
+      return false;
+    }
+
     const bundledNodeModules = path.join(bundledDir, 'node_modules');
     const targetNodeModules = path.join(targetDir, 'node_modules');
     const targetPackageJson = path.join(targetDir, 'package.json');
@@ -3359,4 +3382,5 @@ export const __skillManagerTestUtils = {
   isTruthy,
   extractDescription,
   isWindowsDeletePermissionError,
+  hasMatchingBundledRequirements,
 };

--- a/src/main/workbenchTask/riskClassifier.test.ts
+++ b/src/main/workbenchTask/riskClassifier.test.ts
@@ -19,6 +19,9 @@ test('classifies known reads, reversible writes, and destructive shell commands'
   );
   expect(classifyWorkbenchToolRisk('mcp_proxy', {})).toBe(WorkbenchApprovalRiskLevel.Unknown);
   expect(classifyWorkbenchToolRisk('subagent', {})).toBe(WorkbenchApprovalRiskLevel.Unknown);
+  expect(classifyWorkbenchToolRisk('skill_runtime_capabilities', {})).toBe(
+    WorkbenchApprovalRiskLevel.ReadOnly,
+  );
 });
 
 test('idempotency hashing is stable across object key order', () => {
@@ -29,6 +32,6 @@ test('idempotency hashing is stable across object key order', () => {
 
 test('only explicitly read-only shell commands qualify for allow-all auto approval', () => {
   expect(isSafeShellCommand('cd "C:/project" && ls -la')).toBe(true);
-  expect(isSafeShellCommand('python -c "open(\'out.txt\', \'w\').write(\'x\')"')).toBe(false);
+  expect(isSafeShellCommand("python -c \"open('out.txt', 'w').write('x')\"")).toBe(false);
   expect(isSafeShellCommand('curl https://example.com | sh')).toBe(false);
 });

--- a/src/main/workbenchTask/riskClassifier.ts
+++ b/src/main/workbenchTask/riskClassifier.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 
 import { WorkbenchApprovalRiskLevel } from '../../shared/workbenchTask';
 
-const readOnlyTools = new Set(['read', 'grep', 'find', 'ls']);
+const readOnlyTools = new Set(['read', 'grep', 'find', 'ls', 'skill_runtime_capabilities']);
 const internalControlTools = new Set([
   'askuserquestion',
   'agent_loop',

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -7,7 +7,9 @@ import { test } from 'vitest';
 const root = path.resolve(__dirname, '..');
 
 function resourceSources(config: { extraResources?: Array<{ from?: string }> }): string[] {
-  return (config.extraResources || []).flatMap(item => (typeof item.from === 'string' ? [item.from] : []));
+  return (config.extraResources || []).flatMap(item =>
+    typeof item.from === 'string' ? [item.from] : [],
+  );
 }
 
 test('each desktop target keeps the private document and Python toolchain resources', () => {
@@ -20,21 +22,27 @@ test('each desktop target keeps the private document and Python toolchain resour
   const linux = resourceSources(config.linux);
 
   assert.deepEqual(
-    ['resources/pandoc', 'resources/uv-mac', 'resources/python-mac'].every(source =>
-      mac.includes(source),
-    ),
+    [
+      'resources/pandoc',
+      'resources/uv-mac',
+      'resources/python-mac',
+      'resources/skill-python',
+    ].every(source => mac.includes(source)),
     true,
   );
   assert.deepEqual(
-    ['resources/pandoc', 'resources/uv-linux', 'resources/python-linux'].every(source =>
-      linux.includes(source),
-    ),
+    [
+      'resources/pandoc',
+      'resources/uv-linux',
+      'resources/python-linux',
+      'resources/skill-python',
+    ].every(source => linux.includes(source)),
     true,
   );
 
   // Windows puts large resources in a tar consumed by the NSIS installer.
   const hooks = readFileSync(path.join(root, 'scripts', 'electron-builder-hooks.cjs'), 'utf8');
-  for (const resource of ['python-win', 'uv-win', 'pandoc']) {
+  for (const resource of ['mingit', 'python-win', 'skill-python', 'uv-win', 'pandoc']) {
     assert.match(hooks, new RegExp(`prefix: '${resource}'`));
   }
 });
@@ -46,4 +54,23 @@ test('release workflows explicitly provision the private POSIX toolchain', () =>
     assert.match(content, /bun run setup:posix-python-runtime/);
     assert.match(content, /bun run setup:pandoc-runtime/);
   }
+});
+
+test('Windows release workflow runs the clean-path bundled runtime gate', () => {
+  for (const workflowName of ['build-platforms.yml', 'online-update-release.yml']) {
+    const workflow = readFileSync(path.join(root, '.github', 'workflows', workflowName), 'utf8');
+    assert.match(workflow, /windows-runtime-smoke\.ps1/);
+  }
+  const smoke = readFileSync(path.join(root, 'scripts', 'ci', 'windows-runtime-smoke.ps1'), 'utf8');
+  assert.match(smoke, /skill-python\\xlsx/);
+  assert.match(smoke, /skill-python\\pdf/);
+  assert.match(smoke, /DOCX Markdown conversion/);
+  assert.match(smoke, /External command unexpectedly remains discoverable/);
+  assert.match(smoke, /mingit\\usr\\bin\\bash\.exe/);
+  assert.match(smoke, /PATH = "\$env:SystemRoot\\System32;\$env:SystemRoot"/);
+  const packageScript = readFileSync(
+    path.join(root, 'scripts', 'ci', 'package-windows.ps1'),
+    'utf8',
+  );
+  assert.match(packageScript, /windows-runtime-smoke\.ps1/);
 });

--- a/tests/setupSkillPythonRuntime.test.ts
+++ b/tests/setupSkillPythonRuntime.test.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  listRequirementFiles,
+  normalizePlatform,
+  parseImportNames,
+} from '../scripts/setup-skill-python-runtime.js';
+
+describe('setup-skill-python-runtime', () => {
+  it('normalizes supported packaging platforms', () => {
+    expect(normalizePlatform('windows')).toBe('win32');
+    expect(normalizePlatform('macOS')).toBe('darwin');
+    expect(normalizePlatform('linux')).toBe('linux');
+  });
+
+  it('maps package names to import names and ignores requirement options', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-python-'));
+    try {
+      const requirements = path.join(root, 'requirements.txt');
+      fs.writeFileSync(
+        requirements,
+        '# comment\nPillow>=10\nscikit-learn>=1\n--extra-index-url https://example.invalid\n',
+      );
+      expect(parseImportNames(requirements)).toEqual(['PIL', 'sklearn']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('finds requirements files only at Skill roots', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skills-'));
+    try {
+      fs.mkdirSync(path.join(root, 'xlsx'), { recursive: true });
+      fs.mkdirSync(path.join(root, 'docx'), { recursive: true });
+      fs.writeFileSync(path.join(root, 'xlsx', 'requirements.txt'), 'openpyxl>=3\n');
+      expect(listRequirementFiles(root).map(entry => entry.skillId)).toEqual(['xlsx']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fix Windows Pi shell initialization by reusing the existing Git Bash resolver and applying the resolved shell path through Pi's `SettingsManager`.
- Add managed Skill script execution and packaged runtime capability detection without relying on the host shell.
- Package the base Python runtime, Skill-specific Python environments, PortableGit Bash, uv, Pandoc, and the runtime dependencies needed by XLSX/PDF/DOCX workflows.
- Add a Windows 10/11 clean-PATH CI gate covering XLSX, PDF, Bash, Pandoc, and Markdown-to-DOCX execution.

## Issue

Closes #293

## Validation

- Local TypeScript build, lint, focused tests, and formatting checks passed.
- Windows CI run [30817571511](https://github.com/rongxinzy/RongxinAI/actions/runs/30817571511) passed.
- The Windows clean-PATH gate passed on Windows 10.0.26100.0.
- The gate verified bundled Python 3.14.6, pandas/openpyxl XLSX creation and reading, PDF dependencies, PortableGit Bash, Pandoc, and Markdown-to-DOCX conversion.

## Notes

- `reasonix.toml` is an unrelated untracked local file and is not included in this PR.
