### PR TITLE
feat(harness): add AnyDoc document reader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@earendil-works/pi-ai": "^0.80.3",
         "@earendil-works/pi-coding-agent": "^0.80.3",
         "@electron/remote": "^2.0.12",
+        "@firecrawl/anydoc": "0.1.3",
         "@fontsource-variable/geist": "^5.2.9",
         "@larksuite/openclaw-lark-tools": "~1.0.26",
         "@larksuiteoapi/node-sdk": "^1.58.0",
@@ -497,6 +498,22 @@
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@file-type/xml": ["@file-type/xml@0.4.4", "https://registry.npmmirror.com/@file-type/xml/-/xml-0.4.4.tgz", { "dependencies": { "sax": "^1.4.1", "strtok3": "^10.3.4" } }, "sha512-NhCyXoHlVZ8TqM476hyzwGJ24+D5IPSaZhmrPj7qXnEVb3q6jrFzA3mM9TBpknKSI9EuQeGTKRg2DXGUwvBBoQ=="],
+
+    "@firecrawl/anydoc": ["@firecrawl/anydoc@0.1.3", "", { "optionalDependencies": { "@firecrawl/anydoc-darwin-arm64": "0.1.3", "@firecrawl/anydoc-darwin-x64": "0.1.3", "@firecrawl/anydoc-linux-arm64-gnu": "0.1.3", "@firecrawl/anydoc-linux-arm64-musl": "0.1.3", "@firecrawl/anydoc-linux-x64-gnu": "0.1.3", "@firecrawl/anydoc-linux-x64-musl": "0.1.3", "@firecrawl/anydoc-win32-x64-msvc": "0.1.3" }, "bin": { "anydoc": "cli.js" } }, "sha512-OuYZWJHxiSNxU414g3l4w0gKb5BTqVZKGCwgmrkn8Mq84lf5z1Y2pHcTWQOWbyN4qD2NX7hQhrnozGhYYql6sw=="],
+
+    "@firecrawl/anydoc-darwin-arm64": ["@firecrawl/anydoc-darwin-arm64@0.1.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tCi0pqATVbS4el+lF/XBGvXzMUzc1dLTQd6eZxctLoP5HBLyQsmBQiSDdU+dE5reVpriLdumAo3MRhSJVBfikw=="],
+
+    "@firecrawl/anydoc-darwin-x64": ["@firecrawl/anydoc-darwin-x64@0.1.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-WpegrFgCZfXgbDBsrHrZcUcJNoB31fL7ztGL0x3OCThGNcND/JFOAb0ihS3Y/uwbHvXJDZTt+ZzAQOhSoC/8Rg=="],
+
+    "@firecrawl/anydoc-linux-arm64-gnu": ["@firecrawl/anydoc-linux-arm64-gnu@0.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-5/QCKECO2ujVZ7b3JOcNyvZrH1uSB3I/uLmgN05FWEIERA3rrwdzZi/k6K7ULcmSOD4eMJDfd6g41Ka48gW6zw=="],
+
+    "@firecrawl/anydoc-linux-arm64-musl": ["@firecrawl/anydoc-linux-arm64-musl@0.1.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nf/IakkpFAA3wdIoicohgOW+3D3xDr8gGhU5C+QdWDvRTQjK3Bm2R0DLvZJcnuOonsb01ob+BqFb9Q7PqmCOpw=="],
+
+    "@firecrawl/anydoc-linux-x64-gnu": ["@firecrawl/anydoc-linux-x64-gnu@0.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-VYnBbTIyRwv3HcWZgEaguPMjRs2CdA5aV+Nx60kCBV4Ykp3GOIdiCxJFE0RfOUQN3nfPV6hcaKtXz+1O4jxX0A=="],
+
+    "@firecrawl/anydoc-linux-x64-musl": ["@firecrawl/anydoc-linux-x64-musl@0.1.3", "", { "os": "linux", "cpu": "x64" }, "sha512-gL3dYfVmpN6ixfdmy2Ifgkdd5s3xrIHuwUlTTsTWR15OkhfL9LuA/VkgDO+p82D3SWAVnCTEWI7scE8nkMLmBQ=="],
+
+    "@firecrawl/anydoc-win32-x64-msvc": ["@firecrawl/anydoc-win32-x64-msvc@0.1.3", "", { "os": "win32", "cpu": "x64" }, "sha512-NwjmXqhrL6xVTLAJeZ0Ie7h7Clm2CwSPuJ9wuZX9fPP5nx/p7GvPRDvtLq6PxtXk2LQFWklfHmDczUQmzMh1Kg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "https://registry.npmmirror.com/@floating-ui/core/-/core-1.8.0.tgz", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -292,6 +292,11 @@
     "artifactName": "${productName}-Setup-${version}.${ext}"
   },
   "electronVersion": "40.2.1",
