### PR TITLE
ci: fail fast across platform builds

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -26,9 +26,27 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-macos:
-    if: ${{ inputs.build_macos }}
-    runs-on: macos-latest
+  build-platforms:
+    strategy:
+      # A manual platform build is a single release unit; cancel sibling builds
+      # as soon as one selected platform fails.
+      fail-fast: true
+      matrix:
+        include:
+          - platform: macos
+            enabled: ${{ inputs.build_macos }}
+            runner: macos-latest
+            artifact: macos-build
+          - platform: windows
+            enabled: ${{ inputs.build_windows }}
+            runner: windows-latest
+            artifact: windows-build
+          - platform: linux
+            enabled: ${{ inputs.build_linux }}
+            runner: ubuntu-latest
+            artifact: linux-build
+    if: ${{ matrix.enabled }}
+    runs-on: ${{ matrix.runner }}
     environment: release
     # A release build may download upstream runtimes, but it must never consume
     # a runner indefinitely when an upstream command stalls.
@@ -45,107 +63,74 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up bundled macOS runtimes
-        run: |
-          bun run setup:posix-uv-runtime
-          bun run setup:posix-python-runtime
-          bun run setup:pandoc-runtime
-      - name: Build macOS
-        run: bun run dist:mac
-        env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
-          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: macos-build
-          path: release/*.dmg
-          retention-days: 7
-
-  build-windows:
-    if: ${{ inputs.build_windows }}
-    runs-on: windows-latest
-    environment: release
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.14'
-      # The bundled runtime uses pnpm upstream; Bun installs this repository.
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up bundled uv
-        run: bun run setup:uv-runtime
-      - name: Set up uv-managed Python 3.14.6 runtime
-        run: bun run setup:python-runtime
-      - name: Build Windows
-        run: bun run dist:win
-        env:
-          NODE_OPTIONS: '--max-old-space-size=4096'
-          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
-      - name: Verify Windows package runtimes with a clean PATH
-        shell: powershell
-        run: >-
-          powershell -NoProfile -ExecutionPolicy Bypass
-          -File scripts/ci/windows-runtime-smoke.ps1
-          -ProjectRoot ${{ github.workspace }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: windows-build
-          path: release/*.exe
-          retention-days: 7
-
-  build-linux:
-    if: ${{ inputs.build_linux }}
-    runs-on: ubuntu-latest
-    environment: release
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24.x'
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.3.14'
-      # The bundled runtime uses pnpm upstream; Bun installs this repository.
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - name: Install Electron system dependencies
+        if: ${{ matrix.platform == 'linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
             libxss1 libxtst6 libuuid1 xdg-utils xvfb
       - run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up bundled Ubuntu runtimes
+      - name: Set up Windows runtimes
+        if: ${{ matrix.platform == 'windows' }}
+        run: |
+          bun run setup:uv-runtime
+          bun run setup:python-runtime
+      - name: Set up POSIX runtimes
+        if: ${{ matrix.platform != 'windows' }}
         run: |
           bun run setup:posix-uv-runtime
           bun run setup:posix-python-runtime
           bun run setup:pandoc-runtime
+      - name: Build macOS
+        if: ${{ matrix.platform == 'macos' }}
+        run: bun run dist:mac
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Build Windows
+        if: ${{ matrix.platform == 'windows' }}
+        run: bun run dist:win
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
       - name: Build Linux
+        if: ${{ matrix.platform == 'linux' }}
         run: bun run dist:linux
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify Windows package runtimes with a clean PATH
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/windows-runtime-smoke.ps1
+          -ProjectRoot ${{ github.workspace }}
       - name: Verify the packaged renderer in a virtual Ubuntu desktop
+        if: ${{ matrix.platform == 'linux' }}
         run: >-
           node scripts/verify-linux-renderer.mjs
           release/linux-unpacked
           release/linux-render-smoke.png
       - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ matrix.platform == 'macos' }}
         with:
-          name: linux-build
+          name: ${{ matrix.artifact }}
+          path: release/*.dmg
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.platform == 'windows' }}
+        with:
+          name: ${{ matrix.artifact }}
+          path: release/*.exe
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() && matrix.platform == 'linux' }}
+        with:
+          name: ${{ matrix.artifact }}
           path: |
             release/*.AppImage
             release/*.deb

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -54,73 +54,24 @@ jobs:
   quality:
     uses: ./.github/workflows/ci.yml
 
-  build-windows-lite:
+  build-platforms:
     needs: prepare-release
-    runs-on: windows-latest
-    environment: release
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare-release.outputs.commit }}
-      - uses: actions/setup-node@v4
-        with: { node-version: "24.x" }
-      - uses: oven-sh/setup-bun@v2
-        with: { bun-version: "1.3.14" }
-      # OpenClaw is built with pnpm upstream; Bun remains this repository's installer.
-      - uses: pnpm/action-setup@v4
-        with: { version: 10 }
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - run: bun run setup:uv-runtime
-      - run: bun run setup:python-runtime
-      - run: bun run dist:win:lite
-        env:
-          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
-          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
-          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
-          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
-      - name: Verify Windows package runtimes with a clean PATH
-        shell: powershell
-        run: >-
-          powershell -NoProfile -ExecutionPolicy Bypass
-          -File scripts/ci/windows-runtime-smoke.ps1
-          -ProjectRoot ${{ github.workspace }}
-      - uses: actions/upload-artifact@v4
-        with: { name: win32-x64-lite, path: "release/*.exe" }
-
-  build-macos-arm64:
-    needs: prepare-release
-    runs-on: macos-latest
-    environment: release
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare-release.outputs.commit }}
-      - uses: actions/setup-node@v4
-        with: { node-version: "24.x" }
-      - uses: oven-sh/setup-bun@v2
-        with: { bun-version: "1.3.14" }
-      # OpenClaw is built with pnpm upstream; Bun remains this repository's installer.
-      - uses: pnpm/action-setup@v4
-        with: { version: 10 }
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up bundled macOS runtimes
-        run: |
-          bun run setup:posix-uv-runtime
-          bun run setup:posix-python-runtime
-          bun run setup:pandoc-runtime
-      - run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
-        env:
-          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
-          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
-          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
-      - uses: actions/upload-artifact@v4
-        with: { name: darwin-arm64-default, path: "release/*.dmg" }
-
-  build-linux-x64:
-    needs: prepare-release
-    runs-on: ubuntu-latest
+    strategy:
+      # A release is only valid when every platform artifact is available.
+      # Cancel sibling builds as soon as one platform fails.
+      fail-fast: true
+      matrix:
+        include:
+          - platform: windows
+            runner: windows-latest
+            artifact: win32-x64-lite
+          - platform: macos
+            runner: macos-latest
+            artifact: darwin-arm64-default
+          - platform: linux
+            runner: ubuntu-latest
+            artifact: linux-x64-default
+    runs-on: ${{ matrix.runner }}
     environment: release
     steps:
       - uses: actions/checkout@v4
@@ -134,40 +85,83 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10 }
       - name: Install Electron and virtual desktop dependencies
+        if: ${{ matrix.platform == 'linux' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
             libxss1 libxtst6 libuuid1 xdg-utils xvfb
       - run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up bundled Ubuntu runtimes
+      - name: Set up Windows runtimes
+        if: ${{ matrix.platform == 'windows' }}
+        run: |
+          bun run setup:uv-runtime
+          bun run setup:python-runtime
+      - name: Set up POSIX runtimes
+        if: ${{ matrix.platform != 'windows' }}
         run: |
           bun run setup:posix-uv-runtime
           bun run setup:posix-python-runtime
           bun run setup:pandoc-runtime
-      - name: Build Ubuntu deb and Linux AppImage
+      - name: Build Windows package
+        if: ${{ matrix.platform == 'windows' }}
+        run: bun run dist:win:lite
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Build macOS package
+        if: ${{ matrix.platform == 'macos' }}
+        run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Build Linux packages
+        if: ${{ matrix.platform == 'linux' }}
         run: bun run dist:linux
         env:
           APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify Windows package runtimes with a clean PATH
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/windows-runtime-smoke.ps1
+          -ProjectRoot ${{ github.workspace }}
       - name: Verify the packaged renderer in a virtual Ubuntu desktop
+        if: ${{ matrix.platform == 'linux' }}
         run: >-
           node scripts/verify-linux-renderer.mjs
           release/linux-unpacked
           release/linux-render-smoke.png
       - uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: ${{ matrix.platform == 'windows' }}
         with:
-          name: linux-x64-default
+          name: ${{ matrix.artifact }}
+          path: "release/*.exe"
+      - uses: actions/upload-artifact@v4
+        if: ${{ matrix.platform == 'macos' }}
+        with:
+          name: ${{ matrix.artifact }}
+          path: "release/*.dmg"
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() && matrix.platform == 'linux' }}
+        with:
+          name: ${{ matrix.artifact }}
           path: |
             release/*.deb
             release/*.AppImage
             release/linux-render-smoke.png
 
   publish:
-    needs: [prepare-release, build-windows-lite, build-macos-arm64, build-linux-x64]
+    needs: [prepare-release, build-platforms]
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
## Summary
- run release platform builds as a fail-fast matrix
- cancel sibling platform builds when one platform fails
- apply the same behavior to the manual platform build workflow

## Verification
- YAML parsing passed locally
- git diff --check passed
- existing release run with the known macOS failure was cancelled so build.2 can proceed
