### PR TITLE
fix(shortcuts): 默认快捷键改为跨平台 CmdOrCtrl 形式

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -613,6 +613,15 @@ const SEND_SHORTCUT_OPTIONS = [
 
 const isMacPlatform = navigator.platform.includes('Mac');
 
+const formatShortcutLabel = (shortcut: string): string => {
+  if (!isMacPlatform) return shortcut;
+  return shortcut
+    .replace('CmdOrCtrl', '⌘')
+    .replace('Cmd', '⌘')
+    .replace('Option', '⌥')
+    .replace('Alt', '⌥');
+};
+
 const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void }> = ({
   value,
   onChange,
@@ -666,7 +675,7 @@ const ShortcutRecorder: React.FC<{ value: string; onChange: (v: string) => void 
             : 'dark:border-claude-darkBorder border-claude-border hover:border-claude-accent/50'
         }`}
     >
-      {value || i18nService.t('shortcutNotSet')}
+      {value ? formatShortcutLabel(value) : i18nService.t('shortcutNotSet')}
     </Button>
   );
 };
@@ -826,10 +835,7 @@ const Settings: React.FC<SettingsProps> = ({
   const importInputRef = useRef<HTMLInputElement>(null);
   // 快捷键设置
   const [shortcuts, setShortcuts] = useState({
-    newChat: 'Ctrl+N',
-    search: 'Ctrl+F',
-    settings: 'Ctrl+,',
-    sendMessage: defaultConfig.shortcuts!.sendMessage,
+    ...defaultConfig.shortcuts!,
   });
 
   // GitHub Copilot device code auth state
@@ -5504,7 +5510,6 @@ const Settings: React.FC<SettingsProps> = ({
         {(isAddingModel || isEditingModel) && (
           <div
             className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl"
-            onClick={handleCancelModelEdit}
           >
             <div
               role="dialog"

--- a/src/renderer/config.ts
+++ b/src/renderer/config.ts
@@ -48,6 +48,13 @@ export interface AppConfig {
   };
 }
 
+export const DEFAULT_SHORTCUTS = {
+  newChat: 'CmdOrCtrl+N',
+  search: 'CmdOrCtrl+F',
+  settings: 'CmdOrCtrl+,',
+  sendMessage: 'Enter',
+} as const;
+
 const buildDefaultProviders = (): AppConfig['providers'] => {
   const providers: Record<string, ProviderConfig> = {};
 
@@ -91,10 +98,7 @@ export const defaultConfig: AppConfig = {
     isDevelopment: process.env.NODE_ENV === 'development',
   },
   shortcuts: {
-    newChat: 'Ctrl+N',
-    search: 'Ctrl+F',
-    settings: 'Ctrl+,',
-    sendMessage: 'Enter',
+    ...DEFAULT_SHORTCUTS,
   },
 };
 

--- a/src/renderer/services/config.ts
+++ b/src/renderer/services/config.ts
@@ -395,6 +395,14 @@ class ConfigService {
         } as AppConfig['shortcuts'],
         providers: mergedProviders as AppConfig['providers'],
       });
+      const shortcuts = this.config.shortcuts!;
+      this.config.shortcuts = {
+        ...shortcuts,
+        newChat: shortcuts.newChat === 'Ctrl+N' ? defaultConfig.shortcuts!.newChat : shortcuts.newChat,
+        search: shortcuts.search === 'Ctrl+F' ? defaultConfig.shortcuts!.search : shortcuts.search,
+        settings:
+          shortcuts.settings === 'Ctrl+,' ? defaultConfig.shortcuts!.settings : shortcuts.settings,
+      };
     } else {
       this.config = defaultConfig;
     }


### PR DESCRIPTION
## Summary

将侧边栏/应用默认快捷键改为跨平台 `CmdOrCtrl` 形式,使 macOS 上 ⌘N/⌘F/⌘, 生效、Windows/Linux 上仍为 Ctrl+N/F/,;并在 macOS 下用平台符号(⌘/⌥)渲染快捷键展示。同时修复模型编辑弹层点击遮罩误关闭的问题。

## Related Issue

无关联 issue。

## Changes Made

- `src/renderer/config.ts`:新增 `DEFAULT_SHORTCUTS` 常量,默认值从 `Ctrl+N/F/,` 改为 `CmdOrCtrl+N/F/,`,`defaultConfig.shortcuts` 统一引用
- `src/renderer/services/config.ts`:加载配置时,将历史存储的 `Ctrl` 默认值(`Ctrl+N/F/,`)迁移到新的 `CmdOrCtrl` 默认值;仅替换旧默认字面量,用户自定义快捷键保持不变
- `src/renderer/components/Settings.tsx`:
  - 新增 `formatShortcutLabel()`,macOS 下将 `CmdOrCtrl`/`Cmd`/`Option`/`Alt` 渲染为 ⌘/⌥ 符号
  - 快捷键初始值改为 `...defaultConfig.shortcuts!`,统一来自默认配置
  - 模型编辑弹层:移除点击暗色遮罩即取消编辑的行为(仍需通过按钮操作)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing performed
- [x] Lint 通过(`npm run lint` 无告警)

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] None

## Additional Notes

- `matchesShortcut`(`src/renderer/services/shortcuts.ts`)已原生支持 `CmdOrCtrl`,消费端无需改动
- 非 macOS 平台上,`ShortcutRecorder` 会原样展示 `CmdOrCtrl+N` 形式文案(仅显示层,不影响功能)
