### PR TITLE
fix: NSIS 安装器签名确认弹窗提前并在静默模式下延迟安装

### DIFF
--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -351,7 +351,30 @@
 
   LlamaCppBackendResourcesPresent:
     StrCpy $R8 ""
-    IfFileExists "$INSTDIR\resources\llamacpp-nsis-helper\install-llamacpp-backend-nsis.cjs" LlamaCppBackendInstallRun LlamaCppBackendHelperMissing
+    IfSilent LlamaCppBackendInstallDeferred 0
+    MessageBox MB_OKCANCEL|MB_ICONQUESTION "The local inference runtime contains unsigned executable files. ZhiYuan Agent can create a local code-signing certificate and sign only these runtime files during installation. Choose OK to confirm local signing and continue, or Cancel to stop installation." IDOK LlamaCppBackendLocalSigningConfirmed IDCANCEL LlamaCppBackendLocalSigningCancelled
+
+  LlamaCppBackendLocalSigningConfirmed:
+    StrCpy $R8 "--local-signing-confirmed"
+    Goto LlamaCppBackendInstallRun
+
+  LlamaCppBackendInstallDeferred:
+    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=llamacpp-backend-install-skipped reason=silent-no-local-signing-confirmation$\r$\n"
+    FileClose $2
+    DetailPrint "[Installer] Skipping local inference runtime installation during unattended update"
+    Goto LlamaCppBackendInstallDone
+
+  LlamaCppBackendLocalSigningCancelled:
+    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro GetTimestamp $8
+    FileWrite $2 "$8 phase=llamacpp-backend-install-local-signing-cancelled$\r$\n"
+    FileClose $2
+    Abort
+
+  LlamaCppBackendInstallRun:
+    IfFileExists "$INSTDIR\resources\llamacpp-nsis-helper\install-llamacpp-backend-nsis.cjs" LlamaCppBackendInstallExecute LlamaCppBackendHelperMissing
 
   LlamaCppBackendHelperMissing:
     FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
@@ -361,7 +384,7 @@
     MessageBox MB_OK|MB_ICONSTOP "llama.cpp backend installer helper is missing from the installer resources. Please reinstall 知远 with a valid installer package."
     Abort
 
-  LlamaCppBackendInstallRun:
+  LlamaCppBackendInstallExecute:
   FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
   !insertmacro GetTimestamp $8
   FileWrite $2 "$8 phase=llamacpp-backend-install-start helper=$INSTDIR\resources\llamacpp-nsis-helper\install-llamacpp-backend-nsis.cjs manifest=$INSTDIR\resources\llamacpp-backends\manifest.json local_signing_arg=$R8$\r$\n"
@@ -397,31 +420,8 @@
   IntCmp $0 0 LlamaCppBackendInstallDone LlamaCppBackendInstallNonZero LlamaCppBackendInstallNonZero
 
   LlamaCppBackendInstallNonZero:
-    IntCmp $0 30 LlamaCppBackendLocalSigningConfirmationRequired 0 0
     IntCmp $0 31 LlamaCppBackendLocalSigningFailed 0 0
     IntCmp $0 16 LlamaCppBackendInstallNetworkFailed LlamaCppBackendInstallFailed LlamaCppBackendInstallFailed
-
-  LlamaCppBackendLocalSigningConfirmationRequired:
-    StrCmp $R8 "--local-signing-confirmed" LlamaCppBackendLocalSigningFailed
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
-    !insertmacro GetTimestamp $8
-    FileWrite $2 "$8 phase=llamacpp-backend-install-local-signing-confirmation-required exit=$0 output=$1$\r$\n"
-    FileClose $2
-    ; /S is used only after the user explicitly chooses Restart to Update.
-    ; Continue unattended instead of blocking the background updater on a MessageBox.
-    IfSilent LlamaCppBackendLocalSigningConfirmed 0
-    MessageBox MB_OKCANCEL|MB_ICONQUESTION "The local inference backend contains unsigned executable files. ZhiYuan Agent can create a local code-signing certificate and sign only the unsigned inference files during installation. Choose OK to confirm local signing and continue, or Cancel to stop installation." IDOK LlamaCppBackendLocalSigningConfirmed IDCANCEL LlamaCppBackendLocalSigningCancelled
-
-  LlamaCppBackendLocalSigningConfirmed:
-    StrCpy $R8 "--local-signing-confirmed"
-    Goto LlamaCppBackendInstallRun
-
-  LlamaCppBackendLocalSigningCancelled:
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
-    !insertmacro GetTimestamp $8
-    FileWrite $2 "$8 phase=llamacpp-backend-install-local-signing-cancelled$\r$\n"
-    FileClose $2
-    Abort
 
   LlamaCppBackendLocalSigningFailed:
     MessageBox MB_OK|MB_ICONSTOP "llama.cpp backend local signing failed (exit code $0). See %APPDATA%\ZhiYuanAgent\install-llamacpp.log and %APPDATA%\ZhiYuanAgent\install-timing.log for details."

