### PR TITLE
fix: remove unused chat skill test import

### DIFF
--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -5,7 +5,7 @@
  * Regression covered: locally enabled skills were filtered out of Chat even
  * though the same skills were available in Work.
  */
-import { AcademicResearchSkillIds, CoreSkillId, isCoreSkill } from '@shared/skills/constants';
+import { AcademicResearchSkillIds, isCoreSkill } from '@shared/skills/constants';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 


### PR DESCRIPTION
## Summary\n- remove the unused CoreSkillId import from the chat constants test\n- restore the full TypeScript build required by macOS/Linux release packaging\n\n## Evidence\n- local: bun run build:tsc passes\n- root cause: release run 30874183557 failed at src/renderer/components/chat/constants.test.ts:8\n