### PR TITLE
修复：会话切换后预览丢失与重载

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -14,7 +14,7 @@ import {
   selectActiveTab,
   selectArtifactLayoutMode,
   selectArtifact,
-  selectSelectedArtifact,
+  selectSessionSelectedArtifact,
   setActiveTab,
   setArtifactLayoutMode,
 } from '@/store/slices/artifactSlice';
@@ -55,6 +55,7 @@ function escapeHtml(str: string): string {
 }
 
 interface ArtifactPanelProps {
+  sessionId: string | null;
   artifacts: Artifact[];
   panelWidth: number;
   minPanelWidth?: number;
@@ -64,6 +65,7 @@ interface ArtifactPanelProps {
 }
 
 const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
+  sessionId,
   artifacts,
   panelWidth,
   minPanelWidth = MIN_PANEL_WIDTH,
@@ -72,7 +74,9 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
   onResizeComplete,
 }) => {
   const dispatch = useDispatch();
-  const selectedArtifact = useSelector(selectSelectedArtifact);
+  const selectedArtifact = useSelector((state: RootState) =>
+    selectSessionSelectedArtifact(state, sessionId),
+  );
   const activeTab = useSelector(selectActiveTab);
   const layoutMode = useSelector(selectArtifactLayoutMode);
   const selectedArtifactId = useSelector((state: RootState) => state.artifact.selectedArtifactId);
@@ -82,6 +86,8 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
   const toggleBtnRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const isMac = window.electron.platform === 'darwin';
+  const isTopLevelPanel = layoutMode === ArtifactLayoutMode.Workspace || isFullscreen;
 
   const visibleArtifacts = artifacts.filter(
     artifact => showIntermediateArtifacts || artifact.role === ArtifactRole.Deliverable,
@@ -280,7 +286,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
           maxWidth:
             layoutMode === ArtifactLayoutMode.Workspace || isFullscreen ? 'none' : undefined,
         }}
