### PR TITLE
fix(sidebar): 点击搜索结果滚动区域不再误关闭搜索

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -190,7 +190,13 @@ const Sidebar: React.FC<SidebarProps> = ({
   useEffect(() => {
     if (!searchActive) return;
     const handlePointerDown = (event: MouseEvent) => {
-      if (searchControlRef.current?.contains(event.target as Node)) return;
+      const target = event.target as Node;
+      if (
+        searchControlRef.current?.contains(target) ||
+        agentScrollContainerRef.current?.contains(target)
+      ) {
+        return;
+      }
       setSearchActive(false);
       setSearchQuery('');
     };


### PR DESCRIPTION
## Summary

修复侧边栏搜索的误关闭问题:搜索激活后,点击搜索结果所在的滚动区域(空白处或滚动条)不再立即关闭搜索并清空查询,只有点击具体搜索结果项时才会关闭并跳转。

## Related Issue

无关联 issue。

## Changes Made

- 在搜索激活时的外部点击监听中,将 `agentScrollContainerRef`(搜索结果所在滚动容器)纳入"不关闭搜索"的范围
- 点击具体结果项仍由各项自身的 `onSelect` / 分享处理器显式调用 `setSearchActive(false)`,跳转行为不变

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing performed
- [x] Lint 通过(`npm run lint` 无告警)

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] None

## Additional Notes

无
