### PR TITLE
ci: reclaim expired release artifacts

### DIFF
--- a/.github/workflows/online-update-cleanup.yml
+++ b/.github/workflows/online-update-cleanup.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: read
 
 jobs:
@@ -61,9 +62,27 @@ jobs:
             exit "$previous_status"
           fi
 
-          aws s3api list-objects-v2 \
-            --bucket "$R2_BUCKET" \
-            --prefix releases/ \
+          page=1
+          continuation_token=''
+          while :; do
+            page_path="manifest/cleanup/release-objects-${page}.json"
+            list_args=(--bucket "$R2_BUCKET" --prefix releases/ --max-keys 1000)
+            if [[ -n "$continuation_token" ]]; then
+              list_args+=(--continuation-token "$continuation_token")
+            fi
+            aws s3api list-objects-v2 "${list_args[@]}" > "$page_path"
+
+            if [[ "$(jq -r '.IsTruncated // false' "$page_path")" != 'true' ]]; then
+              break
+            fi
+            continuation_token="$(jq -r '.NextContinuationToken // empty' "$page_path")"
+            if [[ -z "$continuation_token" ]]; then
+              echo "R2 returned a truncated listing without a continuation token" >&2
+              exit 1
+            fi
+            page=$((page + 1))
+          done
+          jq -s '{Contents: [.[].Contents[]?]}' manifest/cleanup/release-objects-*.json \
             > manifest/release-objects.json
       - name: Plan expired object cleanup
         run: |
@@ -85,3 +104,37 @@ jobs:
             [[ -e "$batch" ]] || continue
             aws s3api delete-objects --bucket "$R2_BUCKET" --delete "file://$batch"
           done
+
+  github-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow artifacts older than seven days
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_RETENTION_DAYS: '7'
+        run: |
+          set -euo pipefail
+          cutoff_epoch="$(date -u -d "${ARTIFACT_RETENTION_DAYS} days ago" +%s)"
+          artifact_ids="$(mktemp)"
+          trap 'rm -f "$artifact_ids"' EXIT
+
+          page=1
+          while :; do
+            response="$(gh api \
+              "/repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100&page=${page}")"
+            jq -r --argjson cutoff "$cutoff_epoch" \
+              '.artifacts[] | select(.created_at | fromdateiso8601 < $cutoff) | .id' \
+              <<< "$response" >> "$artifact_ids"
+            count="$(jq '.artifacts | length' <<< "$response")"
+            [[ "$count" -lt 100 ]] && break
+            page=$((page + 1))
+          done
+
+          deleted=0
+          while IFS= read -r artifact_id; do
+            [[ -z "$artifact_id" ]] && continue
+            gh api --method DELETE \
+              "/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+            deleted=$((deleted + 1))
+          done < "$artifact_ids"
+          echo "Deleted ${deleted} workflow artifacts older than ${ARTIFACT_RETENTION_DAYS} days."

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -170,11 +170,13 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: "release/*.exe"
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.platform == 'macos' }}
         with:
           name: ${{ matrix.artifact }}
           path: "release/*.dmg"
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         if: ${{ always() && matrix.platform == 'linux' }}
         with:
@@ -183,6 +185,7 @@ jobs:
             release/*.deb
             release/*.AppImage
             release/linux-render-smoke.png
+          retention-days: 7
 
   publish:
     needs: [prepare-release, build-platforms]


### PR DESCRIPTION
## Summary
- retain online-update build artifacts for seven days and remove expired Actions artifacts daily
- paginate R2 release inventory before planning deletion, so cleanup covers inventories larger than 1,000 objects
- preserve the signed stable manifest and its short-lived previous manifest through the existing cleanup planner

## Validation
- 
- YAML parsed with Ruby
- 
 RUN  v4.1.10 /Users/krli/workspace/RongxinAI


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  13:12:32
   Duration  475ms (transform 17ms, setup 90ms, import 9ms, tests 312ms, environment 0ms)