### PR TITLE
修复会话权限隔离与实时运行状态

### DIFF
--- a/src/main/coworkPermissionModeChanges.test.ts
+++ b/src/main/coworkPermissionModeChanges.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from 'vitest';
+
+import { CoworkPermissionMode } from '../shared/cowork/constants';
+import { getChangedSessionPermissionModes } from './coworkPermissionModeChanges';
+
+test('returns only the session whose permission mode changed', () => {
+  expect(
+    getChangedSessionPermissionModes(
+      { 'session-a': CoworkPermissionMode.Ask, 'session-b': CoworkPermissionMode.AllowAll },
+      { 'session-a': CoworkPermissionMode.AllowAll, 'session-b': CoworkPermissionMode.AllowAll },
+      CoworkPermissionMode.Ask,
+    ),
+  ).toEqual([['session-a', CoworkPermissionMode.AllowAll]]);
+});
+
+test('restores the fallback mode when a session override is removed', () => {
+  expect(
+    getChangedSessionPermissionModes(
+      { 'session-a': CoworkPermissionMode.AllowAll },
+      {},
+      CoworkPermissionMode.Ask,
+    ),
+  ).toEqual([['session-a', CoworkPermissionMode.Ask]]);
+});

--- a/src/main/coworkPermissionModeChanges.ts
+++ b/src/main/coworkPermissionModeChanges.ts
@@ -1,0 +1,15 @@
+import type { CoworkPermissionMode as CoworkPermissionModeType } from '../shared/cowork/constants';
+
+export const getChangedSessionPermissionModes = (
+  previousModes: Record<string, CoworkPermissionModeType>,
+  nextModes: Record<string, CoworkPermissionModeType>,
+  fallbackMode: CoworkPermissionModeType,
+): Array<[string, CoworkPermissionModeType]> => {
+  const sessionIds = new Set([...Object.keys(previousModes), ...Object.keys(nextModes)]);
+
+  return [...sessionIds].flatMap(sessionId => {
+    const previous = previousModes[sessionId] ?? fallbackMode;
+    const next = nextModes[sessionId] ?? fallbackMode;
+    return previous === next ? [] : [[sessionId, next]];
+  });
+};

