### PR TITLE
feat(模型市场): 将模型市场只访问/v1/catalog/search

### DIFF
--- a/src/main/libs/marketplaceService.test.ts
+++ b/src/main/libs/marketplaceService.test.ts
@@ -373,10 +373,15 @@ test('MarketplaceService reports catalogue failures without leaking token detail
   expect(result.warning).not.toMatch(/token|api key/i);
 });
 
-test('MarketplaceService resolves install metadata only through the cloud catalogue', async () => {
-  const fetchMock = vi.fn(async (url: string) => {
-    expect(url).toBe('https://catalog.example.test/v1/catalog/models/Qwen/Qwen3-8B-GGUF');
-    return Response.json(verifiedModel());
+test('MarketplaceService resolves install metadata through the catalogue search endpoint', async () => {
+  const fetchMock = vi.fn(async (urlValue: string) => {
+    const url = new URL(urlValue);
+    expect(url.pathname).toBe('/v1/catalog/search');
+    expect(url.searchParams.get('q')).toBe('Qwen/Qwen3-8B-GGUF');
+    expect(url.searchParams.get('limit')).toBe('8');
+    expect(url.searchParams.get('page')).toBe('1');
+    expect(url.searchParams.has('featured')).toBe(false);
+    return Response.json({ models: [verifiedModel()], totalCount: 1 });
   });
   vi.stubGlobal('fetch', fetchMock);
   const service = new MarketplaceService(() => createTempDir(), {
@@ -436,7 +441,7 @@ test('MarketplaceService falls back to a stale cached search when the catalogue 
 test('MarketplaceService caches resolved model details and serves them offline', async () => {
   const fetchMock = vi
     .fn()
-    .mockResolvedValueOnce(Response.json({ model: verifiedModel() }))
+    .mockResolvedValueOnce(Response.json({ models: [verifiedModel()], totalCount: 1 }))
     .mockRejectedValueOnce(new Error('network unreachable'));
   vi.stubGlobal('fetch', fetchMock);
   const cacheDir = createTempDir();

--- a/src/main/libs/modelCatalogClient.test.ts
+++ b/src/main/libs/modelCatalogClient.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, vi } from 'vitest';
+
+import { ModelCatalogClient } from './modelCatalogClient';
+
+const VERIFIED_SHA = 'a'.repeat(64);
+
+test('uses the search endpoint without sending the legacy featured query', async () => {
+  let requestedUrl = '';
+  const fetchMock = vi.fn(async (input: string | Request) => {
+    requestedUrl = String(input);
+    return Response.json({
+      models: [
+        {
+          id: 'Qwen/Qwen3-8B-GGUF',
+          repoId: 'Qwen/Qwen3-8B-GGUF',
+          name: 'Qwen3 8B GGUF',
+          files: [
+            {
+              path: 'Qwen3-8B-Q4_K_M.gguf',
+              isRecommended: true,
+              sizeBytes: 100,
+              sha256: VERIFIED_SHA,
+            },
+          ],
+          metadataStatus: 'verified',
+          runtime: { format: 'gguf', ggufFilesVerified: true },
+        },
+      ],
+      totalCount: 1,
+    });
+  });
+
+  const client = new ModelCatalogClient('https://catalog.example.test', fetchMock);
+  await client.search({ featuredOnly: true, limit: 8, pageNumber: 2 });
+
+  const url = new URL(requestedUrl);
+  expect(url.pathname).toBe('/v1/catalog/search');
+  expect(url.searchParams.get('limit')).toBe('8');
+  expect(url.searchParams.get('page')).toBe('2');
+  expect(url.searchParams.has('featured')).toBe(false);
+});

--- a/src/main/libs/modelCatalogClient.ts
+++ b/src/main/libs/modelCatalogClient.ts
@@ -98,7 +98,6 @@ export class ModelCatalogClient {
     if (params.limit) url.searchParams.set('limit', String(params.limit));
     if (params.pageNumber) url.searchParams.set('page', String(params.pageNumber));
     if (params.sortby) url.searchParams.set('sortby', params.sortby);
-    if (params.featuredOnly) url.searchParams.set('featured', '1');
     const payload = await this.fetchJson(url.toString(), signal) as CatalogSearchPayload;
     const normalizedModels = (payload.models ?? []).map(normalizeModel);
     return {
@@ -113,25 +112,21 @@ export class ModelCatalogClient {
     };
   }
 
-  async bootstrap(): Promise<MarketplaceSearchResult> {
-    const payload = await this.fetchJson(`${this.baseUrl}/v1/catalog/bootstrap`) as { models?: CatalogModelPayload[]; totalCount?: number; warning?: string; source?: MarketplaceSearchResult['source']; catalogUpdatedAt?: string; scoreVersion?: string };
-    return {
-      models: (payload.models ?? []).map(normalizeModel).filter(isGenerativeLanguageModel).filter(isVerifiedGgufCatalogModel), totalCount: payload.totalCount, warning: payload.warning,
-      source: payload.source ?? 'cloud-catalog', catalogUpdatedAt: payload.catalogUpdatedAt, scoreVersion: payload.scoreVersion,
-    };
-  }
-
   async resolveModel(repoId: string): Promise<MarketplaceModel | null> {
-    const [owner, repo] = repoId.trim().split('/');
-    if (!owner || !repo) return null;
-    const payload = await this.fetchJson(
-      `${this.baseUrl}/v1/catalog/models/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
-    ) as CatalogModelPayload | { model?: CatalogModelPayload };
-    const value: CatalogModelPayload | undefined =
-      (payload as { model?: CatalogModelPayload }).model ?? (payload as CatalogModelPayload);
-    if (!value || !value.repoId) return null;
-    const model = normalizeModel(value);
-    return isGenerativeLanguageModel(model) && isVerifiedGgufCatalogModel(model) ? model : null;
+    const normalizedRepoId = repoId.trim();
+    if (!normalizedRepoId) return null;
+    const result = await this.search({
+      query: normalizedRepoId,
+      limit: 8,
+      pageNumber: 1,
+      fit: 'all',
+    });
+    const model = result.models.find(candidate =>
+      candidate.repoId === normalizedRepoId || candidate.id === normalizedRepoId,
+    );
+    return model && isGenerativeLanguageModel(model) && isVerifiedGgufCatalogModel(model)
+      ? model
+      : null;
   }
 
   private async fetchJson(url: string, externalSignal?: AbortSignal): Promise<unknown> {


### PR DESCRIPTION
## 摘要

  统一模型市场云端目录 API 调用，解决客户端使用多个旧接口导致请求不一致的问题。

  ## 关联问题

  修复 #（issue 编号）

  ## 修改内容

  - 统一使用 /v1/catalog/search 获取模型目录。
  - 移除 /v1/catalog/bootstrap 调用。
  - 移除旧的详情接口调用，模型详情通过搜索接口精确查询。
  - 不再向服务端发送 featured=1。
  - featuredOnly 保留为客户端本地筛选逻辑。
  - 新增并更新相关单元测试。

  ## 修改类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## 测试

  - [x] 已完成本地测试
  - [x] 已新增测试
  - [x] 已更新现有测试
  - [ ] 已完成手动界面测试

  ## 截图

  不适用，无界面变更。

  ## 检查清单

  - [x] 代码符合项目编码规范
  - [x] 已完成代码自检
  - [x] 已为关键逻辑补充测试
  - [ ] 已同步更新相关文档
  - [x] 未产生新的 lint 警告
  - [x] 新增和现有单元测试全部通过

  验证结果：

  - 7 个测试文件通过
  - 84 个测试用例通过
  - npm run lint 通过
  - git diff --check 通过

  ## Electron 相关变更

  - [x] 修改主进程代码（src/main/）
  - [ ] 修改 preload 脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [ ] 无

  ## 补充说明

  模型市场客户端当前不再调用 bootstrap、oldsearch 或 featured=1，所有目录查询统一走 /v1/catalog/search。