-  "asarUnpack": ["node_modules/@img/**", "node_modules/@firecrawl/**", "node_modules/better-sqlite3/**", "node_modules/npm/**"],
+  "asarUnpack": [
+    "node_modules/@img/**",
+    "node_modules/@firecrawl/**",
+    "node_modules/better-sqlite3/**",
+    "node_modules/npm/**"
+  ],
   "asar": true
 }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -292,6 +292,6 @@
     "artifactName": "${productName}-Setup-${version}.${ext}"
   },
   "electronVersion": "40.2.1",
-  "asarUnpack": ["node_modules/@img/**", "node_modules/better-sqlite3/**", "node_modules/npm/**"],
+  "asarUnpack": ["node_modules/@img/**", "node_modules/@firecrawl/**", "node_modules/better-sqlite3/**", "node_modules/npm/**"],
   "asar": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@earendil-works/pi-ai": "^0.80.3",
         "@earendil-works/pi-coding-agent": "^0.80.3",
         "@electron/remote": "^2.0.12",
+        "@firecrawl/anydoc": "0.1.3",
         "@fontsource-variable/geist": "^5.2.9",
         "@larksuite/openclaw-lark-tools": "~1.0.26",
         "@larksuiteoapi/node-sdk": "^1.58.0",
@@ -90,10 +91,10 @@
         "react-markdown": "^10.0.0",
         "react-redux": "^9.1.0",
         "react-syntax-highlighter": "^15.6.1",
-        "semver": "^7.8.5",
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
+        "semver": "^7.8.5",
         "shadcn": "^4.12.0",
         "shiki": "^4.3.1",
         "sonner": "^2.0.7",
@@ -113,6 +114,9 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@napi-rs/canvas": "^0.1.100",
         "@tailwindcss/typography": "^0.5.16",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/dompurify": "^3.0.5",
         "@types/extract-zip": "^2.0.1",
@@ -124,6 +128,7 @@
         "@types/sql.js": "^1.4.9",
         "@types/yazl": "^3.3.0",
         "@vitejs/plugin-react": "^6.0.3",
+        "@xmldom/xmldom": "0.8.13",
         "7zip-bin": "^5.2.0",
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
@@ -131,6 +136,7 @@
         "electron-builder": "^26.15.3",
         "esbuild": "^0.28.0",
         "husky": "^9.1.7",
+        "jsdom": "^30.0.1",
         "lint-staged": "^16.4.0",
         "oxfmt": "^0.59.0",
         "oxlint": "^1.74.0",
