### PR TITLE
fix(release): isolate unsigned macOS build

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -204,8 +204,16 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      - name: Build macOS package
-        if: ${{ matrix.platform == 'macos' }}
+      - name: Build unsigned macOS package
+        if: ${{ matrix.platform == 'macos' && env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED != 'true' }}
+        run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Build signed macOS package
+        if: ${{ matrix.platform == 'macos' && env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED == 'true' }}
         run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
         env:
           APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -67,6 +67,27 @@ test('stable release metadata does not inherit the build prerelease channel', ()
   }
 });
 
+test('unsigned macOS release builds do not receive empty signing credentials', () => {
+  const workflow = readFileSync(
+    path.join(root, '.github', 'workflows', 'online-update-release.yml'),
+    'utf8',
+  );
+  const unsignedStart = workflow.indexOf('- name: Build unsigned macOS package');
+  const signedStart = workflow.indexOf('- name: Build signed macOS package');
+  const verifyStart = workflow.indexOf('- name: Verify signed and notarized macOS app');
+
+  assert.ok(unsignedStart >= 0 && signedStart > unsignedStart && verifyStart > signedStart);
+  const unsignedStep = workflow.slice(unsignedStart, signedStart);
+  const signedStep = workflow.slice(signedStart, verifyStart);
+  assert.match(unsignedStep, /ZHIYUAN_MAC_AUTO_UPDATE_ENABLED != 'true'/);
+  assert.doesNotMatch(
+    unsignedStep,
+    /CSC_LINK|CSC_KEY_PASSWORD|APPLE_ID|APPLE_APP_SPECIFIC_PASSWORD|APPLE_TEAM_ID/,
+  );
+  assert.match(signedStep, /ZHIYUAN_MAC_AUTO_UPDATE_ENABLED == 'true'/);
+  assert.match(signedStep, /CSC_LINK:[\s\S]*APPLE_TEAM_ID:/);
+});
+
 test('release workflows explicitly provision the private POSIX toolchain', () => {
   for (const workflow of ['build-platforms.yml', 'online-update-release.yml']) {
     const content = readFileSync(path.join(root, '.github', 'workflows', workflow), 'utf8');


### PR DESCRIPTION
## Summary
- split macOS packaging into mutually exclusive unsigned and signed steps
- keep Apple/CSC variables completely out of the unsigned build environment
- preserve the future signed and notarized path when all five credentials are configured
- add regression coverage for secret isolation

## Root cause
Release run 31075093659 correctly selected manual macOS updates, but the build step still received an empty CSC_LINK. electron-builder resolved that empty value to the repository directory and failed with 'not a file'. The stable manifest was not published.

## Validation
- bunx vitest run tests/runtimePackagingConfig.test.ts
- bun run lint
- bun run build:tsc
- js-yaml workflow parse
- bunx oxfmt --check .github/workflows/online-update-release.yml tests/runtimePackagingConfig.test.ts
- git diff --check
- independent review of unsigned and future signed branches