### PR TITLE
统一侧栏导航选中与悬停状态

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -5260,10 +5260,10 @@ const Settings: React.FC<SettingsProps> = ({
                 onMouseEnter={() => startSettingsIconAnimation(tab.key)}
                 onMouseLeave={() => stopSettingsIconAnimation(tab.key)}
                 className={cn(
-                  'flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium justify-start w-full',
+                  'flex w-full items-center justify-start gap-3 rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm font-medium !transition-colors !duration-200 ease-out',
                   activeTab === tab.key
-                    ? 'bg-surface shadow-elevated text-foreground hover:bg-surface'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-surface-raised',
+                    ? 'border-border bg-card text-foreground hover:border-border hover:!bg-card hover:!text-foreground'
+                    : 'text-muted-foreground hover:border-border hover:!bg-card hover:!text-foreground',
                 )}
               >
                 {tab.icon}

--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -3,11 +3,12 @@ import { Switch } from '@shared/components/ui/switch';
 import { cn } from '@shared/lib/utils';
 import { useReducedMotion } from 'motion/react';
 import { type RefObject, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { i18nService } from '../services/i18n';
 import type { RootState } from '../store';
 import { selectHasActiveChannelRun } from '../store/selectors/activitySelectors';
+import { clearActiveSkills } from '../store/slices/skillSlice';
 import { WorkMode } from '../store/workMode/constants';
 import type { PrefetchableFeatureView } from './featureViewPrefetch';
 import {
@@ -53,11 +54,17 @@ interface SidebarNavigationControlsProps {
   onPrefetchView?: (view: PrefetchableFeatureView) => void;
 }
 
-const sidebarNavItemClassName =
-  'w-full inline-flex items-center justify-start gap-2 rounded-lg px-3 py-1.5 text-left text-sm font-normal text-muted-foreground transition-[background-color,color,box-shadow] duration-150 hover:bg-card hover:text-foreground';
-const activeSidebarNavItemClassName = cn(
-  sidebarNavItemClassName,
-  'bg-card font-medium text-foreground shadow-sm ring-1 ring-inset ring-border hover:bg-card',
+const sidebarViewNavItemClassName =
+  'w-full inline-flex items-center justify-start gap-2 rounded-lg border border-transparent bg-transparent px-3 py-1.5 text-left text-sm font-normal text-muted-foreground !transition-colors !duration-200 ease-out hover:border-border hover:!bg-card hover:!text-foreground';
+const activeSidebarViewNavItemClassName = cn(
+  sidebarViewNavItemClassName,
+  'border-border bg-card font-medium text-foreground hover:border-border hover:!bg-card hover:!text-foreground',
+);
+const sidebarActionNavItemClassName =
+  'w-full inline-flex items-center justify-start gap-2 rounded-lg border border-transparent bg-transparent px-3 py-1.5 text-left text-sm font-normal text-muted-foreground !transition-colors !duration-200 ease-out hover:border-border hover:!bg-card hover:!text-foreground';
+const activeSidebarActionNavItemClassName = cn(
+  sidebarActionNavItemClassName,
+  'border-border bg-card font-medium text-foreground hover:border-border hover:!bg-card hover:!text-foreground',
 );
 
 export const SidebarNavigationControls = ({
@@ -71,16 +78,24 @@ export const SidebarNavigationControls = ({
   workMode,
   onPrefetchView,
 }: SidebarNavigationControlsProps) => {
+  const dispatch = useDispatch();
   const hasActiveChannelRun = useSelector((state: RootState) => selectHasActiveChannelRun(state));
+  const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const scheduledTasksIconRef = useRef<SidebarAnimatedAlarmClockIconHandle>(null);
   const activityIconRef = useRef<SidebarAnimatedActivityIconHandle>(null);
   const newConversationIconRef = useRef<SidebarAnimatedMessageCirclePlusIconHandle>(null);
   const localInferenceIconRef = useRef<SidebarAnimatedBotIconHandle>(null);
   const expertIconRef = useRef<SidebarAnimatedUsersIconHandle>(null);
   const prefersReducedMotion = useReducedMotion();
+  const isNewConversationActive =
+    activeView === 'cowork' && (workMode !== WorkMode.Chat || activeSkillIds.length === 0);
 
   const startIconAnimation = (iconRef: RefObject<{ startAnimation: () => void } | null>) => {
     if (!prefersReducedMotion) iconRef.current?.startAnimation();
+  };
+  const handleNewConversation = () => {
+    if (workMode === WorkMode.Chat) dispatch(clearActiveSkills());
+    onNewChat();
   };
 
   return (
@@ -126,10 +141,14 @@ export const SidebarNavigationControls = ({
         <Button
           type="button"
           variant="ghost"
-          onClick={onNewChat}
+          onClick={handleNewConversation}
           onMouseEnter={() => startIconAnimation(newConversationIconRef)}
           onMouseLeave={() => newConversationIconRef.current?.stopAnimation()}
-          className={sidebarNavItemClassName}
+          className={
+            isNewConversationActive
+              ? activeSidebarActionNavItemClassName
+              : sidebarActionNavItemClassName
+          }
         >
           <SidebarAnimatedMessageCirclePlusIcon ref={newConversationIconRef} />
           {workMode === WorkMode.Chat ? i18nService.t('newChat') : i18nService.t('newTask')}
@@ -148,8 +167,8 @@ export const SidebarNavigationControls = ({
           onMouseLeave={() => localInferenceIconRef.current?.stopAnimation()}
           className={
             activeView === 'localInference'
-              ? activeSidebarNavItemClassName
-              : sidebarNavItemClassName
+              ? activeSidebarViewNavItemClassName
+              : sidebarViewNavItemClassName
           }
           aria-current={activeView === 'localInference' ? 'page' : undefined}
         >
@@ -170,8 +189,8 @@ export const SidebarNavigationControls = ({
           onMouseLeave={() => scheduledTasksIconRef.current?.stopAnimation()}
           className={
             activeView === 'scheduledTasks'
-              ? activeSidebarNavItemClassName
-              : sidebarNavItemClassName
+              ? activeSidebarViewNavItemClassName
+              : sidebarViewNavItemClassName
           }
           aria-current={activeView === 'scheduledTasks' ? 'page' : undefined}
         >
@@ -191,7 +210,9 @@ export const SidebarNavigationControls = ({
           onFocus={() => onPrefetchView?.('activity')}
           onMouseLeave={() => activityIconRef.current?.stopAnimation()}
           className={
-            activeView === 'activity' ? activeSidebarNavItemClassName : sidebarNavItemClassName
+            activeView === 'activity'
+              ? activeSidebarViewNavItemClassName
+              : sidebarViewNavItemClassName
           }
           aria-current={activeView === 'activity' ? 'page' : undefined}
         >
@@ -217,7 +238,9 @@ export const SidebarNavigationControls = ({
           onFocus={() => onPrefetchView?.('expert')}
           onMouseLeave={() => expertIconRef.current?.stopAnimation()}
           className={
-            activeView === 'expert' ? activeSidebarNavItemClassName : sidebarNavItemClassName
+            activeView === 'expert'
+              ? activeSidebarViewNavItemClassName
+              : sidebarViewNavItemClassName
           }
           aria-current={activeView === 'expert' ? 'page' : undefined}
         >

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -30,7 +30,12 @@ import {
   AnimatedTelescopeIcon,
   type AnimatedTelescopeIconHandle,
 } from '../icons/AnimatedTelescopeIcon';
-import { CHAT_SKILL_SHORTCUTS, ChatSkillShortcut } from './constants';
+import {
+  CHAT_SKILL_SHORTCUTS,
+  ChatSkillShortcut,
+  getChatSkillShortcutIds,
+  isChatSkillShortcutActive,
+} from './constants';
 
 type AnimatedIconHandle = {
   startAnimation: () => void;
@@ -71,7 +76,7 @@ const ChatSkillShortcuts: React.FC = () => {
 
   const handleSelect = (entry: ChatSkillShortcut) => {
     if (isStreaming) return;
-    const selectedSkillIds = entry.skillIds || [entry.skillId];
+    const selectedSkillIds = getChatSkillShortcutIds(entry);
     // Require the skill to be enabled — disabled skills must not be
     // re-activated through the shortcut (matches SkillsPopover filtering).
     const allSkillsAvailable = selectedSkillIds.every(skillId =>
@@ -102,8 +107,7 @@ const ChatSkillShortcuts: React.FC = () => {
           {CHAT_SKILL_SHORTCUTS.map(entry => {
             const Icon = entry.icon;
             const animatedIcon = animatedShortcutIcons[entry.id];
-            const selectedSkillIds = entry.skillIds || [entry.skillId];
-            const isActive = selectedSkillIds.every(skillId => activeSkillIds.includes(skillId));
+            const isActive = isChatSkillShortcutActive(entry, activeSkillIds);
             return (
               <Button
                 key={entry.id}
@@ -119,10 +123,10 @@ const ChatSkillShortcuts: React.FC = () => {
                 }}
                 onClick={() => handleSelect(entry)}
                 className={cn(
-                  'chat-skill-shortcut w-full justify-start gap-2 px-3 text-left',
+                  'chat-skill-shortcut w-full justify-start gap-2 border border-transparent bg-transparent px-3 text-left !transition-colors !duration-200 ease-out hover:border-border hover:!bg-card hover:!text-foreground',
                   isActive
-                    ? 'bg-surface-raised font-medium text-foreground'
-                    : 'text-muted-foreground hover:bg-surface-raised hover:text-foreground',
+                    ? 'border-border bg-card font-medium text-foreground hover:border-border hover:!bg-card hover:!text-foreground'
+                    : 'text-muted-foreground',
                 )}
               >
                 {animatedIcon?.icon ?? (

--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -14,7 +14,7 @@ import { resolveShortcutWorkflowKind } from '../../../main/libs/agentEngine/piSh
 
 import { expect, test } from 'vitest';
 
-import { CHAT_SKILL_SHORTCUTS } from './constants';
+import { CHAT_SKILL_SHORTCUTS, isChatSkillShortcutActive } from './constants';
 
 test('every chat quick-skill shortcut points at a core skill', () => {
   // Core skills are always enabled (skillManager forces enabled=true), so a
@@ -59,6 +59,29 @@ test('academic research keeps a valid internal Skill name and Zhiyuan-facing met
 test('deep research selects explicit web search with its research protocol', () => {
   const deepResearch = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'deep-research');
   expect(deepResearch?.skillIds).toEqual(['deep-research', 'web-search']);
+});
+
+test('quick skill selection requires an exact skill set', () => {
+  const deepResearch = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'deep-research');
+  const academicResearch = CHAT_SKILL_SHORTCUTS.find(entry => entry.id === 'academic-research');
+
+  expect(deepResearch).toBeDefined();
+  expect(academicResearch).toBeDefined();
+  expect(isChatSkillShortcutActive(deepResearch!, ['deep-research', 'web-search'])).toBe(true);
+  expect(
+    isChatSkillShortcutActive(academicResearch!, [
+      'deli-autoresearch',
+      'deep-research',
+      'web-search',
+    ]),
+  ).toBe(true);
+  expect(
+    isChatSkillShortcutActive(deepResearch!, [
+      'deli-autoresearch',
+      'deep-research',
+      'web-search',
+    ]),
+  ).toBe(false);
 });
 
 test('every sidebar shortcut is protected by a Pi completion controller', () => {

--- a/src/renderer/components/chat/constants.ts
+++ b/src/renderer/components/chat/constants.ts
@@ -71,6 +71,20 @@ export const CHAT_SKILL_SHORTCUTS: readonly ChatSkillShortcut[] = [
 export const findChatSkillShortcut = (skillId: string): ChatSkillShortcut | undefined =>
   CHAT_SKILL_SHORTCUTS.find(entry => entry.skillId === skillId);
 
+export const getChatSkillShortcutIds = (entry: ChatSkillShortcut): readonly string[] =>
+  entry.skillIds ?? [entry.skillId];
+
+export const isChatSkillShortcutActive = (
+  entry: ChatSkillShortcut,
+  activeSkillIds: readonly string[],
+): boolean => {
+  const shortcutSkillIds = getChatSkillShortcutIds(entry);
+  return (
+    shortcutSkillIds.length === activeSkillIds.length &&
+    shortcutSkillIds.every(skillId => activeSkillIds.includes(skillId))
+  );
+};
+
 /**
  * Returns the placeholder i18n key of the first active shortcut skill, so
  * the chat input can hint at the task the attached skill performs.


### PR DESCRIPTION
## Summary

统一工作区、对话快捷技能和设置侧栏的选中与悬停视觉状态，修复快捷技能因共享依赖而同时高亮的问题。

## Related Issue

无

## Changes Made

- 侧栏与设置导航统一为：当前入口静态白色，其他入口仅 hover 时临时白色。
- 将按钮过渡限定为 200ms `ease-out` 的颜色过渡，避免基础按钮 `transition-all` 引起的卡顿感。
- 新建对话会清空当前快捷技能选择，确保只有一个静态选中项。
- 快捷技能使用完整技能集合判断选中，避免深度调研与学术研究同时高亮。
- 补充快捷技能精确选中逻辑测试。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

已执行：

- `npm test -- constants`（42 项通过）
- `npm run lint`
- `npm run build`
- 对抗式 UI 审查（无阻断或高风险问题）

## Screenshots (if applicable)

已在本地验证侧栏、快捷技能和设置导航的选中与 hover 状态。

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

分支已 rebase 到最新 `main`（含 #319），不包含其他未跟踪的 `logs/` 文件。