### PR TITLE
Harden updater release fallback without Apple credentials

### DIFF
--- a/.github/workflows/online-update-cleanup.yml
+++ b/.github/workflows/online-update-cleanup.yml
@@ -46,6 +46,7 @@ jobs:
             aws s3api get-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json \
               manifest/stable-pointer.json > /dev/null
             generation="$(jq -er 'select(.schemaVersion == 1) | .generation | select(type == "string" and test("^[A-Za-z0-9._-]+$"))' manifest/stable-pointer.json)"
+            echo "generation=$generation" >> "$GITHUB_OUTPUT"
             aws s3api get-object --bucket "$R2_BUCKET" \
               --key "generations/${generation}/legacy/stable.json" manifest/stable.json > /dev/null
             pointer=true
@@ -55,6 +56,7 @@ jobs:
               manifest/stable.json > /dev/null
             pointer=false
             echo 'pointer=false' >> "$GITHUB_OUTPUT"
+            echo 'generation=-' >> "$GITHUB_OUTPUT"
           else
             cat manifest/stable-pointer-head.err >&2
             exit "$pointer_status"
@@ -71,11 +73,13 @@ jobs:
               aws s3api get-object --bucket "$R2_BUCKET" --key channels/stable.previous-pointer.json \
                 manifest/previous-pointer.json > /dev/null
               previous_generation="$(jq -er 'select(.schemaVersion == 1) | .generation | select(type == "string" and test("^[A-Za-z0-9._-]+$"))' manifest/previous-pointer.json)"
+              echo "previous_generation=$previous_generation" >> "$GITHUB_OUTPUT"
               aws s3api get-object --bucket "$R2_BUCKET" \
                 --key "generations/${previous_generation}/legacy/stable.json" manifest/previous.json > /dev/null
               echo 'previous=true' >> "$GITHUB_OUTPUT"
             elif grep -Eq '404|Not Found|NoSuchKey' manifest/previous-head.err; then
               echo 'previous=false' >> "$GITHUB_OUTPUT"
+              echo 'previous_generation=-' >> "$GITHUB_OUTPUT"
             else
               cat manifest/previous-head.err >&2
               exit "$previous_status"
@@ -89,36 +93,43 @@ jobs:
             if [[ $previous_status -eq 0 ]]; then
               aws s3api get-object --bucket "$R2_BUCKET" --key "$previous_key" manifest/previous.json > /dev/null
               echo 'previous=true' >> "$GITHUB_OUTPUT"
+              echo 'previous_generation=-' >> "$GITHUB_OUTPUT"
             elif grep -Eq '404|Not Found|NoSuchKey' manifest/previous-head.err; then
               echo 'previous=false' >> "$GITHUB_OUTPUT"
+              echo 'previous_generation=-' >> "$GITHUB_OUTPUT"
             else
               cat manifest/previous-head.err >&2
               exit "$previous_status"
             fi
           fi
 
-          page=1
-          continuation_token=''
-          while :; do
-            page_path="manifest/cleanup/release-objects-${page}.json"
-            list_args=(--bucket "$R2_BUCKET" --prefix releases/ --max-keys 1000)
-            if [[ -n "$continuation_token" ]]; then
-              list_args+=(--continuation-token "$continuation_token")
-            fi
-            aws s3api list-objects-v2 "${list_args[@]}" > "$page_path"
+          inventory_files=()
+          for prefix in releases/ generations/; do
+            label="${prefix%/}"
+            page=1
+            continuation_token=''
+            while :; do
+              page_path="manifest/cleanup/${label}-objects-${page}.json"
+              inventory_files+=("$page_path")
+              list_args=(--bucket "$R2_BUCKET" --prefix "$prefix" --max-keys 1000)
+              if [[ -n "$continuation_token" ]]; then
+                list_args+=(--continuation-token "$continuation_token")
+              fi
+              aws s3api list-objects-v2 "${list_args[@]}" > "$page_path"
 
-            if [[ "$(jq -r '.IsTruncated // false' "$page_path")" != 'true' ]]; then
-              break
-            fi
-            continuation_token="$(jq -r '.NextContinuationToken // empty' "$page_path")"
-            if [[ -z "$continuation_token" ]]; then
-              echo "R2 returned a truncated listing without a continuation token" >&2
-              exit 1
-            fi
-            page=$((page + 1))
+              if [[ "$(jq -r '.IsTruncated // false' "$page_path")" != 'true' ]]; then
+                break
+              fi
+              continuation_token="$(jq -r '.NextContinuationToken // empty' "$page_path")"
+              if [[ -z "$continuation_token" ]]; then
+                echo "R2 returned a truncated listing without a continuation token for $prefix" >&2
+                exit 1
+              fi
+              page=$((page + 1))
+            done
           done
-          jq -s '{Contents: [.[].Contents[]?]}' manifest/cleanup/release-objects-*.json \
-            > manifest/release-objects.json
+          jq -s '{Contents: [.[].Contents[]?]}' "${inventory_files[@]}" \
+            > manifest/r2-objects.json
       - name: Plan expired object cleanup
         run: |
           previous_path='-'
