### PR TITLE
ci: cache platform build dependencies

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -42,15 +42,15 @@ jobs:
           separator=''
 
           if [[ "$BUILD_MACOS" == "true" ]]; then
-            matrix+='{"platform":"macos","runner":"macos-latest","artifact":"macos-build"}'
+            matrix+='{"platform":"macos","runner":"macos-latest","artifact":"macos-build","runtime_target":"mac-arm64"}'
             separator=','
           fi
           if [[ "$BUILD_WINDOWS" == "true" ]]; then
-            matrix+="${separator}{\"platform\":\"windows\",\"runner\":\"windows-latest\",\"artifact\":\"windows-build\"}"
+            matrix+="${separator}{\"platform\":\"windows\",\"runner\":\"windows-latest\",\"artifact\":\"windows-build\",\"runtime_target\":\"win-x64\"}"
             separator=','
           fi
           if [[ "$BUILD_LINUX" == "true" ]]; then
-            matrix+="${separator}{\"platform\":\"linux\",\"runner\":\"ubuntu-latest\",\"artifact\":\"linux-build\"}"
+            matrix+="${separator}{\"platform\":\"linux\",\"runner\":\"ubuntu-latest\",\"artifact\":\"linux-build\",\"runtime_target\":\"linux-x64\"}"
           fi
 
           matrix+=']}'
@@ -80,6 +80,23 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+      - name: Restore packaging caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/.local/share/pnpm/store
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+            ~/AppData/Local/pnpm/store
+            vendor/openclaw-runtime/${{ matrix.runtime_target }}
+            vendor/openclaw-plugins
+          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          restore-keys: |
+            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
       - name: Install Electron system dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-1.3.14-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Validate bundled Skill frontmatter
         run: bun run validate:skills
@@ -44,6 +51,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
+      - name: Restore Bun and Electron caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: test-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            test-${{ runner.os }}-1.3.14-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Compile Electron sources used by integration tests
         run: bun run compile:electron
@@ -64,6 +81,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-1.3.14-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Build renderer bundle
         run: bun run build:vite

--- a/.github/workflows/electron-verify.yml
+++ b/.github/workflows/electron-verify.yml
@@ -17,6 +17,16 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
+      - name: Restore build dependency caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: electron-verify-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            electron-verify-${{ runner.os }}-1.3.14-
 
       - name: Install Electron Dependencies
         run: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -65,12 +65,15 @@ jobs:
           - platform: windows
             runner: windows-latest
             artifact: win32-x64-lite
+            runtime_target: win-x64
           - platform: macos
             runner: macos-latest
             artifact: darwin-arm64-default
+            runtime_target: mac-arm64
           - platform: linux
             runner: ubuntu-latest
             artifact: linux-x64-default
+            runtime_target: linux-x64
     runs-on: ${{ matrix.runner }}
     environment: release
     env:
@@ -88,6 +91,23 @@ jobs:
       # OpenClaw is built with pnpm upstream; Bun remains this repository's installer.
       - uses: pnpm/action-setup@v4
         with: { version: 10 }
+      - name: Restore packaging caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/.local/share/pnpm/store
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+            ~/AppData/Local/pnpm/store
+            vendor/openclaw-runtime/${{ matrix.runtime_target }}
+            vendor/openclaw-plugins
+          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          restore-keys: |
+            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
       - name: Install Electron and virtual desktop dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,11 +36,11 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package.json') }}
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-
 
-      # npm install ????? package-lock.json ? audit ??
-      - run: npm install
+      # Keep the audited dependency graph identical to the checked-in lockfile.
+      - run: npm ci --ignore-scripts
 
       # npm audit
       - name: Run npm audit

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ generate-ppt.mjs
 ppt-assets/
 *.pptx
 documents.md
+reasonix.toml


### PR DESCRIPTION
## Summary
- cache Bun, Electron, npm, pnpm, and platform-specific packaged runtime dependencies
- key packaging caches by OS, runtime target, lockfile, package metadata, and build scripts
- use lockfile-driven npm audit installation and ignore local reasonix.toml

## Validation
- YAML parse validation
- build matrix JSON validation
- git diff --check