### PR TITLE
feat(evaluation): support isolated reviewer subagent

### DIFF
--- a/src/main/evaluation/constants.ts
+++ b/src/main/evaluation/constants.ts
@@ -1,6 +1,6 @@
 export const ZhiyuanEvaluationPolicyProtocolVersion = '1';
 export const ZhiyuanEvaluationPolicyId = 'rongxinai-production-loop';
-export const ZhiyuanEvaluationPolicyVersion = '237-p2-v2';
+export const ZhiyuanEvaluationPolicyVersion = '237-p2-v3';
 
 export const ZhiyuanEvaluationToolMode = {
   None: 'none',

--- a/src/main/evaluation/types.ts
+++ b/src/main/evaluation/types.ts
@@ -21,6 +21,15 @@ export interface ZhiyuanEvaluationPolicyContext {
   candidateRoot: string;
   workspace: string;
   agentDir: string;
+  runtimeCapabilities?: Readonly<{
+    reviewerSubagent?:
+      | false
+      | Readonly<{
+          isolated: boolean;
+          readOnly: boolean;
+          tools: ReadonlyArray<string>;
+        }>;
+  }>;
   emitActivation(name: string, evidence?: WorkbenchJsonObject): void;
 }
 

--- a/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
@@ -15,6 +15,9 @@ import { createZhiyuanEvaluationPolicy } from './zhiyuanEvaluationPolicy';
 
 const context = (
   toolMode: ZhiyuanEvaluationPolicyContext['toolMode'],
+  reviewerSubagent: NonNullable<
+    ZhiyuanEvaluationPolicyContext['runtimeCapabilities']
+  >['reviewerSubagent'] = false,
 ): { value: ZhiyuanEvaluationPolicyContext; activations: HarnessActivationEvent[] } => {
   const activations: HarnessActivationEvent[] = [];
   return {
@@ -32,6 +35,7 @@ const context = (
       candidateRoot: process.cwd(),
       workspace: process.cwd(),
       agentDir: process.cwd(),
+      runtimeCapabilities: { reviewerSubagent },
       emitActivation: (activation, evidence) => {
         activations.push({
           activation: activation as HarnessActivationEvent['activation'],
@@ -137,6 +141,88 @@ describe('createZhiyuanEvaluationPolicy', () => {
 
     expect(() => createZhiyuanEvaluationPolicy(testContext.value)).toThrow(
       'Unsupported evaluation policy protocol',
+    );
+  });
+
+  test('degrades safely when reviewer capability evidence is malformed', () => {
+    const testContext = context(ZhiyuanEvaluationToolMode.Execute);
+    testContext.value.runtimeCapabilities = {
+      reviewerSubagent: { isolated: true, readOnly: true } as never,
+    };
+
+    const policy = createZhiyuanEvaluationPolicy(testContext.value);
+
+    expect(policy.customTools?.map(candidate => candidate.name)).not.toContain('subagent');
+    expect(testContext.activations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ activation: ZhiyuanEvaluationActivation.CriticDegraded }),
+      ]),
+    );
+  });
+
+  test('uses an isolated read-only reviewer when the bridge provides one', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testContext = context(ZhiyuanEvaluationToolMode.Execute, {
+      isolated: true,
+      readOnly: true,
+      tools: [],
+    });
+    const policy = createZhiyuanEvaluationPolicy(testContext.value);
+    const productionTool = tool(policy.customTools, 'production_loop');
+
+    const plan = (await productionTool.execute('plan', {
+      action: ProductionLoopAction.CommitPlan,
+      items: [{ title: 'Inspect and solve the task' }],
+      acceptanceCriteria: ['The requested state is observable.'],
+      expectedVerifiers: [{ name: 'official benchmark scorer', deterministic: true }],
+    })) as { details: { planItems: Array<{ id: string }> } };
+    await productionTool.execute('item', {
+      action: ProductionLoopAction.UpdatePlanItem,
+      itemId: plan.details.planItems[0].id,
+      status: ProductionPlanItemStatus.Completed,
+    });
+    await productionTool.execute('inspect', { action: ProductionLoopAction.StartInspection });
+    await productionTool.execute('critic', { action: ProductionLoopAction.RequestCritique });
+    policy.onEvent?.({
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'checks passed' }] },
+      isError: false,
+    });
+
+    const delegation = await policy.onAgentEnd?.({ iteration: 1, messages: [], usage: {} });
+    expect(delegation?.nextPrompt).toContain('isolated context and no tools');
+    expect(delegation?.nextPrompt).toContain('checks passed');
+    policy.onEvent?.({
+      type: 'tool_execution_start',
+      toolName: 'subagent',
+      toolCallId: 'review-1',
+      args: { agent: 'reviewer', task: 'Review the supplied evidence.' },
+    });
+    policy.onEvent?.({
+      type: 'tool_execution_end',
+      toolName: 'subagent',
+      toolCallId: 'review-1',
+      result: {
+        content: [{ type: 'text', text: '{"verdict":"pass","findings":[]}' }],
+      },
+      isError: false,
+    });
+
+    const delivery = await policy.onAgentEnd?.({ iteration: 2, messages: [], usage: {} });
+    expect(delivery?.nextPrompt).toContain('agent_loop done');
+    expect(testContext.activations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ activation: ZhiyuanEvaluationActivation.CriticDegraded }),
+      ]),
+    );
+    expect(testContext.activations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          activation: ZhiyuanEvaluationActivation.CriticCompleted,
+          evidence: expect.objectContaining({ mode: 'isolated_reviewer_subsession' }),
+        }),
+      ]),
     );
   });
 });

