### PR TITLE
feat(memory): 建立受监管的本地记忆运行边界

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ __pycache__/
 vendor/openclaw-runtime/
 vendor/openclaw-plugins/
 vendor/llamacpp-runtime/
+vendor/engram-runtime/
 
 # Tar archives generated during Windows packaging
 build-tar/

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -65,6 +65,11 @@
       "from": "MCPs",
       "to": "MCPs",
       "filter": ["**/*"]
+    },
+    {
+      "from": "vendor/engram-runtime/current",
+      "to": "memory",
+      "filter": ["engram", "engram.exe", "runtime-build-info.json", "LICENSE"]
     }
   ],
   "protocols": [

--- a/package.json
+++ b/package.json
@@ -55,6 +55,26 @@
       "win-x64-cuda-12": []
     }
   },
+  "engram": {
+    "version": "v1.20.0",
+    "repo": "Gentleman-Programming/engram",
+    "runtimeAssets": {
+      "mac-x64": "engram_1.20.0_darwin_amd64.tar.gz",
+      "mac-arm64": "engram_1.20.0_darwin_arm64.tar.gz",
+      "win-x64": "engram_1.20.0_windows_amd64.zip",
+      "win-arm64": "engram_1.20.0_windows_arm64.zip",
+      "linux-x64": "engram_1.20.0_linux_amd64.tar.gz",
+      "linux-arm64": "engram_1.20.0_linux_arm64.tar.gz"
+    },
+    "runtimeChecksums": {
+      "mac-x64": "3b9015dcfcdd9f823eb7ad0b590b1dbc4c25bb5d81dda3f84e623709815afe80",
+      "mac-arm64": "2363d5012f23e58878f86c3ddcc1f63cfe9dcf3eec7f413e70eaafcbb9d394cc",
+      "win-x64": "c945c47d58367f943642cb8451fa45f208174407839f1dda33a975a05d6e465b",
+      "win-arm64": "eb93c6d7d5a4020ddcf1ff956909f3e90694f6447519433316b10f964f8f37b5",
+      "linux-x64": "7dc3003318e303bee269a4772144f3ce01c8ec700bfd524aaec76770acd389ca",
+      "linux-arm64": "7eb815910a76ae6cfa9a5d0161d3701e293dcca71f7743cffa62e236e5af59af"
+    }
+  },
   "main": "dist-electron/main.js",
   "engines": {
     "node": ">=24 <25"
@@ -87,17 +107,17 @@
     "electron:dev": "rimraf dist-electron && npm run compile:electron && concurrently \"vite --port 5175\" \"wait-on -l -t 120000 -d 20000 -i 1000 -s 1 http://localhost:5175 && wait-on -l -t 120000 -i 1000 dist-electron/.electron-ready && npm run start:electron\"",
     "electron:dev:openclaw": "npm run openclaw:runtime:host && npm run llamacpp:runtime:host && npm run electron:dev",
     "postinstall": "patch-package && electron-builder install-app-deps",
-    "pack": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:host && npm run prepare:modelscope-tokens && electron-builder --dir",
-    "dist": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:host && npm run prepare:modelscope-tokens && electron-builder",
+    "pack": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:host && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder --dir",
+    "dist": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:host && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder",
     "dist:mac": "npm run prepare:modelscope-tokens && electron-builder --mac --config electron-builder.json --publish never",
-    "predist:mac": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64",
-    "dist:mac:x64": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-x64 && npm run prepare:modelscope-tokens && electron-builder --mac --x64",
-    "dist:mac:arm64": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64 && npm run prepare:modelscope-tokens && electron-builder --mac --arm64",
-    "dist:mac:universal": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64 && npm run prepare:modelscope-tokens && electron-builder --mac --universal",
+    "predist:mac": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64 && npm run engram:runtime:mac-arm64",
+    "dist:mac:x64": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-x64 && npm run engram:runtime:mac-x64 && npm run prepare:modelscope-tokens && electron-builder --mac --x64",
+    "dist:mac:arm64": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64 && npm run engram:runtime:mac-arm64 && npm run prepare:modelscope-tokens && electron-builder --mac --arm64",
+    "dist:mac:universal": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run openclaw:runtime:mac-arm64 && npm run engram:runtime:mac-arm64 && npm run prepare:modelscope-tokens && electron-builder --mac --universal",
     "dist:win": "npm run dist:win:lite",
-    "dist:win:lite": "npm run openclaw:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=lite node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=lite electron-builder --win nsis --x64 --config electron-builder.json --publish never",
-    "dist:win:full": "npm run openclaw:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=full node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=full electron-builder --win nsis --x64 --config electron-builder.json --publish never",
-    "predist:linux": "npm run openclaw:runtime:linux-x64 && node scripts/ensure-build-version.js && npm run prepare:update-release",
+    "dist:win:lite": "npm run openclaw:runtime:win-x64 && npm run engram:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=lite node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=lite electron-builder --win nsis --x64 --config electron-builder.json --publish never",
+    "dist:win:full": "npm run openclaw:runtime:win-x64 && npm run engram:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=full node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && cross-env ZHIYUAN_WIN_LLAMACPP_BACKEND_BUNDLE=full electron-builder --win nsis --x64 --config electron-builder.json --publish never",
+    "predist:linux": "npm run openclaw:runtime:linux-x64 && npm run engram:runtime:linux-x64 && node scripts/ensure-build-version.js && npm run prepare:update-release",
     "dist:linux": "npm run build && npm run compile:electron && npm run build:skills && npm run prepare:modelscope-tokens && electron-builder --linux --publish never",
     "clean:release": "rimraf release",
     "generate:tray-icons": "node scripts/generate-tray-icons.js",
@@ -125,6 +145,13 @@
     "openclaw:runtime:win-arm64": "npm run openclaw:ensure && npm run openclaw:patch && node scripts/run-build-openclaw-runtime.cjs win-arm64 && node scripts/sync-openclaw-runtime-current.cjs win-arm64 && npm run openclaw:bundle && npm run openclaw:plugins && npm run openclaw:extensions:local && npm run openclaw:precompile && npm run openclaw:channel-deps && npm run openclaw:prune",
     "openclaw:runtime:linux-x64": "npm run openclaw:ensure && npm run openclaw:patch && node scripts/run-build-openclaw-runtime.cjs linux-x64 && node scripts/sync-openclaw-runtime-current.cjs linux-x64 && npm run openclaw:bundle && npm run openclaw:plugins && npm run openclaw:extensions:local && npm run openclaw:precompile && npm run openclaw:channel-deps && npm run openclaw:prune",
     "openclaw:runtime:linux-arm64": "npm run openclaw:ensure && npm run openclaw:patch && node scripts/run-build-openclaw-runtime.cjs linux-arm64 && node scripts/sync-openclaw-runtime-current.cjs linux-arm64 && npm run openclaw:bundle && npm run openclaw:plugins && npm run openclaw:extensions:local && npm run openclaw:precompile && npm run openclaw:channel-deps && npm run openclaw:prune",
+    "engram:runtime:host": "node scripts/download-engram-runtime.cjs",
+    "engram:runtime:mac-x64": "node scripts/download-engram-runtime.cjs mac-x64",
+    "engram:runtime:mac-arm64": "node scripts/download-engram-runtime.cjs mac-arm64",
+    "engram:runtime:win-x64": "node scripts/download-engram-runtime.cjs win-x64",
+    "engram:runtime:win-arm64": "node scripts/download-engram-runtime.cjs win-arm64",
+    "engram:runtime:linux-x64": "node scripts/download-engram-runtime.cjs linux-x64",
+    "engram:runtime:linux-arm64": "node scripts/download-engram-runtime.cjs linux-arm64",
     "llamacpp:runtime:host": "node scripts/llamacpp-runtime-host.cjs",
     "llamacpp:runtime:download": "node scripts/download-llamacpp-runtime.cjs",
     "llamacpp:runtime:download:mac-arm64": "node scripts/download-llamacpp-runtime.cjs mac-arm64",

--- a/scripts/download-engram-runtime.cjs
+++ b/scripts/download-engram-runtime.cjs
@@ -1,0 +1,121 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const extractZip = require('extract-zip');
+const tar = require('tar');
+
+function resolveHostTargetId() {
+  const platform = { darwin: 'mac', win32: 'win', linux: 'linux' }[process.platform];
+  const architecture = { x64: 'x64', arm64: 'arm64' }[process.arch];
+  if (!platform || !architecture) {
+    throw new Error(`Unsupported host platform/arch: ${process.platform}/${process.arch}`);
+  }
+  return `${platform}-${architecture}`;
+}
+
+function readRuntimeConfig(rootDir) {
+  const packageJson = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'));
+  if (!packageJson.engram?.version || !packageJson.engram?.repo) {
+    throw new Error('package.json is missing the pinned memory runtime configuration.');
+  }
+  return packageJson.engram;
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+async function download(url, destination) {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'ZhiYuanAgent/memory-runtime-downloader' },
+  });
+  if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}.`);
+  fs.writeFileSync(destination, Buffer.from(await response.arrayBuffer()));
+}
+
+function findExecutable(rootDir, executableName) {
+  const queue = [rootDir];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const direct = path.join(current, executableName);
+    if (fs.existsSync(direct)) return direct;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) queue.push(path.join(current, entry.name));
+    }
+  }
+  return null;
+}
+
+async function extract(archivePath, destination) {
+  if (archivePath.endsWith('.zip')) {
+    await extractZip(archivePath, { dir: destination });
+    return;
+  }
+  if (archivePath.endsWith('.tar.gz')) {
+    await tar.x({ file: archivePath, cwd: destination });
+    return;
+  }
+  throw new Error(`Unsupported memory runtime archive: ${archivePath}`);
+}
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const targetId = process.argv[2]?.trim() || resolveHostTargetId();
+  const config = readRuntimeConfig(rootDir);
+  const assetName = config.runtimeAssets?.[targetId];
+  const checksum = config.runtimeChecksums?.[targetId];
+  if (!assetName || !checksum) throw new Error(`Unsupported memory runtime target: ${targetId}`);
+
+  const executableName = targetId.startsWith('win-') ? 'engram.exe' : 'engram';
+  const runtimeRoot = path.join(rootDir, 'vendor', 'engram-runtime');
+  const targetDirectory = path.join(runtimeRoot, targetId);
+  const targetExecutable = path.join(targetDirectory, executableName);
+  if (!fs.existsSync(targetExecutable)) {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-memory-runtime-'));
+    try {
+      const archivePath = path.join(temporaryDirectory, assetName);
+      const extractDirectory = path.join(temporaryDirectory, 'extract');
+      const url = `https://github.com/${config.repo}/releases/download/${config.version}/${assetName}`;
+      console.log(`[MemoryRuntime] Downloading ${assetName}.`);
+      await download(url, archivePath);
+      const actualChecksum = sha256(archivePath);
+      if (actualChecksum !== checksum) {
+        throw new Error(`Memory runtime checksum mismatch for ${assetName}.`);
+      }
+      fs.mkdirSync(extractDirectory, { recursive: true });
+      await extract(archivePath, extractDirectory);
+      const sourceExecutable = findExecutable(extractDirectory, executableName);
+      if (!sourceExecutable) throw new Error(`Archive does not contain ${executableName}.`);
+      fs.mkdirSync(targetDirectory, { recursive: true });
+      fs.copyFileSync(sourceExecutable, targetExecutable);
+      if (process.platform !== 'win32') fs.chmodSync(targetExecutable, 0o755);
+      fs.copyFileSync(
+        path.join(rootDir, 'third_party', 'engram.LICENSE'),
+        path.join(targetDirectory, 'LICENSE'),
+      );
+      fs.writeFileSync(
+        path.join(targetDirectory, 'runtime-build-info.json'),
+        `${JSON.stringify({ target: targetId, version: config.version, assetName, checksum }, null, 2)}\n`,
+      );
+    } finally {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  }
+
+  const currentDirectory = path.join(runtimeRoot, 'current');
+  fs.rmSync(currentDirectory, { recursive: true, force: true });
+  fs.cpSync(targetDirectory, currentDirectory, { recursive: true });
+  console.log(`[MemoryRuntime] Runtime ready for ${targetId}.`);
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(`[MemoryRuntime] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { resolveHostTargetId, readRuntimeConfig, sha256 };

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -78,8 +78,12 @@ import { ProviderName } from '../shared/providers';
 import { WorkspaceIpc, WorkspaceStoreKey } from '../shared/workspace';
 import type { WorkbenchRun, WorkbenchTask } from '../shared/workbenchTask';
 import { AgentManager } from './agentManager';
+import { EngramManager } from './memory/engramManager';
 import { searchAnySearchGateway } from './libs/anysearchGateway';
-import { resolveAnySearchGatewayToken, resolveAnySearchGatewayUrl } from './libs/anysearchGatewayCredentials';
+import {
+  resolveAnySearchGatewayToken,
+  resolveAnySearchGatewayUrl,
+} from './libs/anysearchGatewayCredentials';
 import { APP_DATA_DIR_NAME, APP_NAME, DB_FILENAME } from './appConstants';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
 import { getChangedSessionPermissionModes } from './coworkPermissionModeChanges';
@@ -744,8 +748,7 @@ const isMac = process.platform === 'darwin';
 const isWindows = process.platform === 'win32';
 // The packaged Ubuntu smoke test needs an actual painted window. Production
 // startup stays hidden until ready-to-show to avoid a flash of empty content.
-const isLinuxRendererSmoke =
-  isLinux && process.argv.includes('--zhiyuan-linux-renderer-smoke');
+const isLinuxRendererSmoke = isLinux && process.argv.includes('--zhiyuan-linux-renderer-smoke');
 const DEV_SERVER_URL = process.env.ELECTRON_START_URL || 'http://localhost:5175';
 const enableVerboseLogging =
   process.env.ELECTRON_ENABLE_LOGGING === '1' || process.env.ELECTRON_ENABLE_LOGGING === 'true';
@@ -969,12 +972,24 @@ let coworkStore: CoworkStore | null = null;
 let openClawChannelGateway: OpenClawChannelGateway | null = null;
 let piRuntimeAdapter: PiRuntimeAdapter | null = null;
 let workbenchTaskService: WorkbenchTaskService | null = null;
+let engramManager: EngramManager | null = null;
 
 const getWorkbenchTaskService = (): WorkbenchTaskService => {
   if (!workbenchTaskService) {
     workbenchTaskService = new WorkbenchTaskService(getStore().getDatabase());
   }
   return workbenchTaskService;
+};
+
+const getEngramManager = (): EngramManager => {
+  if (!engramManager) {
+    engramManager = new EngramManager({
+      userDataPath: app.getPath('userData'),
+      resourcesPath: process.resourcesPath,
+      projectRoot: app.isPackaged ? undefined : process.cwd(),
+    });
+  }
+  return engramManager;
 };
 
 const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
@@ -1111,14 +1126,18 @@ let appUpdatePollTimer: NodeJS.Timeout | null = null;
 let lastSuccessfulAppUpdateCheckAt = 0;
 
 const checkForAppUpdate = (): void => {
-  void getAppUpdateCoordinator().checkNow().then(result => {
-    if (result.success) lastSuccessfulAppUpdateCheckAt = Date.now();
-  });
+  void getAppUpdateCoordinator()
+    .checkNow()
+    .then(result => {
+      if (result.success) lastSuccessfulAppUpdateCheckAt = Date.now();
+    });
 };
 
 const startAppUpdatePolling = (): void => {
   if (appUpdatePollTimer) return;
-  const startupDelay = APP_UPDATE_STARTUP_DELAY_MIN_MS + Math.floor(Math.random() * APP_UPDATE_STARTUP_DELAY_JITTER_MS);
+  const startupDelay =
+    APP_UPDATE_STARTUP_DELAY_MIN_MS +
+    Math.floor(Math.random() * APP_UPDATE_STARTUP_DELAY_JITTER_MS);
   setTimeout(checkForAppUpdate, startupDelay);
   appUpdatePollTimer = setInterval(checkForAppUpdate, APP_UPDATE_POLL_INTERVAL_MS);
 };
@@ -2121,7 +2140,9 @@ const removeFeishuSkills = (): void => {
   console.log('[Feishu] official CLI skills removed from the Agent');
 };
 
-const refreshMcpOAuthHeaders = async <T extends { id: string; registryId?: string; url?: string; headers?: Record<string, string> }>(
+const refreshMcpOAuthHeaders = async <
+  T extends { id: string; registryId?: string; url?: string; headers?: Record<string, string> },
+>(
   servers: T[],
 ): Promise<T[]> => {
   const oauthManager = new McpOAuthManager(getStore());
@@ -2657,9 +2678,7 @@ const getAppIconPath = (): string | undefined => {
   }
 
   const developmentIconPath =
-    process.platform === 'win32'
-      ? path.join('win', 'icon.ico')
-      : path.join('png', '256x256.png');
+    process.platform === 'win32' ? path.join('win', 'icon.ico') : path.join('png', '256x256.png');
   return path.join(__dirname, '..', 'build', 'icons', developmentIconPath);
 };
 
@@ -3466,17 +3485,20 @@ if (!gotTheLock) {
     }
   });
 
-  ipcMain.handle(SkillsIpc.SetEnabledBatch, (_event, options: { ids: string[]; enabled: boolean }) => {
-    try {
-      const skills = getSkillManager().setSkillsEnabled(options.ids, options.enabled);
-      return { success: true, skills };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to update skills',
-      };
-    }
-  });
+  ipcMain.handle(
+    SkillsIpc.SetEnabledBatch,
+    (_event, options: { ids: string[]; enabled: boolean }) => {
+      try {
+        const skills = getSkillManager().setSkillsEnabled(options.ids, options.enabled);
+        return { success: true, skills };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to update skills',
+        };
+      }
+    },
+  );
 
   ipcMain.handle(SkillsIpc.SetPinned, (_event, options: { id: string; pinned: boolean }) => {
     try {
@@ -3921,7 +3943,9 @@ if (!gotTheLock) {
   ipcMain.handle(McpIpc.LoadIcon, async (_event, iconPath: string) => {
     try {
       const marketplace = loadBundledMcpMarketplace(app.getAppPath(), process.resourcesPath);
-      if (!marketplace.servers.some(server => (server as { iconPath?: string }).iconPath === iconPath)) {
+      if (
+        !marketplace.servers.some(server => (server as { iconPath?: string }).iconPath === iconPath)
+      ) {
         return { success: false, error: 'MCP icon is not registered' };
       }
       const roots = [
@@ -3942,11 +3966,17 @@ if (!gotTheLock) {
                 ? 'image/svg+xml'
                 : null;
         if (!mimeType) return { success: false, error: 'Unsupported MCP icon format' };
-        return { success: true, data: `data:${mimeType};base64,${fs.readFileSync(filePath).toString('base64')}` };
+        return {
+          success: true,
+          data: `data:${mimeType};base64,${fs.readFileSync(filePath).toString('base64')}`,
+        };
       }
       return { success: false, error: 'MCP icon was not found' };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Failed to load MCP icon' };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to load MCP icon',
+      };
     }
   });
 
@@ -3965,7 +3995,10 @@ if (!gotTheLock) {
       await prepareFeishuCli();
       return { success: true };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Failed to install Feishu CLI' };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to install Feishu CLI',
+      };
     }
   });
 
@@ -3980,60 +4013,67 @@ if (!gotTheLock) {
       const ensureNotCancelled = () => {
         if (cancellation?.signal.aborted) throw new Error('MCP authorization was cancelled');
       };
-    try {
-      ensureNotCancelled();
-      if (data.registryId === FEISHU_MCP_REGISTRY_ID) {
-        await authorizeFeishuCli(cancellation?.signal);
+      try {
         ensureNotCancelled();
-        installFeishuSkills();
-        ensureNotCancelled();
-        const existingFeishu = getMcpStore()
-          .listServers()
-          .find(server => server.registryId === FEISHU_MCP_REGISTRY_ID);
-        if (!existingFeishu) {
-          getMcpStore().createServer({
-            name: data.name,
-            description: data.description,
-            transportType: 'stdio',
-            command: 'lark-cli',
-            isBuiltIn: true,
-            registryId: FEISHU_MCP_REGISTRY_ID,
-          });
+        if (data.registryId === FEISHU_MCP_REGISTRY_ID) {
+          await authorizeFeishuCli(cancellation?.signal);
+          ensureNotCancelled();
+          installFeishuSkills();
+          ensureNotCancelled();
+          const existingFeishu = getMcpStore()
+            .listServers()
+            .find(server => server.registryId === FEISHU_MCP_REGISTRY_ID);
+          if (!existingFeishu) {
+            getMcpStore().createServer({
+              name: data.name,
+              description: data.description,
+              transportType: 'stdio',
+              command: 'lark-cli',
+              isBuiltIn: true,
+              registryId: FEISHU_MCP_REGISTRY_ID,
+            });
+          }
+          const servers = getMcpStore().listServers();
+          const refreshResult = await refreshMcpBridge();
+          if (refreshResult.error) {
+            console.error('[McpBridge] Feishu refresh error:', refreshResult.error);
+          }
+          return { success: true, servers, refreshError: refreshResult.error };
         }
+        const validationError = await validateMcpServerConfig(data);
+        if (validationError) return { success: false, error: validationError };
+        if (!data.registryId || !data.url)
+          return { success: false, error: 'Official MCP configuration is incomplete' };
+
+        const accessToken = await new McpOAuthManager(getStore()).authorize(
+          data.registryId,
+          data.url,
+          cancellation?.signal,
+        );
+        ensureNotCancelled();
+        if (!accessToken)
+          return { success: false, error: 'OAuth authorization did not return an access token' };
+
+        const createdServer = getMcpStore().createServer({
+          ...data,
+          isBuiltIn: true,
+          headers: { ...data.headers, Authorization: `Bearer ${accessToken}` },
+        });
+        getMcpStore().setEnabled(createdServer.id, true);
         const servers = getMcpStore().listServers();
-        const refreshResult = await refreshMcpBridge();
-        if (refreshResult.error) {
-          console.error('[McpBridge] Feishu refresh error:', refreshResult.error);
-        }
-        return { success: true, servers, refreshError: refreshResult.error };
+        refreshMcpBridge().catch(err =>
+          console.error('[McpBridge] background refresh error:', err),
+        );
+        return { success: true, servers };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to authorize MCP server',
+        };
+      } finally {
+        if (authorizationRequestId) activeMcpAuthorizations.delete(authorizationRequestId);
       }
-      const validationError = await validateMcpServerConfig(data);
-      if (validationError) return { success: false, error: validationError };
-      if (!data.registryId || !data.url) return { success: false, error: 'Official MCP configuration is incomplete' };
-
-      const accessToken = await new McpOAuthManager(getStore()).authorize(
-        data.registryId,
-        data.url,
-        cancellation?.signal,
-      );
-      ensureNotCancelled();
-      if (!accessToken) return { success: false, error: 'OAuth authorization did not return an access token' };
-
-      const createdServer = getMcpStore().createServer({
-        ...data,
-        isBuiltIn: true,
-        headers: { ...data.headers, Authorization: `Bearer ${accessToken}` },
-      });
-      getMcpStore().setEnabled(createdServer.id, true);
-      const servers = getMcpStore().listServers();
-      refreshMcpBridge().catch(err => console.error('[McpBridge] background refresh error:', err));
-      return { success: true, servers };
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : 'Failed to authorize MCP server' };
-    } finally {
-      if (authorizationRequestId) activeMcpAuthorizations.delete(authorizationRequestId);
-    }
-  },
+    },
   );
 
   // Explicit bridge refresh — renderer can await this for loading state
@@ -4105,7 +4145,12 @@ if (!gotTheLock) {
   ipcMain.handle(WorkspaceIpc.Rename, async (_event, id: string, name: string) => {
     try {
       const normalizedName = name.trim();
-      if (!normalizedName || /[\\/:*?"<>|]/.test(normalizedName) || normalizedName === '.' || normalizedName === '..') {
+      if (
+        !normalizedName ||
+        /[\\/:*?"<>|]/.test(normalizedName) ||
+        normalizedName === '.' ||
+        normalizedName === '..'
+      ) {
         return { success: false, error: 'Invalid project name' };
       }
 
@@ -4154,7 +4199,9 @@ if (!gotTheLock) {
       const workspace = coworkStore.getWorkspace(id);
       if (!workspace) return { success: false, error: 'Workspace not found' };
       const deletedSessionIds = coworkStore.deleteWorkspace(id);
-      console.log(`[CoworkStore] removed a workspace along with ${deletedSessionIds.length} session(s)`);
+      console.log(
+        `[CoworkStore] removed a workspace along with ${deletedSessionIds.length} session(s)`,
+      );
       return { success: true, deletedSessionIds };
     } catch (error) {
       return {
@@ -4187,7 +4234,9 @@ if (!gotTheLock) {
   };
   const isUnmanagedWorkspacePath = (candidatePath: string): boolean => {
     const relativePath = path.relative(getUnmanagedWorkspaceBaseDir(), candidatePath);
-    return Boolean(relativePath) && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+    return (
+      Boolean(relativePath) && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+    );
   };
   const isInternalWorkspacePath = (candidatePath: string): boolean =>
     isLegacyUnmanagedWorkspacePath(candidatePath) || isUnmanagedWorkspacePath(candidatePath);
@@ -4249,10 +4298,7 @@ if (!gotTheLock) {
 
   ipcMain.handle(ProjectIpc.CreateRandomWorkspace, async () => {
     try {
-      const randomWorkspacePath = path.join(
-        getUnmanagedWorkspaceBaseDir(),
-        crypto.randomUUID(),
-      );
+      const randomWorkspacePath = path.join(getUnmanagedWorkspaceBaseDir(), crypto.randomUUID());
       await fs.promises.mkdir(randomWorkspacePath, { recursive: true });
       return { success: true, path: randomWorkspacePath };
     } catch (error) {
@@ -4893,16 +4939,18 @@ if (!gotTheLock) {
         const workspaceId = options?.workspaceId;
         const mode = options?.mode;
         const store = getCoworkStore();
-        const sessions = store.listSessions(limit, offset, agentId, workspaceId, mode).map(session => {
-          const reconciledSession = reconcileWorkSessionRuntimeState(
-            session,
-            getPiRuntimeAdapter().isSessionRunning(session.id),
-          );
-          if (reconciledSession.status !== session.status) {
-            store.updateSession(session.id, { status: reconciledSession.status });
-          }
-          return reconciledSession;
-        });
+        const sessions = store
+          .listSessions(limit, offset, agentId, workspaceId, mode)
+          .map(session => {
+            const reconciledSession = reconcileWorkSessionRuntimeState(
+              session,
+              getPiRuntimeAdapter().isSessionRunning(session.id),
+            );
+            if (reconciledSession.status !== session.status) {
+              store.updateSession(session.id, { status: reconciledSession.status });
+            }
+            return reconciledSession;
+          });
         const total = store.countSessions(agentId, workspaceId, mode);
         return { success: true, sessions, hasMore: offset + sessions.length < total };
       } catch (error) {
@@ -7647,6 +7695,12 @@ if (!gotTheLock) {
       });
     }
 
+    if (engramManager) {
+      await engramManager.stop().catch(error => {
+        console.error('[MemoryRuntime] Failed to stop local memory service:', error);
+      });
+    }
+
     // Stop the cron job polling
     try {
       getCronJobService().stopPolling();
@@ -7716,6 +7770,10 @@ if (!gotTheLock) {
     await app.whenReady();
     profiler.measure('app.whenReady');
     console.log('[Main] initApp: app is ready');
+
+    void getEngramManager()
+      .start()
+      .catch(error => console.warn('[MemoryRuntime] Failed to start local memory service:', error));
 
     // Note: Calendar permission is checked on-demand when calendar operations are requested
     // We don't trigger permission dialogs at startup to avoid annoying users

--- a/src/main/memory/authenticatedProxy.test.ts
+++ b/src/main/memory/authenticatedProxy.test.ts
@@ -1,0 +1,56 @@
+import http from 'http';
+import { afterEach, expect, test } from 'vitest';
+
+import { createAuthenticatedEngramProxy, isAllowedEngramRequest } from './authenticatedProxy';
+
+const closeCallbacks: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(closeCallbacks.splice(0).map(close => close()));
+});
+
+test('requires the launch token before forwarding an allowed request', async () => {
+  const backend = http.createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ status: 'ok' }));
+  });
+  await new Promise<void>(resolve => backend.listen(0, '127.0.0.1', resolve));
+  closeCallbacks.push(() => new Promise(resolve => backend.close(() => resolve())));
+  const address = backend.address();
+  if (!address || typeof address === 'string') throw new Error('Backend did not bind.');
+  const proxy = await createAuthenticatedEngramProxy({
+    backendPort: address.port,
+    token: 'secret',
+  });
+  closeCallbacks.push(proxy.close);
+
+  const unauthorized = await fetch(`${proxy.url}/health`);
+  const authorized = await fetch(`${proxy.url}/health`, {
+    headers: { Authorization: 'Bearer secret' },
+  });
+
+  expect(unauthorized.status).toBe(401);
+  expect(authorized.status).toBe(200);
+  await expect(authorized.json()).resolves.toEqual({ status: 'ok' });
+});
+
+test('blocks routes outside the product memory capability boundary', async () => {
+  const backend = http.createServer((_request, response) => response.end('unexpected'));
+  await new Promise<void>(resolve => backend.listen(0, '127.0.0.1', resolve));
+  closeCallbacks.push(() => new Promise(resolve => backend.close(() => resolve())));
+  const address = backend.address();
+  if (!address || typeof address === 'string') throw new Error('Backend did not bind.');
+  const proxy = await createAuthenticatedEngramProxy({
+    backendPort: address.port,
+    token: 'secret',
+  });
+  closeCallbacks.push(proxy.close);
+
+  const response = await fetch(`${proxy.url}/export`, {
+    headers: { Authorization: 'Bearer secret' },
+  });
+
+  expect(response.status).toBe(404);
+  expect(isAllowedEngramRequest('GET', '/search')).toBe(true);
+  expect(isAllowedEngramRequest('POST', '/conflicts/judge')).toBe(false);
+});

--- a/src/main/memory/authenticatedProxy.ts
+++ b/src/main/memory/authenticatedProxy.ts
@@ -1,0 +1,108 @@
+import { timingSafeEqual } from 'crypto';
+import http from 'http';
+
+import { ENGRAM_LOOPBACK_HOST } from './constants';
+
+const MAX_REQUEST_BYTES = 2 * 1024 * 1024;
+
+export interface AuthenticatedEngramProxy {
+  url: string;
+  close: () => Promise<void>;
+}
+
+export interface CreateAuthenticatedEngramProxyOptions {
+  backendPort: number;
+  token: string;
+}
+
+function tokensMatch(expected: string, actual: string): boolean {
+  const expectedBytes = Buffer.from(expected);
+  const actualBytes = Buffer.from(actual);
+  return expectedBytes.length === actualBytes.length && timingSafeEqual(expectedBytes, actualBytes);
+}
+
+export function isAllowedEngramRequest(method = '', pathname = ''): boolean {
+  if (method === 'GET' && pathname === '/health') return true;
+  if (method === 'GET' && pathname === '/search') return true;
+  if (method === 'POST' && pathname === '/sessions') return true;
+  if (method === 'POST' && /^\/sessions\/[^/]+\/end$/.test(pathname)) return true;
+  if (method === 'POST' && pathname === '/observations') return true;
+  if (method === 'PATCH' && /^\/observations\/\d+$/.test(pathname)) return true;
+  if (method === 'DELETE' && /^\/observations\/\d+$/.test(pathname)) return true;
+  return false;
+}
+
+export async function createAuthenticatedEngramProxy(
+  options: CreateAuthenticatedEngramProxyOptions,
+): Promise<AuthenticatedEngramProxy> {
+  const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? '/', `http://${ENGRAM_LOOPBACK_HOST}`);
+    const authorization = request.headers.authorization ?? '';
+    const providedToken = authorization.startsWith('Bearer ')
+      ? authorization.slice('Bearer '.length)
+      : '';
+
+    if (!providedToken || !tokensMatch(options.token, providedToken)) {
+      response.writeHead(401, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'authorization required' }));
+      return;
+    }
+    if (!isAllowedEngramRequest(request.method, requestUrl.pathname)) {
+      response.writeHead(404, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'unsupported memory operation' }));
+      return;
+    }
+
+    const declaredLength = Number(request.headers['content-length'] ?? 0);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_REQUEST_BYTES) {
+      response.writeHead(413, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'request body too large' }));
+      return;
+    }
+
+    const upstreamHeaders = { ...request.headers };
+    upstreamHeaders.host = `${ENGRAM_LOOPBACK_HOST}:${options.backendPort}`;
+    upstreamHeaders.authorization = `Bearer ${options.token}`;
+    const upstream = http.request(
+      {
+        host: ENGRAM_LOOPBACK_HOST,
+        port: options.backendPort,
+        method: request.method,
+        path: `${requestUrl.pathname}${requestUrl.search}`,
+        headers: upstreamHeaders,
+      },
+      upstreamResponse => {
+        response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+        upstreamResponse.pipe(response);
+      },
+    );
+    upstream.once('error', () => {
+      if (response.headersSent) {
+        response.destroy();
+        return;
+      }
+      response.writeHead(503, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'memory service unavailable' }));
+    });
+    request.pipe(upstream);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, ENGRAM_LOOPBACK_HOST, () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Memory proxy did not bind to a TCP port.');
+  }
+
+  return {
+    url: `http://${ENGRAM_LOOPBACK_HOST}:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      }),
+  };
+}

--- a/src/main/memory/binaryResolver.test.ts
+++ b/src/main/memory/binaryResolver.test.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import { expect, test } from 'vitest';
+
+import { EngramEnvironment } from './constants';
+import { resolveEngramBinary } from './binaryResolver';
+
+test('explicit runtime path takes precedence over packaged and development paths', () => {
+  const explicit = path.resolve('custom', 'engram.exe');
+  const resolved = resolveEngramBinary({
+    env: { [EngramEnvironment.BinaryPath]: explicit },
+    platform: 'win32',
+    resourcesPath: path.resolve('resources'),
+    projectRoot: path.resolve('project'),
+    fileExists: () => true,
+  });
+
+  expect(resolved).toBe(explicit);
+});
+
+test('returns null when no managed runtime exists', () => {
+  expect(
+    resolveEngramBinary({
+      env: {},
+      platform: 'linux',
+      resourcesPath: '/app/resources',
+      projectRoot: '/workspace',
+      fileExists: () => false,
+    }),
+  ).toBeNull();
+});

--- a/src/main/memory/binaryResolver.ts
+++ b/src/main/memory/binaryResolver.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  ENGRAM_PACKAGED_DIRECTORY,
+  ENGRAM_RUNTIME_DIRECTORY,
+  EngramEnvironment,
+} from './constants';
+
+export interface ResolveEngramBinaryOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  resourcesPath?: string;
+  projectRoot?: string;
+  fileExists?: (candidate: string) => boolean;
+}
+
+export function resolveEngramBinary(options: ResolveEngramBinaryOptions = {}): string | null {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const executableName = platform === 'win32' ? 'engram.exe' : 'engram';
+  const fileExists = options.fileExists ?? fs.existsSync;
+  const explicitPath = env[EngramEnvironment.BinaryPath]?.trim();
+  const candidates = [
+    explicitPath,
+    options.resourcesPath
+      ? path.join(options.resourcesPath, ENGRAM_PACKAGED_DIRECTORY, executableName)
+      : undefined,
+    options.projectRoot
+      ? path.join(
+          options.projectRoot,
+          'vendor',
+          ENGRAM_RUNTIME_DIRECTORY,
+          'current',
+          executableName,
+        )
+      : undefined,
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  return candidates.find(fileExists) ?? null;
+}

--- a/src/main/memory/constants.ts
+++ b/src/main/memory/constants.ts
@@ -1,0 +1,51 @@
+export const EngramManagerPhase = {
+  Stopped: 'stopped',
+  Starting: 'starting',
+  Running: 'running',
+  Degraded: 'degraded',
+  Stopping: 'stopping',
+} as const;
+
+export type EngramManagerPhase = (typeof EngramManagerPhase)[keyof typeof EngramManagerPhase];
+
+export const EngramMemoryScope = {
+  Project: 'project',
+  Personal: 'personal',
+  Session: 'session',
+} as const;
+
+export type EngramMemoryScope = (typeof EngramMemoryScope)[keyof typeof EngramMemoryScope];
+
+export const EngramMemoryCapability = {
+  Recall: 'recall',
+  SaveCandidate: 'saveCandidate',
+  ConfirmMemory: 'confirmMemory',
+  Supersede: 'supersede',
+  Forget: 'forget',
+  SessionSummary: 'sessionSummary',
+} as const;
+
+export type EngramMemoryCapability =
+  (typeof EngramMemoryCapability)[keyof typeof EngramMemoryCapability];
+
+export const EngramObservationType = {
+  Decision: 'decision',
+  Preference: 'preference',
+  SessionSummary: 'session_summary',
+} as const;
+
+export type EngramObservationType =
+  (typeof EngramObservationType)[keyof typeof EngramObservationType];
+
+export const EngramEnvironment = {
+  BinaryPath: 'ZHIYUAN_ENGRAM_BIN',
+  DataDirectory: 'ENGRAM_DATA_DIR',
+  Port: 'ENGRAM_PORT',
+  HttpToken: 'ENGRAM_HTTP_TOKEN',
+  CloudAutosync: 'ENGRAM_CLOUD_AUTOSYNC',
+} as const;
+
+export const ENGRAM_RUNTIME_DIRECTORY = 'engram-runtime';
+export const ENGRAM_PACKAGED_DIRECTORY = 'memory';
+export const ENGRAM_DATA_DIRECTORY_SEGMENTS = ['memory', 'engram'] as const;
+export const ENGRAM_LOOPBACK_HOST = '127.0.0.1';

--- a/src/main/memory/engramManager.test.ts
+++ b/src/main/memory/engramManager.test.ts
@@ -1,0 +1,102 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { EngramEnvironment, EngramManagerPhase } from './constants';
+import { EngramManager } from './engramManager';
+
+class FakeProcess extends EventEmitter {
+  pid = 42;
+  kill = vi.fn(() => true);
+}
+
+const temporaryDirectories: string[] = [];
+
+function createUserDataDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-memory-manager-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('starts the supervised runtime with private storage and launch credentials', async () => {
+  const child = new FakeProcess();
+  const spawnProcess = vi.fn(() => child);
+  const close = vi.fn(async () => undefined);
+  const manager = new EngramManager({
+    userDataPath: createUserDataDirectory(),
+    env: {},
+    fileExists: () => true,
+    projectRoot: path.resolve('project'),
+    reservePort: async () => 43123,
+    createProxy: async ({ token }) => ({ url: 'http://127.0.0.1:43124', close, token }),
+    spawnProcess,
+    checkHealth: async () => true,
+  });
+
+  const connection = await manager.start();
+  const [, childEnvironment] = spawnProcess.mock.calls[0];
+
+  expect(connection?.url).toBe('http://127.0.0.1:43124');
+  expect(connection?.token).toHaveLength(64);
+  expect(
+    childEnvironment[EngramEnvironment.DataDirectory]?.endsWith(path.join('memory', 'engram')),
+  ).toBe(true);
+  expect(childEnvironment[EngramEnvironment.Port]).toBe('43123');
+  expect(childEnvironment[EngramEnvironment.HttpToken]).toBe(connection?.token);
+  expect(manager.getStatus()).toMatchObject({
+    phase: EngramManagerPhase.Running,
+    available: true,
+  });
+
+  await manager.stop();
+  expect(close).toHaveBeenCalledOnce();
+  expect(child.kill).toHaveBeenCalledOnce();
+});
+
+test('degrades without preventing the app from running when the binary is missing', async () => {
+  const manager = new EngramManager({
+    userDataPath: createUserDataDirectory(),
+    env: {},
+    fileExists: () => false,
+  });
+
+  await expect(manager.start()).resolves.toBeNull();
+  expect(manager.getStatus()).toMatchObject({
+    phase: EngramManagerPhase.Degraded,
+    available: false,
+  });
+});
+
+test('restarts after an unexpected process exit', async () => {
+  vi.useFakeTimers();
+  const children = [new FakeProcess(), new FakeProcess()];
+  const spawnProcess = vi.fn(() => children.shift() ?? new FakeProcess());
+  const manager = new EngramManager({
+    userDataPath: createUserDataDirectory(),
+    env: {},
+    fileExists: () => true,
+    projectRoot: path.resolve('project'),
+    reservePort: async () => 43123,
+    createProxy: async () => ({ url: 'http://127.0.0.1:43124', close: async () => undefined }),
+    spawnProcess,
+    checkHealth: async () => true,
+    restartDelaysMs: [1],
+  });
+  await manager.start();
+
+  (spawnProcess.mock.results[0].value as FakeProcess).emit('exit', 1);
+  await vi.advanceTimersByTimeAsync(1);
+
+  expect(spawnProcess).toHaveBeenCalledTimes(2);
+  expect(manager.getStatus().phase).toBe(EngramManagerPhase.Running);
+  await manager.stop();
+});

--- a/src/main/memory/engramManager.ts
+++ b/src/main/memory/engramManager.ts
@@ -1,0 +1,259 @@
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
+import { randomBytes } from 'crypto';
+import fs from 'fs';
+import net from 'net';
+import path from 'path';
+
+import {
+  ENGRAM_DATA_DIRECTORY_SEGMENTS,
+  ENGRAM_LOOPBACK_HOST,
+  EngramEnvironment,
+  EngramManagerPhase,
+} from './constants';
+import {
+  createAuthenticatedEngramProxy,
+  type AuthenticatedEngramProxy,
+} from './authenticatedProxy';
+import { resolveEngramBinary } from './binaryResolver';
+import type { EngramConnection, EngramManagerStatus } from './types';
+
+const START_TIMEOUT_MS = 10_000;
+const HEALTH_POLL_MS = 100;
+const MAX_RESTART_ATTEMPTS = 3;
+const RESTART_DELAYS_MS = [500, 1_000, 2_000] as const;
+
+interface EngramProcess extends Pick<ChildProcess, 'once' | 'kill' | 'pid'> {}
+
+export interface EngramManagerOptions {
+  userDataPath: string;
+  resourcesPath?: string;
+  projectRoot?: string;
+  env?: NodeJS.ProcessEnv;
+  fileExists?: (candidate: string) => boolean;
+  spawnProcess?: (binaryPath: string, env: NodeJS.ProcessEnv) => EngramProcess;
+  reservePort?: () => Promise<number>;
+  createProxy?: typeof createAuthenticatedEngramProxy;
+  checkHealth?: (connection: EngramConnection) => Promise<boolean>;
+  restartDelaysMs?: readonly number[];
+}
+
+export class EngramManager {
+  private status: EngramManagerStatus = {
+    phase: EngramManagerPhase.Stopped,
+    available: false,
+    restartAttempts: 0,
+  };
+  private connection: EngramConnection | null = null;
+  private child: EngramProcess | null = null;
+  private proxy: AuthenticatedEngramProxy | null = null;
+  private startPromise: Promise<EngramConnection | null> | null = null;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private shouldRun = false;
+  private generation = 0;
+
+  constructor(private readonly options: EngramManagerOptions) {}
+
+  getStatus(): EngramManagerStatus {
+    return { ...this.status };
+  }
+
+  getConnection(): EngramConnection | null {
+    return this.connection ? { ...this.connection } : null;
+  }
+
+  start(): Promise<EngramConnection | null> {
+    this.shouldRun = true;
+    if (this.connection) return Promise.resolve({ ...this.connection });
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.startInternal()
+      .catch(async (error: unknown): Promise<null> => {
+        await this.disposeCurrentInstance();
+        this.status = {
+          phase: EngramManagerPhase.Degraded,
+          available: false,
+          restartAttempts: this.status.restartAttempts,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        console.warn('[MemoryRuntime] Failed to start local memory service:', error);
+        this.scheduleRestart();
+        return null;
+      })
+      .finally(() => {
+        this.startPromise = null;
+      });
+    return this.startPromise;
+  }
+
+  async stop(): Promise<void> {
+    this.shouldRun = false;
+    this.generation += 1;
+    this.status = { ...this.status, phase: EngramManagerPhase.Stopping, available: false };
+    if (this.restartTimer) clearTimeout(this.restartTimer);
+    this.restartTimer = null;
+    const proxy = this.proxy;
+    const child = this.child;
+    this.proxy = null;
+    this.child = null;
+    this.connection = null;
+    if (proxy) await proxy.close().catch((): undefined => undefined);
+    child?.kill();
+    this.status = {
+      phase: EngramManagerPhase.Stopped,
+      available: false,
+      restartAttempts: 0,
+    };
+  }
+
+  private async startInternal(): Promise<EngramConnection | null> {
+    const binaryPath = resolveEngramBinary({
+      env: this.options.env,
+      resourcesPath: this.options.resourcesPath,
+      projectRoot: this.options.projectRoot,
+      fileExists: this.options.fileExists,
+    });
+    if (!binaryPath) {
+      this.status = {
+        phase: EngramManagerPhase.Degraded,
+        available: false,
+        restartAttempts: this.status.restartAttempts,
+        error: 'Bundled memory runtime is unavailable.',
+      };
+      console.warn('[MemoryRuntime] Bundled runtime is unavailable; continuing without memory.');
+      return null;
+    }
+
+    this.status = { ...this.status, phase: EngramManagerPhase.Starting, available: false };
+    const generation = ++this.generation;
+    const token = randomBytes(32).toString('hex');
+    const backendPort = await (this.options.reservePort ?? reserveLoopbackPort)();
+    const proxy = await (this.options.createProxy ?? createAuthenticatedEngramProxy)({
+      backendPort,
+      token,
+    });
+    const dataDirectory = path.join(this.options.userDataPath, ...ENGRAM_DATA_DIRECTORY_SEGMENTS);
+    fs.mkdirSync(dataDirectory, { recursive: true });
+    const childEnvironment: NodeJS.ProcessEnv = {
+      ...(this.options.env ?? process.env),
+      [EngramEnvironment.DataDirectory]: dataDirectory,
+      [EngramEnvironment.Port]: String(backendPort),
+      [EngramEnvironment.HttpToken]: token,
+      [EngramEnvironment.CloudAutosync]: '0',
+    };
+    this.proxy = proxy;
+    const child = (this.options.spawnProcess ?? spawnEngram)(binaryPath, childEnvironment);
+    this.child = child;
+    this.connection = { url: proxy.url, token };
+    child.once('exit', () => this.handleUnexpectedExit(generation));
+    child.once('error', error => this.handleUnexpectedExit(generation, error));
+
+    const healthy = await this.waitForHealth(this.connection);
+    if (!healthy || generation !== this.generation) {
+      await this.disposeCurrentInstance();
+      this.status = {
+        phase: EngramManagerPhase.Degraded,
+        available: false,
+        restartAttempts: this.status.restartAttempts,
+        error: 'Memory runtime failed its startup health check.',
+      };
+      this.scheduleRestart();
+      return null;
+    }
+
+    this.status = {
+      phase: EngramManagerPhase.Running,
+      available: true,
+      restartAttempts: 0,
+    };
+    console.log('[MemoryRuntime] Local memory service started.');
+    return { ...this.connection };
+  }
+
+  private async waitForHealth(connection: EngramConnection): Promise<boolean> {
+    const checkHealth = this.options.checkHealth ?? defaultHealthCheck;
+    const deadline = Date.now() + START_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      if (await checkHealth(connection).catch(() => false)) return true;
+      await new Promise(resolve => setTimeout(resolve, HEALTH_POLL_MS));
+    }
+    return false;
+  }
+
+  private handleUnexpectedExit(generation: number, error?: Error): void {
+    if (generation !== this.generation || !this.shouldRun) return;
+    this.generation += 1;
+    this.child = null;
+    this.connection = null;
+    const proxy = this.proxy;
+    this.proxy = null;
+    void proxy?.close().catch((): undefined => undefined);
+    this.status = {
+      phase: EngramManagerPhase.Degraded,
+      available: false,
+      restartAttempts: this.status.restartAttempts,
+      error: error?.message ?? 'Memory runtime exited unexpectedly.',
+    };
+    if (error) {
+      console.warn('[MemoryRuntime] Local memory service failed:', error);
+    } else {
+      console.warn('[MemoryRuntime] Local memory service exited unexpectedly.');
+    }
+    this.scheduleRestart();
+  }
+
+  private scheduleRestart(): void {
+    if (!this.shouldRun || this.restartTimer) return;
+    const delays = this.options.restartDelaysMs ?? RESTART_DELAYS_MS;
+    if (this.status.restartAttempts >= Math.min(MAX_RESTART_ATTEMPTS, delays.length)) return;
+    const attempt = this.status.restartAttempts + 1;
+    const delay = delays[attempt - 1] ?? delays[delays.length - 1] ?? 1_000;
+    this.status = { ...this.status, restartAttempts: attempt };
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      void this.start();
+    }, delay);
+  }
+
+  private async disposeCurrentInstance(): Promise<void> {
+    this.generation += 1;
+    const proxy = this.proxy;
+    const child = this.child;
+    this.proxy = null;
+    this.child = null;
+    this.connection = null;
+    if (proxy) await proxy.close().catch((): undefined => undefined);
+    child?.kill();
+  }
+}
+
+function spawnEngram(binaryPath: string, env: NodeJS.ProcessEnv): EngramProcess {
+  return spawn(binaryPath, ['serve'], {
+    env,
+    windowsHide: true,
+    stdio: 'ignore',
+  });
+}
+
+async function reserveLoopbackPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, ENGRAM_LOOPBACK_HOST, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to reserve a memory service port.'));
+        return;
+      }
+      server.close(error => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+}
+
+async function defaultHealthCheck(connection: EngramConnection): Promise<boolean> {
+  const response = await fetch(`${connection.url}/health`, {
+    headers: { Authorization: `Bearer ${connection.token}` },
+    signal: AbortSignal.timeout(500),
+  });
+  return response.ok;
+}

--- a/src/main/memory/types.ts
+++ b/src/main/memory/types.ts
@@ -1,0 +1,43 @@
+import type { EngramManagerPhase, EngramMemoryScope, EngramObservationType } from './constants';
+
+export interface EngramConnection {
+  url: string;
+  token: string;
+}
+
+export interface EngramManagerStatus {
+  phase: EngramManagerPhase;
+  available: boolean;
+  restartAttempts: number;
+  error?: string;
+}
+
+export interface EngramObservation {
+  id: number;
+  sync_id: string;
+  session_id: string;
+  type: string;
+  title: string;
+  content: string;
+  project?: string;
+  scope: string;
+  topic_key?: string;
+  revision_count: number;
+  duplicate_count: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string;
+  rank?: number;
+}
+
+export interface MemoryCandidate {
+  id: string;
+  sessionId: string;
+  project: string;
+  scope: EngramMemoryScope;
+  type: EngramObservationType;
+  title: string;
+  content: string;
+  topicKey?: string;
+  createdAt: string;
+}

--- a/src/main/memory/zhiyuanEngramAdapter.test.ts
+++ b/src/main/memory/zhiyuanEngramAdapter.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { EngramMemoryScope, EngramObservationType } from './constants';
+import { ZhiYuanEngramAdapter } from './zhiyuanEngramAdapter';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('keeps candidates local until they are explicitly confirmed', async () => {
+  const manager = {
+    getConnection: () => ({ url: 'http://127.0.0.1:4000', token: 'token' }),
+    start: vi.fn(),
+  };
+  const requests: Array<{ pathname: string; init?: RequestInit }> = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL, init?: RequestInit) => {
+      requests.push({ pathname: new URL(url).pathname, init });
+      const payload = new URL(url).pathname === '/observations' ? { id: 17 } : { id: 'session' };
+      return new Response(JSON.stringify(payload), {
+        status: new URL(url).pathname === '/observations' ? 201 : 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }),
+  );
+  const adapter = new ZhiYuanEngramAdapter(manager as never);
+
+  const candidate = adapter.saveCandidate({
+    sessionId: 'session-1',
+    project: 'project-a',
+    scope: EngramMemoryScope.Project,
+    type: EngramObservationType.Decision,
+    title: 'Use SQLite',
+    content: 'Keep local state in SQLite.',
+  });
+  expect(requests).toHaveLength(0);
+
+  await expect(adapter.confirmMemory(candidate.id, '/workspace/project-a')).resolves.toBe(17);
+  expect(requests.map(request => request.pathname)).toEqual(['/sessions', '/observations']);
+  expect(requests[1].init?.headers).toMatchObject({ Authorization: 'Bearer token' });
+});
+
+test('recall degrades to an empty result when the runtime is unavailable', async () => {
+  const adapter = new ZhiYuanEngramAdapter({
+    getConnection: () => null,
+    start: async () => null,
+  } as never);
+
+  await expect(adapter.recall({ query: 'decision', project: 'project-a' })).resolves.toEqual([]);
+});
+
+test('normalizes the runtime null search response after the last memory is forgotten', async () => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response('null', { status: 200, headers: { 'content-type': 'application/json' } }),
+    ),
+  );
+  const adapter = new ZhiYuanEngramAdapter({
+    getConnection: () => ({ url: 'http://127.0.0.1:4000', token: 'token' }),
+    start: vi.fn(),
+  } as never);
+
+  await expect(adapter.recall({ query: 'decision', project: 'project-a' })).resolves.toEqual([]);
+});

--- a/src/main/memory/zhiyuanEngramAdapter.ts
+++ b/src/main/memory/zhiyuanEngramAdapter.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'crypto';
+
+import {
+  EngramMemoryScope,
+  EngramObservationType,
+  type EngramMemoryScope as EngramMemoryScopeValue,
+  type EngramObservationType as EngramObservationTypeValue,
+} from './constants';
+import type { EngramManager } from './engramManager';
+import type { EngramConnection, EngramObservation, MemoryCandidate } from './types';
+
+interface CandidateInput {
+  sessionId: string;
+  project: string;
+  scope: EngramMemoryScopeValue;
+  type: EngramObservationTypeValue;
+  title: string;
+  content: string;
+  topicKey?: string;
+}
+
+export class ZhiYuanEngramAdapter {
+  private readonly candidates = new Map<string, MemoryCandidate>();
+  private readonly registeredSessions = new Set<string>();
+
+  constructor(private readonly manager: EngramManager) {}
+
+  async recall(input: {
+    query: string;
+    project: string;
+    scope?: EngramMemoryScopeValue;
+    limit?: number;
+  }): Promise<EngramObservation[]> {
+    const connection = await this.getConnection();
+    if (!connection) return [];
+    const params = new URLSearchParams({
+      q: input.query,
+      project: input.project,
+      scope: input.scope ?? EngramMemoryScope.Project,
+      limit: String(Math.min(Math.max(input.limit ?? 8, 1), 20)),
+    });
+    const observations = await this.request<EngramObservation[] | null>(
+      connection,
+      `/search?${params.toString()}`,
+    );
+    return Array.isArray(observations) ? observations : [];
+  }
+
+  saveCandidate(input: CandidateInput): MemoryCandidate {
+    const candidate: MemoryCandidate = {
+      id: randomUUID(),
+      ...input,
+      createdAt: new Date().toISOString(),
+    };
+    this.candidates.set(candidate.id, candidate);
+    return candidate;
+  }
+
+  async confirmMemory(candidateId: string, workingDirectory: string): Promise<number | null> {
+    const candidate = this.candidates.get(candidateId);
+    if (!candidate) throw new Error('Memory candidate not found.');
+    const connection = await this.getConnection();
+    if (!connection) return null;
+    await this.ensureSession(connection, candidate.sessionId, candidate.project, workingDirectory);
+    const saved = await this.request<{ id: number }>(connection, '/observations', {
+      method: 'POST',
+      body: JSON.stringify({
+        session_id: candidate.sessionId,
+        project: candidate.project,
+        scope: candidate.scope,
+        type: candidate.type,
+        title: candidate.title,
+        content: candidate.content,
+        topic_key: candidate.topicKey,
+      }),
+    });
+    this.candidates.delete(candidateId);
+    return saved.id;
+  }
+
+  async supersede(input: {
+    observationId: number;
+    replacementCandidateId: string;
+    workingDirectory: string;
+  }): Promise<number | null> {
+    const replacementId = await this.confirmMemory(
+      input.replacementCandidateId,
+      input.workingDirectory,
+    );
+    if (replacementId === null) return null;
+    await this.forget(input.observationId, false);
+    return replacementId;
+  }
+
+  async forget(observationId: number, hardDelete: boolean): Promise<boolean> {
+    const connection = await this.getConnection();
+    if (!connection) return false;
+    await this.request(connection, `/observations/${observationId}?hard=${hardDelete}`, {
+      method: 'DELETE',
+    });
+    return true;
+  }
+
+  async sessionSummary(input: {
+    sessionId: string;
+    project: string;
+    workingDirectory: string;
+    summary: string;
+  }): Promise<number | null> {
+    const candidate = this.saveCandidate({
+      sessionId: input.sessionId,
+      project: input.project,
+      scope: EngramMemoryScope.Session,
+      type: EngramObservationType.SessionSummary,
+      title: 'Session summary',
+      content: input.summary,
+      topicKey: `session/${input.sessionId}`,
+    });
+    return await this.confirmMemory(candidate.id, input.workingDirectory);
+  }
+
+  private async getConnection(): Promise<EngramConnection | null> {
+    return this.manager.getConnection() ?? (await this.manager.start());
+  }
+
+  private async ensureSession(
+    connection: EngramConnection,
+    sessionId: string,
+    project: string,
+    workingDirectory: string,
+  ): Promise<void> {
+    if (this.registeredSessions.has(sessionId)) return;
+    await this.request(connection, '/sessions', {
+      method: 'POST',
+      body: JSON.stringify({ id: sessionId, project, directory: workingDirectory }),
+    });
+    this.registeredSessions.add(sessionId);
+  }
+
+  private async request<T = unknown>(
+    connection: EngramConnection,
+    pathname: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    const response = await fetch(`${connection.url}${pathname}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${connection.token}`,
+        'Content-Type': 'application/json',
+        ...init.headers,
+      },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      throw new Error(`Memory service request failed with HTTP ${response.status}.`);
+    }
+    return (await response.json()) as T;
+  }
+}

--- a/third_party/engram.LICENSE
+++ b/third_party/engram.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alan Buscaglia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 背景

关联 #161。本 PR 是长期记忆整合的第 1 阶段（Integration spike），先建立安全、可监管、可降级的本地记忆运行边界，不在本阶段向 Pi 或 UI 启用自动记忆。

## 方案

- 固定并校验 Engram `v1.20.0` 的 Windows、macOS、Linux x64/arm64 release 资产与 SHA-256。
- 主进程监管内置 binary，使用 `<userData>/memory/engram` 私有数据目录和随机后端端口。
- 每次启动生成 256-bit launch token；所有产品请求必须先经过随机端口认证代理。
- 代理使用路由白名单，只允许 `recall`、候选确认、替代、遗忘和 session summary 所需的最小 HTTP 面。
- binary 缺失、启动失败或崩溃时降级为无长期记忆，Work/Chat 不受阻；异常退出最多分级重启 3 次。
- 新增 `ZhiYuanEngramAdapter`，模型和 renderer 不接触 binary、后端端口或 token。
- 保留 Engram MIT 许可，并将 runtime 纳入 Electron 三平台打包流程。

## 关键调研结论

Engram 原生 `ENGRAM_HTTP_TOKEN` 目前只保护删除、导入导出和项目迁移，保存、更新、检索等路由仍未认证，因此不能直接把 `engram serve` 作为产品 API。该 PR 增加知远自管认证代理，并避免暴露默认 `7437` 端口。

真实 binary 验证还发现：删除最后一条记忆后 `/search` 返回 JSON `null`，Adapter 已在边界归一化为 `[]`。

## 验证

- `npx vitest run src/main/memory`：4 个测试文件、10 个用例通过。
- `npx tsc --project electron-tsconfig.json --noEmit`：通过。
- `npm run build:tsc`：通过。
- `npx oxlint src/main/memory src/main/main.ts`：通过。
- Engram Windows binary SHA-256 与 release 元数据一致。
- 真实 binary 冒烟：随机端口启动、保存/检索、进程重启后持久化、soft delete 后停止召回均通过。

`npm test -- memory` 未进入 Vitest：本机已有 Electron/Node 进程锁定 `better_sqlite3.node`，测试包装器在 `electron-rebuild` 阶段报 `EPERM`。已使用不触发 native rebuild 的定向 Vitest 完成覆盖。

## 后续阶段

1. Project memory MVP：项目身份、`memory_links`/outbox、受控 Pi 能力与预算化召回。
2. Personal memory 与遗忘：候选确认、TTL、supersede、archive、hard delete 和传播状态。
3. Task/Run 与评测：仅在 verifier 通过后晋升 durable memory，并加入 golden tasks 与指标。

Closes #161 的基础设施部分；完整功能将在后续堆叠 PR 中完成。