-        className={`bg-background flex flex-col h-full overflow-hidden ${
+        className={`non-draggable bg-background flex flex-col h-full overflow-hidden ${
           layoutMode === ArtifactLayoutMode.Workspace || isFullscreen
             ? 'fixed inset-0 z-200 w-screen border-0'
             : 'relative min-w-0 flex-1 border-l border-border'
@@ -309,7 +315,11 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
         {selectedArtifact ? (
           <div className="flex-1 flex flex-col min-w-0 h-full overflow-hidden">
             {/* Header: file list toggle + filename + type + actions */}
-            <div className="h-10 flex items-center gap-2 px-3 border-b border-border shrink-0">
+            <div
+              className={`h-10 flex items-center gap-2 border-b border-border shrink-0 ${
+                isMac && isTopLevelPanel ? 'pl-20 pr-3' : 'px-3'
+              }`}
+            >
               <span className="text-sm font-medium truncate">
                 {selectedArtifact.fileName || selectedArtifact.title}
               </span>
@@ -461,7 +471,11 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
         ) : (
           /* No artifact selected: show full-width file list */
           <div className="flex-1 flex flex-col h-full overflow-hidden">
-            <div className="h-10 flex items-center px-3 border-b border-border shrink-0">
+            <div
+              className={`h-10 flex items-center border-b border-border shrink-0 ${
+                isMac && isTopLevelPanel ? 'pl-20 pr-3' : 'px-3'
+              }`}
+            >
               <span className="text-xs font-medium text-muted-foreground">
                 {t('artifactFiles')}
               </span>

--- a/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
@@ -18,6 +18,7 @@ import {
 } from './artifactPanelResize';
 
 interface ArtifactPanelFrameProps {
+  sessionId: string | null;
   artifacts: Artifact[];
   isOpen: boolean;
   isVisible: boolean;
@@ -28,6 +29,7 @@ interface ArtifactPanelFrameProps {
 }
 
 const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
+  sessionId,
   artifacts,
   isOpen,
   isVisible,
@@ -91,6 +93,7 @@ const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
     >
       <div className="flex h-full w-full">
         <ArtifactPanel
+          sessionId={sessionId}
           artifacts={artifacts}
           panelWidth={panelWidth}
           minPanelWidth={minPanelWidth}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -12,7 +12,7 @@ import {
   Image as ImageIcon,
   PanelLeft,
 } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -36,14 +36,15 @@ import {
 } from '../../store/selectors/coworkSelectors';
 import {
   addArtifact,
+  activateSessionArtifactView,
   ArtifactLayoutMode,
   closePanel,
   DEFAULT_PANEL_WIDTH,
   MIN_PANEL_WIDTH,
   EMPTY_ARTIFACTS,
   selectArtifact,
-  selectArtifactLayoutMode,
-  selectIsPanelOpen,
+  selectIsSessionArtifactPanelOpen,
+  selectSessionArtifactLayoutMode,
   selectSessionArtifacts,
   togglePanel,
 } from '../../store/slices/artifactSlice';
@@ -248,21 +249,33 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const [showExportOptions, setShowExportOptions] = useState(false);
 
   // ─── Artifact detection ─────────────────────────────────────────────
-  const isPanelOpen = useSelector(selectIsPanelOpen);
-  const artifactLayoutMode = useSelector(selectArtifactLayoutMode);
+  const isPanelOpen = useSelector((state: RootState) =>
+    selectIsSessionArtifactPanelOpen(state, sessionId),
+  );
+  const artifactLayoutMode = useSelector((state: RootState) =>
+    selectSessionArtifactLayoutMode(state, sessionId),
+  );
   const isArtifactWorkspace = artifactLayoutMode === ArtifactLayoutMode.Workspace;
   const [shouldRenderArtifactPanel, setShouldRenderArtifactPanel] = useState(isPanelOpen);
   const [isArtifactPanelVisible, setIsArtifactPanelVisible] = useState(isPanelOpen);
   const [isArtifactPanelTransitioning, setIsArtifactPanelTransitioning] = useState(false);
+  const [previewSessionId, setPreviewSessionId] = useState<string | null>(() =>
+    isPanelOpen ? (sessionId ?? null) : null,
+  );
   const [artifactPanelMaxWidth, setArtifactPanelMaxWidth] = useState(() =>
     typeof window === 'undefined'
       ? DEFAULT_PANEL_WIDTH
       : Math.max(MIN_PANEL_WIDTH, window.innerWidth),
   );
   const previousArtifactPanelOpenRef = useRef(isPanelOpen);
+  const previousArtifactSessionIdRef = useRef(sessionId);
+  const skipArtifactPanelTransitionRef = useRef(false);
   const contentRowRef = useRef<HTMLDivElement>(null);
   const sessionArtifacts = useSelector((state: RootState) =>
     sessionId ? selectSessionArtifacts(state, sessionId) : EMPTY_ARTIFACTS,
+  );
+  const previewArtifacts = useSelector((state: RootState) =>
+    previewSessionId ? selectSessionArtifacts(state, previewSessionId) : EMPTY_ARTIFACTS,
   );
 
   const artifactDetectionServiceRef = useRef<ArtifactDetectionService | null>(null);
@@ -302,6 +315,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
 
     previousArtifactPanelOpenRef.current = isPanelOpen;
 
+    if (skipArtifactPanelTransitionRef.current) {
+      skipArtifactPanelTransitionRef.current = false;
+      setShouldRenderArtifactPanel(isPanelOpen);
+      setIsArtifactPanelVisible(isPanelOpen);
+      setIsArtifactPanelTransitioning(false);
+      return undefined;
+    }
+
     if (wasOpen === isPanelOpen) {
       return undefined;
     }
@@ -322,7 +343,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       setIsArtifactPanelTransitioning(true);
       setIsArtifactPanelVisible(false);
       transitionTimeout = window.setTimeout(() => {
-        setShouldRenderArtifactPanel(false);
         setIsArtifactPanelTransitioning(false);
       }, ARTIFACT_PANEL_TRANSITION_MS);
     }
@@ -365,10 +385,19 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     };
   }, [currentSession?.id, updateArtifactPanelMaxWidth]);
 
-  useEffect(() => {
-    dispatch(selectArtifact(null));
-    dispatch(closePanel());
+  useLayoutEffect(() => {
+    if (previousArtifactSessionIdRef.current && previousArtifactSessionIdRef.current !== sessionId) {
+      skipArtifactPanelTransitionRef.current = true;
+    }
+    previousArtifactSessionIdRef.current = sessionId;
+    dispatch(activateSessionArtifactView(sessionId ?? null));
   }, [sessionId, dispatch]);
+
+  useLayoutEffect(() => {
+    if (isPanelOpen && sessionId) {
+      setPreviewSessionId(sessionId);
+    }
+  }, [isPanelOpen, sessionId]);
 
   useEffect(() => {
     if (!sessionId || !currentSession?.messages?.length) return;
@@ -1550,7 +1579,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               }
             >
               <ArtifactPanelFrame
-                artifacts={sessionArtifacts}
+                sessionId={previewSessionId}
+                artifacts={previewArtifacts}
                 isOpen={isPanelOpen}
                 isVisible={isArtifactPanelVisible}
                 isTransitioning={isArtifactPanelTransitioning}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -484,14 +484,20 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     };
   }, []);
 
-  // Reset nav state when session changes
-  useEffect(() => {
+  // Reset all rail measurements before the next session paints. This component
+  // stays mounted so artifact renderers can be reused across session switches.
+  useLayoutEffect(() => {
     setCurrentRailIndex(-1);
     currentRailIndexRef.current = -1;
+    railItemCountRef.current = 0;
+    turnToRailRangeRef.current = [];
     isNavigatingRef.current = false;
     if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
+    railLinesRef.current?.scrollTo({ top: 0 });
     setHoveredRailIndex(null);
-  }, [currentSession?.id]);
+    setIsRailHovered(false);
+    setRailTooltip(null);
+  }, [sessionId]);
 
   useEffect(() => {
     const handleOpenShareOptions = (event: Event) => {
@@ -808,15 +814,6 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       })();
     });
   };
