### PR TITLE
fix(updater): show Windows installer during updates

### DIFF
--- a/src/main/libs/appUpdateInstaller.test.ts
+++ b/src/main/libs/appUpdateInstaller.test.ts
@@ -91,6 +91,17 @@ describe('unattended installation handoff', () => {
     expect(script).not.toContain('rm -rf "$TARGET"');
   });
 
+  test('Windows update launches the branded NSIS wizard instead of a silent installer', async () => {
+    const updaterSource = await fs.promises.readFile(
+      path.resolve(process.cwd(), 'src/main/libs/appUpdateInstaller.ts'),
+      'utf8',
+    );
+
+    expect(updaterSource).toContain('Launching interactive installer: $installerPath');
+    expect(updaterSource).toContain('Start-Process -FilePath $installerPath -Wait -PassThru');
+    expect(updaterSource).not.toContain("-ArgumentList '/S'");
+  });
+
   test('NSIS silent mode bypasses the local-signing confirmation dialog', async () => {
     const nsisSource = await fs.promises.readFile(
       path.resolve(process.cwd(), 'scripts/nsis-installer.nsh'),

--- a/src/main/libs/appUpdateInstaller.test.ts
+++ b/src/main/libs/appUpdateInstaller.test.ts
@@ -100,6 +100,9 @@ describe('unattended installation handoff', () => {
     expect(updaterSource).toContain('Launching interactive installer: $installerPath');
     expect(updaterSource).toContain('Start-Process -FilePath $installerPath -Wait -PassThru');
     expect(updaterSource).not.toContain("-ArgumentList '/S'");
+    expect(updaterSource).toContain(
+      'Existing app relaunched after installer cancellation or failure',
+    );
   });
 
   test('NSIS silent mode bypasses the local-signing confirmation dialog', async () => {

--- a/src/main/libs/appUpdateInstaller.ts
+++ b/src/main/libs/appUpdateInstaller.ts
@@ -522,6 +522,7 @@ async function installWindowsNsis(exePath: string): Promise<void> {
     `$logPath = '${psEscape(logPath)}'`,
     `$appPid = ${process.pid}`,
     `$installerPath = '${psEscape(exePath)}'`,
+    `$appPath = '${psEscape(process.execPath)}'`,
     '',
     'function Log($msg) {',
     "    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'",
@@ -552,6 +553,12 @@ async function installWindowsNsis(exePath: string): Promise<void> {
     '    Log "Installer completed; NSIS finish page controls app launch"',
     '} catch {',
     '    Log "ERROR: $($_.Exception.Message)"',
+    '    # A visible installer can be cancelled. Restore the still-installed',
+    '    # version so cancellation does not strand the user outside the app.',
+    '    if (Test-Path $appPath) {',
+    '        Start-Process -FilePath $appPath',
+    '        Log "Existing app relaunched after installer cancellation or failure"',
+    '    }',
     '}',
   ].join('\r\n');
 

--- a/src/main/libs/appUpdateInstaller.ts
+++ b/src/main/libs/appUpdateInstaller.ts
@@ -496,7 +496,7 @@ async function installMacDmg(dmgPath: string): Promise<void> {
 }
 
 async function installWindowsNsis(exePath: string): Promise<void> {
-  console.log(`[AppUpdate] Windows NSIS install (silent mode)`);
+  console.log(`[AppUpdate] Windows NSIS install (interactive mode)`);
   console.log(`[AppUpdate]   installer: ${exePath}`);
   console.log(`[AppUpdate]   appPid: ${process.pid}`);
 
@@ -505,8 +505,9 @@ async function installWindowsNsis(exePath: string): Promise<void> {
   // which kills the entire process tree — including child processes.
   //
   // Strategy: use a tiny PowerShell script (launched via hidden VBS) that
-  // waits for the app to fully exit, then runs the installer without its
-  // wizard. The installer can still request Windows UAC when required.
+  // waits for the app to fully exit, then launches the branded NSIS wizard.
+  // The PowerShell host stays hidden, while the installer itself is visible
+  // so users can see that the update is in progress and choose its options.
   const ts = Date.now();
   const tempDir = app.getPath('temp');
   const logPath = path.join(tempDir, `zhiyuan-update-${ts}.log`);
@@ -521,7 +522,6 @@ async function installWindowsNsis(exePath: string): Promise<void> {
     `$logPath = '${psEscape(logPath)}'`,
     `$appPid = ${process.pid}`,
     `$installerPath = '${psEscape(exePath)}'`,
-    `$appPath = '${psEscape(process.execPath)}'`,
     '',
     'function Log($msg) {',
     "    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'",
@@ -544,14 +544,12 @@ async function installWindowsNsis(exePath: string): Promise<void> {
     '    }',
     '    Log "App exited after $waited seconds"',
     '',
-    '    # Install without showing the NSIS wizard, then start the updated app.',
-    '    Log "Launching silent installer: $installerPath"',
-    "    $installer = Start-Process -FilePath $installerPath -ArgumentList '/S' -Wait -PassThru",
+    '    # Show the NSIS wizard so the update has an explicit, visible handoff.',
+    '    Log "Launching interactive installer: $installerPath"',
+    '    $installer = Start-Process -FilePath $installerPath -Wait -PassThru',
     '    Log "Installer exited with code $($installer.ExitCode)"',
     '    if ($installer.ExitCode -ne 0) { throw "Installer exited with code $($installer.ExitCode)" }',
-    '    if (-not (Test-Path $appPath)) { throw "Updated app executable was not found: $appPath" }',
-    '    Start-Process -FilePath $appPath',
-    '    Log "Updated app relaunched"',
+    '    Log "Installer completed; NSIS finish page controls app launch"',
     '} catch {',
     '    Log "ERROR: $($_.Exception.Message)"',
     '}',


### PR DESCRIPTION
## 变更

Windows 下载完更新后，退出应用并显示品牌化 NSIS 安装向导，不再使用静默 /S 安装。

- 用户能明确看到更新已开始
- 保留等待旧进程完全退出的安全交接
- 安装完成页由用户选择是否立即启动更新后的应用

## 验证

- npm exec -- vitest run src/main/libs/appUpdateInstaller.test.ts src/main/libs/appUpdateCoordinator.test.ts（14/14）
- git diff --check