### PR TITLE
ci: cache bundled release runtimes

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -69,8 +69,8 @@ jobs:
     # a runner indefinitely when an upstream command stalls.
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
@@ -81,7 +81,7 @@ jobs:
         with:
           version: 10
       - name: Restore packaging caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -149,19 +149,19 @@ jobs:
           node scripts/verify-linux-renderer.mjs
           release/linux-unpacked
           release/linux-render-smoke.png
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ matrix.platform == 'macos' }}
         with:
           name: ${{ matrix.artifact }}
           path: release/*.dmg
           retention-days: 7
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ matrix.platform == 'windows' }}
         with:
           name: ${{ matrix.artifact }}
           path: release/*.exe
           retention-days: 7
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: ${{ always() && matrix.platform == 'linux' }}
         with:
           name: ${{ matrix.artifact }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
@@ -44,15 +44,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
       - name: Restore Bun and Electron caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -74,15 +74,15 @@ jobs:
   bundle-budget:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/electron-verify.yml
+++ b/.github/workflows/electron-verify.yml
@@ -10,15 +10,15 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.14'
       - name: Restore build dependency caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/online-update-cleanup.yml
+++ b/.github/workflows/online-update-cleanup.yml
@@ -26,8 +26,8 @@ jobs:
       UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
       UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with: { node-version: '24.x' }
       - name: Install release tools
         run: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -23,7 +23,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       commit: ${{ steps.source.outputs.commit }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Derive and validate the release version from the tag
@@ -81,10 +81,10 @@ jobs:
       # exposing its name or value in the build command line.
       CLAWHUB_TOKEN: ${{ secrets.CLAW_HUB }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare-release.outputs.commit }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: "24.x" }
       - uses: oven-sh/setup-bun@v2
         with: { bun-version: "1.3.14" }
@@ -96,7 +96,7 @@ jobs:
       # boundary here so changing an unrelated build script does not require
       # re-downloading Python, uv, or Pandoc for every release platform.
       - name: Restore bundled runtime cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             resources/python-win
@@ -114,12 +114,12 @@ jobs:
       # contract changes instead of being tied to every file under scripts/.
       - name: Restore Windows llama.cpp backend cache
         if: ${{ matrix.platform == 'windows' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/win-lite
           key: windows-llamacpp-lite-${{ hashFiles('package.json', 'electron-builder.json', 'scripts/electron-builder-hooks.cjs', 'scripts/download-llamacpp-runtime.cjs', 'scripts/ci/package-windows.ps1') }}
       - name: Restore packaging caches
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -244,7 +244,7 @@ jobs:
           AWS_DEFAULT_REGION: auto
           AWS_ENDPOINT_URL_S3: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
       - name: Upload immutable artifact metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact }}-metadata
           path: update-artifacts.json
@@ -255,12 +255,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare-release.outputs.commit }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { path: artifacts }
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with: { node-version: "24.x" }
       - name: Install release tools
         run: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -91,6 +91,33 @@ jobs:
       # OpenClaw is built with pnpm upstream; Bun remains this repository's installer.
       - uses: pnpm/action-setup@v4
         with: { version: 10 }
+      # These are application-bundled runtimes, not package-manager caches.
+      # GitLab's release runners retain them independently; keep the same
+      # boundary here so changing an unrelated build script does not require
+      # re-downloading Python, uv, or Pandoc for every release platform.
+      - name: Restore bundled runtime cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            resources/python-win
+            resources/uv-win
+            resources/python-mac
+            resources/uv-mac
+            resources/python-linux
+            resources/uv-linux
+            resources/pandoc
+            resources/pandoc-archives
+            resources/uv-archives
+          key: bundled-runtimes-${{ runner.os }}-${{ matrix.runtime_target }}-${{ hashFiles('scripts/setup-python-runtime.js', 'scripts/setup-uv-runtime.js', 'scripts/setup-mac-python-runtime.js', 'scripts/setup-mac-uv-runtime.js', 'scripts/setup-pandoc-runtime.js', 'electron-builder.json') }}
+      # The Windows backend is an immutable downloaded bundle. It is expensive
+      # to prepare, but is invalidated whenever its download or packaging
+      # contract changes instead of being tied to every file under scripts/.
+      - name: Restore Windows llama.cpp backend cache
+        if: ${{ matrix.platform == 'windows' }}
+        uses: actions/cache@v4
+        with:
+          path: build/win-lite
+          key: windows-llamacpp-lite-${{ hashFiles('package.json', 'electron-builder.json', 'scripts/electron-builder-hooks.cjs', 'scripts/download-llamacpp-runtime.cjs', 'scripts/ci/package-windows.ps1') }}
       - name: Restore packaging caches
         uses: actions/cache@v4
         with:

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -192,26 +192,62 @@ jobs:
           node scripts/verify-linux-renderer.mjs
           release/linux-unpacked
           release/linux-render-smoke.png
-      - uses: actions/upload-artifact@v4
+      # Uploading installers directly from their platform runner avoids the
+      # GitHub artifact upload -> download -> R2 upload relay. The signed
+      # stable manifest is still withheld until every matrix job succeeds.
+      - name: Upload Windows immutable artifact to R2
         if: ${{ matrix.platform == 'windows' }}
-        with:
-          name: ${{ matrix.artifact }}
-          path: "release/*.exe"
-          retention-days: 7
-      - uses: actions/upload-artifact@v4
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(release/*.exe)
+          [[ ${#files[@]} -eq 1 ]] || { echo 'Expected exactly one Windows installer' >&2; exit 1; }
+          node scripts/release/upload-update-artifacts.mjs \
+            '${{ needs.prepare-release.outputs.version }}' \
+            update-artifacts.json \
+            "${files[0]}:win32:x64:lite"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL_S3: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      - name: Upload macOS immutable artifact to R2
         if: ${{ matrix.platform == 'macos' }}
+        run: |
+          shopt -s nullglob
+          files=(release/*.dmg)
+          [[ ${#files[@]} -eq 1 ]] || { echo 'Expected exactly one macOS installer' >&2; exit 1; }
+          node scripts/release/upload-update-artifacts.mjs \
+            '${{ needs.prepare-release.outputs.version }}' \
+            update-artifacts.json \
+            "${files[0]}:darwin:arm64:default"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL_S3: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      - name: Upload Linux immutable artifacts to R2
+        if: ${{ matrix.platform == 'linux' }}
+        run: |
+          shopt -s nullglob
+          debs=(release/*.deb)
+          appimages=(release/*.AppImage)
+          [[ ${#debs[@]} -eq 1 && ${#appimages[@]} -eq 1 ]] || { echo 'Expected exactly one deb and AppImage installer' >&2; exit 1; }
+          node scripts/release/upload-update-artifacts.mjs \
+            '${{ needs.prepare-release.outputs.version }}' \
+            update-artifacts.json \
+            "${debs[0]}:linux:x64:deb" \
+            "${appimages[0]}:linux:x64:appimage"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL_S3: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      - name: Upload immutable artifact metadata
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: "release/*.dmg"
-          retention-days: 7
-      - uses: actions/upload-artifact@v4
-        if: ${{ always() && matrix.platform == 'linux' }}
-        with:
-          name: ${{ matrix.artifact }}
-          path: |
-            release/*.deb
-            release/*.AppImage
-            release/linux-render-smoke.png
+          name: ${{ matrix.artifact }}-metadata
+          path: update-artifacts.json
           retention-days: 7
 
   publish:
@@ -230,34 +266,22 @@ jobs:
         run: |
           pipx install 'awscli>=1.45.10,<2'
           npm ci --prefix scripts/release --ignore-scripts --no-audit --no-fund
-      - name: Resolve artifacts
-        id: artifacts
+      - name: Resolve uploaded artifact metadata
         run: |
-          mapfile -t windows_artifacts < <(find artifacts/win32-x64-lite -type f -name '*.exe')
-          mapfile -t macos_artifacts < <(find artifacts/darwin-arm64-default -type f -name '*.dmg')
-          mapfile -t linux_deb_artifacts < <(find artifacts/linux-x64-default -type f -name '*.deb')
-          mapfile -t linux_appimage_artifacts < <(find artifacts/linux-x64-default -type f -name '*.AppImage')
-          if [[ ${#windows_artifacts[@]} -ne 1 ||
-                ${#macos_artifacts[@]} -ne 1 ||
-                ${#linux_deb_artifacts[@]} -ne 1 ||
-                ${#linux_appimage_artifacts[@]} -ne 1 ]]; then
-            echo 'Expected exactly one Windows, macOS, Ubuntu deb, and AppImage installer' >&2
+          mapfile -t metadata < <(find artifacts -type f -name update-artifacts.json | sort)
+          if [[ ${#metadata[@]} -ne 3 ]]; then
+            echo 'Expected exactly three platform artifact metadata files' >&2
             exit 1
           fi
-          echo "windows=${windows_artifacts[0]}" >> "$GITHUB_OUTPUT"
-          echo "macos=${macos_artifacts[0]}" >> "$GITHUB_OUTPUT"
-          echo "linux_deb=${linux_deb_artifacts[0]}" >> "$GITHUB_OUTPUT"
-          echo "linux_appimage=${linux_appimage_artifacts[0]}" >> "$GITHUB_OUTPUT"
+          jq -e 'all(.artifacts[]; .key and .size and .sha256)' "${metadata[@]}" > /dev/null
       - name: Create and verify signed manifest
         run: |
           node scripts/release/publish-update-manifest.mjs \
             manifest/stable.json \
             '${{ needs.prepare-release.outputs.version }}' \
             '${{ needs.prepare-release.outputs.commit }}' \
-            '${{ steps.artifacts.outputs.windows }}:win32:x64:lite' \
-            '${{ steps.artifacts.outputs.macos }}:darwin:arm64:default' \
-            '${{ steps.artifacts.outputs.linux_deb }}:linux:x64:deb' \
-            '${{ steps.artifacts.outputs.linux_appimage }}:linux:x64:appimage'
+            --metadata \
+            $(find artifacts -type f -name update-artifacts.json | sort)
         env:
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PRIVATE_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PRIVATE_KEY_BASE64 }}
@@ -303,56 +327,20 @@ jobs:
         env:
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
-      - name: Upload immutable artifacts and verify remote sizes
+      - name: Verify parallel uploaded immutable artifacts
         if: steps.version_check.outputs.idempotent != 'true'
         run: |
-          upload_artifact() {
-            local file_path="$1"
-            local object_key="$2"
-            local attempt
-
-            # R2 multipart completion can transiently return InvalidPart for
-            # large installers. Retry the whole immutable-object upload with a
-            # fresh multipart session; the following head-object checks still
-            # verify the exact remote byte count before manifest publication.
-            for attempt in 1 2 3; do
-              if aws s3 cp "$file_path" "s3://$R2_BUCKET/$object_key" \
-                --cache-control 'public, max-age=31536000, immutable' \
-                --no-progress; then
-                return 0
-              fi
-              if [[ "$attempt" -eq 3 ]]; then
-                echo "Upload failed after ${attempt} attempts: $object_key" >&2
-                return 1
-              fi
-              echo "Upload attempt ${attempt} failed for $object_key; retrying in $((attempt * 10))s..." >&2
-              sleep $((attempt * 10))
-            done
-          }
-
-          version='${{ needs.prepare-release.outputs.version }}'
-          windows_path='${{ steps.artifacts.outputs.windows }}'
-          macos_path='${{ steps.artifacts.outputs.macos }}'
-          linux_deb_path='${{ steps.artifacts.outputs.linux_deb }}'
-          linux_appimage_path='${{ steps.artifacts.outputs.linux_appimage }}'
-          windows_key="releases/$version/win32-x64-lite/$(basename "$windows_path")"
-          macos_key="releases/$version/darwin-arm64-default/$(basename "$macos_path")"
-          linux_deb_key="releases/$version/linux-x64-deb/$(basename "$linux_deb_path")"
-          linux_appimage_key="releases/$version/linux-x64-appimage/$(basename "$linux_appimage_path")"
-
-          upload_artifact "$windows_path" "$windows_key"
-          upload_artifact "$macos_path" "$macos_key"
-          upload_artifact "$linux_deb_path" "$linux_deb_key"
-          upload_artifact "$linux_appimage_path" "$linux_appimage_key"
-
-          windows_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$windows_key" --query ContentLength --output text)
-          macos_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$macos_key" --query ContentLength --output text)
-          linux_deb_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$linux_deb_key" --query ContentLength --output text)
-          linux_appimage_remote_size=$(aws s3api head-object --bucket "$R2_BUCKET" --key "$linux_appimage_key" --query ContentLength --output text)
-          [[ "$windows_remote_size" == "$(stat --format='%s' "$windows_path")" ]]
-          [[ "$macos_remote_size" == "$(stat --format='%s' "$macos_path")" ]]
-          [[ "$linux_deb_remote_size" == "$(stat --format='%s' "$linux_deb_path")" ]]
-          [[ "$linux_appimage_remote_size" == "$(stat --format='%s' "$linux_appimage_path")" ]]
+          mapfile -t metadata < <(find artifacts -type f -name update-artifacts.json | sort)
+          for metadata_path in "${metadata[@]}"; do
+            while IFS=$'\t' read -r key size; do
+              remote_size=$(aws s3api head-object \
+                --bucket "$R2_BUCKET" \
+                --key "$key" \
+                --query ContentLength \
+                --output text)
+              [[ "$remote_size" == "$size" ]]
+            done < <(jq -r '.artifacts[] | [.key, .size] | @tsv' "$metadata_path")
+          done
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/openclaw-check.yml
+++ b/.github/workflows/openclaw-check.yml
@@ -10,8 +10,8 @@ jobs:
   check-openclaw-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
   secrets-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -29,11 +29,11 @@ jobs:
   dependency-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -57,8 +57,8 @@ jobs:
   skills-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 
@@ -85,7 +85,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/test-artifact-upload.yml
+++ b/.github/workflows/test-artifact-upload.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Tailscale
         run: |
@@ -118,7 +118,7 @@ jobs:
           cat /tmp/tailscaled.log || true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 

--- a/scripts/release/publish-update-manifest.mjs
+++ b/scripts/release/publish-update-manifest.mjs
@@ -13,6 +13,13 @@ const keyId = process.env.UPDATE_MANIFEST_KEY_ID;
 const privateKeyBase64 = process.env.UPDATE_MANIFEST_PRIVATE_KEY_BASE64;
 if (!keyId || !privateKeyBase64) throw new Error('Update signing secrets are required');
 
+const REQUIRED_RELEASE_TARGETS = new Set([
+  'win32:x64:lite',
+  'darwin:arm64:default',
+  'linux:x64:deb',
+  'linux:x64:appimage',
+]);
+
 const privateKey = crypto.createPrivateKey({
   key: Buffer.from(privateKeyBase64, 'base64'),
   format: 'der',
@@ -39,20 +46,27 @@ function resolveArtifactFormat(platform, variant) {
 }
 
 async function localArtifact(spec) {
-    const [file, platform, arch, variant] = spec.split(':');
-    if (!file || !platform || !arch || !variant) {
-      throw new Error(`Invalid artifact spec: ${spec}`);
-    }
+  const [file, platform, arch, variant] = spec.split(':');
+  if (!file || !platform || !arch || !variant) {
+    throw new Error(`Invalid artifact spec: ${spec}`);
+  }
 
-    const content = await fs.readFile(file);
-    const extension = path.extname(file).toLowerCase();
-    const format = resolveArtifactFormat(platform, variant);
-    if (extension !== format.extension || content.length === 0) {
-      throw new Error(`Invalid ${platform} artifact: ${file}`);
-    }
+  const content = await fs.readFile(file);
+  const extension = path.extname(file).toLowerCase();
+  const format = resolveArtifactFormat(platform, variant);
+  if (extension !== format.extension || content.length === 0) {
+    throw new Error(`Invalid ${platform} artifact: ${file}`);
+  }
 
-    const filename = path.basename(file);
-    return { platform, arch, variant, filename, size: content.length, sha256: crypto.createHash('sha256').update(content).digest('hex') };
+  const filename = path.basename(file);
+  return {
+    platform,
+    arch,
+    variant,
+    filename,
+    size: content.length,
+    sha256: crypto.createHash('sha256').update(content).digest('hex'),
+  };
 }
 
 async function metadataArtifacts(metadataPath) {
@@ -98,44 +112,54 @@ const artifacts = [
   ...(await Promise.all(metadataPaths.map(metadataArtifacts))).flat(),
 ];
 const targets = new Set();
+for (const { platform, arch, variant } of artifacts) {
+  const target = `${platform}:${arch}:${variant}`;
+  if (targets.has(target)) throw new Error(`Duplicate release target: ${target}`);
+  targets.add(target);
+}
+const missingTargets = [...REQUIRED_RELEASE_TARGETS].filter(target => !targets.has(target));
+const unexpectedTargets = [...targets].filter(target => !REQUIRED_RELEASE_TARGETS.has(target));
+if (missingTargets.length > 0 || unexpectedTargets.length > 0) {
+  throw new Error(
+    `Release manifest must contain exactly the required targets; missing=${missingTargets.join(',') || 'none'} unexpected=${unexpectedTargets.join(',') || 'none'}`,
+  );
+}
+
 const manifests = artifacts.map(({ platform, arch, variant, filename, size, sha256 }) => {
-    const format = resolveArtifactFormat(platform, variant);
-    const target = `${platform}:${arch}:${variant}`;
-    if (targets.has(target)) throw new Error(`Duplicate release target: ${target}`);
-    targets.add(target);
-    const payload = {
-      channel: 'stable',
-      version: releaseVersion,
-      publishedAt: new Date().toISOString(),
-      minimumSupportedVersion: '2026.7.1',
-      mandatory: false,
-      releaseNotes: {
-        zh: { title: `知远智能体 ${releaseVersion}`, items: ['修复若干问题'] },
-        en: { title: `ZhiYuan Agent ${releaseVersion}`, items: ['Bug fixes'] },
-      },
-      artifact: {
-        platform,
-        arch,
-        variant,
-        url: `https://downloads.rongxzyai.com/releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`,
-        size,
-        sha256,
-        contentType: format.contentType,
-      },
-      source: {
-        commitSha,
-        pipelineId: process.env.GITHUB_RUN_ID ?? 'local',
-      },
-    };
-    const payloadBytes = Buffer.from(JSON.stringify(payload));
-    return {
-      schemaVersion: 1,
-      keyId,
-      algorithm: 'Ed25519',
-      payload: payloadBytes.toString('base64url'),
-      signature: crypto.sign(null, payloadBytes, privateKey).toString('base64url'),
-    };
-  });
+  const format = resolveArtifactFormat(platform, variant);
+  const payload = {
+    channel: 'stable',
+    version: releaseVersion,
+    publishedAt: new Date().toISOString(),
+    minimumSupportedVersion: '2026.7.1',
+    mandatory: false,
+    releaseNotes: {
+      zh: { title: `知远智能体 ${releaseVersion}`, items: ['修复若干问题'] },
+      en: { title: `ZhiYuan Agent ${releaseVersion}`, items: ['Bug fixes'] },
+    },
+    artifact: {
+      platform,
+      arch,
+      variant,
+      url: `https://downloads.rongxzyai.com/releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`,
+      size,
+      sha256,
+      contentType: format.contentType,
+    },
+    source: {
+      commitSha,
+      pipelineId: process.env.GITHUB_RUN_ID ?? 'local',
+    },
+  };
+  const payloadBytes = Buffer.from(JSON.stringify(payload));
+  return {
+    schemaVersion: 1,
+    keyId,
+    algorithm: 'Ed25519',
+    payload: payloadBytes.toString('base64url'),
+    signature: crypto.sign(null, payloadBytes, privateKey).toString('base64url'),
+  };
+});
 
 await fs.mkdir(path.dirname(outputPath), { recursive: true });
 await fs.writeFile(outputPath, JSON.stringify({ schemaVersion: 1, manifests }));

--- a/scripts/release/publish-update-manifest.mjs
+++ b/scripts/release/publish-update-manifest.mjs
@@ -38,8 +38,7 @@ function resolveArtifactFormat(platform, variant) {
   throw new Error(`Unsupported release target: ${platform}:${variant}`);
 }
 
-const artifacts = await Promise.all(
-  specs.map(async spec => {
+async function localArtifact(spec) {
     const [file, platform, arch, variant] = spec.split(':');
     if (!file || !platform || !arch || !variant) {
       throw new Error(`Invalid artifact spec: ${spec}`);
@@ -53,6 +52,57 @@ const artifacts = await Promise.all(
     }
 
     const filename = path.basename(file);
+    return { platform, arch, variant, filename, size: content.length, sha256: crypto.createHash('sha256').update(content).digest('hex') };
+}
+
+async function metadataArtifacts(metadataPath) {
+  const metadata = JSON.parse(await fs.readFile(metadataPath, 'utf8'));
+  if (
+    !metadata ||
+    metadata.schemaVersion !== 1 ||
+    metadata.releaseVersion !== releaseVersion ||
+    !Array.isArray(metadata.artifacts)
+  ) {
+    throw new Error(`Invalid uploaded artifact metadata: ${metadataPath}`);
+  }
+  return metadata.artifacts.map(artifact => {
+    const { platform, arch, variant, filename, key, size, sha256 } = artifact ?? {};
+    const format = resolveArtifactFormat(platform, variant);
+    const expectedKey = `releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`;
+    if (
+      typeof arch !== 'string' ||
+      typeof filename !== 'string' ||
+      filename !== path.basename(filename) ||
+      path.extname(filename).toLowerCase() !== format.extension ||
+      key !== expectedKey ||
+      !Number.isSafeInteger(size) ||
+      size <= 0 ||
+      typeof sha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(sha256)
+    ) {
+      throw new Error(`Invalid uploaded artifact metadata entry: ${metadataPath}`);
+    }
+    return { platform, arch, variant, filename, size, sha256 };
+  });
+}
+
+const metadataFlag = specs.indexOf('--metadata');
+const localSpecs = metadataFlag === -1 ? specs : specs.slice(0, metadataFlag);
+const metadataPaths = metadataFlag === -1 ? [] : specs.slice(metadataFlag + 1);
+if (metadataFlag !== -1 && metadataPaths.length === 0) {
+  throw new Error('Expected at least one metadata file after --metadata');
+}
+
+const artifacts = [
+  ...(await Promise.all(localSpecs.map(localArtifact))),
+  ...(await Promise.all(metadataPaths.map(metadataArtifacts))).flat(),
+];
+const targets = new Set();
+const manifests = artifacts.map(({ platform, arch, variant, filename, size, sha256 }) => {
+    const format = resolveArtifactFormat(platform, variant);
+    const target = `${platform}:${arch}:${variant}`;
+    if (targets.has(target)) throw new Error(`Duplicate release target: ${target}`);
+    targets.add(target);
     const payload = {
       channel: 'stable',
       version: releaseVersion,
@@ -68,8 +118,8 @@ const artifacts = await Promise.all(
         arch,
         variant,
         url: `https://downloads.rongxzyai.com/releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`,
-        size: content.length,
-        sha256: crypto.createHash('sha256').update(content).digest('hex'),
+        size,
+        sha256,
         contentType: format.contentType,
       },
       source: {
@@ -85,8 +135,7 @@ const artifacts = await Promise.all(
       payload: payloadBytes.toString('base64url'),
       signature: crypto.sign(null, payloadBytes, privateKey).toString('base64url'),
     };
-  }),
-);
+  });
 
 await fs.mkdir(path.dirname(outputPath), { recursive: true });
-await fs.writeFile(outputPath, JSON.stringify({ schemaVersion: 1, manifests: artifacts }));
+await fs.writeFile(outputPath, JSON.stringify({ schemaVersion: 1, manifests }));

--- a/scripts/release/update-manifest-lib.test.ts
+++ b/scripts/release/update-manifest-lib.test.ts
@@ -93,6 +93,48 @@ describe('online update release tools', () => {
     );
   });
 
+  test('publishes a signed manifest from verified uploaded-artifact metadata', () => {
+    const metadataPath = path.join(temporaryDirectory, 'uploaded-artifacts.json');
+    const manifestPath = path.join(temporaryDirectory, 'metadata-manifest.json');
+    const version = '2026.7.5';
+    const artifacts = [
+      ['win32', 'x64', 'lite', 'installer.exe'],
+      ['darwin', 'arm64', 'default', 'installer.dmg'],
+      ['linux', 'x64', 'deb', 'installer.deb'],
+      ['linux', 'x64', 'appimage', 'installer.AppImage'],
+    ].map(([platform, arch, variant, filename], index) => ({
+      platform,
+      arch,
+      variant,
+      filename,
+      key: `releases/${version}/${platform}-${arch}-${variant}/${filename}`,
+      size: index + 1,
+      sha256: `${index}`.repeat(64),
+    }));
+    fs.writeFileSync(
+      metadataPath,
+      JSON.stringify({ schemaVersion: 1, releaseVersion: version, artifacts }),
+    );
+
+    const result = runScript(
+      'publish-update-manifest.mjs',
+      [manifestPath, version, 'b'.repeat(40), '--metadata', metadataPath],
+      releaseEnvironment,
+    );
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+
+    const collection = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      manifests: Array<{ payload: string }>;
+    };
+    const payloads = collection.manifests.map(envelope =>
+      JSON.parse(Buffer.from(envelope.payload, 'base64url').toString('utf8')),
+    );
+    expect(payloads.map(payload => payload.artifact.sha256)).toEqual(
+      artifacts.map(artifact => artifact.sha256),
+    );
+  });
+
   test('enforces monotonic versions and same-version artifact idempotency', () => {
     const currentManifest = createManifest('2026.7.3', 'current');
     const outputPath = path.join(temporaryDirectory, 'github-output.txt');

--- a/scripts/release/update-manifest-lib.test.ts
+++ b/scripts/release/update-manifest-lib.test.ts
@@ -135,6 +135,56 @@ describe('online update release tools', () => {
     );
   });
 
+  test('rejects uploaded metadata with a missing, duplicate, or unexpected release target', () => {
+    const version = '2026.7.5';
+    const artifacts = [
+      ['win32', 'x64', 'lite', 'installer.exe'],
+      ['darwin', 'arm64', 'default', 'installer.dmg'],
+      ['linux', 'x64', 'deb', 'installer.deb'],
+      ['linux', 'x64', 'appimage', 'installer.AppImage'],
+    ].map(([platform, arch, variant, filename], index) => ({
+      platform,
+      arch,
+      variant,
+      filename,
+      key: `releases/${version}/${platform}-${arch}-${variant}/${filename}`,
+      size: index + 1,
+      sha256: `${index}`.repeat(64),
+    }));
+
+    for (const [caseName, invalidArtifacts, expectedError] of [
+      ['missing', artifacts.slice(0, -1), 'must contain exactly the required targets'],
+      ['duplicate', [...artifacts, artifacts[0]], 'Duplicate release target'],
+      [
+        'unexpected',
+        [
+          ...artifacts,
+          {
+            ...artifacts[1],
+            arch: 'x64',
+            key: `releases/${version}/darwin-x64-default/installer.dmg`,
+          },
+        ],
+        'must contain exactly the required targets',
+      ],
+    ] as const) {
+      const metadataPath = path.join(temporaryDirectory, `${caseName}-artifacts.json`);
+      const manifestPath = path.join(temporaryDirectory, `${caseName}-manifest.json`);
+      fs.writeFileSync(
+        metadataPath,
+        JSON.stringify({ schemaVersion: 1, releaseVersion: version, artifacts: invalidArtifacts }),
+      );
+      const result = runScript(
+        'publish-update-manifest.mjs',
+        [manifestPath, version, 'b'.repeat(40), '--metadata', metadataPath],
+        releaseEnvironment,
+      );
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(expectedError);
+      expect(fs.existsSync(manifestPath)).toBe(false);
+    }
+  });
+
   test('enforces monotonic versions and same-version artifact idempotency', () => {
     const currentManifest = createManifest('2026.7.3', 'current');
     const outputPath = path.join(temporaryDirectory, 'github-output.txt');

--- a/scripts/release/upload-update-artifacts.mjs
+++ b/scripts/release/upload-update-artifacts.mjs
@@ -1,0 +1,111 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const [releaseVersion, outputPath, ...specs] = process.argv.slice(2);
+if (!releaseVersion || !outputPath || specs.length === 0) {
+  throw new Error(
+    'usage: upload-update-artifacts.mjs <version> <metadata-output> <file:platform:arch:variant>...',
+  );
+}
+
+const bucket = process.env.R2_BUCKET;
+if (!bucket) throw new Error('R2_BUCKET is required');
+
+function resolveArtifactFormat(platform, variant) {
+  if (platform === 'win32' && (variant === 'lite' || variant === 'full')) {
+    return { extension: '.exe', contentType: 'application/vnd.microsoft.portable-executable' };
+  }
+  if (platform === 'darwin' && variant === 'default') {
+    return { extension: '.dmg', contentType: 'application/x-apple-diskimage' };
+  }
+  if (platform === 'linux' && variant === 'deb') {
+    return { extension: '.deb', contentType: 'application/vnd.debian.binary-package' };
+  }
+  if (platform === 'linux' && variant === 'appimage') {
+    return { extension: '.appimage', contentType: 'application/vnd.appimage' };
+  }
+  throw new Error(`Unsupported release target: ${platform}:${variant}`);
+}
+
+async function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  return hash.digest('hex');
+}
+
+function runAws(args, options = {}) {
+  const result = spawnSync('aws', args, { encoding: 'utf8', stdio: options.stdio ?? 'inherit' });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function uploadWithRetry(filePath, objectKey) {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const result = runAws(
+      [
+        's3',
+        'cp',
+        filePath,
+        `s3://${bucket}/${objectKey}`,
+        '--cache-control',
+        'public, max-age=31536000, immutable',
+        '--no-progress',
+      ],
+      { stdio: 'inherit' },
+    );
+    if (result.status === 0) return;
+    if (attempt === 3) throw new Error(`Upload failed after ${attempt} attempts: ${objectKey}`);
+    console.warn(`[UpdateRelease] Upload attempt ${attempt} failed for ${objectKey}; retrying...`);
+    await sleep(attempt * 10_000);
+  }
+}
+
+const artifacts = [];
+for (const spec of specs) {
+  const [filePath, platform, arch, variant, ...extra] = spec.split(':');
+  if (!filePath || !platform || !arch || !variant || extra.length > 0) {
+    throw new Error(`Invalid artifact spec: ${spec}`);
+  }
+  const format = resolveArtifactFormat(platform, variant);
+  const stat = await fsp.stat(filePath);
+  const filename = path.basename(filePath);
+  if (!stat.isFile() || stat.size === 0 || path.extname(filename).toLowerCase() !== format.extension) {
+    throw new Error(`Invalid ${platform} artifact: ${filePath}`);
+  }
+
+  const key = `releases/${releaseVersion}/${platform}-${arch}-${variant}/${filename}`;
+  await uploadWithRetry(filePath, key);
+  const remote = runAws(
+    ['s3api', 'head-object', '--bucket', bucket, '--key', key, '--query', 'ContentLength', '--output', 'text'],
+    { stdio: 'pipe' },
+  );
+  if (remote.status !== 0 || Number.parseInt(remote.stdout.trim(), 10) !== stat.size) {
+    throw new Error(`Remote size verification failed: ${key}`);
+  }
+  artifacts.push({
+    platform,
+    arch,
+    variant,
+    filename,
+    key,
+    size: stat.size,
+    sha256: await sha256File(filePath),
+  });
+}
+
+await fsp.writeFile(
+  outputPath,
+  `${JSON.stringify({ schemaVersion: 1, releaseVersion, artifacts }, null, 2)}\n`,
+);


### PR DESCRIPTION
## Summary
- transfer GitLab's runtime-cache strategy to the tag-driven GitHub release workflow
- cache the bundled Python, uv, and Pandoc runtime directories independently of dependency caches
- cache the Windows llama.cpp backend with an input-specific key, so unrelated scripts do not invalidate it

## Validation
- 
- workflow YAML parsed with Ruby
- 
 RUN  v4.1.10 /Users/krli/workspace/RongxinAI


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  13:20:40
   Duration  470ms (transform 15ms, setup 75ms, import 8ms, tests 311ms, environment 0ms)