-
-  // scroll + loadMore handled by Conversation (StickToBottom); rail state reset on session change
-  useEffect(() => {
-    setCurrentRailIndex(-1);
-    currentRailIndexRef.current = -1;
-    isNavigatingRef.current = false;
-    if (navigatingTimerRef.current) clearTimeout(navigatingTimerRef.current);
-    setHoveredRailIndex(null);
-  }, [currentSession?.id]);
 
   const navigateToRailItem = useCallback((railIndex: number) => {
     if (railIndex < 0 || railIndex >= railItemCountRef.current) return;

--- a/src/renderer/components/cowork/CoworkSessionViewport.tsx
+++ b/src/renderer/components/cowork/CoworkSessionViewport.tsx
@@ -27,7 +27,10 @@ const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportPro
     );
   }
 
-  return <CoworkSessionDetail key={sessionId} {...props} />;
+  // Keep the detail tree mounted while switching sessions. In particular, this
+  // preserves expensive document and PPT preview renderers instead of rebuilding
+  // them whenever the selected session changes.
+  return <CoworkSessionDetail {...props} />;
 };
 
 export default CoworkSessionViewport;

--- a/src/renderer/store/slices/artifactSlice.test.ts
+++ b/src/renderer/store/slices/artifactSlice.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, test } from 'vitest';
 import { ArtifactRole, type Artifact } from '../../types/artifact';
 import {
   addArtifact,
+  activateSessionArtifactView,
   ArtifactLayoutMode,
   closePanel,
   selectArtifact,
+  selectSessionSelectedArtifact,
+  selectSelectedArtifact,
   setActiveArtifactProjection,
   setArtifactLayoutMode,
   setPanelWidth,
@@ -91,5 +94,44 @@ describe('artifact reducer', () => {
       taskId: 'task-1',
       runId: 'run-1',
     });
+  });
+
+  test('restores the preview belonging to the active session after switching back', () => {
+    let state = artifactReducer(undefined, activateSessionArtifactView('session-1'));
+    state = artifactReducer(
+      state,
+      addArtifact({ sessionId: 'session-1', artifact: makeArtifact({ id: 'session-1-artifact' }) }),
+    );
+    state = artifactReducer(state, selectArtifact('session-1-artifact'));
+    state = artifactReducer(state, setArtifactLayoutMode(ArtifactLayoutMode.Workspace));
+
+    state = artifactReducer(state, activateSessionArtifactView('session-2'));
+    expect(state.isPanelOpen).toBe(false);
+    expect(state.selectedArtifactId).toBeNull();
+
+    state = artifactReducer(state, activateSessionArtifactView('session-1'));
+    expect(state.isPanelOpen).toBe(true);
+    expect(state.selectedArtifactId).toBe('session-1-artifact');
+    expect(state.layoutMode).toBe(ArtifactLayoutMode.Workspace);
+  });
+
+  test('selects the preview from the active session when artifact ids overlap', () => {
+    let state = artifactReducer(undefined, activateSessionArtifactView('session-1'));
+    state = artifactReducer(
+      state,
+      addArtifact({ sessionId: 'session-1', artifact: makeArtifact({ id: 'shared-id', title: 'first.pptx' }) }),
+    );
+    state = artifactReducer(state, selectArtifact('shared-id'));
+    state = artifactReducer(state, activateSessionArtifactView('session-2'));
+    state = artifactReducer(
+      state,
+      addArtifact({ sessionId: 'session-2', artifact: makeArtifact({ id: 'shared-id', title: 'second.pptx' }) }),
+    );
+    state = artifactReducer(state, selectArtifact('shared-id'));
+
+    expect(selectSelectedArtifact({ artifact: state } as never)?.title).toBe('second.pptx');
+    expect(selectSessionSelectedArtifact({ artifact: state } as never, 'session-1')?.title).toBe(
+      'first.pptx',
+    );
   });
 });

