### PR TITLE
fix(release): pin updater metadata to stable channel

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -307,6 +307,7 @@
   },
   "electronVersion": "40.2.1",
   "electronUpdaterCompatibility": ">=6.0.0",
+  "detectUpdateChannel": false,
   "generateUpdatesFilesForAllChannels": false,
   "asarUnpack": [
     "node_modules/@img/**",

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { prerelease } from 'semver';
 import { test } from 'vitest';
 
 const root = path.resolve(__dirname, '..');
@@ -22,19 +23,15 @@ test('each desktop target keeps the private document and Python toolchain resour
   const linux = resourceSources(config.linux);
 
   assert.deepEqual(
-    [
-      'resources/uv-mac',
-      'resources/python-mac',
-      'resources/skill-python',
-    ].every(source => mac.includes(source)),
+    ['resources/uv-mac', 'resources/python-mac', 'resources/skill-python'].every(source =>
+      mac.includes(source),
+    ),
     true,
   );
   assert.deepEqual(
-    [
-      'resources/uv-linux',
-      'resources/python-linux',
-      'resources/skill-python',
-    ].every(source => linux.includes(source)),
+    ['resources/uv-linux', 'resources/python-linux', 'resources/skill-python'].every(source =>
+      linux.includes(source),
+    ),
     true,
   );
 
@@ -53,6 +50,21 @@ test('unpacks AnyDoc native bindings from the application archive', () => {
 
   const viteConfig = readFileSync(path.join(root, 'vite.config.ts'), 'utf8');
   assert.match(viteConfig, /staticExternals\s*=\s*\[[\s\S]*['"]@firecrawl\/anydoc['"]/);
+});
+
+test('stable release metadata does not inherit the build prerelease channel', () => {
+  const config = JSON.parse(readFileSync(path.join(root, 'electron-builder.json'), 'utf8')) as {
+    detectUpdateChannel?: boolean;
+    linux?: { publish?: Array<{ url?: string }> };
+    mac?: { publish?: Array<{ url?: string }> };
+    win?: { publish?: Array<{ url?: string }> };
+  };
+
+  assert.deepEqual(prerelease('2026.8.6-build.1'), ['build', 1]);
+  assert.equal(config.detectUpdateChannel, false);
+  for (const target of [config.win, config.mac, config.linux]) {
+    assert.match(target?.publish?.[0]?.url || '', /\/v2\/electron\/stable\//);
+  }
 });
 
 test('release workflows explicitly provision the private POSIX toolchain', () => {


### PR DESCRIPTION
## Summary
- disable electron-builder prerelease-channel inference for stable desktop releases
- keep Windows, macOS, and Linux metadata names on latest*.yml even when the app version contains -build.N
- add a regression assertion covering the build prerelease segment and stable feed URLs

## Root cause
Release run 31073730601 built the Linux packages but electron-builder inferred channel build from version 2026.8.6-build.1, so it wrote build-linux.yml while the stable release workflow required latest-linux.yml. The stable manifest was not published.

## Validation
- bunx vitest run tests/runtimePackagingConfig.test.ts
- bun run lint
- bun run build:tsc
- electron-builder 26.15.3 schema validation
- bunx oxfmt --check electron-builder.json tests/runtimePackagingConfig.test.ts
- git diff --check