--- a/src/main/coworkSessionRuntimeState.test.ts
+++ b/src/main/coworkSessionRuntimeState.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from 'vitest';
+
+import { CoworkSessionMode } from '../shared/cowork/constants';
+import type { CoworkSessionSummary } from './coworkStore';
+import { reconcileWorkSessionRuntimeState } from './coworkSessionRuntimeState';
+
+const makeSession = (overrides: Partial<CoworkSessionSummary> = {}): CoworkSessionSummary => ({
+  id: 'session-1',
+  title: 'Session',
+  status: 'running',
+  mode: CoworkSessionMode.Work,
+  pinned: false,
+  pinOrder: null,
+  workspaceId: 'workspace-1',
+  agentId: 'main',
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+test('clears a stale running state for a Work session that is absent from the runtime', () => {
+  expect(reconcileWorkSessionRuntimeState(makeSession(), false).status).toBe('idle');
+});
+
+test('preserves a running state for an active Work session', () => {
+  expect(reconcileWorkSessionRuntimeState(makeSession(), true).status).toBe('running');
+});
+
+test('does not reconcile direct Chat sessions through the Work runtime', () => {
+  expect(
+    reconcileWorkSessionRuntimeState(makeSession({ mode: CoworkSessionMode.Chat }), false).status,
+  ).toBe('running');
+});

--- a/src/main/coworkSessionRuntimeState.ts
+++ b/src/main/coworkSessionRuntimeState.ts
@@ -1,0 +1,31 @@
+import { CoworkSessionMode } from '../shared/cowork/constants';
+import type { CoworkSession, CoworkSessionSummary } from './coworkStore';
+
+const CoworkRuntimeSessionStatus = {
+  Idle: 'idle',
+  Running: 'running',
+} as const;
+
+type RuntimeTrackedSession = CoworkSession | CoworkSessionSummary;
+
+/**
+ * A persisted running status is only a snapshot. Work sessions must still be
+ * present in the in-process runtime before the renderer treats them as live.
+ */
+export const reconcileWorkSessionRuntimeState = <T extends RuntimeTrackedSession>(
+  session: T,
+  isRuntimeRunning: boolean,
+): T => {
+  if (
+    session.mode !== CoworkSessionMode.Work ||
+    session.status !== CoworkRuntimeSessionStatus.Running ||
+    isRuntimeRunning
+  ) {
+    return session;
+  }
+
+  return {
+    ...session,
+    status: CoworkRuntimeSessionStatus.Idle,
+  };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -82,8 +82,10 @@ import { searchAnySearchGateway } from './libs/anysearchGateway';
 import { resolveAnySearchGatewayToken, resolveAnySearchGatewayUrl } from './libs/anysearchGatewayCredentials';
 import { APP_DATA_DIR_NAME, APP_NAME, DB_FILENAME } from './appConstants';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
+import { getChangedSessionPermissionModes } from './coworkPermissionModeChanges';
 import type { CoworkPromptLanguage } from './coworkLanguagePrompt';
 import { composeCoworkSystemPrompt } from './coworkPrompt/composer';
+import { reconcileWorkSessionRuntimeState } from './coworkSessionRuntimeState';
 import {
   type CoworkExecutionMode,
   type CoworkMessageType,
@@ -4728,10 +4730,20 @@ if (!gotTheLock) {
     },
   );
 
-  ipcMain.handle('cowork:session:get', async (_event, sessionId: string) => {
+  ipcMain.handle(CoworkSessionIpc.Get, async (_event, sessionId: string) => {
     try {
-      const session = getCoworkStore().getSession(sessionId);
-      return { success: true, session };
+      const store = getCoworkStore();
+      const session = store.getSession(sessionId);
+      if (!session) return { success: true, session: null };
+
+      const reconciledSession = reconcileWorkSessionRuntimeState(
+        session,
+        getPiRuntimeAdapter().isSessionRunning(sessionId),
+      );
+      if (reconciledSession.status !== session.status) {
+        store.updateSession(sessionId, { status: reconciledSession.status });
+      }
+      return { success: true, session: reconciledSession };
     } catch (error) {
       return {
         success: false,
@@ -4770,7 +4782,7 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle(
-    'cowork:session:list',
+    CoworkSessionIpc.List,
     async (
       _event,
       options?: {
@@ -4788,7 +4800,16 @@ if (!gotTheLock) {
         const workspaceId = options?.workspaceId;
         const mode = options?.mode;
         const store = getCoworkStore();
-        const sessions = store.listSessions(limit, offset, agentId, workspaceId, mode);
+        const sessions = store.listSessions(limit, offset, agentId, workspaceId, mode).map(session => {
+          const reconciledSession = reconcileWorkSessionRuntimeState(
+            session,
+            getPiRuntimeAdapter().isSessionRunning(session.id),
+          );
+          if (reconciledSession.status !== session.status) {
+            store.updateSession(session.id, { status: reconciledSession.status });
+          }
+          return reconciledSession;
+        });
         const total = store.countSessions(agentId, workspaceId, mode);
         return { success: true, sessions, hasMore: offset + sessions.length < total };
       } catch (error) {
@@ -5626,7 +5647,11 @@ if (!gotTheLock) {
         const previousWorkingDir = previousConfig.workingDirectory;
         getCoworkStore().setConfig(normalizedConfig);
         if (normalizedPermissionModeBySession !== undefined) {
-          for (const [sessionId, mode] of Object.entries(normalizedPermissionModeBySession)) {
+          for (const [sessionId, mode] of getChangedSessionPermissionModes(
+            previousConfig.permissionModeBySession ?? {},
+            normalizedPermissionModeBySession,
+            normalizedPermissionMode ?? previousConfig.permissionMode,
+          )) {
             getPiRuntimeAdapter().setAutoApproveForSession(
               sessionId,
               mode === CoworkPermissionMode.AllowAll,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -35,7 +35,7 @@ import { themeService } from './services/theme';
 import { RootState, store } from './store';
 import {
   selectCurrentSessionId,
-  selectPendingPermissions,
+  selectPendingPermissionForSession,
 } from './store/selectors/coworkSelectors';
 import { setDraftPrompt } from './store/slices/coworkSlice';
 import { setAvailableModels, setDefaultSelectedModel } from './store/slices/modelSlice';
@@ -118,8 +118,9 @@ const App: React.FC = () => {
   const dispatch = useDispatch();
   const defaultSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const currentSessionId = useSelector(selectCurrentSessionId);
-  const pendingPermissions = useSelector(selectPendingPermissions);
-  const pendingPermission = pendingPermissions.find(permission => permission.sessionId === currentSessionId) ?? null;
+  const pendingPermission = useSelector((state: RootState) =>
+    selectPendingPermissionForSession(state, currentSessionId),
+  );
   const isWindows = window.electron.platform === 'win32';
 
   const waitWithTimeout = useCallback(

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -152,7 +152,10 @@ const Sidebar: React.FC<SidebarProps> = ({
       ? sessions.filter(s => s.title.toLowerCase().includes(searchQueryTrimmed))
       : sessions;
     const sorted = sortAgentSidebarTasks(scoped, streamingSessionIds);
-    return sorted.map(s => toAgentSidebarTaskNode(s, currentSessionId, unreadSessionIdSet));
+    const streamingSessionIdSet = new Set(streamingSessionIds);
+    return sorted.map(s =>
+      toAgentSidebarTaskNode(s, currentSessionId, unreadSessionIdSet, streamingSessionIdSet),
+    );
   }, [
     workMode,
     sessions,

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -21,7 +21,8 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
-import { selectPendingPermissions } from '../../store/selectors/coworkSelectors';
+import type { RootState } from '../../store';
+import { selectHasPendingPermissionForSession } from '../../store/selectors/coworkSelectors';
 import { useSelector } from 'react-redux';
 import { BatchSelectionCheckbox } from './BatchSelectionCheckbox';
 import { AgentSidebarIndicator } from './constants';
@@ -105,8 +106,8 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
   const pinLabel = task.pinned
     ? i18nService.t('coworkUnpinSession')
     : i18nService.t('coworkPinSession');
-  const hasPendingPermission = useSelector(selectPendingPermissions).some(
-    permission => permission.sessionId === task.id,
+  const hasPendingPermission = useSelector((state: RootState) =>
+    selectHasPendingPermissionForSession(state, task.id),
   );
   const showRelativeTime = !isRunning && !hasPendingPermission;
 

--- a/src/renderer/components/agentSidebar/useAgentSidebarState.test.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.test.ts
@@ -5,7 +5,11 @@ import {
   CoworkSessionStatusValue,
   type CoworkSessionSummary,
 } from '../../types/cowork';
-import { sortAgentSidebarTasks } from './useAgentSidebarState';
+import {
+  deriveAgentSidebarIndicator,
+  sortAgentSidebarTasks,
+} from './useAgentSidebarState';
+import { AgentSidebarIndicator } from './constants';
 
 const makeSession = (
   id: string,
@@ -37,6 +41,14 @@ test('sortAgentSidebarTasks keeps unpinned tasks ordered by last update time', (
     'middle',
     'newer-created-older-update',
   ]);
+});
+
+test('deriveAgentSidebarIndicator uses the live stream registry for an active session', () => {
+  const session = makeSession('active-session', 100, 100, CoworkSessionStatusValue.Idle);
+
+  expect(deriveAgentSidebarIndicator(session, new Set(), new Set(['active-session']))).toBe(
+    AgentSidebarIndicator.Running,
+  );
 });
 
 test('sortAgentSidebarTasks orders two concurrent streaming sessions by creation time', () => {

--- a/src/renderer/components/agentSidebar/useAgentSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.ts
@@ -8,8 +8,12 @@ const normalizeAgentId = (agentId?: string) => agentId?.trim() || 'main';
 export const deriveAgentSidebarIndicator = (
   session: CoworkSessionSummary,
   unreadSessionIds: Set<string>,
+  streamingSessionIds: Set<string> = new Set(),
 ) => {
-  if (session.status === CoworkSessionStatusValue.Running) {
+  if (
+    session.status === CoworkSessionStatusValue.Running ||
+    streamingSessionIds.has(session.id)
+  ) {
     return AgentSidebarIndicator.Running;
   }
   if (session.status === CoworkSessionStatusValue.Completed && unreadSessionIds.has(session.id)) {
@@ -51,6 +55,7 @@ export const toAgentSidebarTaskNode = (
   session: CoworkSessionSummary,
   currentSessionId: string | null,
   unreadSessionIds: Set<string>,
+  streamingSessionIds?: Set<string>,
 ): AgentSidebarTaskNode => {
   return {
     id: session.id,
@@ -61,7 +66,7 @@ export const toAgentSidebarTaskNode = (
     pinOrder: session.pinOrder ?? null,
     updatedAt: session.updatedAt,
     createdAt: session.createdAt,
-    indicator: deriveAgentSidebarIndicator(session, unreadSessionIds),
+    indicator: deriveAgentSidebarIndicator(session, unreadSessionIds, streamingSessionIds),
     isSelected: session.id === currentSessionId,
   };
 };

--- a/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
@@ -9,6 +9,7 @@ import { RootState } from '../../store';
 import {
   selectCoworkSessions,
   selectCurrentSessionId,
+  selectStreamingSessionIds,
   selectUnreadSessionIds,
 } from '../../store/selectors/coworkSelectors';
 import { WorkMode, type WorkMode as WorkModeType } from '../../store/workMode/constants';
@@ -38,6 +39,7 @@ const toTaskNode = (
   session: CoworkSessionSummary,
   currentSessionId: string | null,
   unread: Set<string>,
+  streamingSessionIds: Set<string>,
 ): AgentSidebarTaskNode => ({
   id: session.id,
   agentId: session.agentId?.trim() || 'main',
@@ -49,7 +51,7 @@ const toTaskNode = (
   updatedAt: session.updatedAt,
   createdAt: session.createdAt,
   indicator:
-    session.status === CoworkSessionStatusValue.Running
+    session.status === CoworkSessionStatusValue.Running || streamingSessionIds.has(session.id)
       ? AgentSidebarIndicator.Running
       : session.status === CoworkSessionStatusValue.Completed && unread.has(session.id)
         ? AgentSidebarIndicator.CompletedUnread
@@ -76,8 +78,13 @@ export const useWorkspaceSidebarState = (
   const workspaces = useSelector((state: RootState) => state.workspace.workspaces);
   const currentSessionId = useSelector(selectCurrentSessionId);
   const sessions = useSelector(selectCoworkSessions);
+  const streamingSessionIds = useSelector(selectStreamingSessionIds);
   const unreadSessionIds = useDeferredValue(useSelector(selectUnreadSessionIds));
   const unreadSet = useMemo(() => new Set(unreadSessionIds), [unreadSessionIds]);
+  const streamingSessionIdSet = useMemo(
+    () => new Set(streamingSessionIds),
+    [streamingSessionIds],
+  );
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
   const [expandedTaskIds, setExpandedTaskIds] = useState<string[]>([]);
   const [scheduledExpandedIds, setScheduledExpandedIds] = useState<string[]>([]);
@@ -301,10 +308,22 @@ export const useWorkspaceSidebarState = (
           canCollapseTasks: taskExpanded && filtered.length > AgentSidebarPageSize.Preview,
           isLoadingTasks: loadingIds.includes(workspace.id),
           hasLoadError: failedIds.includes(workspace.id),
-          tasks: visible.map(session => toTaskNode(session, currentSessionId, unreadSet)),
+          tasks: visible.map(session =>
+            toTaskNode(session, currentSessionId, unreadSet, streamingSessionIdSet),
+          ),
         } satisfies WorkspaceSidebarNode;
       }),
-    [currentSessionId, failedIds, hasMore, loadingIds, previews, unreadSet, workMode, workspaces],
+    [
+      currentSessionId,
+      failedIds,
+      hasMore,
+      loadingIds,
+      previews,
+      streamingSessionIdSet,
+      unreadSet,
+      workMode,
+      workspaces,
+    ],
   );
 
   const workspaceNodes = useMemo<WorkspaceSidebarNode[]>(
@@ -354,7 +373,9 @@ export const useWorkspaceSidebarState = (
             isTaskListExpanded: true,
             canExpandTasks: false,
             canCollapseTasks: false,
-            tasks: tasks.map(session => toTaskNode(session, currentSessionId, unreadSet)),
+            tasks: tasks.map(session =>
+              toTaskNode(session, currentSessionId, unreadSet, streamingSessionIdSet),
+            ),
           },
         ];
       });
@@ -367,6 +388,7 @@ export const useWorkspaceSidebarState = (
     searchQuery,
     searchSource,
     searching,
+    streamingSessionIdSet,
     unreadSet,
     workspaceNodes,
     scheduledWorkspaceNodes,

--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -44,3 +44,14 @@ test('does not reintroduce the PR #184 textarea-token implementation', () => {
   // The broken version cleared the textarea placeholder while skills were active.
   expect(source).not.toContain("? '' : placeholder");
 });
+
+test('keeps the session permission selector available during an active run', () => {
+  const permissionMenuStart = source.indexOf('<PermissionModeMenu');
+  const permissionMenuEnd = source.indexOf('/>', permissionMenuStart);
+  const permissionMenu = source.slice(permissionMenuStart, permissionMenuEnd);
+
+  expect(permissionMenuStart).toBeGreaterThanOrEqual(0);
+  expect(permissionMenu).toContain('onChange={mode => onPermissionModeChange?.(mode)}');
+  expect(permissionMenu).toContain('disabled={disabled}');
+  expect(permissionMenu).not.toContain('disabled={disabled || isStreaming}');
+});

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1227,7 +1227,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                     <PermissionModeMenu
                       value={permissionMode ?? CoworkPermissionMode.Ask}
                       onChange={mode => onPermissionModeChange?.(mode)}
-                      disabled={disabled || isStreaming}
+                      disabled={disabled}
                     />
                   )}
                   {isWorkVariant && goalMode && <GoalModeChip onRemove={() => setGoalMode(false)} />}

--- a/src/renderer/store/selectors/coworkSelectors.test.ts
+++ b/src/renderer/store/selectors/coworkSelectors.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from 'vitest';
 
 import { CoworkSessionStatusValue } from '../../types/cowork';
-import { resolveDisplayedSessionId, selectIsStreaming } from './coworkSelectors';
+import {
+  resolveDisplayedSessionId,
+  selectHasPendingPermissionForSession,
+  selectIsStreaming,
+  selectPendingPermissionForSession,
+} from './coworkSelectors';
 
 test('selectIsStreaming follows the active session stream registry', () => {
   const state = {
@@ -43,6 +48,22 @@ test('shows the loading target instead of the previous session', () => {
 
 test('keeps the current session visible when it is also the loading target', () => {
   expect(resolveDisplayedSessionId('session-b', 'session-b')).toBe('session-b');
+});
+
+test('selects pending permissions only for the requested session', () => {
+  const state = {
+    cowork: {
+      pendingPermissions: [
+        { sessionId: 'session-a', requestId: 'request-a' },
+        { sessionId: 'session-b', requestId: 'request-b' },
+      ],
+    },
+  };
+
+  expect(selectPendingPermissionForSession(state as never, 'session-a')?.requestId).toBe('request-a');
+  expect(selectPendingPermissionForSession(state as never, 'session-c')).toBeNull();
+  expect(selectHasPendingPermissionForSession(state as never, 'session-b')).toBe(true);
+  expect(selectHasPendingPermissionForSession(state as never, 'session-c')).toBe(false);
 });
 
 test('shows the current session when no session is loading', () => {

--- a/src/renderer/store/selectors/coworkSelectors.ts
+++ b/src/renderer/store/selectors/coworkSelectors.ts
@@ -27,6 +27,12 @@ export const selectRemoteManaged = (state: RootState) => state.cowork.remoteMana
 export const selectCoworkConfig = (state: RootState) => state.cowork.config;
 export const selectDraftPrompts = (state: RootState) => state.cowork.draftPrompts;
 export const selectPendingPermissions = (state: RootState) => state.cowork.pendingPermissions;
+export const selectPendingPermissionForSession = (state: RootState, sessionId: string | null) => {
+  if (!sessionId) return null;
+  return state.cowork.pendingPermissions.find(permission => permission.sessionId === sessionId) ?? null;
+};
+export const selectHasPendingPermissionForSession = (state: RootState, sessionId: string) =>
+  selectPendingPermissionForSession(state, sessionId) !== null;
 export const selectUnreadSessionIds = (state: RootState) => state.cowork.unreadSessionIds;
 
 // --- Derived (memoized) selectors ---

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { CoworkPermissionMode } from '../../../shared/cowork/constants';
+import { CoworkPermissionMode, CoworkPermissionOrigin } from '../../../shared/cowork/constants';
 import {
   CoworkToolActivityEventType,
   CoworkToolActivityPhase,
@@ -11,6 +11,7 @@ import coworkReducer, {
   addSession,
   clearCurrentSessionForWorkspaceChange,
   clearLoadingSessionId,
+  enqueuePendingPermission,
   setConfig,
   setCurrentSession,
   setCurrentSessionId,
@@ -18,6 +19,7 @@ import coworkReducer, {
   setChatSessions,
   setSessions,
   updateCurrentSessionModelOverride,
+  updateConfig,
   updateMessageContents,
   updateToolActivity,
   updateSessionStatus,
@@ -107,6 +109,44 @@ test('updateCurrentSessionModelOverride only patches the active session', () => 
   );
 
   expect(ignoredState.currentSession?.modelOverride).toBe('zhiyuan-server/qwen3.6-plus');
+});
+
+test('changing a session permission mode preserves pending approvals from every session', () => {
+  const withPermissions = coworkReducer(
+    coworkReducer(
+      undefined,
+      enqueuePendingPermission({
+        origin: CoworkPermissionOrigin.PiWorkbench,
+        sessionId: 'session-a',
+        requestId: 'request-a',
+        toolName: 'write',
+        toolInput: {},
+        toolUseId: null,
+      }),
+    ),
+    enqueuePendingPermission({
+      origin: CoworkPermissionOrigin.PiWorkbench,
+      sessionId: 'session-b',
+      requestId: 'request-b',
+      toolName: 'bash',
+      toolInput: {},
+      toolUseId: null,
+    }),
+  );
+
+  const next = coworkReducer(
+    withPermissions,
+    updateConfig({
+      permissionModeBySession: {
+        'session-a': CoworkPermissionMode.AllowAll,
+      },
+    }),
+  );
+
+  expect(next.pendingPermissions.map(permission => permission.requestId)).toEqual([
+    'request-a',
+    'request-b',
+  ]);
 });
 
 test('addSession preserves the agent id in session summaries', () => {


### PR DESCRIPTION
## Summary

修复 Work / Chat 会话之间的权限状态串扰，并让侧栏依据实时执行状态显示动态加载标识。

## Related Issue

无

## Changes Made

- 权限请求、审批状态和权限模式更新按 `sessionId` 隔离，切换当前会话的权限模式不会改写其他会话。
- 会话运行时已结束但数据库仍为 `running` 时，加载阶段自动校正为 `idle`。
- 侧栏同时读取实时流会话列表，正在执行的会话显示转圈，非执行会话继续显示相对时间。
- 支持在会话执行中切换权限模式；新增覆盖关键隔离逻辑的单测。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

已执行：

- `npm test -- coworkPermissionModeChanges coworkSessionRuntimeState useAgentSidebarState coworkSelectors coworkSlice CoworkPromptInput`（59 项通过）
- `npm run lint`
- `npm run build`

## Screenshots (if applicable)

本次为会话状态与权限逻辑修复，已在本地验证侧栏动态状态。

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

该分支从最新 `main`（含 #314）创建，不包含 #316 的消息队列改动。