### PR TITLE
fix(cowork): 清理停止会话时的待审批请求

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1135,6 +1135,20 @@ describe('PiRuntimeAdapter', () => {
 
   // ── Cleanup ──
 
+  it('dismisses pending workbench approvals when a session stops', async () => {
+    const dismissals: string[] = [];
+    adapter.on('permissionDismiss', requestId => dismissals.push(requestId));
+    await adapter.startSession('test', 'Hello');
+    const approvalSessionMap = (adapter as unknown as { approvalSessionMap: Map<string, string> })
+      .approvalSessionMap;
+    approvalSessionMap.set('approval-1', 'test');
+
+    adapter.stopSession('test');
+
+    expect(approvalSessionMap.has('approval-1')).toBe(false);
+    expect(dismissals).toEqual(['approval-1']);
+  });
+
   describe('onSessionDeleted', () => {
     it('should stop the session', async () => {
       await adapter.startSession('test', 'Hello');

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1107,13 +1107,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.abortController.abort();
     active.unsubscribe();
     void active.piSession.abort();
+    this.workbenchTaskService?.pauseRun?.(
+      sessionId,
+      'The session resources changed before the approval was resolved.',
+    );
+    this.clearApprovalsBySession(sessionId);
     this.activeSessions.delete(sessionId);
   }
 
   stopSession(sessionId: string): void {
     this.dismissAskUserQuestionsBySession(sessionId);
     const active = this.activeSessions.get(sessionId);
-    if (!active) return;
+    if (!active) {
+      this.workbenchTaskService?.pauseRun?.(sessionId, 'The user stopped this run.');
+      this.clearApprovalsBySession(sessionId);
+      return;
+    }
     const wasRunning = active.isRunning;
 
     this.finalizeActiveThinking(sessionId, active);
@@ -1136,7 +1145,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.abortController.abort();
     active.unsubscribe();
     void active.piSession.abort();
-    this.workbenchTaskService?.pauseRun(sessionId, 'The user stopped this run.');
+    this.workbenchTaskService?.pauseRun?.(sessionId, 'The user stopped this run.');
+    this.clearApprovalsBySession(sessionId);
     this.emit('sessionStopped', sessionId);
 
     // A user stop ends the current turn without cancelling messages already
@@ -1390,6 +1400,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   onSessionDeleted(sessionId: string): void {
     this.stopSession(sessionId);
+    this.clearApprovalsBySession(sessionId);
     this.activeSessions.delete(sessionId);
     if (this.pendingMessageQueue.clear(sessionId)) this.emitQueueUpdated(sessionId);
     this.workbenchTaskService?.deleteSession(sessionId);
@@ -2190,7 +2201,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   private clearApprovalsBySession(sessionId: string): void {
     for (const [requestId, sid] of this.approvalSessionMap.entries()) {
-      if (sid === sessionId) this.approvalSessionMap.delete(requestId);
+      if (sid !== sessionId) continue;
+      this.approvalSessionMap.delete(requestId);
+      this.emit('permissionDismiss', requestId);
     }
   }
 

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -437,6 +437,18 @@ export class WorkbenchTaskRepository {
     return rows.map(row => this.mapApproval(row));
   }
 
+  listPendingApprovalsForSession(sessionId: string): WorkbenchApproval[] {
+    const rows = this.db
+      .prepare(
+        `SELECT a.* FROM workbench_approvals a
+         JOIN workbench_tasks t ON t.id = a.task_id
+         WHERE t.session_id = ? AND a.decision = ?
+         ORDER BY a.created_at`,
+      )
+      .all(sessionId, WorkbenchApprovalDecision.Pending) as ApprovalRow[];
+    return rows.map(row => this.mapApproval(row));
+  }
+
   updateApproval(
     approvalId: string,
     patch: Partial<

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -355,6 +355,68 @@ test('agent end does not verify a run paused by a denied approval', async () => 
   }
 });
 
+test('pausing a run expires and resolves its pending approval', async () => {
+  const { db, service } = createService();
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'write',
+      contract: chatContract,
+    });
+    const authorization = service.authorizeToolCall({
+      sessionId: 'session',
+      runId: run.id,
+      toolCallId: 'call',
+      toolName: 'write',
+      toolInput: { path: 'result.txt', content: 'ok' },
+      autoApprove: false,
+    });
+
+    service.pauseRun('session', 'The user stopped this run.');
+
+    await expect(authorization).resolves.toEqual({
+      allow: false,
+      reason: 'The user stopped this run.',
+    });
+    const detail = service.getDetail(task.id);
+    expect(detail?.task.status).toBe(WorkbenchTaskStatus.Paused);
+    expect(detail?.runs[0].status).toBe(WorkbenchRunStatus.Paused);
+    expect(detail?.approvals[0].decision).toBe(WorkbenchApprovalDecision.Expired);
+    expect(detail?.approvals[0].decisionSource).toBe(WorkbenchApprovalDecisionSource.Recovery);
+  } finally {
+    db.close();
+  }
+});
+
+test('deleting a session resolves pending approvals before removing their records', async () => {
+  const { db, service } = createService();
+  try {
+    const { run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'write',
+      contract: chatContract,
+    });
+    const authorization = service.authorizeToolCall({
+      sessionId: 'session',
+      runId: run.id,
+      toolCallId: 'call',
+      toolName: 'write',
+      toolInput: { path: 'result.txt', content: 'ok' },
+      autoApprove: false,
+    });
+
+    service.deleteSession('session');
+
+    await expect(authorization).resolves.toEqual({
+      allow: false,
+      reason: 'The session was deleted.',
+    });
+    expect(service.getCurrent('session')).toBeNull();
+  } finally {
+    db.close();
+  }
+});
+
 test('startup recovery preserves pending approval projection until resume', async () => {
   const { db, service } = createService();
   try {

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -256,14 +256,22 @@ export class WorkbenchTaskService extends EventEmitter {
 
   pauseRun(sessionId: string, reason: string): void {
     const task = this.repository.getActiveTaskForSession(sessionId);
-    if (!task?.activeRunId) return;
+    if (!task?.activeRunId) {
+      this.cancelPendingApprovalsForSession(sessionId, reason);
+      return;
+    }
     const run = this.repository.getRun(task.activeRunId);
-    if (!run || !this.isRunActive(run.status)) return;
-    this.repository.transaction(() => {
+    if (!run || !this.isRunActive(run.status)) {
+      this.cancelPendingApprovalsForSession(sessionId, reason);
+      return;
+    }
+    const expiredApprovals = this.repository.transaction(() => {
       this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Paused);
       this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Paused, run.id);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RunPaused, { reason });
+      return this.expirePendingApprovalsForSession(sessionId, reason);
     });
+    this.resolvePendingApprovals(expiredApprovals, reason);
     this.emitChanged(this.requireTask(task.id));
   }
 
@@ -494,10 +502,48 @@ export class WorkbenchTaskService extends EventEmitter {
   }
 
   deleteSession(sessionId: string): void {
+    const pendingApprovals = this.repository.listPendingApprovalsForSession(sessionId);
     this.repository.transaction(() => {
       this.productionLoop.deleteSession(sessionId);
       this.repository.deleteSessionDomainData(sessionId);
     });
+    this.resolvePendingApprovals(pendingApprovals, 'The session was deleted.');
+  }
+
+  private cancelPendingApprovalsForSession(sessionId: string, reason: string): void {
+    const expiredApprovals = this.repository.transaction(() =>
+      this.expirePendingApprovalsForSession(sessionId, reason),
+    );
+    this.resolvePendingApprovals(expiredApprovals, reason);
+    for (const taskId of new Set(expiredApprovals.map(approval => approval.taskId))) {
+      const task = this.repository.getTask(taskId);
+      if (task) this.emitChanged(task);
+    }
+  }
+
+  private expirePendingApprovalsForSession(sessionId: string, reason: string): WorkbenchApproval[] {
+    const approvals = this.repository.listPendingApprovalsForSession(sessionId);
+    for (const approval of approvals) {
+      this.repository.updateApproval(approval.id, {
+        decision: WorkbenchApprovalDecision.Expired,
+        decisionSource: WorkbenchApprovalDecisionSource.Recovery,
+        result: { reason },
+      });
+      this.repository.appendRunEvent(approval.runId, WorkbenchRunEventType.ApprovalResolved, {
+        approvalId: approval.id,
+        approved: false,
+        expired: true,
+      });
+    }
+    return approvals;
+  }
+
+  private resolvePendingApprovals(approvals: WorkbenchApproval[], reason: string): void {
+    for (const approval of approvals) {
+      const pending = this.pendingApprovals.get(approval.id);
+      this.pendingApprovals.delete(approval.id);
+      pending?.resolve({ allow: false, reason });
+    }
   }
 
   private emitChanged(task: WorkbenchTask): void {


### PR DESCRIPTION
## 问题

会话在审批等待期间停止、重建或删除时，只会暂停运行或删除数据库记录，不会完成内存中的审批 Promise，也不会清理运行时请求映射和界面弹窗。

## 修改

- 按 session 查询所有待审批记录
- 暂停运行时原子地将待审批标记为 expired，并以拒绝结果完成等待 Promise
- 删除会话时在移除持久化数据后完成对应等待者
- 停止、资源重建和删除时清理运行时映射并发送 permission dismiss
- 增加暂停、删除和运行时 dismiss 回归测试

## 验证

- Electron ABI 下相关测试：90 passed
- npx tsc --noEmit --pretty false
- npx tsc -p electron-tsconfig.json --noEmit --pretty false
- 定向 oxlint 通过

## Electron 行为

不修改 IPC 协议或数据库结构；停止和删除会话现在会同步关闭审批弹窗并释放内存等待者。