--- a/src/main/libs/appUpdateInstaller.test.ts
+++ b/src/main/libs/appUpdateInstaller.test.ts
@@ -105,19 +105,16 @@ describe('unattended installation handoff', () => {
     );
   });
 
-  test('NSIS silent mode bypasses the local-signing confirmation dialog', async () => {
+  test('NSIS silent mode defers local signing without implicit approval', async () => {
     const nsisSource = await fs.promises.readFile(
       path.resolve(process.cwd(), 'scripts/nsis-installer.nsh'),
       'utf8',
     );
-    const confirmationBlock = nsisSource.slice(
-      nsisSource.indexOf('LlamaCppBackendLocalSigningConfirmationRequired:'),
-      nsisSource.indexOf('LlamaCppBackendLocalSigningConfirmed:'),
-    );
 
-    expect(confirmationBlock).toContain('IfSilent LlamaCppBackendLocalSigningConfirmed 0');
-    expect(confirmationBlock.indexOf('IfSilent')).toBeLessThan(
-      confirmationBlock.indexOf('    MessageBox'),
+    expect(nsisSource).toContain('IfSilent LlamaCppBackendInstallDeferred 0');
+    expect(nsisSource).toContain(
+      'phase=llamacpp-backend-install-skipped reason=silent-no-local-signing-confirmation',
     );
+    expect(nsisSource).not.toContain('IfSilent LlamaCppBackendLocalSigningConfirmed 0');
   });
 });

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const installerScriptPath = path.resolve('scripts/nsis-installer.nsh');
+
+describe('NSIS local inference runtime signing flow', () => {
+  test('requires interactive confirmation before invoking the runtime helper', () => {
+    const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+    const confirmationIndex = installerScript.indexOf(
+      'MessageBox MB_OKCANCEL|MB_ICONQUESTION "The local inference runtime contains unsigned executable files.',
+    );
+    const helperInvocationIndex = installerScript.indexOf('LlamaCppBackendInstallExecute:');
+
+    expect(confirmationIndex).toBeGreaterThan(-1);
+    expect(helperInvocationIndex).toBeGreaterThan(confirmationIndex);
+    expect(installerScript).toContain('StrCpy $R8 "--local-signing-confirmed"');
+    expect(installerScript).toContain('Goto LlamaCppBackendInstallRun');
+  });
+
+  test('does not silently authorize local signing during unattended updates', () => {
+    const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+
+    expect(installerScript).toContain('IfSilent LlamaCppBackendInstallDeferred 0');
+    expect(installerScript).toContain(
+      'phase=llamacpp-backend-install-skipped reason=silent-no-local-signing-confirmation',
+    );
+    expect(installerScript).not.toContain('IfSilent LlamaCppBackendLocalSigningConfirmed 0');
+  });
+});


### PR DESCRIPTION
## Summary

修复 Windows NSIS 安装器在 llamacpp 本地推理运行时签名流程中的行为：签名确认弹窗提前到安装前主动询问，静默（无头）更新模式下改为延迟安装而不是隐式同意本地签名。

## Related Issue

<!-- Link to the related issue(s) if applicable -->

## Changes Made

- **签名确认提前**：NSIS 安装脚本在调用运行时安装 helper 之前主动弹出确认框，询问用户是否允许创建本地代码签名证书并签署未签名运行时文件
- **静默模式延迟安装**：`IfSilent` 场景下不再自动进入签名确认（此前会隐式同意），改为记录安装时机日志并跳过运行时安装，避免后台更新被弹窗阻塞或未经确认执行签名
- **新增测试**：`tests/nsis-installer.test.ts` 覆盖交互确认前置与静默不隐式授权的断言；同步更新 `appUpdateInstaller.test.ts` 中的静默行为断言

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

改动集中在 NSIS 安装脚本 `scripts/nsis-installer.nsh` 与其测试，涉及 Windows 安装程序在交互/静默两种模式下的本地签名确认行为。
