### PR TITLE
fix(cowork): simplify pending message actions

### DIFF
--- a/src/renderer/components/cowork/PendingMessageQueue.tsx
+++ b/src/renderer/components/cowork/PendingMessageQueue.tsx
@@ -1,13 +1,7 @@
 import { Button } from '@shared/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@shared/components/ui/dropdown-menu';
 import { Input } from '@shared/components/ui/input';
 import { cn } from '@shared/lib/utils';
-import { Check, Compass, Ellipsis, ListTodo, Pencil, RotateCcw, Trash2, X } from 'lucide-react';
+import { Check, Compass, ListTodo, Pencil, RotateCcw, Trash2, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import {
@@ -221,6 +215,17 @@ const PendingMessageQueue = ({ sessionId, isStreaming }: PendingMessageQueueProp
                       <Button
                         type="button"
                         variant="ghost"
+                        size="sm"
+                        className="h-7 gap-1 px-2 text-xs"
+                        disabled={isSending}
+                        onClick={() => beginEdit(item)}
+                      >
+                        <Pencil />
+                        {i18nService.t('edit')}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
                         size="icon-xs"
                         title={i18nService.t('delete')}
                         aria-label={i18nService.t('delete')}
@@ -229,28 +234,6 @@ const PendingMessageQueue = ({ sessionId, isStreaming }: PendingMessageQueueProp
                       >
                         <Trash2 />
                       </Button>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger
-                          render={
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              title={i18nService.t('coworkQueueMore')}
-                              aria-label={i18nService.t('coworkQueueMore')}
-                              disabled={isSending}
-                            >
-                              <Ellipsis />
-                            </Button>
-                          }
-                        />
-                        <DropdownMenuContent align="end" className="min-w-28">
-                          <DropdownMenuItem onClick={() => beginEdit(item)}>
-                            <Pencil />
-                            {i18nService.t('edit')}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
                     </>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

调整待处理消息操作栏的顺序与可见性：由“引导｜删除｜更多菜单”改为“引导｜编辑｜删除”。

## Related Issue

无。

## Changes Made

- 移除仅包含编辑操作的省略号下拉菜单。
- 将编辑改为直接可见的按钮，放在引导操作之后。
- 将删除操作移动至最右侧，保留原有删除逻辑与禁用状态。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

已执行：

- `npm run lint`
- `npm run build`

## Screenshots (if applicable)

待本地界面验证时补充。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

本次仅调整渲染层操作入口，不改变待处理消息的引导、编辑或删除业务逻辑。
