### PR TITLE
修复：移除会话右侧导航轨道

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1264,10 +1264,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               />
             </Conversation>
 
-            {/* Turn Navigation Rail — to the left of scrollbar */}
+            {/* Turn navigation rail removed: message content remains scrollable in the conversation. */}
             {turns.length > 1 && (
               <div
-                className="absolute right-[18px] top-1/2 -translate-y-1/2 w-5 flex flex-col items-end z-10"
+                className="hidden absolute right-[18px] top-1/2 -translate-y-1/2 w-5 flex flex-col items-end z-10"
                 style={{ maxHeight: 'calc(100% - 40px)' }}
                 onMouseEnter={() => setIsRailHovered(true)}
                 onMouseLeave={() => {


### PR DESCRIPTION
## Summary

移除会话详情右侧的消息导航轨道，避免其显示与实际消息位置不一致。

## Related Issue

无

## Changes Made

- 移除会话详情右侧的消息导航轨道展示。
- 保留原有对话滚动与会话预览功能。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

已执行：

- `npm run lint`
- `npm test -- artifactSlice`
- `npm run build`

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

此前的 PR #323 已合并；本 PR 仅删除右侧导航轨道，不重复包含预览修复。