### PR TITLE
fix: 避免将中间产物显示为交付物

### DIFF
--- a/src/main/coworkArtifactCollector.test.ts
+++ b/src/main/coworkArtifactCollector.test.ts
@@ -45,8 +45,47 @@ describe('collectSessionArtifactCandidates', () => {
     });
     expect(candidates[1]).toMatchObject({
       artifactKey: 'path:d:/output/report.html',
-      artifact: { content: '', declared: false },
+      artifact: {
+        content: '',
+        declared: false,
+        role: CoworkArtifactRole.Intermediate,
+      },
     });
+  });
+
+  test('keeps undeclared verification scripts out of deliverables', () => {
+    const candidates = collectSessionArtifactCandidates([
+      message('write-verification-script', 1, 'tool_use', '', {
+        toolName: 'write',
+        toolInput: { path: 'D:/output/_verify_tetris.js', content: 'runTests();' },
+      }),
+      message('declare-html', 2, 'tool_use', '', {
+        toolName: 'declare_artifact',
+        toolInput: {
+          filePath: 'D:/output/tetris.html',
+          role: CoworkArtifactRole.Deliverable,
+        },
+      }),
+    ]);
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          artifact: expect.objectContaining({
+            fileName: '_verify_tetris.js',
+            role: CoworkArtifactRole.Intermediate,
+            declared: false,
+          }),
+        }),
+        expect.objectContaining({
+          artifact: expect.objectContaining({
+            fileName: 'tetris.html',
+            role: CoworkArtifactRole.Deliverable,
+            declared: true,
+          }),
+        }),
+      ]),
+    );
   });
 
   test('collects supported assistant code blocks with stable keys and content', () => {

--- a/src/main/coworkArtifactCollector.ts
+++ b/src/main/coworkArtifactCollector.ts
@@ -181,7 +181,7 @@ function collectWrites(messages: CoworkArtifactMessage[]): CoworkArtifactCandida
         fileName,
         filePath,
         source: CoworkArtifactSource.Tool,
-        role: CoworkArtifactRole.Deliverable,
+        role: CoworkArtifactRole.Intermediate,
         declared: false,
         createdAt: message.timestamp,
       },

--- a/src/main/coworkArtifactIndex.test.ts
+++ b/src/main/coworkArtifactIndex.test.ts
@@ -1,7 +1,7 @@
 import BetterSqlite3 from 'better-sqlite3';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { CoworkArtifactRole } from '../shared/cowork/artifacts';
+import { CoworkArtifactRole, CoworkArtifactSource } from '../shared/cowork/artifacts';
 import {
   COWORK_ARTIFACT_INDEX_VERSION,
   CoworkArtifactIndex,
@@ -86,6 +86,46 @@ describe('CoworkArtifactIndex', () => {
       )
       .get() as { cursor_sequence: number };
     expect(state.cursor_sequence).toBe(2);
+  });
+
+  test('rebuilds stale running-session indexes with write outputs as intermediate', () => {
+    insertMessage('write-1', 1, 'tool_use', '', {
+      toolName: 'write',
+      toolInput: { path: 'D:/output/_verify_tetris.js', content: 'runTests();' },
+    });
+    db.prepare(
+      `INSERT INTO cowork_session_artifacts (
+         session_id, artifact_key, id, message_id, type, title, content,
+         file_name, file_path, source, role, declared, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'session-1',
+      'path:d:/output/_verify_tetris.js',
+      'legacy-artifact',
+      'write-1',
+      'code',
+      '_verify_tetris.js',
+      '',
+      '_verify_tetris.js',
+      'D:/output/_verify_tetris.js',
+      CoworkArtifactSource.Tool,
+      CoworkArtifactRole.Deliverable,
+      0,
+      100,
+    );
+    db.prepare(
+      `INSERT INTO cowork_artifact_index_state
+         (session_id, cursor_sequence, index_version)
+       VALUES (?, ?, ?)`,
+    ).run('session-1', 1, COWORK_ARTIFACT_INDEX_VERSION - 1);
+
+    expect(index.listSession('session-1')).toEqual([
+      expect.objectContaining({
+        fileName: '_verify_tetris.js',
+        role: CoworkArtifactRole.Intermediate,
+        declared: false,
+      }),
+    ]);
   });
 
   test('keeps declaration metadata authoritative across incremental batches', () => {

--- a/src/main/coworkArtifactIndex.ts
+++ b/src/main/coworkArtifactIndex.ts
@@ -7,7 +7,7 @@ import {
   type CoworkArtifactMessage,
 } from './coworkArtifactCollector';
 
-export const COWORK_ARTIFACT_INDEX_VERSION = 1;
+export const COWORK_ARTIFACT_INDEX_VERSION = 2;
 
 interface ArtifactIndexStateRow {
   cursor_sequence: number;
@@ -137,11 +137,26 @@ export class CoworkArtifactIndex {
         )
         .run(sessionId, nextCursor, COWORK_ARTIFACT_INDEX_VERSION);
 
-      return this.listSession(sessionId);
+      return this.readSession(sessionId);
     })();
   }
 
   listSession(sessionId: string): CoworkPersistedArtifact[] {
+    const state = this.db
+      .prepare(
+        `SELECT index_version
+         FROM cowork_artifact_index_state
+         WHERE session_id = ?`,
+      )
+      .get(sessionId) as Pick<ArtifactIndexStateRow, 'index_version'> | undefined;
+    if (!state || state.index_version !== COWORK_ARTIFACT_INDEX_VERSION) {
+      return this.refreshSession(sessionId);
+    }
+
+    return this.readSession(sessionId);
+  }
+
+  private readSession(sessionId: string): CoworkPersistedArtifact[] {
     const rows = this.db
       .prepare(
         `SELECT id, message_id, type, title, content, language, file_name,

--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -292,7 +292,7 @@ describe('detectArtifactsFromMessages', () => {
     expect(artifacts).toHaveLength(0);
   });
 
-  test('keeps explicit write-tool outputs as artifacts', () => {
+  test('keeps write-tool outputs intermediate until explicitly declared', () => {
     const artifacts = detectArtifactsFromMessages(
       [
         {
@@ -322,8 +322,73 @@ describe('detectArtifactsFromMessages', () => {
 
     expect(artifacts).toHaveLength(1);
     expect(artifacts[0].artifact.filePath).toBe('D:/workspace/output.ts');
-    expect(artifacts[0].artifact.role).toBe(ArtifactRole.Deliverable);
+    expect(artifacts[0].artifact.role).toBe(ArtifactRole.Intermediate);
     expect(artifacts[0].needsFileLoad).toBe(true);
+  });
+
+  test('does not show an undeclared verification script with declared deliverables', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'write-verification-script',
+          type: 'tool_use',
+          content: 'Using tool: Write',
+          timestamp: Date.now(),
+          metadata: {
+            toolName: 'write',
+            toolInput: { path: 'D:/workspace/_verify_tetris.js', content: 'runTests();' },
+          },
+        },
+        ...['tetris.html', 'tetris-preview.png', 'validation.md'].map((filePath, index) => ({
+          id: `declare-${index}`,
+          type: 'tool_use' as const,
+          content: '',
+          timestamp: Date.now(),
+          metadata: {
+            toolName: 'declare_artifact',
+            toolInput: {
+              filePath: `D:/workspace/${filePath}`,
+              role: ArtifactRole.Deliverable,
+            },
+          },
+        })),
+      ],
+      'sess1',
+    );
+
+    expect(
+      artifacts
+        .filter(({ artifact }) => artifact.role === ArtifactRole.Deliverable)
+        .map(({ artifact }) => artifact.fileName),
+    ).toEqual(['tetris.html', 'tetris-preview.png', 'validation.md']);
+    expect(
+      artifacts.find(({ artifact }) => artifact.fileName === '_verify_tetris.js'),
+    ).toMatchObject({
+      artifact: {
+        role: ArtifactRole.Intermediate,
+        declared: false,
+      },
+    });
+  });
+
+  test('uses the declare_artifact default deliverable role when role is omitted', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'declare-output',
+          type: 'tool_use',
+          content: '',
+          timestamp: Date.now(),
+          metadata: {
+            toolName: 'declare_artifact',
+            toolInput: { filePath: 'D:/workspace/output.html' },
+          },
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts[0].artifact.role).toBe(ArtifactRole.Deliverable);
   });
 
   test('marks only the final answer artifact as deliverable via declare_artifact', () => {

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -288,8 +288,6 @@ export interface DetectedArtifact {
   artifact: Artifact;
   /** If true, the artifact references a file that should be loaded from disk. */
   needsFileLoad: boolean;
-  /** If true, the role was explicitly set by a declare_artifact call and should not be auto-promoted. */
-  roleIsExplicit?: boolean;
 }
 
 /**
@@ -305,16 +303,15 @@ export function detectArtifactsFromMessages(
 ): DetectedArtifact[] {
   const detected: DetectedArtifact[] = [];
   const detectedFilePathIndexes = new Map<string, number>();
-  const finalAnswerMessageId = findFinalAnswerMessageId(messages);
 
-  const addPathArtifact = (artifact: Artifact, needsFileLoad: boolean, roleIsExplicit = false) => {
+  const addPathArtifact = (artifact: Artifact, needsFileLoad: boolean) => {
     if (!artifact.filePath) return;
 
     const normalized = normalizeFilePathForDedup(artifact.filePath);
     const existingIndex = detectedFilePathIndexes.get(normalized);
     if (existingIndex === undefined) {
       detectedFilePathIndexes.set(normalized, detected.length);
-      detected.push({ artifact, needsFileLoad, roleIsExplicit });
+      detected.push({ artifact, needsFileLoad });
       return;
     }
 
@@ -326,7 +323,6 @@ export function detectArtifactsFromMessages(
       detected[existingIndex] = {
         artifact,
         needsFileLoad: existing.needsFileLoad || needsFileLoad,
-        roleIsExplicit: existing.roleIsExplicit || roleIsExplicit,
       };
     }
   };
@@ -342,11 +338,13 @@ export function detectArtifactsFromMessages(
 
   // Structured artifact declarations from declare_artifact tool calls.
   // These are the authoritative source for file-backed artifacts — no regex.
-  const declaredArtifacts = parseDeclareArtifactFromMessages(messages, sessionId, msg => {
-    return msg.id === finalAnswerMessageId ? ArtifactRole.Deliverable : ArtifactRole.Intermediate;
-  });
+  const declaredArtifacts = parseDeclareArtifactFromMessages(
+    messages,
+    sessionId,
+    () => ArtifactRole.Deliverable,
+  );
   for (const artifact of declaredArtifacts) {
-    addPathArtifact(artifact, true, /* roleIsExplicit */ true);
+    addPathArtifact(artifact, true);
   }
 
   for (let i = 0; i < messages.length; i++) {
@@ -367,47 +365,5 @@ export function detectArtifactsFromMessages(
     }
   }
 
-  // Auto-promotion safety net: intermediate file-backed artifacts (from
-  // write tools) that were not explicitly declared via declare_artifact
-  // are promoted so they remain visible by default.
-  // Explicit declare_artifact role:intermediate calls are preserved.
-  for (const entry of detected) {
-    if (
-      entry.artifact.filePath &&
-      entry.artifact.role === ArtifactRole.Intermediate &&
-      !entry.roleIsExplicit
-    ) {
-      entry.artifact = { ...entry.artifact, role: ArtifactRole.Deliverable };
-    }
-  }
-
   return detected;
-}
-
-function findFinalAnswerMessageId(messages: CoworkMessage[]): string | null {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (
-      message.type === 'assistant' &&
-      !message.metadata?.isThinking &&
-      message.metadata?.isFinalAnswer === true &&
-      message.content.trim()
-    ) {
-      return message.id;
-    }
-  }
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (
-      message.type === 'assistant' &&
-      !message.metadata?.isThinking &&
-      message.metadata?.isStreaming !== true &&
-      message.content.trim()
-    ) {
-      return message.id;
-    }
-  }
-
-  return null;
 }


### PR DESCRIPTION
## 问题

通过 `write` / `write_file` 创建的文件会被 Artifact Collector 自动提升为交付物，导致 `_verify_tetris.js` 等验证脚本、构建脚本和草稿文件出现在最终回答的交付卡片中。此前错误角色还会持久化到 SQLite artifact 索引，升级后重新打开旧会话仍可能继续显示。

## 修复

- 主进程和 Renderer 统一将未声明的写入文件保留为 `intermediate`
- 最终回答区域只展示显式 `declare_artifact(role: deliverable)` 的文件及显式消息 Artifact
- 对齐 `declare_artifact` 的默认语义：省略 `role` 时按 `deliverable` 处理
- 将 Cowork artifact 索引升级到 v2，自动重建历史错误记录
- 运行中的旧会话读取 artifact 时同样检查索引版本，避免迁移遗漏

## 行为变化

- HTML、预览图、验证报告等显式声明的交付物继续正常展示
- Playwright 验证脚本、生成脚本和其他未声明文件仍保留为中间产物，可供内部 Artifact 管理使用，但不再附加到最终回答
- 旧会话会在下次读取时自动修正已持久化的错误角色

## 验证

- `32` 个相关 Vitest 测试通过
- `npm run lint` 通过
- `npm run build:tsc` 通过
- `npm run build` 通过

新增回归覆盖 `_verify_tetris.js` 与三个显式交付物并存，以及运行中旧会话的 artifact 索引迁移。

## Electron / 存储影响

本次将 `cowork_artifact_index_state.index_version` 逻辑版本提升到 `2`。迁移采用已有的惰性重建机制，不修改原始会话消息，也不新增数据库表或 IPC。

## 截图

无视觉样式改动；本次仅修正 Artifact 角色判定和历史索引迁移。
