### PR TITLE
fix(release): await packaged Windows runtime

### DIFF
--- a/scripts/ci/validate-docx-smoke.mjs
+++ b/scripts/ci/validate-docx-smoke.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { inflateRawSync } from 'node:zlib';
+
+const docxPath = process.argv[2];
+if (!docxPath) {
+  console.error('Usage: validate-docx-smoke.mjs <document.docx>');
+  process.exit(1);
+}
+
+try {
+  const archive = readFileSync(docxPath);
+  if (archive.length < 4 || archive.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error('document is not a ZIP archive');
+  }
+
+  let offset = 0;
+  let documentXml = '';
+  while (offset + 30 <= archive.length && archive.readUInt32LE(offset) === 0x04034b50) {
+    const compressionMethod = archive.readUInt16LE(offset + 8);
+    const compressedSize = archive.readUInt32LE(offset + 18);
+    const filenameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    const dataStart = offset + 30 + filenameLength + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    if (dataEnd > archive.length) throw new Error('document contains a truncated ZIP entry');
+
+    const filename = archive.subarray(offset + 30, offset + 30 + filenameLength).toString();
+    if (filename === 'word/document.xml') {
+      const compressed = archive.subarray(dataStart, dataEnd);
+      if (compressionMethod === 0) documentXml = compressed.toString();
+      else if (compressionMethod === 8) documentXml = inflateRawSync(compressed).toString();
+      else throw new Error(`word/document.xml uses unsupported compression ${compressionMethod}`);
+      break;
+    }
+    offset = dataEnd;
+  }
+
+  if (!documentXml.includes('Heading1')) {
+    throw new Error('word/document.xml is missing the Heading1 style');
+  }
+  console.log(`Validated DOCX: ${docxPath}`);
+} catch (error) {
+  console.error(
+    `DOCX validation failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exit(1);
+}

--- a/scripts/ci/windows-runtime-smoke.ps1
+++ b/scripts/ci/windows-runtime-smoke.ps1
@@ -24,6 +24,28 @@ function Invoke-Checked {
   }
 }
 
+function Invoke-PackagedElectronChecked {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [string]$Label = $FilePath
+  )
+  # The packaged Electron binary is a Windows GUI executable even when
+  # ELECTRON_RUN_AS_NODE is set. Start-Process -Wait provides deterministic
+  # process-tree completion and an explicit exit code on Windows PowerShell 5.1.
+  $quotedArguments = @($ArgumentList | ForEach-Object {
+    if ($_ -match '"') {
+      throw "$Label received an argument containing an unsupported double quote: $_"
+    }
+    '"' + $_ + '"'
+  })
+  $process = Start-Process -FilePath $FilePath -ArgumentList $quotedArguments `
+    -NoNewWindow -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    throw "$Label failed with exit code $($process.ExitCode)"
+  }
+}
+
 $osVersion = [Environment]::OSVersion.Version
 if ($osVersion.Major -ne 10) {
   throw "This gate requires a Windows 10/11-compatible host; detected $osVersion"
@@ -64,6 +86,7 @@ try {
   # Exercise the packaged Electron binary instead of relying on the optional
   # node_modules Electron download that bun install --ignore-scripts omits.
   $electron = Join-Path $ProjectRoot ("release\win-unpacked\{0}.exe" -f $appExecutableName)
+  $docxValidator = Join-Path $ProjectRoot 'scripts\ci\validate-docx-smoke.mjs'
   $skillsRoot = Join-Path $resourcesRoot 'SKILLs'
 
   Assert-Path $bash 'bundled PortableGit Bash'
@@ -71,6 +94,7 @@ try {
   Assert-Path $skillPython 'bundled XLSX Skill Python'
   Assert-Path $pdfPython 'bundled PDF Skill Python'
   Assert-Path $electron 'packaged Electron Node runtime'
+  Assert-Path $docxValidator 'DOCX smoke validator'
   Assert-Path (Join-Path $resourcesRoot 'uv-win\uv.exe') 'bundled uv'
   Assert-Path (Join-Path $skillsRoot 'xlsx\scripts\xlsx_reader.py') 'XLSX Skill reader'
   Assert-Path (Join-Path $skillsRoot 'docx\scripts\markdown_to_docx.mjs') 'DOCX Markdown converter'
@@ -96,10 +120,9 @@ try {
   $docx = Join-Path $smokeRoot 'smoke.docx'
   $converter = Join-Path $skillsRoot 'docx\scripts\markdown_to_docx.mjs'
   Set-Content -LiteralPath $markdown -Value "# Windows runtime smoke`n`nManaged DOCX conversion works.`n" -Encoding UTF8
-  Invoke-Checked $electron @($converter, $markdown, $docx) 'DOCX Markdown conversion'
+  Invoke-PackagedElectronChecked $electron @($converter, $markdown, $docx) 'DOCX Markdown conversion'
   Assert-Path $docx 'generated DOCX'
-  Invoke-Checked $electron @('-e', "const fs=require('fs'); const b=fs.readFileSync(process.argv[1]); if (b.readUInt32LE(0) !== 0x04034b50) { process.exit(1) }", $docx) 'generated DOCX ZIP validation'
-  Invoke-Checked $electron @('-e', "const fs=require('fs'),z=require('zlib'); const b=fs.readFileSync(process.argv[1]); let o=0,x=''; while(o+30<=b.length&&b.readUInt32LE(o)===0x04034b50){const m=b.readUInt16LE(o+8),n=b.readUInt32LE(o+18),l=b.readUInt16LE(o+26),e=b.readUInt16LE(o+28),s=o+30+l+e,k=b.subarray(o+30,o+30+l).toString(); if(k==='word/document.xml'){x=(m===8?z.inflateRawSync(b.subarray(s,s+n)):b.subarray(s,s+n)).toString();break} o=s+n} if(!x.includes('Heading1'))process.exit(1)", $docx) 'generated DOCX heading validation'
+  Invoke-PackagedElectronChecked $electron @($docxValidator, $docx) 'generated DOCX validation'
   $fixture = Join-Path $smokeRoot 'smoke.xlsx'
   $createFixture = "from openpyxl import Workbook; w=Workbook(); s=w.active; s.title='Smoke'; s.append(['Name','Score']); s.append(['Windows',100]); w.save(r'$fixture')"
   Invoke-Checked $skillPython @('-c', $createFixture) 'XLSX fixture creation'

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { prerelease } from 'semver';
@@ -112,9 +114,11 @@ test('Windows release workflow runs the clean-path bundled runtime gate', () => 
   assert.match(smoke, /packaged Electron Node runtime/);
   assert.doesNotMatch(smoke, /node_modules\\electron\\dist\\electron\.exe/);
   assert.match(smoke, /ELECTRON_RUN_AS_NODE/);
+  assert.match(smoke, /Start-Process[\s\S]*-Wait[\s\S]*-PassThru/);
   assert.match(smoke, /DOCX Markdown conversion/);
-  assert.match(smoke, /DOCX heading validation/);
-  assert.doesNotMatch(smoke, /readUInt32LE\(0\) -ne/);
+  assert.match(smoke, /validate-docx-smoke\.mjs/);
+  assert.match(smoke, /generated DOCX validation/);
+  assert.doesNotMatch(smoke, /Invoke-Checked \$electron/);
   assert.match(smoke, /External command unexpectedly remains discoverable/);
   assert.match(smoke, /mingit\\usr\\bin\\bash\.exe/);
   assert.match(smoke, /PATH = "\$env:SystemRoot\\System32;\$env:SystemRoot"/);
@@ -123,4 +127,29 @@ test('Windows release workflow runs the clean-path bundled runtime gate', () => 
     'utf8',
   );
   assert.match(packageScript, /windows-runtime-smoke\.ps1/);
+});
+
+test('DOCX smoke validator accepts the bundled Markdown converter output', () => {
+  const workspace = mkdtempSync(path.join(tmpdir(), 'zhiyuan-docx-smoke-'));
+  const markdown = path.join(workspace, 'smoke.md');
+  const docx = path.join(workspace, 'smoke.docx');
+  try {
+    writeFileSync(markdown, '# Runtime smoke\n\nPackaged Electron conversion works.\n');
+    execFileSync(
+      process.execPath,
+      [path.join(root, 'SKILLs', 'docx', 'scripts', 'markdown_to_docx.mjs'), markdown, docx],
+      { stdio: 'pipe' },
+    );
+    execFileSync(
+      process.execPath,
+      [path.join(root, 'scripts', 'ci', 'validate-docx-smoke.mjs'), docx],
+      {
+        stdio: 'pipe',
+      },
+    );
+    assert.equal(existsSync(docx), true);
+    assert.ok(statSync(docx).size > 0);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- wait synchronously for the packaged Electron GUI process on Windows PowerShell 5.1
- validate process exit codes instead of relying on LASTEXITCODE from a GUI executable
- run a dedicated DOCX ZIP/content validator through the same packaged Electron runtime
- add a converter-to-validator behavior regression test

## Root cause
Tag v2026.8.6-build.4 proved that release\win-unpacked\知远.exe can run the bundled converter with ELECTRON_RUN_AS_NODE and print Created DOCX. The direct PowerShell invocation of the GUI-subsystem executable did not provide deterministic process completion; the parent checked the file after the GUI launch lifecycle instead of using an explicit waited Process object.

## Validation
- bun test tests/runtimePackagingConfig.test.ts (7/7)
- bun x oxfmt --check scripts/ci/validate-docx-smoke.mjs tests/runtimePackagingConfig.test.ts
- git diff --check
- independent review: no P0-P2 blockers

Before merge, Build platform artifacts will be manually dispatched for Windows only on this branch. That Windows result is the merge gate.