### PR TITLE
feat(memory): 接入已验证任务记忆与评测

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -83,6 +83,7 @@ import { ProjectMemoryService } from './memory/projectMemoryService';
 import { MemoryRepository } from './memory/repository';
 import { ZhiYuanEngramAdapter } from './memory/zhiyuanEngramAdapter';
 import { registerMemoryIpcHandlers } from './memory/ipc';
+import { promoteVerifiedWorkbenchRun } from './memory/taskMemoryPromotion';
 import { searchAnySearchGateway } from './libs/anysearchGateway';
 import {
   resolveAnySearchGatewayToken,
@@ -983,7 +984,11 @@ let projectMemoryService: ProjectMemoryService | null = null;
 
 const getWorkbenchTaskService = (): WorkbenchTaskService => {
   if (!workbenchTaskService) {
-    workbenchTaskService = new WorkbenchTaskService(getStore().getDatabase());
+    workbenchTaskService = new WorkbenchTaskService(getStore().getDatabase(), {
+      onVerifiedRun: event => {
+        promoteVerifiedWorkbenchRun(getProjectMemoryService(), event);
+      },
+    });
   }
   return workbenchTaskService;
 };

--- a/src/main/memory/goldenEvaluation.test.ts
+++ b/src/main/memory/goldenEvaluation.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest';
+
+import { evaluateMemoryGoldenRuns, type MemoryGoldenRunResult } from './goldenEvaluation';
+
+const goldenRuns: MemoryGoldenRunResult[] = [
+  {
+    id: 'project-isolation',
+    expectedRecallIds: ['project-a'],
+    actualRecallIds: ['project-a'],
+    contextTokens: 120,
+    totalPromptTokens: 1_200,
+    userCorrected: false,
+    forgetRequested: false,
+    forgetPropagated: false,
+    sideEffectKeys: ['save:project-a'],
+  },
+  {
+    id: 'superseded-decision',
+    expectedRecallIds: ['decision-new'],
+    actualRecallIds: ['decision-new', 'unrelated'],
+    expectedConflictWinner: 'decision-new',
+    actualConflictWinner: 'decision-new',
+    contextTokens: 180,
+    totalPromptTokens: 1_800,
+    userCorrected: true,
+    forgetRequested: false,
+    forgetPropagated: false,
+    sideEffectKeys: ['save:decision-new', 'save:decision-new'],
+  },
+  {
+    id: 'forget-propagation',
+    expectedRecallIds: [],
+    actualRecallIds: [],
+    contextTokens: 0,
+    totalPromptTokens: 1_000,
+    userCorrected: false,
+    forgetRequested: true,
+    forgetPropagated: true,
+    sideEffectKeys: ['forget:decision-old'],
+  },
+];
+
+test('computes the seven issue 161 golden evaluation metrics', () => {
+  expect(evaluateMemoryGoldenRuns(goldenRuns)).toEqual({
+    correctRecallRate: 1,
+    wrongRecallRate: 1 / 3,
+    conflictResolutionRate: 1,
+    tokenShare: 0.075,
+    userCorrectionRate: 1 / 3,
+    forgetPropagationRate: 1,
+    duplicateSideEffectRate: 1 / 4,
+  });
+});

--- a/src/main/memory/goldenEvaluation.ts
+++ b/src/main/memory/goldenEvaluation.ts
@@ -1,0 +1,76 @@
+export interface MemoryGoldenRunResult {
+  id: string;
+  expectedRecallIds: string[];
+  actualRecallIds: string[];
+  expectedConflictWinner?: string;
+  actualConflictWinner?: string;
+  contextTokens: number;
+  totalPromptTokens: number;
+  userCorrected: boolean;
+  forgetRequested: boolean;
+  forgetPropagated: boolean;
+  sideEffectKeys: string[];
+}
+
+export interface MemoryGoldenMetrics {
+  correctRecallRate: number;
+  wrongRecallRate: number;
+  conflictResolutionRate: number;
+  tokenShare: number;
+  userCorrectionRate: number;
+  forgetPropagationRate: number;
+  duplicateSideEffectRate: number;
+}
+
+export function evaluateMemoryGoldenRuns(results: MemoryGoldenRunResult[]): MemoryGoldenMetrics {
+  let expectedRecallCount = 0;
+  let correctRecallCount = 0;
+  let actualRecallCount = 0;
+  let wrongRecallCount = 0;
+  let conflictCount = 0;
+  let correctConflictCount = 0;
+  let contextTokens = 0;
+  let totalPromptTokens = 0;
+  let correctionCount = 0;
+  let forgetCount = 0;
+  let propagatedForgetCount = 0;
+  let sideEffectCount = 0;
+  let duplicateSideEffectCount = 0;
+
+  for (const result of results) {
+    const expected = new Set(result.expectedRecallIds);
+    expectedRecallCount += expected.size;
+    actualRecallCount += result.actualRecallIds.length;
+    correctRecallCount += result.actualRecallIds.filter(id => expected.has(id)).length;
+    wrongRecallCount += result.actualRecallIds.filter(id => !expected.has(id)).length;
+    if (result.expectedConflictWinner !== undefined) {
+      conflictCount += 1;
+      if (result.actualConflictWinner === result.expectedConflictWinner) {
+        correctConflictCount += 1;
+      }
+    }
+    contextTokens += Math.max(0, result.contextTokens);
+    totalPromptTokens += Math.max(0, result.totalPromptTokens);
+    if (result.userCorrected) correctionCount += 1;
+    if (result.forgetRequested) {
+      forgetCount += 1;
+      if (result.forgetPropagated) propagatedForgetCount += 1;
+    }
+    sideEffectCount += result.sideEffectKeys.length;
+    duplicateSideEffectCount += result.sideEffectKeys.length - new Set(result.sideEffectKeys).size;
+  }
+
+  return {
+    correctRecallRate: ratio(correctRecallCount, expectedRecallCount, 1),
+    wrongRecallRate: ratio(wrongRecallCount, actualRecallCount, 0),
+    conflictResolutionRate: ratio(correctConflictCount, conflictCount, 1),
+    tokenShare: ratio(contextTokens, totalPromptTokens, 0),
+    userCorrectionRate: ratio(correctionCount, results.length, 0),
+    forgetPropagationRate: ratio(propagatedForgetCount, forgetCount, 1),
+    duplicateSideEffectRate: ratio(duplicateSideEffectCount, sideEffectCount, 0),
+  };
+}
+
+function ratio(numerator: number, denominator: number, emptyValue: number): number {
+  return denominator === 0 ? emptyValue : numerator / denominator;
+}

--- a/src/main/memory/personalMemoryService.test.ts
+++ b/src/main/memory/personalMemoryService.test.ts
@@ -18,11 +18,13 @@ import type { MemoryOutboxItem, PersonalMemoryCandidateInput } from './repositor
 class PersonalRepositoryFake {
   items: MemoryOutboxItem[] = [];
   candidates = new Map<string, ManagedMemoryRecord>();
+  candidateInputs = new Map<string, PersonalMemoryCandidateInput>();
   links = new Map<string, ManagedMemoryRecord>();
   events: string[] = [];
 
   createPersonalCandidate(input: PersonalMemoryCandidateInput) {
     const id = input.id ?? 'candidate-1';
+    this.candidateInputs.set(id, input);
     this.candidates.set(id, recordFor(id, input));
     return id;
   }
@@ -31,8 +33,13 @@ class PersonalRepositoryFake {
     return this.candidates.get(id) ?? null;
   }
 
-  getCandidateDetails() {
-    return { supersedesLinkId: null };
+  getCandidateDetails(id: string) {
+    const input = this.candidateInputs.get(id);
+    return {
+      supersedesLinkId: input?.supersedesLinkId ?? null,
+      projectRoot: input?.projectRoot ?? '',
+      metadata: input?.metadata ?? {},
+    };
   }
 
   getLink(id: string) {
@@ -111,14 +118,14 @@ function recordFor(id: string, input: PersonalMemoryCandidateInput): ManagedMemo
   return {
     id,
     memoryId: null,
-    projectId: PERSONAL_MEMORY_PROJECT_ID,
-    scope: MemoryScope.Personal,
+    projectId: input.projectId ?? PERSONAL_MEMORY_PROJECT_ID,
+    scope: input.scope ?? MemoryScope.Personal,
     sessionId: input.sessionId,
     sourceKind: input.sourceKind,
-    taskId: null,
-    runId: null,
-    artifactId: null,
-    approvalId: null,
+    taskId: input.taskId ?? null,
+    runId: input.runId ?? null,
+    artifactId: input.artifactId ?? null,
+    approvalId: input.approvalId ?? null,
     status: MemoryLifecycleStatus.NeedsReview,
     title: input.title,
     content: input.content,
@@ -193,4 +200,38 @@ test('marks a memory deleted before attempting remote propagation', async () => 
     status: MemoryDeliveryStatus.Pending,
     lastError: 'Memory runtime unavailable.',
   });
+});
+
+test('keeps verified Task and Run provenance on a project review candidate', async () => {
+  const repository = new PersonalRepositoryFake();
+  const adapter = {
+    saveCandidate: vi.fn(input => ({ id: 'adapter-candidate', ...input })),
+    confirmMemory: vi.fn(async () => 92),
+    discardCandidate: vi.fn(),
+  };
+  const service = new ProjectMemoryService(repository as never, adapter as never, identityFor);
+  const id = service.proposeProjectMemoryCandidate({
+    sessionId: 'session-1',
+    workingDirectory: 'project-alpha',
+    type: MemoryKind.Decision,
+    title: 'Verified decision',
+    content: 'The deterministic verifier accepted the durable project decision.',
+    taskId: 'task-1',
+    runId: 'run-1',
+    artifactId: 'artifact-1',
+    approvalId: 'approval-1',
+    metadata: { artifactIds: ['artifact-1'] },
+  });
+
+  expect(repository.candidates.get(id)).toMatchObject({
+    projectId: 'project-alpha',
+    scope: MemoryScope.Project,
+    taskId: 'task-1',
+    runId: 'run-1',
+  });
+  await expect(service.confirmMemoryCandidate(id)).resolves.toBe(92);
+  expect(adapter.saveCandidate).toHaveBeenCalledWith(
+    expect.objectContaining({ project: 'project-alpha', scope: MemoryScope.Project }),
+  );
+  expect(repository.links.get(id)).toMatchObject({ memoryId: 92 });
 });

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -44,6 +44,8 @@ interface ConfirmPayload {
   sensitivity?: MemorySensitivityValue;
   expiresAt?: string;
   supersededObservationId?: number;
+  candidateBacked?: boolean;
+  metadata?: Record<string, unknown>;
 }
 
 interface ForgetPayload {
@@ -162,6 +164,9 @@ export class ProjectMemoryService {
         : undefined);
     return this.repository.createPersonalCandidate({
       ...input,
+      projectId: PERSONAL_MEMORY_PROJECT_ID,
+      projectRoot: this.personalDirectory,
+      scope: MemoryScope.Personal,
       kind: input.type,
       title: redactPrivateBlocks(input.title),
       content: redactPrivateBlocks(input.content),
@@ -171,7 +176,40 @@ export class ProjectMemoryService {
     });
   }
 
+  proposeProjectMemoryCandidate(input: {
+    sessionId: string;
+    workingDirectory: string;
+    type: MemoryKindValue;
+    title: string;
+    content: string;
+    topicKey?: string;
+    importance?: number;
+    confidence?: number;
+    sensitivity?: MemorySensitivityValue;
+    taskId: string;
+    runId: string;
+    artifactId?: string;
+    approvalId?: string;
+    metadata?: Record<string, unknown>;
+  }): string {
+    const project = this.resolveIdentity(input.workingDirectory);
+    return this.repository.createPersonalCandidate({
+      ...input,
+      projectId: project.id,
+      projectRoot: project.root,
+      scope: MemoryScope.Project,
+      kind: input.type,
+      title: redactPrivateBlocks(input.title),
+      content: redactPrivateBlocks(input.content),
+      sourceKind: MemorySourceKind.TaskVerifier,
+    });
+  }
+
   async confirmPersonalCandidate(id: string): Promise<number | null> {
+    return await this.confirmMemoryCandidate(id);
+  }
+
+  async confirmMemoryCandidate(id: string): Promise<number | null> {
     const candidate = this.repository.getCandidate(id);
     if (!candidate || candidate.status !== MemoryLifecycleStatus.NeedsReview) {
       throw new Error('Personal memory candidate is not available for review.');
@@ -187,15 +225,18 @@ export class ProjectMemoryService {
     const outboxId = this.repository.enqueue(
       operation,
       {
-        sessionId: `personal:${candidate.sessionId}`,
-        projectId: PERSONAL_MEMORY_PROJECT_ID,
-        projectRoot: this.personalDirectory,
+        sessionId:
+          candidate.scope === MemoryScope.Personal
+            ? `personal:${candidate.sessionId}`
+            : candidate.sessionId,
+        projectId: candidate.projectId,
+        projectRoot: rawCandidate?.projectRoot || this.personalDirectory,
         type: candidate.kind,
         title: candidate.title,
         content: candidate.content,
         topicKey: candidate.topicKey ?? undefined,
         sourceKind: candidate.sourceKind,
-        scope: MemoryScope.Personal,
+        scope: candidate.scope,
         linkId: candidate.id,
         taskId: candidate.taskId ?? undefined,
         runId: candidate.runId ?? undefined,
@@ -206,6 +247,8 @@ export class ProjectMemoryService {
         sensitivity: candidate.sensitivity,
         expiresAt: candidate.expiresAt ?? undefined,
         supersededObservationId: superseded?.memoryId ?? undefined,
+        candidateBacked: true,
+        metadata: rawCandidate?.metadata,
       },
       candidate.id,
     );
@@ -350,6 +393,7 @@ export class ProjectMemoryService {
         confidence: payload.confidence,
         sensitivity: payload.sensitivity,
         expiresAt: payload.expiresAt,
+        metadata: payload.metadata,
       });
       if (payload.topicKey) {
         this.repository.supersedeActiveTopic(
@@ -359,7 +403,7 @@ export class ProjectMemoryService {
           payload.linkId,
         );
       }
-      if (payload.scope === MemoryScope.Personal) this.repository.deleteCandidate(payload.linkId);
+      if (payload.candidateBacked) this.repository.deleteCandidate(payload.linkId);
       this.repository.markCompleted(item.id);
       return memoryId;
     } catch (error) {

--- a/src/main/memory/repository.test.ts
+++ b/src/main/memory/repository.test.ts
@@ -11,6 +11,8 @@ test('creates the link and outbox schema without importing the memory kernel dat
   expect(schema).toContain('CREATE TABLE IF NOT EXISTS memory_links');
   expect(schema).toContain('CREATE TABLE IF NOT EXISTS memory_outbox');
   expect(schema).toContain('CREATE TABLE IF NOT EXISTS memory_candidates');
+  expect(schema).toContain('project_root TEXT');
+  expect(schema).toContain("scope TEXT NOT NULL DEFAULT 'personal'");
   expect(schema).toContain('superseded_by TEXT');
   expect(schema).toContain('sensitivity TEXT');
   expect(schema).toContain('idx_memory_outbox_pending');

--- a/src/main/memory/repository.ts
+++ b/src/main/memory/repository.ts
@@ -4,9 +4,10 @@ import { randomUUID } from 'crypto';
 import type { ManagedMemoryListInput, ManagedMemoryRecord } from '../../shared/memory';
 import {
   MemoryLifecycleStatus,
+  MemoryScope,
   MemorySensitivity,
+  PERSONAL_MEMORY_PROJECT_ID,
   type MemoryKind,
-  type MemoryScope,
 } from '../../shared/memory';
 import { MemoryOutboxStatus, type MemoryOutboxOperation, type MemorySourceKind } from './constants';
 
@@ -37,6 +38,9 @@ export interface MemoryLinkInput extends MemoryProjectionInput {
 
 export interface PersonalMemoryCandidateInput extends MemoryProjectionInput {
   id?: string;
+  projectId?: string;
+  projectRoot?: string;
+  scope?: MemoryScope;
   sessionId: string;
   sourceKind: MemorySourceKind;
   taskId?: string;
@@ -128,13 +132,17 @@ export class MemoryRepository {
     this.db
       .prepare(
         `INSERT INTO memory_candidates (
-          id, session_id, source_kind, task_id, run_id, artifact_id, approval_id,
+          id, project_id, project_root, scope, session_id, source_kind,
+          task_id, run_id, artifact_id, approval_id,
           status, title, content, kind, topic_key, importance, confidence,
           sensitivity, expires_at, supersedes_link_id, metadata_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
+        input.projectId ?? PERSONAL_MEMORY_PROJECT_ID,
+        input.projectRoot ?? '',
+        input.scope ?? MemoryScope.Personal,
         input.sessionId,
         input.sourceKind,
         input.taskId ?? null,
@@ -163,11 +171,25 @@ export class MemoryRepository {
     return row ? mapCandidate(row, this.getDelivery(id)) : null;
   }
 
-  getCandidateDetails(id: string): { supersedesLinkId: string | null } | null {
+  getCandidateDetails(id: string): {
+    supersedesLinkId: string | null;
+    projectRoot: string;
+    metadata: Record<string, unknown>;
+  } | null {
     const row = this.db
-      .prepare('SELECT supersedes_link_id FROM memory_candidates WHERE id = ?')
-      .get(id) as { supersedes_link_id: string | null } | undefined;
-    return row ? { supersedesLinkId: row.supersedes_link_id } : null;
+      .prepare(
+        'SELECT supersedes_link_id, project_root, metadata_json FROM memory_candidates WHERE id = ?',
+      )
+      .get(id) as
+      | { supersedes_link_id: string | null; project_root: string; metadata_json: string }
+      | undefined;
+    return row
+      ? {
+          supersedesLinkId: row.supersedes_link_id,
+          projectRoot: row.project_root,
+          metadata: JSON.parse(row.metadata_json) as Record<string, unknown>,
+        }
+      : null;
   }
 
   getLink(id: string): ManagedMemoryRecord | null {
@@ -408,6 +430,9 @@ export class MemoryRepository {
 
       CREATE TABLE IF NOT EXISTS memory_candidates (
         id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL DEFAULT 'personal://zhiyuan-agent/user',
+        project_root TEXT NOT NULL DEFAULT '',
+        scope TEXT NOT NULL DEFAULT 'personal',
         session_id TEXT NOT NULL,
         source_kind TEXT NOT NULL,
         task_id TEXT,
@@ -475,6 +500,22 @@ export class MemoryRepository {
     if (!outboxColumns.some(column => column.name === 'link_id')) {
       this.db.exec('ALTER TABLE memory_outbox ADD COLUMN link_id TEXT');
     }
+    const candidateAdditions: Record<string, string> = {
+      project_id: "TEXT NOT NULL DEFAULT 'personal://zhiyuan-agent/user'",
+      project_root: "TEXT NOT NULL DEFAULT ''",
+      scope: "TEXT NOT NULL DEFAULT 'personal'",
+    };
+    const candidateColumns = this.db
+      .prepare('PRAGMA table_info(memory_candidates)')
+      .all() as Array<{
+      name: string;
+    }>;
+    const existingCandidateColumns = new Set(candidateColumns.map(column => column.name));
+    for (const [name, definition] of Object.entries(candidateAdditions)) {
+      if (!existingCandidateColumns.has(name)) {
+        this.db.exec(`ALTER TABLE memory_candidates ADD COLUMN ${name} ${definition}`);
+      }
+    }
   }
 }
 
@@ -502,7 +543,7 @@ function mapCandidate(
   row: SqlRow,
   delivery: { status: string; error: string | null } | null,
 ): ManagedMemoryRecord {
-  return mapRecord(row, delivery, null, 'personal://zhiyuan-agent/user', 'personal');
+  return mapRecord(row, delivery, null, String(row.project_id), String(row.scope));
 }
 
 function mapRecord(

--- a/src/main/memory/taskMemoryPromotion.test.ts
+++ b/src/main/memory/taskMemoryPromotion.test.ts
@@ -1,0 +1,138 @@
+import { expect, test, vi } from 'vitest';
+
+import {
+  WorkbenchApprovalEffectStatus,
+  WorkbenchApprovalDecision,
+  WorkbenchApprovalDecisionSource,
+  WorkbenchApprovalRiskLevel,
+  WorkbenchArtifactKind,
+  WorkbenchArtifactProvenance,
+  WorkbenchArtifactVerificationStatus,
+  WorkbenchContractKind,
+  WorkbenchRunStatus,
+  WorkbenchRunTrigger,
+  WorkbenchTaskStatus,
+  WorkbenchVerificationOutcome,
+  type WorkbenchApproval,
+  type WorkbenchArtifact,
+  type WorkbenchRun,
+  type WorkbenchTask,
+  type WorkbenchVerificationResult,
+} from '../../shared/workbenchTask';
+import {
+  promoteVerifiedWorkbenchRun,
+  type VerifiedWorkbenchRunMemorySource,
+} from './taskMemoryPromotion';
+
+function source(overrides: Partial<VerifiedWorkbenchRunMemorySource> = {}) {
+  const task: WorkbenchTask = {
+    id: 'task-1',
+    sessionId: 'session-1',
+    goal: 'Persist the verified architecture decision',
+    status: WorkbenchTaskStatus.Completed,
+    contract: { kind: WorkbenchContractKind.GenericWork, requiresUserAcceptance: false },
+    activeRunId: null,
+    createdAt: 1,
+    updatedAt: 2,
+    completedAt: 2,
+  };
+  const run: WorkbenchRun = {
+    id: 'run-1',
+    taskId: task.id,
+    attempt: 1,
+    status: WorkbenchRunStatus.Succeeded,
+    trigger: WorkbenchRunTrigger.Message,
+    startedAt: 1,
+    endedAt: 2,
+    verificationResult: null,
+    failure: null,
+    createdAt: 1,
+    updatedAt: 2,
+  };
+  const verificationResult: WorkbenchVerificationResult = {
+    outcome: WorkbenchVerificationOutcome.Passed,
+    checks: [],
+    evidence: [],
+    summary: 'All deterministic checks passed.',
+  };
+  const artifact = {
+    id: 'artifact-1',
+    taskId: task.id,
+    runId: run.id,
+    kind: WorkbenchArtifactKind.File,
+    mimeType: 'text/plain',
+    reference: 'result.txt',
+    contentHash: 'hash',
+    provenance: WorkbenchArtifactProvenance.Workspace,
+    verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+    metadata: {},
+    createdAt: 1,
+    updatedAt: 2,
+  } satisfies WorkbenchArtifact;
+  const approval = {
+    id: 'approval-1',
+    taskId: task.id,
+    runId: run.id,
+    toolCallId: 'call-1',
+    toolName: 'write',
+    riskLevel: WorkbenchApprovalRiskLevel.Reversible,
+    decision: WorkbenchApprovalDecision.Approved,
+    decisionSource: WorkbenchApprovalDecisionSource.User,
+    effectStatus: WorkbenchApprovalEffectStatus.Succeeded,
+    idempotencyKey: 'key',
+    request: {},
+    result: {},
+    createdAt: 1,
+    updatedAt: 2,
+    decidedAt: 2,
+  } as WorkbenchApproval;
+  return {
+    task,
+    run,
+    artifacts: [artifact],
+    approvals: [approval],
+    verificationResult,
+    workspaceRoot: 'C:/workspace/project',
+    finalAnswer: 'The verified result establishes SQLite as the durable project store.',
+    ...overrides,
+  } satisfies VerifiedWorkbenchRunMemorySource;
+}
+
+test('creates a review candidate with Task, Run, Artifact, and Approval provenance', () => {
+  const proposeProjectMemoryCandidate = vi.fn(() => 'candidate-1');
+  const result = promoteVerifiedWorkbenchRun({ proposeProjectMemoryCandidate } as never, source());
+
+  expect(result).toBe('candidate-1');
+  expect(proposeProjectMemoryCandidate).toHaveBeenCalledWith(
+    expect.objectContaining({
+      taskId: 'task-1',
+      runId: 'run-1',
+      artifactId: 'artifact-1',
+      approvalId: 'approval-1',
+      topicKey: 'task/task-1',
+      confidence: 1,
+    }),
+  );
+});
+
+test('does not promote failed verification or ordinary chat completion', () => {
+  const proposeProjectMemoryCandidate = vi.fn();
+  const failed = source({
+    verificationResult: {
+      ...source().verificationResult,
+      outcome: WorkbenchVerificationOutcome.Failed,
+    },
+  });
+  const chat = source({
+    task: {
+      ...source().task,
+      contract: { kind: WorkbenchContractKind.Chat, requiresUserAcceptance: false },
+    },
+  });
+
+  expect(
+    promoteVerifiedWorkbenchRun({ proposeProjectMemoryCandidate } as never, failed),
+  ).toBeNull();
+  expect(promoteVerifiedWorkbenchRun({ proposeProjectMemoryCandidate } as never, chat)).toBeNull();
+  expect(proposeProjectMemoryCandidate).not.toHaveBeenCalled();
+});

--- a/src/main/memory/taskMemoryPromotion.ts
+++ b/src/main/memory/taskMemoryPromotion.ts
@@ -1,0 +1,71 @@
+import {
+  WorkbenchApprovalEffectStatus,
+  WorkbenchArtifactVerificationStatus,
+  WorkbenchContractKind,
+  WorkbenchVerificationOutcome,
+  type WorkbenchApproval,
+  type WorkbenchArtifact,
+  type WorkbenchRun,
+  type WorkbenchTask,
+  type WorkbenchVerificationResult,
+} from '../../shared/workbenchTask';
+import { MemoryKind, MemorySensitivity } from '../../shared/memory';
+import type { ProjectMemoryService } from './projectMemoryService';
+
+const MAX_VERIFIED_RESULT_LENGTH = 1_600;
+
+export interface VerifiedWorkbenchRunMemorySource {
+  task: WorkbenchTask;
+  run: WorkbenchRun;
+  artifacts: WorkbenchArtifact[];
+  approvals: WorkbenchApproval[];
+  verificationResult: WorkbenchVerificationResult;
+  workspaceRoot: string;
+  finalAnswer: string;
+}
+
+export function promoteVerifiedWorkbenchRun(
+  service: ProjectMemoryService,
+  source: VerifiedWorkbenchRunMemorySource,
+): string | null {
+  if (source.verificationResult.outcome !== WorkbenchVerificationOutcome.Passed) return null;
+  if (source.task.contract.kind === WorkbenchContractKind.Chat) return null;
+  const content = compactVerifiedResult(source.finalAnswer);
+  if (content.length < 32) return null;
+  const artifacts = source.artifacts.filter(
+    artifact =>
+      artifact.runId === source.run.id &&
+      artifact.verificationStatus === WorkbenchArtifactVerificationStatus.Verified,
+  );
+  const approvals = source.approvals.filter(
+    approval =>
+      approval.runId === source.run.id &&
+      approval.effectStatus === WorkbenchApprovalEffectStatus.Succeeded,
+  );
+  return service.proposeProjectMemoryCandidate({
+    sessionId: source.task.sessionId,
+    workingDirectory: source.workspaceRoot,
+    type: MemoryKind.Decision,
+    title: source.task.goal.slice(0, 120),
+    content,
+    topicKey: `task/${source.task.id}`,
+    importance: artifacts.length > 0 ? 0.8 : 0.65,
+    confidence: 1,
+    sensitivity: MemorySensitivity.Normal,
+    taskId: source.task.id,
+    runId: source.run.id,
+    artifactId: artifacts[0]?.id,
+    approvalId: approvals[0]?.id,
+    metadata: {
+      artifactIds: artifacts.map(artifact => artifact.id),
+      approvalIds: approvals.map(approval => approval.id),
+      verificationSummary: source.verificationResult.summary,
+    },
+  });
+}
+
+function compactVerifiedResult(value: string): string {
+  const compact = value.trim().replace(/\n{3,}/g, '\n\n');
+  if (compact.length <= MAX_VERIFIED_RESULT_LENGTH) return compact;
+  return `${compact.slice(0, MAX_VERIFIED_RESULT_LENGTH - 3).trimEnd()}...`;
+}

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import {
   WorkbenchApprovalDecision,
@@ -20,12 +20,13 @@ import {
 import { initializeWorkbenchTaskSchema } from './schema';
 import { initializeProductionLoopSchema } from '../productionLoop/schema';
 import { WorkbenchTaskService } from './taskService';
+import type { WorkbenchTaskServiceOptions } from './taskService';
 
-const createService = () => {
+const createService = (options: WorkbenchTaskServiceOptions = {}) => {
   const db = new Database(':memory:');
   initializeWorkbenchTaskSchema(db);
   initializeProductionLoopSchema(db);
-  return { db, service: new WorkbenchTaskService(db) };
+  return { db, service: new WorkbenchTaskService(db, options) };
 };
 
 const chatContract = {
@@ -98,8 +99,41 @@ test('completes the production loop only after deterministic verification passes
   }
 });
 
+test('emits a verified run source only after deterministic verification passes', () => {
+  const onVerifiedRun = vi.fn();
+  const { db, service } = createService({ onVerifiedRun });
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'record a verified outcome',
+      contract: chatContract,
+    });
+    prepareProductionDelivery(service, task.id, run.id, WorkbenchContractKind.Chat);
+    service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: process.cwd(),
+      finalAnswer: 'The deterministic verifier accepted this completed task result.',
+    });
+
+    expect(onVerifiedRun).toHaveBeenCalledOnce();
+    expect(onVerifiedRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({ id: task.id }),
+        run: expect.objectContaining({ id: run.id, status: WorkbenchRunStatus.Succeeded }),
+        verificationResult: expect.objectContaining({
+          outcome: WorkbenchVerificationOutcome.Passed,
+        }),
+      }),
+    );
+  } finally {
+    db.close();
+  }
+});
+
 test('returns critic-approved work to revision when deterministic verification fails', () => {
-  const { db, service } = createService();
+  const onVerifiedRun = vi.fn();
+  const { db, service } = createService({ onVerifiedRun });
   try {
     const contract = {
       kind: WorkbenchContractKind.Shortcut,
@@ -129,6 +163,7 @@ test('returns critic-approved work to revision when deterministic verification f
       status: ProductionLoopStatus.NeedsRevision,
       deliveryReason: null,
     });
+    expect(onVerifiedRun).not.toHaveBeenCalled();
   } finally {
     db.close();
   }

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -42,6 +42,20 @@ export interface WorkbenchToolAuthorizationResult {
   reason?: string;
 }
 
+export interface VerifiedWorkbenchRunEvent {
+  task: WorkbenchTask;
+  run: WorkbenchRun;
+  artifacts: WorkbenchTaskDetail['artifacts'];
+  approvals: WorkbenchTaskDetail['approvals'];
+  verificationResult: WorkbenchVerificationResult;
+  workspaceRoot: string;
+  finalAnswer: string;
+}
+
+export interface WorkbenchTaskServiceOptions {
+  onVerifiedRun?: (event: VerifiedWorkbenchRunEvent) => void;
+}
+
 type PendingApproval = {
   resolve: (result: WorkbenchToolAuthorizationResult) => void;
 };
@@ -58,7 +72,10 @@ export class WorkbenchTaskService extends EventEmitter {
   readonly productionLoop: ProductionLoopService;
   private readonly pendingApprovals = new Map<string, PendingApproval>();
 
-  constructor(db: Database.Database) {
+  constructor(
+    db: Database.Database,
+    private readonly options: WorkbenchTaskServiceOptions = {},
+  ) {
     super();
     this.repository = new WorkbenchTaskRepository(db);
     this.measurement = new HarnessMeasurementService(this.repository);
@@ -206,6 +223,24 @@ export class WorkbenchTaskService extends EventEmitter {
     });
     const detail = this.repository.getDetail(task.id);
     if (!detail) throw new Error('Workbench task detail disappeared after verification.');
+    if (result.outcome === WorkbenchVerificationOutcome.Passed) {
+      const verifiedRun = detail.runs.find(candidate => candidate.id === run.id);
+      if (verifiedRun) {
+        try {
+          this.options.onVerifiedRun?.({
+            task: detail.task,
+            run: verifiedRun,
+            artifacts: detail.artifacts.filter(artifact => artifact.runId === run.id),
+            approvals: detail.approvals.filter(approval => approval.runId === run.id),
+            verificationResult: result,
+            workspaceRoot: input.workspaceRoot,
+            finalAnswer: input.finalAnswer,
+          });
+        } catch (error) {
+          console.warn('[WorkbenchTask] Failed to propose verified run memory:', error);
+        }
+      }
+    }
     this.emitChanged(detail.task);
     return detail;
   }


### PR DESCRIPTION
## 背景

继续落实 #161 的分层记忆方案。本阶段在项目记忆与个人记忆能力之上，接入“已验证任务结果”的受控沉淀流程，避免普通对话、未完成任务或验证失败结果污染长期记忆。

> 此 PR 为堆叠 PR，基于 `codex/issue-161-personal-memory`；前置阶段合并后可改回 `main`。

## 本阶段改动

- 在任务运行通过 verifier 后发出 verified run 事件；普通 `agent_end`、验证失败和仍需验收的结果不会触发记忆候选。
- 新增任务记忆晋升策略：自动排除普通 Chat 与低价值短结果，只创建 Project 范围的 `needs_review` 候选，不直接写入记忆内核。
- 候选关联 Task、Run、已验证 Artifact、成功 Approval，并保留 verification summary，形成可追溯的来源链。
- 将候选存储泛化为 Project / Personal 共用模型，补充项目标识、项目根目录与 scope。
- 新增 golden evaluation，覆盖正确/错误召回、冲突处理、token 占比、用户纠错、遗忘传播和重复副作用七项指标。

## 安全边界

- 仅 `passed` 的任务验证结果可进入候选流程。
- 自动流程只生成待审阅候选，不绕过用户确认写入长期记忆。
- 记忆按项目隔离，且保留完整来源标识，便于审计、纠错和删除传播。

## 验证

- `npx tsc --project electron-tsconfig.json --noEmit`
- `npm run build`
- `npx oxlint <阶段四相关文件>`
- `npx oxfmt --check <阶段四相关文件>`
- `npx vitest run src/main/memory`：11 个测试文件、26 个用例通过

`src/main/workbenchTask/taskService.test.ts` 在测试初始化前因本机 native ABI 不匹配失败：当前 `better_sqlite3.node` 为 Electron ABI 143，Node 测试运行时需要 ABI 137；不是业务断言失败。未终止用户正在运行的 Electron 进程来重建该模块。

## 关联

- Closes #161（完整方案由本堆叠 PR 链共同交付）
- 前置 PR：#356、#357、#358