--- a/src/renderer/store/slices/artifactSlice.ts
+++ b/src/renderer/store/slices/artifactSlice.ts
@@ -15,9 +15,19 @@ export const ArtifactLayoutMode = {
 } as const;
 export type ArtifactLayoutMode = (typeof ArtifactLayoutMode)[keyof typeof ArtifactLayoutMode];
 
+interface ArtifactSessionViewState {
+  selectedArtifactId: string | null;
+  isPanelOpen: boolean;
+  activeTab: ArtifactActiveTab;
+  panelView: ArtifactPanelView;
+  layoutMode: ArtifactLayoutMode;
+}
+
 interface ArtifactState {
   artifactsBySession: Record<string, Artifact[]>;
   activeProjectionBySession: Record<string, { taskId: string; runId: string | null } | undefined>;
+  activeSessionId: string | null;
+  viewStateBySession: Record<string, ArtifactSessionViewState>;
   selectedArtifactId: string | null;
   isPanelOpen: boolean;
   activeTab: ArtifactActiveTab;
@@ -29,6 +39,8 @@ interface ArtifactState {
 const initialState: ArtifactState = {
   artifactsBySession: {},
   activeProjectionBySession: {},
+  activeSessionId: null,
+  viewStateBySession: {},
   selectedArtifactId: null,
   isPanelOpen: false,
   activeTab: 'preview',
@@ -36,6 +48,38 @@ const initialState: ArtifactState = {
   panelWidth: DEFAULT_PANEL_WIDTH,
   layoutMode: ArtifactLayoutMode.Split,
 };
+
+const DEFAULT_SESSION_VIEW_STATE: ArtifactSessionViewState = {
+  selectedArtifactId: null,
+  isPanelOpen: false,
+  activeTab: 'preview',
+  panelView: 'files',
+  layoutMode: ArtifactLayoutMode.Split,
+};
+
+function getDefaultSessionViewState(): ArtifactSessionViewState {
+  return { ...DEFAULT_SESSION_VIEW_STATE };
+}
+
+function saveActiveSessionView(state: ArtifactState) {
+  if (!state.activeSessionId) return;
+
+  state.viewStateBySession[state.activeSessionId] = {
+    selectedArtifactId: state.selectedArtifactId,
+    isPanelOpen: state.isPanelOpen,
+    activeTab: state.activeTab,
+    panelView: state.panelView,
+    layoutMode: state.layoutMode,
+  };
+}
+
+function restoreSessionView(state: ArtifactState, viewState: ArtifactSessionViewState) {
+  state.selectedArtifactId = viewState.selectedArtifactId;
+  state.isPanelOpen = viewState.isPanelOpen;
+  state.activeTab = viewState.activeTab;
+  state.panelView = viewState.panelView;
+  state.layoutMode = viewState.layoutMode;
+}
 
 function mergeArtifact(existing: Artifact, incoming: Artifact): Artifact {
   return {
@@ -53,6 +97,18 @@ const artifactSlice = createSlice({
   name: 'artifact',
   initialState,
   reducers: {
+    activateSessionArtifactView(state, action: PayloadAction<string | null>) {
+      const sessionId = action.payload;
+      if (state.activeSessionId === sessionId) return;
+
+      saveActiveSessionView(state);
+      state.activeSessionId = sessionId;
+      restoreSessionView(
+        state,
+        sessionId ? (state.viewStateBySession[sessionId] ?? getDefaultSessionViewState()) : getDefaultSessionViewState(),
+      );
+    },
+
     setSessionArtifacts(
       state,
       action: PayloadAction<{ sessionId: string; artifacts: Artifact[] }>,
@@ -143,15 +199,19 @@ const artifactSlice = createSlice({
     },
 
     clearSessionArtifacts(state, action: PayloadAction<string>) {
-      delete state.artifactsBySession[action.payload];
-      delete state.activeProjectionBySession[action.payload];
-      state.selectedArtifactId = null;
-      state.layoutMode = ArtifactLayoutMode.Split;
+      const sessionId = action.payload;
+      delete state.artifactsBySession[sessionId];
+      delete state.activeProjectionBySession[sessionId];
+      delete state.viewStateBySession[sessionId];
+      if (state.activeSessionId === sessionId) {
+        restoreSessionView(state, getDefaultSessionViewState());
+      }
     },
   },
 });
 
 export const {
+  activateSessionArtifactView,
   setSessionArtifacts,
   addArtifact,
   setActiveArtifactProjection,
@@ -183,6 +243,12 @@ export const selectTaskRunArtifacts = (
 export const selectSelectedArtifact = (state: RootState): Artifact | null => {
   const id = state.artifact.selectedArtifactId;
   if (!id) return null;
+  const activeSessionId = state.artifact.activeSessionId;
+  if (activeSessionId) {
+    return (
+      state.artifact.artifactsBySession[activeSessionId]?.find(artifact => artifact.id === id) ?? null
+    );
+  }
   for (const artifacts of Object.values(state.artifact.artifactsBySession)) {
     const found = artifacts.find(a => a.id === id);
     if (found) return found;
@@ -190,7 +256,35 @@ export const selectSelectedArtifact = (state: RootState): Artifact | null => {
   return null;
 };
 
+export const selectSessionSelectedArtifact = (
+  state: RootState,
+  sessionId: string | null,
+): Artifact | null => {
+  if (!sessionId) return null;
+  const selectedArtifactId =
+    state.artifact.activeSessionId === sessionId
+      ? state.artifact.selectedArtifactId
+      : state.artifact.viewStateBySession[sessionId]?.selectedArtifactId;
+  if (!selectedArtifactId) return null;
+  return (
+    state.artifact.artifactsBySession[sessionId]?.find(
+      artifact => artifact.id === selectedArtifactId,
+    ) ?? null
+  );
+};
+
 export const selectIsPanelOpen = (state: RootState): boolean => state.artifact.isPanelOpen;
+const selectSessionViewState = (state: RootState, sessionId: string | undefined) => {
+  if (!sessionId) return DEFAULT_SESSION_VIEW_STATE;
+  if (state.artifact.activeSessionId === sessionId) {
+    return state.artifact;
+  }
+  return state.artifact.viewStateBySession[sessionId] ?? DEFAULT_SESSION_VIEW_STATE;
+};
+export const selectIsSessionArtifactPanelOpen = (state: RootState, sessionId: string | undefined) =>
+  selectSessionViewState(state, sessionId).isPanelOpen;
+export const selectSessionArtifactLayoutMode = (state: RootState, sessionId: string | undefined) =>
+  selectSessionViewState(state, sessionId).layoutMode;
 export const selectPanelWidth = (state: RootState): number => state.artifact.panelWidth;
 export const selectPanelView = (state: RootState): ArtifactPanelView => state.artifact.panelView;
 export const selectActiveTab = (state: RootState): ArtifactActiveTab => state.artifact.activeTab;


### PR DESCRIPTION
## Summary

修复 Work/Chat 会话切换时预览面板被关闭、PPT/文档预览重新加载的问题。

## Related Issue

无

## Changes Made

- 将预览面板的打开状态、选中文件、标签页和布局按 session 保存并恢复。
- 移除会话切换时对详情树的强制重挂载，保留已加载的预览渲染器。
- 预览文件选择改为按指定 session 读取，避免切换首帧串会话。
- 补充会话切换、重复 artifact ID 的 reducer 回归测试。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

已执行：

- `npm test -- artifactSlice`
- `npm run lint`
- `npm run build`

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

根因是会话切换通过 `key={sessionId}` 卸载整个详情树，导致预览 renderer 被销毁并重新加载。本 PR 保持详情树挂载，并让预览内容与 session 绑定。