### PR TITLE
fix(release): validate packaged Windows runtime

### DIFF
--- a/scripts/ci/windows-runtime-smoke.ps1
+++ b/scripts/ci/windows-runtime-smoke.ps1
@@ -51,14 +51,26 @@ try {
   $python = Join-Path $resourcesRoot 'python-win\python.exe'
   $skillPython = Join-Path $resourcesRoot 'skill-python\xlsx\Scripts\python.exe'
   $pdfPython = Join-Path $resourcesRoot 'skill-python\pdf\Scripts\python.exe'
-  $electron = Join-Path $ProjectRoot 'node_modules\electron\dist\electron.exe'
+  $builderConfigPath = Join-Path $ProjectRoot 'electron-builder.json'
+  Assert-Path $builderConfigPath 'electron-builder configuration'
+  $builderConfig = Get-Content -LiteralPath $builderConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json
+  $appExecutableName = $builderConfig.executableName
+  if (-not $appExecutableName) {
+    $appExecutableName = $builderConfig.productName
+  }
+  if (-not $appExecutableName) {
+    throw 'electron-builder.json must define executableName or productName'
+  }
+  # Exercise the packaged Electron binary instead of relying on the optional
+  # node_modules Electron download that bun install --ignore-scripts omits.
+  $electron = Join-Path $ProjectRoot ("release\win-unpacked\{0}.exe" -f $appExecutableName)
   $skillsRoot = Join-Path $resourcesRoot 'SKILLs'
 
   Assert-Path $bash 'bundled PortableGit Bash'
   Assert-Path $python 'bundled application Python'
   Assert-Path $skillPython 'bundled XLSX Skill Python'
   Assert-Path $pdfPython 'bundled PDF Skill Python'
-  Assert-Path $electron 'Electron Node runtime'
+  Assert-Path $electron 'packaged Electron Node runtime'
   Assert-Path (Join-Path $resourcesRoot 'uv-win\uv.exe') 'bundled uv'
   Assert-Path (Join-Path $skillsRoot 'xlsx\scripts\xlsx_reader.py') 'XLSX Skill reader'
   Assert-Path (Join-Path $skillsRoot 'docx\scripts\markdown_to_docx.mjs') 'DOCX Markdown converter'

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -107,7 +107,10 @@ test('Windows release workflow runs the clean-path bundled runtime gate', () => 
   assert.match(smoke, /skill-python\\pdf/);
   assert.match(smoke, /markdown_to_docx\.mjs/);
   assert.match(smoke, /docx\\scripts\\markdown_to_docx\.mjs/);
-  assert.match(smoke, /electron\\dist\\electron\.exe/);
+  assert.match(smoke, /electron-builder\.json/);
+  assert.match(smoke, /release\\win-unpacked/);
+  assert.match(smoke, /packaged Electron Node runtime/);
+  assert.doesNotMatch(smoke, /node_modules\\electron\\dist\\electron\.exe/);
   assert.match(smoke, /ELECTRON_RUN_AS_NODE/);
   assert.match(smoke, /DOCX Markdown conversion/);
   assert.match(smoke, /DOCX heading validation/);


### PR DESCRIPTION
## Summary
- use the actual packaged Electron executable for the Windows clean-PATH runtime smoke
- derive its filename from electron-builder.json with UTF-8-safe PowerShell 5.1 parsing
- prevent regression to the optional node_modules Electron download

## Root cause
Tag v2026.8.6-build.3 successfully produced release\win-unpacked\知远.exe, but the post-build gate looked for node_modules\electron\dist\electron.exe. The release workflow installs with bun --ignore-scripts, so that development binary is intentionally absent.

## Validation
- bun test tests/runtimePackagingConfig.test.ts (6/6)
- git diff --check
- independent review: no blockers
- GitHub Actions job 92535849072 confirms appOutDir=release\win-unpacked and executablePath=release\win-unpacked\知远.exe

The Windows tag build remains the final runtime execution proof.