--- a/src/main/evaluation/zhiyuanEvaluationPolicy.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.ts
@@ -150,6 +150,14 @@ export function createZhiyuanEvaluationPolicy(
     start: true,
   });
   const agentLoop = workLoop.controller;
+  const reviewerCapability = context.runtimeCapabilities?.reviewerSubagent;
+  const isolatedReviewerAvailable = Boolean(
+    reviewerCapability &&
+      reviewerCapability.isolated &&
+      reviewerCapability.readOnly &&
+      Array.isArray(reviewerCapability.tools) &&
+      reviewerCapability.tools.length === 0,
+  );
   let criticFallbackPending = false;
   let criticAttempt = 0;
 
@@ -158,14 +166,25 @@ export function createZhiyuanEvaluationPolicy(
     modelProfile: context.modelProfile,
     toolNames: context.tools.map(tool => tool.name),
     resources: ['resources/SYSTEM_PROMPT.md', 'SKILLs'],
-    orchestration: ['production_loop', 'agent_loop'],
-    disabledInteractiveFeatures: ['approval_ui', 'ask_user', 'mcp', 'subagent'],
+    orchestration: [
+      'production_loop',
+      'agent_loop',
+      ...(isolatedReviewerAvailable ? ['reviewer_subagent'] : []),
+    ],
+    disabledInteractiveFeatures: [
+      'approval_ui',
+      'ask_user',
+      'mcp',
+      ...(!isolatedReviewerAvailable ? ['subagent'] : []),
+    ],
   });
-  context.emitActivation(ZhiyuanEvaluationActivation.CriticDegraded, {
-    reason: 'No independent reviewer model is configured for this evaluation.',
-    mode: 'same_model_transcript_only',
-    readOnly: true,
-  });
+  if (!isolatedReviewerAvailable) {
+    context.emitActivation(ZhiyuanEvaluationActivation.CriticDegraded, {
+      reason: 'No isolated reviewer subagent is configured for this evaluation.',
+      mode: 'same_model_transcript_only',
+      readOnly: true,
+    });
+  }
 
   const onEvent = (event: Record<string, unknown>): void => {
     const toolName = typeof event.toolName === 'string' ? event.toolName : '';
@@ -191,6 +210,15 @@ export function createZhiyuanEvaluationPolicy(
         toolResultText(event.result),
         event.isError === true,
       );
+      criticAttempt += 1;
+      const critic = controller.getState().critic;
+      context.emitActivation(ZhiyuanEvaluationActivation.CriticCompleted, {
+        attempt: criticAttempt,
+        mode: 'isolated_reviewer_subsession',
+        outputPresent: Boolean(toolResultText(event.result).trim()),
+        passed: critic.passed,
+        findingSeverities: critic.findings.map(finding => finding.severity),
+      });
     }
   };
 
@@ -218,6 +246,18 @@ export function createZhiyuanEvaluationPolicy(
       state.critic.requested &&
       !state.critic.toolCallId
     ) {
+      if (isolatedReviewerAvailable) {
+        return {
+          shouldContinue: true,
+          nextPrompt: [
+            controller.requestCriticPrompt(),
+            `Observed Inspect sandbox tool outcomes: ${JSON.stringify(toolEvidence)}`,
+            'Include those outcomes in the self-contained reviewer task.',
+            'The reviewer has an isolated context and no tools, so do not rely on unstated evidence.',
+            'The official benchmark scorer remains the final deterministic gate after delivery.',
+          ].join('\n'),
+        };
+      }
       criticFallbackPending = true;
       return {
         shouldContinue: true,


### PR DESCRIPTION
## Summary

Adds an explicit isolated reviewer-subagent capability contract to the production evaluation policy used by the Issue #237 AgentBench harness.

## Related Issue

Fixes #237

## Changes Made

- Accepts only validated reviewer capability evidence from the bridge: isolated session, read-only operation, and an empty tool list.
- Uses the real `subagent` tool for independent review and records `reviewer_subagent` orchestration instead of the degraded same-session critic.
- Safely falls back when capability evidence is absent or malformed; approval UI, AskUserQuestion, and MCP remain disabled in the headless evaluation path.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

`npm run build:tsc`, 5 focused Vitest cases, and `npm run build:eval-policy` pass. A real one-sample AgentBench OS production run loaded `rongxinai-production-loop@237-p2-v3`, completed the isolated reviewer subagent, executed Inspect tools, and reported zero bridge failures or errors.

## Screenshots (if applicable)

Not applicable; no UI changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

The repository-level `npm test` command was not run because it rebuilds shared `better-sqlite3` and the native DLL was locked by an unrelated user process. No process was terminated. The focused policy tests, TypeScript build, policy bundle build, and real production preflight all passed.