@@ -131,7 +142,9 @@ jobs:
             manifest/stable.json \
             "$previous_path" \
             "$previous_head_path" \
-            manifest/release-objects.json \
+            '${{ steps.inventory.outputs.generation }}' \
+            '${{ steps.inventory.outputs.previous_generation }}' \
+            manifest/r2-objects.json \
             manifest/cleanup
       - name: Delete expired unreferenced objects
         run: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -159,19 +159,44 @@ jobs:
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
-      - name: Require macOS signing and notarization credentials
+      - name: Validate optional macOS signing and notarization credentials
         if: ${{ matrix.platform == 'macos' }}
         shell: bash
         run: |
+          names=(
+            MACOS_CSC_LINK
+            MACOS_CSC_KEY_PASSWORD
+            APPLE_ID
+            APPLE_APP_SPECIFIC_PASSWORD
+            APPLE_TEAM_ID
+          )
+          values=(
+            "$CSC_LINK"
+            "$CSC_KEY_PASSWORD"
+            "$APPLE_ID"
+            "$APPLE_APP_SPECIFIC_PASSWORD"
+            "$APPLE_TEAM_ID"
+          )
+          provided=0
           missing=()
-          [[ -n "$CSC_LINK" ]] || missing+=(MACOS_CSC_LINK)
-          [[ -n "$CSC_KEY_PASSWORD" ]] || missing+=(MACOS_CSC_KEY_PASSWORD)
-          [[ -n "$APPLE_ID" ]] || missing+=(APPLE_ID)
-          [[ -n "$APPLE_APP_SPECIFIC_PASSWORD" ]] || missing+=(APPLE_APP_SPECIFIC_PASSWORD)
-          [[ -n "$APPLE_TEAM_ID" ]] || missing+=(APPLE_TEAM_ID)
-          if [[ ${#missing[@]} -gt 0 ]]; then
-            printf 'macOS auto-update requires release secret: %s\n' "${missing[@]}" >&2
+          for index in "${!names[@]}"; do
+            if [[ -n "${values[$index]}" ]]; then
+              provided=$((provided + 1))
+            else
+              missing+=("${names[$index]}")
+            fi
+          done
+          if [[ $provided -eq 0 ]]; then
+            echo 'ZHIYUAN_MAC_AUTO_UPDATE_ENABLED=false' >> "$GITHUB_ENV"
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=false' >> "$GITHUB_ENV"
+            echo '::warning title=Manual macOS updates::Apple credentials are unavailable. The macOS package will be built unsigned and unnotarized with in-app automatic installation disabled.'
+          elif [[ ${#missing[@]} -gt 0 ]]; then
+            printf 'Partially configured macOS release credentials; missing secret: %s\n' "${missing[@]}" >&2
             exit 1
+          else
+            echo 'ZHIYUAN_MAC_AUTO_UPDATE_ENABLED=true' >> "$GITHUB_ENV"
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=true' >> "$GITHUB_ENV"
+            echo '::notice title=Signed macOS release::Code signing and notarization credentials are configured.'
           fi
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
@@ -192,6 +217,19 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify signed and notarized macOS app
+        if: ${{ matrix.platform == 'macos' }}
+        shell: bash
+        run: |
+          if [[ "$ZHIYUAN_MAC_AUTO_UPDATE_ENABLED" != 'true' ]]; then
+            echo 'macOS signing verification skipped for the manual-update build.'
+            exit 0
+          fi
+          app_path="$(find release -maxdepth 3 -type d -name '*.app' -print -quit)"
+          [[ -n "$app_path" ]] || { echo 'Packaged macOS app was not found' >&2; exit 1; }
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          xcrun stapler validate "$app_path"
+          spctl --assess --type execute --verbose=4 "$app_path"
       - name: Build Linux packages
         if: ${{ matrix.platform == 'linux' }}
         run: bun run dist:linux

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -94,6 +94,21 @@ function isLinuxTarget(context) {
   return context?.electronPlatformName === 'linux';
 }
 
+function configureMacAutoUpdateMetadata(context, env = process.env) {
+  if (!isMacTarget(context)) {
+    return;
+  }
+
+  const enabled = env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED === 'true';
+  context.packager.config.extraMetadata = {
+    ...(context.packager.config.extraMetadata || {}),
+    zhiyuanMacAutoUpdateEnabled: enabled,
+  };
+  console.log(
+    `[electron-builder-hooks] macOS in-app automatic installation: ${enabled ? 'enabled' : 'disabled (manual DMG fallback)'}`,
+  );
+}
+
 function collectLatestMtimeMs(dir) {
   let latest = 0;
 
@@ -909,6 +924,7 @@ function installSkillDependencies() {
 }
 
 async function beforePack(context) {
+  configureMacAutoUpdateMetadata(context);
   ensureBundledOpenClawRuntime(context);
   // Install skill dependencies first (for all platforms)
   installSkillDependencies();
@@ -1123,6 +1139,7 @@ module.exports = {
   beforePack,
   afterPack,
   collectRuntimePackageClosure,
+  configureMacAutoUpdateMetadata,
   prepareWindowsLlamaCppBackendResources,
   prepareWindowsLlamaCppNsisHelperResources,
   resolveWindowsLlamaCppBackendBundleMode,

--- a/scripts/release/plan-r2-cleanup.mjs
+++ b/scripts/release/plan-r2-cleanup.mjs
@@ -7,12 +7,32 @@ import {
   referencedObjectKeys,
 } from './update-manifest-lib.mjs';
 
-const [stablePath, previousPath, previousHeadPath, objectListPath, outputDirectory] =
-  process.argv.slice(2);
-if (!stablePath || !previousPath || !previousHeadPath || !objectListPath || !outputDirectory) {
+const [
+  stablePath,
+  previousPath,
+  previousHeadPath,
+  activeGeneration,
+  previousGeneration,
+  objectListPath,
+  outputDirectory,
+] = process.argv.slice(2);
+if (
+  !stablePath ||
+  !previousPath ||
+  !previousHeadPath ||
+  !activeGeneration ||
+  !previousGeneration ||
+  !objectListPath ||
+  !outputDirectory
+) {
   throw new Error(
-    'usage: plan-r2-cleanup.mjs <stable> <previous-or-dash> <previous-head-or-dash> <object-list> <output-dir>',
+    'usage: plan-r2-cleanup.mjs <stable> <previous-or-dash> <previous-head-or-dash> <active-generation-or-dash> <previous-generation-or-dash> <object-list> <output-dir>',
   );
+}
+for (const generation of [activeGeneration, previousGeneration]) {
+  if (generation !== '-' && !/^[A-Za-z0-9._-]+$/.test(generation)) {
+    throw new Error(`Invalid generation identifier: ${generation}`);
+  }
 }
 
 const retentionMs = 24 * 60 * 60 * 1000;
@@ -20,6 +40,10 @@ const cutoff = Date.now() - retentionMs;
 const trustedKey = loadTrustedReleaseKey();
 const stableEntries = await readAndVerifyCollection(stablePath, trustedKey);
 const referencedKeys = referencedObjectKeys(stableEntries);
+const protectedGenerationPrefixes = new Set();
+if (activeGeneration !== '-') {
+  protectedGenerationPrefixes.add(`generations/${activeGeneration}/`);
+}
 
 if (previousPath !== '-' && previousHeadPath !== '-') {
   const previousHead = JSON.parse(await fs.readFile(previousHeadPath, 'utf8'));
@@ -30,6 +54,9 @@ if (previousPath !== '-' && previousHeadPath !== '-') {
   if (previousPublishedAt >= cutoff) {
     const previousEntries = await readAndVerifyCollection(previousPath, trustedKey);
     for (const key of referencedObjectKeys(previousEntries)) referencedKeys.add(key);
+    if (previousGeneration !== '-') {
+      protectedGenerationPrefixes.add(`generations/${previousGeneration}/`);
+    }
   }
 }
 
@@ -40,8 +67,9 @@ const keysToDelete = objects
     if (
       !object ||
       typeof object.Key !== 'string' ||
-      !object.Key.startsWith('releases/') ||
-      referencedKeys.has(object.Key)
+      (!object.Key.startsWith('releases/') && !object.Key.startsWith('generations/')) ||
+      referencedKeys.has(object.Key) ||
+      [...protectedGenerationPrefixes].some(prefix => object.Key.startsWith(prefix))
     ) {
       return false;
     }

--- a/scripts/release/published-update-smoke-lib.mjs
+++ b/scripts/release/published-update-smoke-lib.mjs
@@ -1,0 +1,52 @@
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+
+export async function verifyPublishedBlockmap({
+  fetchImpl = fetch,
+  target,
+  updaterUrl,
+  immutableUpdaterUrl,
+  updaterFilename,
+  timeoutMs = 15_000,
+}) {
+  if (!/\.(?:exe|zip)$/i.test(updaterFilename)) return false;
+
+  const blockmapUrl = new URL(`${updaterUrl.toString()}.blockmap`);
+  const immutableBlockmapUrl = new URL(`${immutableUpdaterUrl.toString()}.blockmap`);
+  const redirectResponse = await fetchImpl(blockmapUrl, {
+    method: 'HEAD',
+    redirect: 'manual',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const location = redirectResponse.headers.get('location');
+  if (
+    !REDIRECT_STATUSES.has(redirectResponse.status) ||
+    !location ||
+    new URL(location, blockmapUrl).toString() !== immutableBlockmapUrl.toString()
+  ) {
+    throw new Error(`${target} blockmap did not redirect to the immutable download`);
+  }
+
+  const headResponse = await fetchImpl(immutableBlockmapUrl, {
+    method: 'HEAD',
+    redirect: 'error',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const size = Number(headResponse.headers.get('content-length'));
+  if (!headResponse.ok || !Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`${target} blockmap HEAD did not return a valid object size`);
+  }
+
+  const rangeResponse = await fetchImpl(immutableBlockmapUrl, {
+    headers: { range: 'bytes=0-0' },
+    redirect: 'error',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  await rangeResponse.body?.cancel();
+  if (
+    rangeResponse.status !== 206 ||
+    rangeResponse.headers.get('content-range') !== `bytes 0-0/${size}`
+  ) {
+    throw new Error(`${target} blockmap did not satisfy the one-byte range smoke test`);
+  }
+  return true;
+}

--- a/scripts/release/published-update-smoke-lib.test.ts
+++ b/scripts/release/published-update-smoke-lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
+
+describe('published update smoke helpers', () => {
+  test('verifies the versioned redirect and Range support for differential blockmaps', async () => {
+    const immutable =
+      'https://downloads.rongxzyai.com/releases/2026.8.6/win32-x64-lite/ZhiYuan.exe.blockmap';
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 307, headers: { location: immutable } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, { status: 200, headers: { 'content-length': '321' } }),
+      )
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1]), {
+          status: 206,
+          headers: { 'content-range': 'bytes 0-0/321' },
+        }),
+      );
+
+    await expect(
+      verifyPublishedBlockmap({
+        fetchImpl,
+        target: 'win32:x64:lite',
+        updaterUrl: new URL(
+          'https://updates.rongxzyai.com/v2/electron/releases/2026.8.6/win32/x64/lite/ZhiYuan.exe',
+        ),
+        immutableUpdaterUrl: new URL(
+          'https://downloads.rongxzyai.com/releases/2026.8.6/win32-x64-lite/ZhiYuan.exe',
+        ),
+        updaterFilename: 'ZhiYuan.exe',
+      }),
+    ).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(fetchImpl.mock.calls[0]?.[0].toString()).toMatch(/ZhiYuan\.exe\.blockmap$/);
+    expect(fetchImpl.mock.calls[2]?.[1]).toMatchObject({
+      headers: { range: 'bytes=0-0' },
+    });
+  });
+
+  test('skips formats whose blockmap is embedded or not supported', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      verifyPublishedBlockmap({
+        fetchImpl,
+        target: 'linux:x64:appimage',
+        updaterUrl: new URL('https://updates.rongxzyai.com/ZhiYuan.AppImage'),
+        immutableUpdaterUrl: new URL('https://downloads.rongxzyai.com/ZhiYuan.AppImage'),
+        updaterFilename: 'ZhiYuan.AppImage',
+      }),
+    ).resolves.toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/release/update-manifest-lib.test.ts
+++ b/scripts/release/update-manifest-lib.test.ts
@@ -295,13 +295,29 @@ describe('online update release tools', () => {
             Key: 'releases/2026.7.2/win32-x64-lite/recent.exe',
             LastModified: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
           },
+          {
+            Key: 'generations/active-opaque-id/legacy/stable.json',
+            LastModified: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+          },
+          {
+            Key: 'generations/2026.7.3/legacy/stable.json',
+            LastModified: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+          },
+          {
+            Key: 'generations/2026.7.1/electron/win32-x64-lite/latest.yml',
+            LastModified: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+          },
+          {
+            Key: 'generations/2026.7.2/legacy/stable.json',
+            LastModified: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+          },
         ],
       }),
     );
 
     const result = runScript(
       'plan-r2-cleanup.mjs',
-      [stableManifest, '-', '-', objectListPath, cleanupDirectory],
+      [stableManifest, '-', '-', 'active-opaque-id', '-', objectListPath, cleanupDirectory],
       releaseEnvironment,
     );
     expect(result.stderr).toBe('');
@@ -312,6 +328,8 @@ describe('online update release tools', () => {
     );
     expect(deletePlan.Objects).toEqual([
       { Key: 'releases/2026.7.1/win32-x64-lite/expired.exe' },
+      { Key: 'generations/2026.7.3/legacy/stable.json' },
+      { Key: 'generations/2026.7.1/electron/win32-x64-lite/latest.yml' },
     ]);
   });
 

--- a/scripts/release/verify-published-update.mjs
+++ b/scripts/release/verify-published-update.mjs
@@ -3,6 +3,7 @@ import {
   loadTrustedReleaseKey,
   verifyEnvelope,
 } from './update-manifest-lib.mjs';
+import { verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
 import yaml from 'js-yaml';
 
 const [expectedVersion, ...targets] = process.argv.slice(2);
@@ -164,5 +165,11 @@ for (const target of targets) {
   ) {
     throw new Error(`${target} updater artifact did not satisfy the one-byte range smoke test`);
   }
+  await verifyPublishedBlockmap({
+    target,
+    updaterUrl,
+    immutableUpdaterUrl: new URL(signedUpdater.url),
+    updaterFilename: signedUpdater.filename,
+  });
   console.log(`[UpdateRelease] ${target} passed electron-updater feed smoke test`);
 }

--- a/src/main/libs/appUpdateCoordinator.test.ts
+++ b/src/main/libs/appUpdateCoordinator.test.ts
@@ -50,16 +50,23 @@ vi.mock('electron-updater', () => ({
 }));
 
 const electronMocks = vi.hoisted(() => ({
+  getAppPath: vi.fn(() => process.cwd()),
   getPath: vi.fn(() => os.tmpdir()),
+  isPackaged: false,
+  openExternal: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
   app: {
-    getAppPath: () => process.cwd(),
+    getAppPath: electronMocks.getAppPath,
     getPath: electronMocks.getPath,
     getVersion: () => '2026.7.1',
+    get isPackaged() {
+      return electronMocks.isPackaged;
+    },
   },
   BrowserWindow: { getAllWindows: () => [] },
+  shell: { openExternal: electronMocks.openExternal },
 }));
 
 vi.mock('./appUpdateInstaller', () => ({ installWindowsNsis: vi.fn() }));
@@ -156,6 +163,9 @@ describe('AppUpdateCoordinator electron-updater bridge', () => {
     vi.mocked(updaterMocks.autoUpdater.checkForUpdates).mockReset();
     vi.mocked(updaterMocks.autoUpdater.downloadUpdate).mockReset();
     vi.mocked(updaterMocks.autoUpdater.quitAndInstall).mockReset();
+    electronMocks.getAppPath.mockReturnValue(process.cwd());
+    electronMocks.isPackaged = false;
+    electronMocks.openExternal.mockReset();
   });
 
   afterEach(async () => {
@@ -285,9 +295,9 @@ describe('AppUpdateCoordinator electron-updater bridge', () => {
 
   test('preserves active download progress when another update check is triggered', async () => {
     const envelope = signedManifest(privateKey, { updaterSha512 });
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(envelope), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(envelope), { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
     vi.mocked(updaterMocks.autoUpdater.checkForUpdates).mockResolvedValue({
       isUpdateAvailable: true,
@@ -335,6 +345,35 @@ describe('AppUpdateCoordinator electron-updater bridge', () => {
     expect(updaterMocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
   });
 
+  test('uses the signed manifest as a manual DMG fallback for unsigned packaged macOS builds', async () => {
+    const envelope = signedManifest(privateKey, { updaterSha512 });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(envelope), { status: 200 })),
+    );
+    electronMocks.isPackaged = true;
+    electronMocks.getAppPath.mockReturnValue(path.dirname(downloadedFile));
+    await fs.promises.writeFile(
+      path.join(path.dirname(downloadedFile), 'package.json'),
+      JSON.stringify({ zhiyuanMacAutoUpdateEnabled: false }),
+    );
+    electronMocks.openExternal.mockResolvedValue(undefined);
+
+    const coordinator = new AppUpdateCoordinator(new MemoryStore() as unknown as SqliteStore);
+    const result = await coordinator.checkNow({ manual: true });
+
+    expect(result.success).toBe(true);
+    expect(result.state.status).toBe(AppUpdateStatus.Available);
+    expect(result.state.info?.manualDownloadOnly).toBe(true);
+    expect(updaterMocks.autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    expect(updaterMocks.autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+
+    await coordinator.retryDownload();
+    expect(electronMocks.openExternal).toHaveBeenCalledWith(
+      'https://downloads.rongxzyai.com/releases/2026.7.2/darwin-arm64-default/ZhiYuan.dmg',
+    );
+  });
+
   test('surfaces update check failures instead of returning to an unchecked idle state', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network offline')));
 
@@ -370,6 +409,62 @@ describe('AppUpdateCoordinator electron-updater bridge', () => {
 
     expect(result.success).toBe(false);
     expect(result.state.status).toBe(AppUpdateStatus.Error);
+    expect(updaterMocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  test('revokes an active download when enterprise policy disables updates', async () => {
+    const envelope = signedManifest(privateKey, { updaterSha512 });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(envelope), { status: 200 })),
+    );
+    vi.mocked(updaterMocks.autoUpdater.checkForUpdates).mockResolvedValue({
+      isUpdateAvailable: true,
+      updateInfo: updaterInfo('2026.7.2', updaterSha512),
+    });
+    vi.mocked(updaterMocks.autoUpdater.downloadUpdate).mockImplementation(
+      () => new Promise(() => {}),
+    );
+    const store = new MemoryStore();
+    const coordinator = new AppUpdateCoordinator(store as unknown as SqliteStore);
+    await coordinator.checkNow();
+    const token = vi.mocked(updaterMocks.autoUpdater.downloadUpdate).mock.calls[0]?.[0] as {
+      cancel: ReturnType<typeof vi.fn>;
+    };
+
+    store.set('enterprise_config', { disableUpdate: true });
+    const state = coordinator.getState();
+
+    expect(token.cancel).toHaveBeenCalledOnce();
+    expect(state.status).toBe(AppUpdateStatus.Idle);
+    expect(state.info).toBeNull();
+  });
+
+  test('rechecks enterprise policy before installing an already ready update', async () => {
+    const envelope = signedManifest(privateKey, { updaterSha512 });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(envelope), { status: 200 })),
+    );
+    vi.mocked(updaterMocks.autoUpdater.checkForUpdates).mockResolvedValue({
+      isUpdateAvailable: true,
+      updateInfo: updaterInfo('2026.7.2', updaterSha512),
+    });
+    vi.mocked(updaterMocks.autoUpdater.downloadUpdate).mockImplementation(async () => {
+      updaterMocks.emit('update-downloaded', { downloadedFile });
+      return [downloadedFile];
+    });
+    const store = new MemoryStore();
+    const coordinator = new AppUpdateCoordinator(store as unknown as SqliteStore);
+    await coordinator.checkNow();
+    await vi.waitFor(() => expect(coordinator.getState().status).toBe(AppUpdateStatus.Ready));
+
+    store.set('enterprise_config', { disableUpdate: true });
+    const result = await coordinator.installReadyUpdate();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Updates are disabled by enterprise policy');
+    expect(result.state.status).toBe(AppUpdateStatus.Idle);
     expect(updaterMocks.autoUpdater.quitAndInstall).not.toHaveBeenCalled();
   });
 });

--- a/src/main/libs/appUpdateCoordinator.ts
+++ b/src/main/libs/appUpdateCoordinator.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, shell } from 'electron';
 import {
   autoUpdater,
   CancellationToken,
@@ -124,6 +124,7 @@ export class AppUpdateCoordinator {
   private state: AppUpdateRuntimeState = initialState();
   private readonly store: SqliteStore;
   private readonly updater: ElectronUpdaterAdapter;
+  private readonly openExternal: (url: string) => Promise<unknown>;
   private checkPromise: Promise<AppUpdateCheckResult> | null = null;
   private downloadPromise: Promise<void> | null = null;
   private downloadCancellation: CancellationToken | null = null;
@@ -136,9 +137,14 @@ export class AppUpdateCoordinator {
   };
   private readonly onUpdaterError = (error: Error): void => this.handleUpdaterError(error);
 
-  constructor(store: SqliteStore, updater: ElectronUpdaterAdapter = autoUpdater) {
+  constructor(
+    store: SqliteStore,
+    updater: ElectronUpdaterAdapter = autoUpdater,
+    openExternal: (url: string) => Promise<unknown> = url => shell.openExternal(url),
+  ) {
     this.store = store;
     this.updater = updater;
+    this.openExternal = openExternal;
     this.updater.autoDownload = false;
     this.updater.autoInstallOnAppQuit = false;
     this.updater.on('download-progress', this.onDownloadProgress);
@@ -155,13 +161,13 @@ export class AppUpdateCoordinator {
   }
 
   getState(): AppUpdateRuntimeState {
+    this.clearStateIfUpdatesDisabled();
     return { ...this.state };
   }
 
   async checkNow(options: { manual?: boolean } = {}): Promise<AppUpdateCheckResult> {
-    if (this.isUpdateDisabled()) {
-      this.currentSignedEnvelope = null;
-      return { success: true, state: this.setState(initialState()), updateFound: false };
+    if (this.clearStateIfUpdatesDisabled()) {
+      return { success: true, state: { ...this.state }, updateFound: false };
     }
     if (this.checkPromise) return this.checkPromise;
     // Do not let the periodic checker replace an active download state. Apart
@@ -183,6 +189,7 @@ export class AppUpdateCoordinator {
   }
 
   async retryDownload(): Promise<AppUpdateRuntimeState> {
+    if (this.clearStateIfUpdatesDisabled()) return { ...this.state };
     const info = this.state.info;
     const target = this.resolveUpdateTarget();
     if (!info || !target || this.state.status === AppUpdateStatus.Installing) {
@@ -201,6 +208,19 @@ export class AppUpdateCoordinator {
         currentState.status === AppUpdateStatus.Installing
       ) {
         return currentState;
+      }
+    }
+    if (info.manualDownloadOnly) {
+      try {
+        await this.openExternal(info.url);
+        return this.getState();
+      } catch (error) {
+        return this.setState({
+          ...this.state,
+          status: AppUpdateStatus.Error,
+          errorMessage:
+            error instanceof Error ? error.message : 'Unable to open the update download page',
+        });
       }
     }
     if (!this.currentSignedEnvelope) {
@@ -245,6 +265,13 @@ export class AppUpdateCoordinator {
     state: AppUpdateRuntimeState;
     error?: string;
   }> {
+    if (this.clearStateIfUpdatesDisabled()) {
+      return {
+        success: false,
+        state: { ...this.state },
+        error: 'Updates are disabled by enterprise policy',
+      };
+    }
     const { info, readyFileHash, readyFilePath } = this.state;
     if (this.state.status !== AppUpdateStatus.Ready || !info || !readyFileHash || !readyFilePath) {
       return { success: false, state: this.getState(), error: 'No verified update is ready' };
@@ -310,6 +337,16 @@ export class AppUpdateCoordinator {
       }
 
       this.currentSignedEnvelope = update.envelope;
+      if (update.info.manualDownloadOnly) {
+        const state = this.setState({
+          ...initialState(),
+          status: AppUpdateStatus.Available,
+          source,
+          info: update.info,
+          lastCheckedAt: Date.now(),
+        });
+        return { success: true, state, updateFound: true };
+      }
       this.configureUpdater(update.target);
       const result = await this.updater.checkForUpdates();
       if (!result?.isUpdateAvailable) {
@@ -481,6 +518,10 @@ export class AppUpdateCoordinator {
   }
 
   private restoreReadyUpdate(): void {
+    if (this.isUpdateDisabled()) {
+      this.store.delete(READY_UPDATE_CACHE_KEY);
+      return;
+    }
     const cached = this.store.get<unknown>(READY_UPDATE_CACHE_KEY);
     if (!cached || typeof cached !== 'object') return;
     // Windows owns the final installer handoff directly. macOS and Linux let
@@ -677,6 +718,7 @@ export class AppUpdateCoordinator {
       expectedSha256: artifact.sha256,
       expectedUpdaterSha512: artifact.updater.sha512,
       expectedUpdaterFileName: artifact.updater.filename,
+      manualDownloadOnly: !this.isElectronUpdaterEnabled(target),
       mandatory: payload.mandatory === true,
       minimumSupportedVersion,
     };
@@ -697,6 +739,33 @@ export class AppUpdateCoordinator {
 
   private isUpdateDisabled(): boolean {
     return this.store.get<{ disableUpdate?: boolean }>('enterprise_config')?.disableUpdate === true;
+  }
+
+  private clearStateIfUpdatesDisabled(): boolean {
+    if (!this.isUpdateDisabled()) return false;
+    this.downloadCancellation?.cancel();
+    this.downloadCancellation = null;
+    this.currentSignedEnvelope = null;
+    this.downloadedFilePath = null;
+    this.store.delete(READY_UPDATE_CACHE_KEY);
+    if (this.state.status !== AppUpdateStatus.Idle || this.state.info !== null) {
+      this.setState(initialState());
+    }
+    return true;
+  }
+
+  private isElectronUpdaterEnabled(target: UpdateTarget): boolean {
+    if (target.platform !== 'darwin' || !app.isPackaged) return true;
+    try {
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(app.getAppPath(), 'package.json'), 'utf8'),
+      ) as { zhiyuanMacAutoUpdateEnabled?: unknown };
+      return packageJson.zhiyuanMacAutoUpdateEnabled === true;
+    } catch {
+      // A packaged macOS build must opt in only after CI has signed and
+      // notarized it. Missing metadata therefore falls back to manual DMG.
+      return false;
+    }
   }
 
   private resolveCurrentVersion(): string {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -507,8 +507,20 @@ const App: React.FC = () => {
     }
     if (appUpdateState.status === AppUpdateStatus.Error) {
       await window.electron.appUpdate.retryDownload();
+      return;
     }
-  }, [appUpdateState.readyFilePath, appUpdateState.status, showToast]);
+    if (
+      appUpdateState.status === AppUpdateStatus.Available &&
+      appUpdateState.info?.manualDownloadOnly
+    ) {
+      await window.electron.appUpdate.retryDownload();
+    }
+  }, [
+    appUpdateState.info?.manualDownloadOnly,
+    appUpdateState.readyFilePath,
+    appUpdateState.status,
+    showToast,
+  ]);
 
   const handlePermissionResponse = useCallback(
     async (result: CoworkPermissionResult) => {
@@ -648,7 +660,8 @@ const App: React.FC = () => {
   const shouldShowUpdateBadge =
     updateInfo &&
     (appUpdateState.status === AppUpdateStatus.Ready ||
-      appUpdateState.status === AppUpdateStatus.Error);
+      appUpdateState.status === AppUpdateStatus.Error ||
+      (appUpdateState.status === AppUpdateStatus.Available && updateInfo.manualDownloadOnly));
   const updateEntry = shouldShowUpdateBadge ? (
     <AppUpdateBadge
       latestVersion={updateInfo.latestVersion}

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -5323,9 +5323,23 @@ const Settings: React.FC<SettingsProps> = ({
                     </Button>
                   </div>
                 ) : update?.status === AppUpdateStatus.Available ? (
-                  <Button size="sm" onClick={() => void window.electron.appUpdate.retryDownload()}>
-                    {i18nService.t('updateDownloadNow')}
-                  </Button>
+                  <div className="space-y-2">
+                    {update.info?.manualDownloadOnly ? (
+                      <div className="text-xs text-muted-foreground">
+                        {i18nService.t('updateManualOnly')}
+                      </div>
+                    ) : null}
+                    <Button
+                      size="sm"
+                      onClick={() => void window.electron.appUpdate.retryDownload()}
+                    >
+                      {i18nService.t(
+                        update.info?.manualDownloadOnly
+                          ? 'updateOpenDownloadPage'
+                          : 'updateDownloadNow',
+                      )}
+                    </Button>
+                  </div>
                 ) : update?.status !== AppUpdateStatus.Checking &&
                   update?.status !== AppUpdateStatus.UpToDate ? (
                   <Button

--- a/src/renderer/components/update/AppUpdateBadge.tsx
+++ b/src/renderer/components/update/AppUpdateBadge.tsx
@@ -18,7 +18,9 @@ const AppUpdateBadge: React.FC<AppUpdateBadgeProps> = ({ latestVersion, status, 
   const label =
     status === AppUpdateStatus.Ready
       ? i18nService.t('updateReadyConfirm')
-      : i18nService.t('updateErrorPill');
+      : status === AppUpdateStatus.Available
+        ? i18nService.t('updateOpenDownloadPage')
+        : i18nService.t('updateErrorPill');
 
   return (
     <Button
@@ -29,7 +31,7 @@ const AppUpdateBadge: React.FC<AppUpdateBadgeProps> = ({ latestVersion, status, 
       title={`${label} ${latestVersion}`}
       aria-label={`${label} ${latestVersion}`}
     >
-      {status === AppUpdateStatus.Error ? (
+      {status === AppUpdateStatus.Error || status === AppUpdateStatus.Available ? (
         <Download className="h-4 w-4 shrink-0" />
       ) : (
         <ArrowUpCircle className="h-4 w-4 shrink-0" />

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1616,6 +1616,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     updateCheckFailed: '检查失败',
     updateNotChecked: '尚未检查',
     updateDownloadNow: '下载更新',
+    updateOpenDownloadPage: '前往下载',
+    updateManualOnly: '当前 macOS 构建暂不支持应用内安装，请下载 DMG 手动更新。',
     updateCheckNow: '检查更新',
     updateLastChecked: '上次检查：',
     coworkStartingSession: '正在启动会话...',
@@ -4520,6 +4522,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     updateCheckFailed: 'Check failed',
     updateNotChecked: 'Not checked yet',
     updateDownloadNow: 'Download update',
+    updateOpenDownloadPage: 'Open download page',
+    updateManualOnly:
+      'In-app installation is unavailable for this macOS build. Download the DMG to update manually.',
     updateCheckNow: 'Check for updates',
     updateLastChecked: 'Last checked: ',
     coworkStartingSession: 'Starting session...',

--- a/src/shared/appUpdate/constants.ts
+++ b/src/shared/appUpdate/constants.ts
@@ -46,6 +46,8 @@ export interface AppUpdateInfo {
   expectedUpdaterSha512: string;
   /** Basename of the updater artifact whose SHA-512 was authorized. */
   expectedUpdaterFileName: string;
+  /** The current build must open the installer URL instead of using electron-updater. */
+  manualDownloadOnly: boolean;
   mandatory: boolean;
   minimumSupportedVersion: string | null;
 }

--- a/tests/electron-builder-hooks.test.ts
+++ b/tests/electron-builder-hooks.test.ts
@@ -7,13 +7,33 @@ import {
   LLAMACPP_NSIS_HELPER_RESOURCES_DIR,
   LLAMACPP_NSIS_HELPER_RUNTIME_PACKAGES,
   LLAMACPP_NSIS_HELPER_SCRIPT,
+  configureMacAutoUpdateMetadata,
   prepareWindowsLlamaCppBackendResources,
   prepareWindowsLlamaCppNsisHelperResources,
   resolveWindowsLlamaCppBackendBundleMode,
   WindowsLlamaCppBackendBundleMode,
 } from '../scripts/electron-builder-hooks.cjs';
 
-describe('electron-builder Windows llama.cpp packaging hooks', () => {
+describe('electron-builder packaging hooks', () => {
+  test('marks macOS automatic installation disabled unless signing explicitly enables it', () => {
+    const context = {
+      electronPlatformName: 'darwin',
+      packager: { config: { extraMetadata: { retained: true } } },
+    };
+
+    configureMacAutoUpdateMetadata(context, {});
+    expect(context.packager.config.extraMetadata).toEqual({
+      retained: true,
+      zhiyuanMacAutoUpdateEnabled: false,
+    });
+
+    configureMacAutoUpdateMetadata(context, { ZHIYUAN_MAC_AUTO_UPDATE_ENABLED: 'true' });
+    expect(context.packager.config.extraMetadata).toEqual({
+      retained: true,
+      zhiyuanMacAutoUpdateEnabled: true,
+    });
+  });
+
   test('defaults Windows llama.cpp backend bundle mode to lite', () => {
     expect(resolveWindowsLlamaCppBackendBundleMode({})).toBe(WindowsLlamaCppBackendBundleMode.Lite);
     expect(


### PR DESCRIPTION
## Summary

- build unsigned and unnotarized macOS packages only when all Apple credentials are absent, and mark those builds for manual DMG updates
- enable macOS in-app installation only for fully signed and notarized builds, with codesign, stapler, and Gatekeeper verification
- reauthorize retry and install operations against enterprise update policy
- clean expired opaque R2 generations and verify published Windows/macOS blockmaps with redirect, HEAD, and Range smoke tests

## Validation

- 27 focused tests passed across updater coordinator, packaging hooks, release manifest cleanup, and blockmap smoke helpers
- TypeScript build passed
- lint, formatting, YAML parsing, and git diff checks passed
- empty, partial, and complete Apple credential branches exercised
- two independent review passes completed with no remaining blockers

## Known limitation

The local full test wrapper was unable to complete its final better-sqlite3 native rebuild cleanup. Focused assertions passed; CI will run the suite in a clean environment.