### PR TITLE
fix(ci): retry transient OpenClaw plugin installs

### DIFF
--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -28,6 +28,8 @@ const path = require('path');
 // ---------------------------------------------------------------------------
 
 const rootDir = path.resolve(__dirname, '..');
+const DEFAULT_PLUGIN_INSTALL_ATTEMPTS = 3;
+const PLUGIN_INSTALL_RETRY_DELAY_MS = 2_000;
 
 function log(msg) {
   console.log(`[openclaw-plugins] ${msg}`);
@@ -36,6 +38,33 @@ function log(msg) {
 function die(msg) {
   console.error(`[openclaw-plugins] ERROR: ${msg}`);
   process.exit(1);
+}
+
+function sleepSync(delayMs) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}
+
+function retryPluginInstall(operation, options = {}) {
+  const attempts = options.attempts || DEFAULT_PLUGIN_INSTALL_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs || PLUGIN_INSTALL_RETRY_DELAY_MS;
+  const sleep = options.sleep || sleepSync;
+  const label = options.label || 'plugin install';
+  let lastError;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+
+      const delayMs = retryDelayMs * 2 ** (attempt - 1);
+      log(`${label} failed (attempt ${attempt}/${attempts}); retrying in ${delayMs}ms.`);
+      sleep(delayMs);
+    }
+  }
+
+  throw lastError;
 }
 
 function copyDirRecursive(src, dest) {
@@ -494,20 +523,24 @@ function main() {
           installSpec = source.installSpec;
         }
 
-        runOpenClawCli(
-          ['plugins', 'install', installSpec, '--force', '--dangerously-force-unsafe-install'],
-          {
-            env: {
-              OPENCLAW_STATE_DIR: stagingDir,
-              // Prevent npm from auto-installing peerDependencies (npm v7+).
-              // Channel plugins declare openclaw as a peerDep, but the host
-              // gateway already provides the SDK at runtime.  Without this,
-              // npm installs the full openclaw SDK + transitive deps (~738 MB)
-              // into each plugin's node_modules.
-              npm_config_legacy_peer_deps: 'true',
-            },
-            stdio: 'inherit',
-          },
+        retryPluginInstall(
+          () =>
+            runOpenClawCli(
+              ['plugins', 'install', installSpec, '--force', '--dangerously-force-unsafe-install'],
+              {
+                env: {
+                  OPENCLAW_STATE_DIR: stagingDir,
+                  // Prevent npm from auto-installing peerDependencies (npm v7+).
+                  // Channel plugins declare openclaw as a peerDep, but the host
+                  // gateway already provides the SDK at runtime.  Without this,
+                  // npm installs the full openclaw SDK + transitive deps (~738 MB)
+                  // into each plugin's node_modules.
+                  npm_config_legacy_peer_deps: 'true',
+                },
+                stdio: 'inherit',
+              },
+            ),
+          { label: `Plugin ${id}` },
         );
 
         // The CLI installs to {OPENCLAW_STATE_DIR}/extensions/{pluginId}/
@@ -858,6 +891,7 @@ module.exports = {
   main,
   npmPack,
   parseGitSpec,
+  retryPluginInstall,
   resolveGitPackSpec,
   resolvePluginInstallSource,
 };

--- a/tests/ensure-openclaw-plugins.test.ts
+++ b/tests/ensure-openclaw-plugins.test.ts
@@ -6,6 +6,7 @@ const {
   isGitSpec,
   isLocalPathSpec,
   parseGitSpec,
+  retryPluginInstall,
   resolveGitPackSpec,
   resolvePluginInstallSource,
 } = require('../scripts/ensure-openclaw-plugins.cjs');
@@ -88,6 +89,41 @@ describe('ensure-openclaw-plugins', () => {
     expect(buildGitEnv()).toMatchObject({
       GIT_TERMINAL_PROMPT: '0',
     });
+  });
+
+  test('retries a failed plugin install with exponential backoff', () => {
+    let calls = 0;
+    const delays: number[] = [];
+
+    const result = retryPluginInstall(
+      () => {
+        calls += 1;
+        if (calls < 3) throw new Error('ClawHub returned 503');
+        return 'installed';
+      },
+      {
+        attempts: 3,
+        retryDelayMs: 10,
+        sleep: (delayMs: number) => delays.push(delayMs),
+      },
+    );
+
+    expect(result).toBe('installed');
+    expect(calls).toBe(3);
+    expect(delays).toEqual([10, 20]);
+  });
+
+  test('keeps the final plugin install error after retries are exhausted', () => {
+    const failure = new Error('ClawHub returned 503');
+
+    expect(() =>
+      retryPluginInstall(
+        () => {
+          throw failure;
+        },
+        { attempts: 2, retryDelayMs: 1, sleep: () => {} },
+      ),
+    ).toThrow(failure);
   });
 
   test('preserves existing registry and local path behavior', () => {


### PR DESCRIPTION
## 修复

平台构建在安装 @wecom/wecom-openclaw-plugin 时遇到 ClawHub 503，并因 fail-fast 取消其他平台。

- 每个必需插件安装最多尝试 3 次
- 重试间隔为 2 秒、4 秒
- 连续失败仍显式终止，不会发布不完整运行时

## 验证

- npm exec -- vitest run tests/ensure-openclaw-plugins.test.ts（10/10）
- node --check scripts/ensure-openclaw-plugins.cjs
- git diff --check