@@ -149,6 +155,13 @@
       "engines": {
         "node": ">=24 <25"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.152",
@@ -233,6 +246,39 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1061,6 +1107,19 @@
       "version": "6.0.4",
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@chevrotain/types": {
       "version": "11.1.2",
       "license": "Apache-2.0"
@@ -1668,6 +1727,146 @@
         "conventional-commits-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -2797,12 +2996,175 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@file-type/xml": {
       "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "sax": "^1.4.1",
         "strtok3": "^10.3.4"
+      }
+    },
+    "node_modules/@firecrawl/anydoc": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc/-/anydoc-0.1.3.tgz",
+      "integrity": "sha512-OuYZWJHxiSNxU414g3l4w0gKb5BTqVZKGCwgmrkn8Mq84lf5z1Y2pHcTWQOWbyN4qD2NX7hQhrnozGhYYql6sw==",
+      "license": "MIT",
+      "bin": {
+        "anydoc": "cli.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@firecrawl/anydoc-darwin-arm64": "0.1.3",
+        "@firecrawl/anydoc-darwin-x64": "0.1.3",
+        "@firecrawl/anydoc-linux-arm64-gnu": "0.1.3",
+        "@firecrawl/anydoc-linux-arm64-musl": "0.1.3",
+        "@firecrawl/anydoc-linux-x64-gnu": "0.1.3",
+        "@firecrawl/anydoc-linux-x64-musl": "0.1.3",
+        "@firecrawl/anydoc-win32-x64-msvc": "0.1.3"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-darwin-arm64": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-darwin-arm64/-/anydoc-darwin-arm64-0.1.3.tgz",
+      "integrity": "sha512-tCi0pqATVbS4el+lF/XBGvXzMUzc1dLTQd6eZxctLoP5HBLyQsmBQiSDdU+dE5reVpriLdumAo3MRhSJVBfikw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-darwin-x64": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-darwin-x64/-/anydoc-darwin-x64-0.1.3.tgz",
+      "integrity": "sha512-WpegrFgCZfXgbDBsrHrZcUcJNoB31fL7ztGL0x3OCThGNcND/JFOAb0ihS3Y/uwbHvXJDZTt+ZzAQOhSoC/8Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-linux-arm64-gnu": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-linux-arm64-gnu/-/anydoc-linux-arm64-gnu-0.1.3.tgz",
+      "integrity": "sha512-5/QCKECO2ujVZ7b3JOcNyvZrH1uSB3I/uLmgN05FWEIERA3rrwdzZi/k6K7ULcmSOD4eMJDfd6g41Ka48gW6zw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-linux-arm64-musl": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-linux-arm64-musl/-/anydoc-linux-arm64-musl-0.1.3.tgz",
+      "integrity": "sha512-nf/IakkpFAA3wdIoicohgOW+3D3xDr8gGhU5C+QdWDvRTQjK3Bm2R0DLvZJcnuOonsb01ob+BqFb9Q7PqmCOpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-linux-x64-gnu": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-linux-x64-gnu/-/anydoc-linux-x64-gnu-0.1.3.tgz",
+      "integrity": "sha512-VYnBbTIyRwv3HcWZgEaguPMjRs2CdA5aV+Nx60kCBV4Ykp3GOIdiCxJFE0RfOUQN3nfPV6hcaKtXz+1O4jxX0A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-linux-x64-musl": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-linux-x64-musl/-/anydoc-linux-x64-musl-0.1.3.tgz",
+      "integrity": "sha512-gL3dYfVmpN6ixfdmy2Ifgkdd5s3xrIHuwUlTTsTWR15OkhfL9LuA/VkgDO+p82D3SWAVnCTEWI7scE8nkMLmBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@firecrawl/anydoc-win32-x64-msvc": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firecrawl/anydoc-win32-x64-msvc/-/anydoc-win32-x64-msvc-0.1.3.tgz",
+      "integrity": "sha512-NwjmXqhrL6xVTLAJeZ0Ie7h7Clm2CwSPuJ9wuZX9fPP5nx/p7GvPRDvtLq6PxtXk2LQFWklfHmDczUQmzMh1Kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6000,6 +6362,99 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "license": "MIT"
@@ -6022,6 +6477,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -7425,6 +7888,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "dev": true,
@@ -7582,6 +8055,16 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bignumber.js": {
@@ -8701,6 +9184,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "license": "BSD-2-Clause",
@@ -8710,6 +9207,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -9160,6 +9664,45 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "license": "MIT"
@@ -9191,6 +9734,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -9451,6 +10001,14 @@
       "dependencies": {
         "jszip": ">=3.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -11260,6 +11818,19 @@
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "license": "MIT",
@@ -11463,6 +12034,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -11690,6 +12271,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
@@ -11845,6 +12433,93 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -12611,6 +13286,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -14536,6 +15222,13 @@
       "version": "2.0.11",
       "license": "MIT"
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "license": "MIT",
@@ -15693,6 +16386,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -18646,6 +19349,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "license": "MIT",
@@ -18784,6 +19517,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pvtsutils": {
@@ -18926,6 +19669,14 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -19095,6 +19846,20 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redux": {
@@ -19752,6 +20517,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -20664,6 +21442,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
@@ -20741,6 +21532,13 @@
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/systeminformation": {
       "version": "5.31.17",
@@ -21015,6 +21813,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.7",
       "dev": true,
@@ -21046,6 +21864,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -21826,6 +22670,19 @@
       "version": "2.2.8",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wait-on": {
       "version": "7.2.0",
       "dev": true,
@@ -21882,6 +22739,16 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "license": "MIT",
@@ -21907,6 +22774,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -22110,6 +22992,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "dev": true,
@@ -22129,6 +23021,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-coding-agent": "^0.80.3",
     "@electron/remote": "^2.0.12",
+    "@firecrawl/anydoc": "0.1.3",
     "@fontsource-variable/geist": "^5.2.9",
     "@larksuite/openclaw-lark-tools": "~1.0.26",
     "@larksuiteoapi/node-sdk": "^1.58.0",
@@ -249,9 +250,9 @@
   },
   "devDependencies": {
     "7zip-bin": "^5.2.0",
-    "@napi-rs/canvas": "^0.1.100",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@napi-rs/canvas": "^0.1.100",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -250,9 +250,9 @@
   },
   "devDependencies": {
     "7zip-bin": "^5.2.0",
+    "@napi-rs/canvas": "^0.1.100",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
-    "@napi-rs/canvas": "^0.1.100",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
+++ b/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 
+import JSZip from 'jszip';
 import { afterEach, expect, test } from 'vitest';
 
 import { buildPiDocumentReaderTool, PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
@@ -14,17 +15,41 @@ const createRoot = (): string => {
   return root;
 };
 
+const writeDocxFixture = async (filePath: string, paragraph: string): Promise<void> => {
+  const archive = new JSZip();
+  archive.file(
+    '[Content_Types].xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  archive.file(
+    '_rels/.rels',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  archive.file(
+    'word/document.xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>${paragraph}</w:t></w:r></w:p></w:body>
+</w:document>`,
+  );
+  fs.writeFileSync(filePath, await archive.generateAsync({ type: 'nodebuffer' }));
+};
+
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
 test('converts a workspace DOCX fixture to Markdown locally', async () => {
   const root = createRoot();
-  const fixture = path.resolve(
-    process.cwd(),
-    'vendor/openclaw-plugins/dingtalk-connector/node_modules/mammoth/test/test-data/single-paragraph.docx',
-  );
-  fs.copyFileSync(fixture, path.join(root, 'example.docx'));
+  await writeDocxFixture(path.join(root, 'example.docx'), 'Walking on imported air');
   const tool = buildPiDocumentReaderTool({ workspaceRoot: root }) as {
     execute: (
       id: string,
@@ -40,11 +65,7 @@ test('converts a workspace DOCX fixture to Markdown locally', async () => {
 test('does not allow symlinks or junctions that leave the workspace', async () => {
   const root = createRoot();
   const outside = createRoot();
-  const fixture = path.resolve(
-    process.cwd(),
-    'vendor/openclaw-plugins/dingtalk-connector/node_modules/mammoth/test/test-data/single-paragraph.docx',
-  );
-  fs.copyFileSync(fixture, path.join(outside, 'outside.docx'));
+  await writeDocxFixture(path.join(outside, 'outside.docx'), 'Outside the workspace');
   fs.symlinkSync(
     outside,
     path.join(root, 'linked'),

--- a/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
+++ b/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
@@ -26,18 +26,48 @@ test('converts a workspace DOCX fixture to Markdown locally', async () => {
   );
   fs.copyFileSync(fixture, path.join(root, 'example.docx'));
   const tool = buildPiDocumentReaderTool({ workspaceRoot: root }) as {
-    execute: (id: string, params: { path: string }) => Promise<{ content: Array<{ text: string }> }>;
+    execute: (
+      id: string,
+      params: { path: string },
+    ) => Promise<{ content: Array<{ text: string }> }>;
   };
 
   const result = await tool.execute('tool-1', { path: 'example.docx' });
 
-  expect(result.content[0]?.text).toContain('Local conversion: AnyDoc');
-  expect(result.content[0]?.text).toContain('Walking on imported air');
+  expect(result.content[0]?.text).toContain('Local conversion: AnyDoc\n\nWalking on imported air');
+});
+
+test('does not allow symlinks or junctions that leave the workspace', async () => {
+  const root = createRoot();
+  const outside = createRoot();
+  const fixture = path.resolve(
+    process.cwd(),
+    'vendor/openclaw-plugins/dingtalk-connector/node_modules/mammoth/test/test-data/single-paragraph.docx',
+  );
+  fs.copyFileSync(fixture, path.join(outside, 'outside.docx'));
+  fs.symlinkSync(
+    outside,
+    path.join(root, 'linked'),
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  const tool = buildPiDocumentReaderTool({ workspaceRoot: root }) as {
+    execute: (
+      id: string,
+      params: { path: string },
+    ) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  const result = await tool.execute('tool-1', { path: 'linked/outside.docx' });
+
+  expect(result.content[0]?.text).toContain('path must be a file inside the workspace');
 });
 
 test('does not allow paths outside the workspace', async () => {
   const tool = buildPiDocumentReaderTool({ workspaceRoot: createRoot() }) as {
-    execute: (id: string, params: { path: string }) => Promise<{ content: Array<{ text: string }> }>;
+    execute: (
+      id: string,
+      params: { path: string },
+    ) => Promise<{ content: Array<{ text: string }> }>;
   };
 
   const result = await tool.execute('tool-1', { path: '../secret.docx' });

--- a/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
+++ b/src/main/libs/agentEngine/piDocumentReaderTool.test.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
+
+import { afterEach, expect, test } from 'vitest';
+
+import { buildPiDocumentReaderTool, PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
+
+const roots: string[] = [];
+
+const createRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-document-reader-'));
+  roots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('converts a workspace DOCX fixture to Markdown locally', async () => {
+  const root = createRoot();
+  const fixture = path.resolve(
+    process.cwd(),
+    'vendor/openclaw-plugins/dingtalk-connector/node_modules/mammoth/test/test-data/single-paragraph.docx',
+  );
+  fs.copyFileSync(fixture, path.join(root, 'example.docx'));
+  const tool = buildPiDocumentReaderTool({ workspaceRoot: root }) as {
+    execute: (id: string, params: { path: string }) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  const result = await tool.execute('tool-1', { path: 'example.docx' });
+
+  expect(result.content[0]?.text).toContain('Local conversion: AnyDoc');
+  expect(result.content[0]?.text).toContain('Walking on imported air');
+});
+
+test('does not allow paths outside the workspace', async () => {
+  const tool = buildPiDocumentReaderTool({ workspaceRoot: createRoot() }) as {
+    execute: (id: string, params: { path: string }) => Promise<{ content: Array<{ text: string }> }>;
+  };
+
+  const result = await tool.execute('tool-1', { path: '../secret.docx' });
+
+  expect(result.content[0]?.text).toContain('path must be a file inside the workspace');
+});
+
+test('publishes the harness document-reading policy', () => {
+  expect(PiDocumentReaderSystemPrompt).toContain('read_document');
+  expect(PiDocumentReaderSystemPrompt).toContain('scanned or image-only PDFs');
+});

--- a/src/main/libs/agentEngine/piDocumentReaderTool.ts
+++ b/src/main/libs/agentEngine/piDocumentReaderTool.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
-import path from 'path';
 
 import { formatFromPath, toMarkdown } from '@firecrawl/anydoc';
+
+import { resolveWorkspaceFile } from '../../workbenchTask/artifactCollector';
 
 export const PiDocumentReaderToolName = 'read_document';
 export const PiDocumentReaderSystemPrompt = [
@@ -21,15 +22,6 @@ type DocumentReaderToolResult = {
 };
 
 const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
-
-function resolveWorkspaceDocument(workspaceRoot: string, candidate: string): string | null {
-  if (!candidate) return null;
-  const root = path.resolve(workspaceRoot);
-  const resolved = path.resolve(root, candidate);
-  const relative = path.relative(root, resolved);
-  if (relative === '' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
-  return resolved;
-}
 
 export function buildPiDocumentReaderTool(options: {
   workspaceRoot: string;
@@ -56,10 +48,15 @@ export function buildPiDocumentReaderTool(options: {
       params: Record<string, unknown>,
     ): Promise<DocumentReaderToolResult> => {
       const requestedPath = text(params.path);
-      const filePath = resolveWorkspaceDocument(options.workspaceRoot, requestedPath);
+      const filePath = resolveWorkspaceFile(options.workspaceRoot, requestedPath);
       if (!filePath) {
         return {
-          content: [{ type: 'text', text: 'Document read denied: path must be a file inside the workspace.' }],
+          content: [
+            {
+              type: 'text',
+              text: 'Document read denied: path must be a file inside the workspace.',
+            },
+          ],
           details: { errorCode: 'DOCUMENT_PATH_DENIED', path: requestedPath },
         };
       }
@@ -75,7 +72,9 @@ export function buildPiDocumentReaderTool(options: {
       }
       if (!stat.isFile()) {
         return {
-          content: [{ type: 'text', text: `Document read denied: ${requestedPath} is not a file.` }],
+          content: [
+            { type: 'text', text: `Document read denied: ${requestedPath} is not a file.` },
+          ],
           details: { errorCode: 'DOCUMENT_NOT_A_FILE', path: requestedPath },
         };
       }
@@ -109,7 +108,7 @@ export function buildPiDocumentReaderTool(options: {
           .filter(Boolean)
           .join('\n');
         return {
-          content: [{ type: 'text', text: `${header}${output}` }],
+          content: [{ type: 'text', text: `${header}\n\n${output}` }],
           details: {
             path: requestedPath,
             format,
@@ -127,7 +126,11 @@ export function buildPiDocumentReaderTool(options: {
               text: `Unable to read ${requestedPath} as ${format ?? 'an auto-detected format'}: ${message}`,
             },
           ],
-          details: { errorCode: 'DOCUMENT_CONVERSION_FAILED', path: requestedPath, format: format ?? null },
+          details: {
+            errorCode: 'DOCUMENT_CONVERSION_FAILED',
+            path: requestedPath,
+            format: format ?? null,
+          },
         };
       }
     },

--- a/src/main/libs/agentEngine/piDocumentReaderTool.ts
+++ b/src/main/libs/agentEngine/piDocumentReaderTool.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs';
+import path from 'path';
+
+import { formatFromPath, toMarkdown } from '@firecrawl/anydoc';
+
+export const PiDocumentReaderToolName = 'read_document';
+export const PiDocumentReaderSystemPrompt = [
+  '## Local document reading',
+  '',
+  '- Use `read_document` for Office, PDF, EPUB, RTF, or CSV files in the workspace when their content is needed.',
+  '- It returns local, structured Markdown. For scanned or image-only PDFs, explain that OCR is not available and use an appropriate fallback.',
+  '- Use the normal read tool for plain text and source-code files.',
+].join('\n');
+
+const MAX_DOCUMENT_BYTES = 50 * 1024 * 1024;
+const MAX_MARKDOWN_CHARS = 1_000_000;
+
+type DocumentReaderToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+};
+
+const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+function resolveWorkspaceDocument(workspaceRoot: string, candidate: string): string | null {
+  if (!candidate) return null;
+  const root = path.resolve(workspaceRoot);
+  const resolved = path.resolve(root, candidate);
+  const relative = path.relative(root, resolved);
+  if (relative === '' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) return null;
+  return resolved;
+}
+
+export function buildPiDocumentReaderTool(options: {
+  workspaceRoot: string;
+}): Record<string, unknown> {
+  return {
+    name: PiDocumentReaderToolName,
+    label: 'Read Document',
+    description:
+      'Read a workspace Office document, PDF, EPUB, RTF, or CSV file as structured Markdown. ' +
+      'The conversion is local and read-only; scanned or image-only PDFs require OCR and are not supported.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to a document relative to the current workspace.',
+        },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    },
+    execute: async (
+      _toolCallId: string,
+      params: Record<string, unknown>,
+    ): Promise<DocumentReaderToolResult> => {
+      const requestedPath = text(params.path);
+      const filePath = resolveWorkspaceDocument(options.workspaceRoot, requestedPath);
+      if (!filePath) {
+        return {
+          content: [{ type: 'text', text: 'Document read denied: path must be a file inside the workspace.' }],
+          details: { errorCode: 'DOCUMENT_PATH_DENIED', path: requestedPath },
+        };
+      }
+
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.stat(filePath);
+      } catch {
+        return {
+          content: [{ type: 'text', text: `Document not found: ${requestedPath}` }],
+          details: { errorCode: 'DOCUMENT_NOT_FOUND', path: requestedPath },
+        };
+      }
+      if (!stat.isFile()) {
+        return {
+          content: [{ type: 'text', text: `Document read denied: ${requestedPath} is not a file.` }],
+          details: { errorCode: 'DOCUMENT_NOT_A_FILE', path: requestedPath },
+        };
+      }
+      if (stat.size > MAX_DOCUMENT_BYTES) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Document read denied: ${requestedPath} is larger than the 50 MiB local conversion limit.`,
+            },
+          ],
+          details: { errorCode: 'DOCUMENT_TOO_LARGE', path: requestedPath, bytes: stat.size },
+        };
+      }
+
+      const format = formatFromPath(filePath);
+
+      try {
+        const markdown = await toMarkdown(filePath);
+        const truncated = markdown.length > MAX_MARKDOWN_CHARS;
+        const output = truncated ? markdown.slice(0, MAX_MARKDOWN_CHARS) : markdown;
+        const header = [
+          `Document: ${requestedPath}`,
+          `Format: ${format ?? 'auto-detected from document bytes'}`,
+          `Local conversion: AnyDoc`,
+          truncated
+            ? `Output truncated to ${MAX_MARKDOWN_CHARS.toLocaleString()} characters; use a more focused file or split the document.`
+            : '',
+          '',
+        ]
+          .filter(Boolean)
+          .join('\n');
+        return {
+          content: [{ type: 'text', text: `${header}${output}` }],
+          details: {
+            path: requestedPath,
+            format,
+            bytes: stat.size,
+            markdownCharacters: markdown.length,
+            truncated,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Unable to read ${requestedPath} as ${format ?? 'an auto-detected format'}: ${message}`,
+            },
+          ],
+          details: { errorCode: 'DOCUMENT_CONVERSION_FAILED', path: requestedPath, format: format ?? null },
+        };
+      }
+    },
+  };
+}

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -991,7 +991,7 @@ describe('PiRuntimeAdapter', () => {
       const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
         appendSystemPromptOverride: () => string[];
       };
-      expect(loaderOptions.appendSystemPromptOverride()[1]).toContain('8000 characters');
+      expect(loaderOptions.appendSystemPromptOverride()[2]).toContain('8000 characters');
     });
 
     it('should not call setModel when no model in patch', async () => {
@@ -1023,6 +1023,7 @@ describe('PiRuntimeAdapter', () => {
       };
       expect(loaderOptions.appendSystemPromptOverride()).toEqual([
         PiAskUserQuestionSystemPrompt,
+        expect.stringContaining('## Local document reading'),
         expect.stringContaining('## Large File Writes'),
       ]);
     });

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -86,10 +86,7 @@ import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { buildPiSkillScriptTool } from './piSkillScriptTool';
 import { buildPiSkillRuntimeCapabilitiesTool } from './piSkillRuntimeCapabilitiesTool';
-import {
-  buildPiDocumentReaderTool,
-  PiDocumentReaderSystemPrompt,
-} from './piDocumentReaderTool';
+import { buildPiDocumentReaderTool, PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { PiPendingMessageQueue } from './piPendingMessageQueue';
 import { buildPiWorkAcceptanceTool, PiWorkExecutionController } from './piWorkExecution';

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -86,6 +86,10 @@ import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { buildPiSkillScriptTool } from './piSkillScriptTool';
 import { buildPiSkillRuntimeCapabilitiesTool } from './piSkillRuntimeCapabilitiesTool';
+import {
+  buildPiDocumentReaderTool,
+  PiDocumentReaderSystemPrompt,
+} from './piDocumentReaderTool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { PiPendingMessageQueue } from './piPendingMessageQueue';
 import { buildPiWorkAcceptanceTool, PiWorkExecutionController } from './piWorkExecution';
@@ -598,6 +602,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           this.requestAskUserQuestion(sessionId, toolCallId, input, signal),
         ),
       );
+      if (resourceState.fileToolsEnabled) {
+        customTools.push(buildPiDocumentReaderTool({ workspaceRoot }));
+      }
 
       // MCP tools: register a single proxy tool (pi-mcp-adapter pattern)
       const mcpProxyTool = this.buildMcpProxyTool();
@@ -1447,6 +1454,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // Append this policy so it remains present for both default and custom prompts.
       appendSystemPromptOverride: (): string[] => [
         PiAskUserQuestionSystemPrompt,
+        ...(resourceState.fileToolsEnabled ? [PiDocumentReaderSystemPrompt] : []),
         ...(resourceState.fileToolsEnabled
           ? [createPiLargeFileWriteSystemPrompt(resourceState.maxOutputTokens)]
           : []),

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -47,6 +47,13 @@ test('each desktop target keeps the private document and Python toolchain resour
   }
 });
 
+test('unpacks AnyDoc native bindings from the application archive', () => {
+  const config = JSON.parse(readFileSync(path.join(root, 'electron-builder.json'), 'utf8')) as {
+    asarUnpack?: string[];
+  };
+  assert.ok(config.asarUnpack?.includes('node_modules/@firecrawl/**'));
+});
+
 test('release workflows explicitly provision the private POSIX toolchain', () => {
   for (const workflow of ['build-platforms.yml', 'online-update-release.yml']) {
     const content = readFileSync(path.join(root, '.github', 'workflows', workflow), 'utf8');

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -52,6 +52,9 @@ test('unpacks AnyDoc native bindings from the application archive', () => {
     asarUnpack?: string[];
   };
   assert.ok(config.asarUnpack?.includes('node_modules/@firecrawl/**'));
+
+  const viteConfig = readFileSync(path.join(root, 'vite.config.ts'), 'utf8');
+  assert.match(viteConfig, /staticExternals\s*=\s*\[[\s\S]*['"]@firecrawl\/anydoc['"]/);
 });
 
 test('release workflows explicitly provision the private POSIX toolchain', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig(async () => ({
                   rollupOptions: {
                     external: id => {
                       const staticExternals = [
+                        '@firecrawl/anydoc',
                         'better-sqlite3',
                         'discord.js',
                         'zlib-sync',


### PR DESCRIPTION
## Summary

- add an AnyDoc-backed `read_document` Harness tool for local Office, PDF, EPUB, RTF, and CSV extraction
- restrict reads to the active workspace and bound input/output sizes
- unpack the N-API binary in Electron packages and cover DOCX conversion plus packaging configuration

## Validation

- `npm test -- src/main/libs/agentEngine/piDocumentReaderTool.test.ts src/main/libs/agentEngine/piRuntimeAdapter.test.ts tests/runtimePackagingConfig.test.ts --reporter=dot`
- `npm run build:tsc`
