### PR TITLE
ci: pass ClawHub token to release builds

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -73,6 +73,10 @@ jobs:
             artifact: linux-x64-default
     runs-on: ${{ matrix.runner }}
     environment: release
+    env:
+      # OpenClaw reads CLAWHUB_TOKEN; map the repository secret without
+      # exposing its name or value in the build command line.
+      CLAWHUB_TOKEN: ${{ secrets.CLAW_HUB }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- map the repository CLAW_HUB secret to OpenClaw CLAWHUB_TOKEN for release platform builds
- keep the token out of command-line arguments and logs

## Verification
- workflow YAML parsed successfully
- git diff --check passed
- a follow-up release tag will verify the authenticated ClawHub path on Windows
