### PR TITLE
fix(cowork): 修复多轮审批绑定错误

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -854,6 +854,68 @@ describe('PiRuntimeAdapter', () => {
       expect(beginRun).toHaveBeenCalledTimes(2);
     });
 
+    it('authorizes follow-up tool calls against the current workbench run', async () => {
+      const beginRun = vi.fn().mockImplementation((_input: unknown) => ({
+        run: { id: `run-${beginRun.mock.calls.length}` },
+      }));
+      const authorizeToolCall = vi.fn().mockResolvedValue({ allow: true });
+      adapter.setWorkbenchTaskService({
+        beginRun,
+        authorizeToolCall,
+        on: vi.fn(),
+        off: vi.fn(),
+      } as unknown as WorkbenchTaskService);
+
+      await adapter.startSession('test', 'First');
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        extensionFactories?: Array<
+          (api: {
+            on: (
+              event: 'tool_call',
+              handler: (toolCall: {
+                toolCallId: string;
+                toolName: string;
+                input: Record<string, unknown>;
+              }) => Promise<unknown>,
+            ) => void;
+          }) => void
+        >;
+      };
+      let handleToolCall:
+        | ((toolCall: {
+            toolCallId: string;
+            toolName: string;
+            input: Record<string, unknown>;
+          }) => Promise<unknown>)
+        | undefined;
+      loaderOptions.extensionFactories?.[0]({
+        on: (_event, handler) => {
+          handleToolCall = handler;
+        },
+      });
+
+      await handleToolCall?.({
+        toolCallId: 'first-call',
+        toolName: 'write',
+        input: { path: 'first.txt' },
+      });
+      await adapter.continueSession('test', 'Second');
+      await handleToolCall?.({
+        toolCallId: 'second-call',
+        toolName: 'write',
+        input: { path: 'second.txt' },
+      });
+
+      expect(authorizeToolCall).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ runId: 'run-1', toolCallId: 'first-call' }),
+      );
+      expect(authorizeToolCall).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ runId: 'run-2', toolCallId: 'second-call' }),
+      );
+    });
+
     it('starts the Goal loop only when Work explicitly enables goal mode', async () => {
       await adapter.startSession('goal-work', 'Finish the requested task', {
         sessionMode: 'work',

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -579,7 +579,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const settingsManager = this.createPiSettingsManager(pi, workspaceRoot);
       const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState, {
         sessionId,
-        runId: workbenchRunId,
+        getRunId: () => this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId,
         settingsManager,
         getAutoApprove: () =>
           this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
@@ -710,7 +710,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             },
             {
               sessionId,
-              runId: workbenchRunId,
+              getRunId: () => this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId,
               getAutoApprove: () =>
                 this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
             },
@@ -1416,7 +1416,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     resourceState: PiResourceState,
     approvalContext?: {
       sessionId: string;
-      runId: string | null;
+      getRunId: () => string | null;
       settingsManager?: PiSettingsManager | null;
       getAutoApprove: () => boolean;
     },
@@ -1456,17 +1456,24 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           ? [createPiLargeFileWriteSystemPrompt(resourceState.maxOutputTokens)]
           : []),
       ],
-      extensionFactories: approvalContext?.runId
+      extensionFactories: approvalContext?.getRunId()
         ? [
             (extensionApi: PiExtensionApi) => {
               extensionApi.on('tool_call', async event => {
+                const runId = approvalContext.getRunId();
+                if (!runId) {
+                  return {
+                    block: true as const,
+                    reason: 'No active workbench run is available.',
+                  };
+                }
                 const toolInput =
                   event.input && typeof event.input === 'object'
                     ? (event.input as Record<string, unknown>)
                     : {};
                 const authorization = await this.workbenchTaskService?.authorizeToolCall({
                   sessionId: approvalContext.sessionId,
-                  runId: approvalContext.runId as string,
+                  runId,
                   toolCallId: event.toolCallId,
                   toolName: event.toolName,
                   toolInput,

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -321,6 +321,53 @@ test('allow-all auto-approves irreversible effects', async () => {
   }
 });
 
+test('rejects tool calls from another session or an inactive run', async () => {
+  const { db, service } = createService();
+  try {
+    const first = service.beginRun({
+      sessionId: 'session',
+      goal: 'first',
+      contract: chatContract,
+    });
+    service.completeRun({
+      sessionId: 'session',
+      runId: first.run.id,
+      workspaceRoot: process.cwd(),
+      finalAnswer: 'done',
+    });
+    const second = service.beginRun({
+      sessionId: 'session',
+      goal: 'second',
+      contract: chatContract,
+    });
+
+    await expect(
+      service.authorizeToolCall({
+        sessionId: 'session',
+        runId: first.run.id,
+        toolCallId: 'stale-call',
+        toolName: 'write',
+        toolInput: { path: 'stale.txt' },
+        autoApprove: true,
+      }),
+    ).resolves.toMatchObject({ allow: false, reason: expect.stringContaining('active run') });
+    await expect(
+      service.authorizeToolCall({
+        sessionId: 'another-session',
+        runId: second.run.id,
+        toolCallId: 'foreign-call',
+        toolName: 'write',
+        toolInput: { path: 'foreign.txt' },
+        autoApprove: true,
+      }),
+    ).resolves.toMatchObject({ allow: false, reason: expect.stringContaining('session') });
+    expect(service.repository.listApprovalsForRun(first.run.id)).toHaveLength(0);
+    expect(service.repository.listApprovalsForRun(second.run.id)).toHaveLength(0);
+  } finally {
+    db.close();
+  }
+});
+
 test('agent end does not verify a run paused by a denied approval', async () => {
   const { db, service } = createService();
   try {

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -296,6 +296,12 @@ export class WorkbenchTaskService extends EventEmitter {
   }): Promise<WorkbenchToolAuthorizationResult> {
     const run = this.requireRun(input.runId);
     const task = this.requireTask(run.taskId);
+    if (task.sessionId !== input.sessionId) {
+      return { allow: false, reason: 'The tool call does not belong to this session.' };
+    }
+    if (task.activeRunId !== run.id || run.status !== WorkbenchRunStatus.Running) {
+      return { allow: false, reason: 'The tool call does not belong to the active run.' };
+    }
     const riskLevel = classifyWorkbenchToolRisk(input.toolName, input.toolInput);
     if (riskLevel === WorkbenchApprovalRiskLevel.ReadOnly) {
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.ToolRead, {


### PR DESCRIPTION
## 问题

同一 Pi 会话进入后续 turn 时会创建新的 workbench run，但工具审批钩子仍使用首轮 run ID。询问模式因此触发非法状态迁移，允许全部模式则会把执行记录留在旧 run。

## 修改

- 将审批上下文改为在每次工具调用时读取当前 run ID
- 在服务层校验 session 归属、活动 run 和运行状态
- 覆盖同一会话多轮工具调用以及旧 run、跨 session 请求

## 验证

- Electron ABI 下相关测试：86 passed
- npx tsc --noEmit --pretty false
- npx tsc -p electron-tsconfig.json --noEmit --pretty false
- 定向 oxlint 通过

## Electron 行为

不涉及 IPC 协议或存储结构变更；仅修正运行时审批归属和防御性校验。