### PR TITLE
fix(ci): build selected platform matrix

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -26,26 +26,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  plan-platforms:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        env:
+          BUILD_MACOS: ${{ inputs.build_macos }}
+          BUILD_WINDOWS: ${{ inputs.build_windows }}
+          BUILD_LINUX: ${{ inputs.build_linux }}
+        shell: bash
+        run: |
+          matrix='{"include":['
+          separator=''
+
+          if [[ "$BUILD_MACOS" == "true" ]]; then
+            matrix+='{"platform":"macos","runner":"macos-latest","artifact":"macos-build"}'
+            separator=','
+          fi
+          if [[ "$BUILD_WINDOWS" == "true" ]]; then
+            matrix+="${separator}{\"platform\":\"windows\",\"runner\":\"windows-latest\",\"artifact\":\"windows-build\"}"
+            separator=','
+          fi
+          if [[ "$BUILD_LINUX" == "true" ]]; then
+            matrix+="${separator}{\"platform\":\"linux\",\"runner\":\"ubuntu-latest\",\"artifact\":\"linux-build\"}"
+          fi
+
+          matrix+=']}'
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   build-platforms:
+    needs: plan-platforms
     strategy:
       # A manual platform build is a single release unit; cancel sibling builds
       # as soon as one selected platform fails.
       fail-fast: true
-      matrix:
-        include:
-          - platform: macos
-            enabled: ${{ inputs.build_macos }}
-            runner: macos-latest
-            artifact: macos-build
-          - platform: windows
-            enabled: ${{ inputs.build_windows }}
-            runner: windows-latest
-            artifact: windows-build
-          - platform: linux
-            enabled: ${{ inputs.build_linux }}
-            runner: ubuntu-latest
-            artifact: linux-build
-    if: ${{ matrix.enabled }}
+      matrix: ${{ fromJSON(needs.plan-platforms.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     environment: release
     # A release build may download upstream runtimes, but it must never consume


### PR DESCRIPTION
## 修复

修复 build-platforms.yml 在 job 级条件中引用 matrix.enabled，导致 workflow 启动即失败、没有任何 job 的问题。

- 先根据手动选择生成精确的矩阵 JSON
- 只为选中的平台创建构建 job
- 保留矩阵的 fail-fast 行为

## 验证

- Ruby YAML 解析通过
- 验证全选、单选、双选、全不选四种输入均生成有效 JSON 矩阵
- git diff --check 通过