### PR TITLE
移除对话输入框的运行态遮罩

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -55,3 +55,8 @@ test('keeps the session permission selector available during an active run', () 
   expect(permissionMenu).toContain('disabled={disabled}');
   expect(permissionMenu).not.toContain('disabled={disabled || isStreaming}');
 });
+
+test('keeps the active-run mask visible while a permission request disables the prompt', () => {
+  expect(source).toContain('{isStreaming && !canQueueWhileStreaming && (');
+  expect(source).not.toContain('isStreaming && !disabled && !canQueueWhileStreaming');
+});

--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -56,7 +56,10 @@ test('keeps the session permission selector available during an active run', () 
   expect(permissionMenu).not.toContain('disabled={disabled || isStreaming}');
 });
 
-test('keeps the active-run mask visible while a permission request disables the prompt', () => {
-  expect(source).toContain('{isStreaming && !canQueueWhileStreaming && (');
-  expect(source).not.toContain('isStreaming && !disabled && !canQueueWhileStreaming');
+test('keeps streaming controls gated without obscuring the prompt', () => {
+  expect(source).not.toContain('bg-input/50 dark:bg-input/80');
+  expect(source).toContain('disabled={disabled || isStreaming || isAddingFile}');
+  expect(source.match(/disabled=\{disabled \|\| isStreaming\}/g)).toHaveLength(2);
+  expect(source).toContain("status={isStreaming ? 'streaming' : 'ready'}");
+  expect(source).toContain('onStop={isStreaming ? onStop : undefined}');
 });

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1160,9 +1160,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               {i18nService.t('coworkDropFileHint')}
             </div>
           )}
-          {isStreaming && !canQueueWhileStreaming && (
-            <div className="pointer-events-none absolute inset-0 z-10 rounded-[inherit] bg-input/50 dark:bg-input/80" />
-          )}
           <PromptInputBody>
             <PromptInputTextarea
               ref={textareaRef}

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1160,7 +1160,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               {i18nService.t('coworkDropFileHint')}
             </div>
           )}
-          {isStreaming && !disabled && !canQueueWhileStreaming && (
+          {isStreaming && !canQueueWhileStreaming && (
             <div className="pointer-events-none absolute inset-0 z-10 rounded-[inherit] bg-input/50 dark:bg-input/80" />
           )}
           <PromptInputBody>
@@ -1230,7 +1230,9 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                       disabled={disabled}
                     />
                   )}
-                  {isWorkVariant && goalMode && <GoalModeChip onRemove={() => setGoalMode(false)} />}
+                  {isWorkVariant && goalMode && (
+                    <GoalModeChip onRemove={() => setGoalMode(false)} />
+                  )}
                   <ActiveSkillBadge />
                 </>
               )}


### PR DESCRIPTION
## 问题

对话运行期间，输入框会覆盖一层灰色遮罩。审批请求出现时输入框状态变化，遮罩的显示与消失会造成不必要的视觉跳变。

## 修复

- 移除输入框在 streaming 状态下的灰色遮罩。
- 保留关键操作的运行态禁用策略：加号菜单和本地思考按钮在 streaming 时不可用。
- 保留发送按钮的运行态切换，使其在 streaming 时继续作为停止按钮使用。
- 保留权限模式选择器在运行期间可调整的既有行为。
- 增加结构回归测试，同时约束“无遮罩、关键按钮禁用、停止按钮可用”。

## 验证

- `npx vitest run src/renderer/components/cowork/CoworkPromptInput.structure.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npx oxfmt --check src/renderer/components/cowork/CoworkPromptInput.tsx src/renderer/components/cowork/CoworkPromptInput.structure.test.ts`

## Electron 影响

本次仅修改 Renderer 输入框的显示与交互状态，不涉及 IPC、主进程或存储行为。
