### PR TITLE
refactor: 抽取工件预览策略共享模块并统一文件路径去重

### DIFF
--- a/src/main/coworkArtifactCollector.ts
+++ b/src/main/coworkArtifactCollector.ts
@@ -1,6 +1,7 @@
 import { discoverWorkbenchMessageArtifactBlocks } from '../shared/workbenchTask';
 import type { CoworkArtifactType, CoworkPersistedArtifact } from '../shared/cowork/artifacts';
 import { CoworkArtifactRole, CoworkArtifactSource } from '../shared/cowork/artifacts';
+import { getArtifactTypeByExtension } from '../shared/cowork/artifactPreview';
 
 const DECLARE_ARTIFACT_TOOL = 'declare_artifact';
 const WRITE_TOOL_NAMES = new Set(['write', 'writefile']);
@@ -16,48 +17,6 @@ const LANGUAGE_TYPES: Record<string, CoworkArtifactType> = {
   text: 'text',
   txt: 'text',
   plaintext: 'text',
-};
-
-const EXTENSION_TYPES: Record<string, CoworkArtifactType> = {
-  '.html': 'html',
-  '.htm': 'html',
-  '.svg': 'svg',
-  '.png': 'image',
-  '.jpg': 'image',
-  '.jpeg': 'image',
-  '.gif': 'image',
-  '.webp': 'image',
-  '.mermaid': 'mermaid',
-  '.mmd': 'mermaid',
-  '.jsx': 'code',
-  '.tsx': 'code',
-  '.js': 'code',
-  '.mjs': 'code',
-  '.cjs': 'code',
-  '.ts': 'code',
-  '.mts': 'code',
-  '.cts': 'code',
-  '.css': 'code',
-  '.scss': 'code',
-  '.less': 'code',
-  '.json': 'code',
-  '.yaml': 'code',
-  '.yml': 'code',
-  '.xml': 'code',
-  '.py': 'code',
-  '.java': 'code',
-  '.go': 'code',
-  '.rs': 'code',
-  '.md': 'markdown',
-  '.txt': 'text',
-  '.log': 'text',
-  '.csv': 'document',
-  '.tsv': 'document',
-  '.xls': 'document',
-  '.docx': 'document',
-  '.xlsx': 'document',
-  '.pptx': 'document',
-  '.pdf': 'document',
 };
 
 export interface CoworkArtifactMessage {
@@ -101,7 +60,7 @@ function resolveArtifactType(filePath: string, declaredKind?: string): CoworkArt
     const declaredType = LANGUAGE_TYPES[declaredKind.toLowerCase()];
     if (declaredType) return declaredType;
   }
-  return EXTENSION_TYPES[getFileExtension(filePath)] ?? null;
+  return getArtifactTypeByExtension(getFileExtension(filePath));
 }
 
 function extractWriteToolPath(input: Record<string, unknown>): string | null {

--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -19,7 +19,13 @@ import {
   setArtifactLayoutMode,
 } from '@/store/slices/artifactSlice';
 import type { ArtifactActiveTab } from '@/store/slices/artifactSlice';
-import { ArtifactRole, type Artifact, type ArtifactType } from '@/types/artifact';
+import {
+  ArtifactPreviewMode,
+  ArtifactRole,
+  getArtifactPreviewMode,
+  type Artifact,
+  type ArtifactType,
+} from '@/types/artifact';
 import { PREVIEWABLE_ARTIFACT_TYPES } from '@/types/artifact';
 
 import ArtifactRenderer from './ArtifactRenderer';
@@ -93,6 +99,16 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
     artifact => showIntermediateArtifacts || artifact.role === ArtifactRole.Deliverable,
   );
   const previewableArtifacts = visibleArtifacts.filter(a => PREVIEWABLE_ARTIFACT_TYPES.has(a.type));
+  const artifactPreviewMode = selectedArtifact
+    ? getArtifactPreviewMode(selectedArtifact.type)
+    : ArtifactPreviewMode.Preview;
+  const availableTabs: ArtifactActiveTab[] =
+    artifactPreviewMode === ArtifactPreviewMode.Preview
+      ? ['preview']
+      : artifactPreviewMode === ArtifactPreviewMode.Source
+        ? ['code']
+        : ['preview', 'code'];
+  const displayedTab = availableTabs.includes(activeTab) ? activeTab : availableTabs[0];
 
   const intermediateToggle = (
     <Button
@@ -145,6 +161,12 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showFileList]);
+
+  useEffect(() => {
+    if (selectedArtifact && displayedTab !== activeTab) {
+      dispatch(setActiveTab(displayedTab));
+    }
+  }, [activeTab, dispatch, displayedTab, selectedArtifact]);
 
   const handleClose = useCallback(() => {
     if (document.fullscreenElement === panelRef.current) {
@@ -446,22 +468,21 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
               </Button>
             </div>
 
-            {/* Preview/Code tabs */}
             <div className="flex shrink-0 border-b border-border px-2 py-1.5">
               <FluidTabs<ArtifactActiveTab>
                 aria-label={t('artifactViewMode')}
-                value={activeTab}
+                value={displayedTab}
                 onValueChange={value => dispatch(setActiveTab(value))}
-                items={[
-                  { value: 'preview', label: t('artifactPreview') },
-                  { value: 'code', label: t('artifactCode') },
-                ]}
+                items={availableTabs.map(value => ({
+                  value,
+                  label: t(value === 'preview' ? 'artifactPreview' : 'artifactCode'),
+                }))}
               />
             </div>
 
             {/* Render area */}
             <div className="flex-1 min-h-0 overflow-hidden">
-              {activeTab === 'preview' ? (
+              {displayedTab === 'preview' ? (
                 <ArtifactRenderer artifact={selectedArtifact} sessionArtifacts={artifacts} />
               ) : (
                 <CodeRenderer artifact={selectedArtifact} />

--- a/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
@@ -17,6 +17,9 @@ function getExtension(name: string): string {
 }
 
 function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
+  if (!/^data:[^,]*;base64,/i.test(dataUrl)) {
+    return new TextEncoder().encode(dataUrl).buffer;
+  }
   const base64 = dataUrl.includes(',') ? dataUrl.split(',')[1] : dataUrl;
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);

--- a/src/renderer/services/artifactDetectionService.test.ts
+++ b/src/renderer/services/artifactDetectionService.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ArtifactRole } from '../types/artifact';
+import { ArtifactRole, type Artifact } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
 import { ArtifactDetectionService } from './artifactDetectionService';
 import type {
@@ -94,5 +94,71 @@ describe('ArtifactDetectionService', () => {
       filePath: 'C:/workspace/presentation.pptx',
       role: ArtifactRole.Deliverable,
     });
+  });
+
+  test('loads UTF-8 CSV files as text for the table preview', async () => {
+    const loadedArtifacts: Artifact[] = [];
+    const service = new ArtifactDetectionService(
+      () => {},
+      artifact => loadedArtifacts.push(artifact),
+      async () => ({
+        success: true,
+        dataUrl: `data:text/csv;base64,${Buffer.from('姓名,分数\n王浩哲,100', 'utf8').toString('base64')}`,
+      }),
+    );
+
+    await service.processMessages(
+      [
+        {
+          id: 'write-csv',
+          type: 'tool_use',
+          content: '',
+          timestamp: 1,
+          metadata: {
+            toolName: 'write',
+            toolInput: { path: 'C:/workspace/scores.csv' },
+          },
+        },
+      ],
+      'session-csv',
+      'C:/workspace',
+    );
+
+    expect(loadedArtifacts).toHaveLength(1);
+    expect(loadedArtifacts[0]).toMatchObject({
+      type: 'document',
+      filePath: 'C:/workspace/scores.csv',
+      content: '姓名,分数\n王浩哲,100',
+    });
+  });
+
+  test('keeps XLS files base64-encoded for the spreadsheet renderer', async () => {
+    const loadedArtifacts: Artifact[] = [];
+    const dataUrl = 'data:application/vnd.ms-excel;base64,AAEC';
+    const service = new ArtifactDetectionService(
+      () => {},
+      artifact => loadedArtifacts.push(artifact),
+      async () => ({ success: true, dataUrl }),
+    );
+
+    await service.processMessages(
+      [
+        {
+          id: 'write-xls',
+          type: 'tool_use',
+          content: '',
+          timestamp: 1,
+          metadata: {
+            toolName: 'write',
+            toolInput: { path: 'C:/workspace/scores.xls' },
+          },
+        },
+      ],
+      'session-xls',
+      'C:/workspace',
+    );
+
+    expect(loadedArtifacts).toHaveLength(1);
+    expect(loadedArtifacts[0].content).toBe(dataUrl);
   });
 });

--- a/src/renderer/services/artifactDetectionService.ts
+++ b/src/renderer/services/artifactDetectionService.ts
@@ -1,26 +1,10 @@
 import type { Artifact } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
+import { isBinaryArtifactFile } from '../../shared/cowork/artifactPreview';
 import type {
   ArtifactDetectionWorkerRequest,
   ArtifactDetectionWorkerResponse,
 } from './artifactDetection.worker';
-
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
-const BINARY_DOCUMENT_EXTENSIONS = new Set(['.docx', '.xlsx', '.pptx', '.pdf']);
-
-function getExtension(filePath: string): string {
-  const lastDot = filePath.lastIndexOf('.');
-  if (lastDot === -1) return '';
-  return filePath.slice(lastDot).toLowerCase();
-}
-
-function isImageExtension(ext: string): boolean {
-  return IMAGE_EXTENSIONS.has(ext.toLowerCase());
-}
-
-function isBinaryDocumentExtension(ext: string): boolean {
-  return BINARY_DOCUMENT_EXTENSIONS.has(ext.toLowerCase());
-}
 
 export type ArtifactDetectionResult = {
   artifact: Artifact;
@@ -176,8 +160,7 @@ export class ArtifactDetectionService {
       try {
         const result = await this.readFile(absPath);
         if (result?.success && result.dataUrl) {
-          const ext = getExtension(absPath);
-          const isTextType = !isImageExtension(ext) && !isBinaryDocumentExtension(ext);
+          const isTextType = !isBinaryArtifactFile(absPath);
           let content = result.dataUrl;
           if (isTextType) {
             try {

--- a/src/renderer/services/artifactParser.test.ts
+++ b/src/renderer/services/artifactParser.test.ts
@@ -30,6 +30,12 @@ describe('normalizeFilePathForDedup', () => {
     const fromTool = 'D:\\new_ws_test_2\\hello-slide.html';
     expect(normalizeFilePathForDedup(fromFileUrl)).toBe(normalizeFilePathForDedup(fromTool));
   });
+
+  test('decodes percent-encoded paths before deduplication', () => {
+    expect(normalizeFilePathForDedup('file:///D:/output/report%20final.csv')).toBe(
+      'd:/output/report final.csv',
+    );
+  });
 });
 
 describe('parseDeclareArtifactFromMessages', () => {
@@ -241,24 +247,79 @@ describe('detectArtifactsFromMessages', () => {
     expect(artifacts[0].needsFileLoad).toBe(true);
   });
 
-  test('does not detect bare paths in assistant messages (no regex)', () => {
+  test('detects supported absolute paths in final assistant answers', () => {
     const artifacts = detectArtifactsFromMessages(
       [
         {
           id: 'assistant-1',
           type: 'assistant',
-          content: 'Created D:/workspace/report.pptx',
+          content: 'Created [report](file:///D:/workspace/report%20final.csv).',
           timestamp: Date.now(),
+          metadata: { isFinal: true, isFinalAnswer: true },
         },
       ],
       'sess1',
     );
 
     // Bare paths in prose are no longer detected — artifacts must be explicitly declared.
-    expect(artifacts).toHaveLength(0);
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]).toMatchObject({
+      needsFileLoad: true,
+      artifact: {
+        filePath: 'D:/workspace/report final.csv',
+        type: 'document',
+        role: ArtifactRole.Deliverable,
+      },
+    });
   });
 
-  test('does not detect file:// links in assistant messages (no regex)', () => {
+  test('recognizes local paths with spaces and parentheses without matching web URLs', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'assistant-1',
+          type: 'assistant',
+          content:
+            'Reference: https://example.com/report.csv. Deliverable: [D:\\Output (final)\\report.csv]',
+          timestamp: Date.now(),
+          metadata: { isFinal: true, isFinalAnswer: true },
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].artifact.filePath).toBe('D:\\Output (final)\\report.csv');
+  });
+
+  test('deduplicates an encoded declaration with the final-answer path', () => {
+    const artifacts = detectArtifactsFromMessages(
+      [
+        {
+          id: 'declare-1',
+          type: 'tool_use',
+          content: '',
+          timestamp: 1,
+          metadata: {
+            toolName: 'declare_artifact',
+            toolInput: { filePath: 'file:///D:/output/report%20final.csv' },
+          },
+        },
+        {
+          id: 'assistant-1',
+          type: 'assistant',
+          content: 'Created D:/output/report final.csv',
+          timestamp: 2,
+          metadata: { isFinal: true, isFinalAnswer: true },
+        },
+      ],
+      'sess1',
+    );
+
+    expect(artifacts).toHaveLength(1);
+  });
+
+  test('does not detect paths from non-final assistant messages', () => {
     const artifacts = detectArtifactsFromMessages(
       [
         {

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -1,6 +1,10 @@
 import { ArtifactRole, type Artifact, type ArtifactType } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
 import { discoverWorkbenchMessageArtifactBlocks } from '../../shared/workbenchTask';
+import {
+  ArtifactTypeByExtension,
+  getArtifactTypeByExtension,
+} from '../../shared/cowork/artifactPreview';
 
 const DECLARE_ARTIFACT_TOOL_NAME = 'declare_artifact';
 
@@ -9,6 +13,12 @@ const DECLARE_ARTIFACT_TOOL_NAME = 'declare_artifact';
  * Handles Windows file:// URL leading slash and backslash differences.
  */
 export function normalizeFilePathForDedup(p: string): string {
+  p = p.replace(/^file:\/\/\/?/i, '');
+  try {
+    p = decodeURIComponent(p);
+  } catch {
+    // Keep malformed percent-encoded paths unchanged for a stable comparison.
+  }
   // Strip leading / before drive letter (e.g. /D:/path from file:///D:/path)
   if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
   // Unify separators and case for comparison
@@ -28,48 +38,6 @@ const LANGUAGE_TO_ARTIFACT_TYPE: Record<string, ArtifactType> = {
   plaintext: 'text',
 };
 
-const EXTENSION_TO_ARTIFACT_TYPE: Record<string, ArtifactType> = {
-  '.html': 'html',
-  '.htm': 'html',
-  '.svg': 'svg',
-  '.png': 'image',
-  '.jpg': 'image',
-  '.jpeg': 'image',
-  '.gif': 'image',
-  '.webp': 'image',
-  '.mermaid': 'mermaid',
-  '.mmd': 'mermaid',
-  '.jsx': 'code',
-  '.tsx': 'code',
-  '.js': 'code',
-  '.mjs': 'code',
-  '.cjs': 'code',
-  '.ts': 'code',
-  '.mts': 'code',
-  '.cts': 'code',
-  '.css': 'code',
-  '.scss': 'code',
-  '.less': 'code',
-  '.json': 'code',
-  '.yaml': 'code',
-  '.yml': 'code',
-  '.xml': 'code',
-  '.py': 'code',
-  '.java': 'code',
-  '.go': 'code',
-  '.rs': 'code',
-  '.md': 'markdown',
-  '.txt': 'text',
-  '.log': 'text',
-  '.csv': 'document',
-  '.tsv': 'document',
-  '.xls': 'document',
-  '.docx': 'document',
-  '.xlsx': 'document',
-  '.pptx': 'document',
-  '.pdf': 'document',
-};
-
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
 const BINARY_DOCUMENT_EXTENSIONS = new Set(['.docx', '.xlsx', '.pptx', '.pdf']);
 
@@ -78,7 +46,7 @@ export function getArtifactTypeFromLanguage(lang: string): ArtifactType | null {
 }
 
 export function getArtifactTypeFromExtension(ext: string): ArtifactType | null {
-  return EXTENSION_TO_ARTIFACT_TYPE[ext.toLowerCase()] ?? null;
+  return getArtifactTypeByExtension(ext) as ArtifactType | null;
 }
 
 export function isImageExtension(ext: string): boolean {
@@ -238,6 +206,61 @@ function getFileName(filePath: string): string {
   return lastSlash === -1 ? filePath : filePath.slice(lastSlash + 1);
 }
 
+const SUPPORTED_ARTIFACT_EXTENSION_PATTERN = Object.keys(ArtifactTypeByExtension)
+  .sort((a, b) => b.length - a.length)
+  .map(extension => extension.replace('.', '\\.'))
+  .join('|');
+const FINAL_ANSWER_PATH_PATTERN = new RegExp(
+  String.raw`(?:^|[\s(\[{"=>：])((?:file:\/\/\/?[A-Za-z]:[\\/]|[A-Za-z]:[\\/]|\/(?!\/))(?:[^\r\n<>"'])*?(?:${SUPPORTED_ARTIFACT_EXTENSION_PATTERN})(?=$|[\s\])}>,;:!?，。；：！？]))`,
+  'gm',
+);
+
+function normalizeDetectedPath(rawPath: string): string {
+  const withoutFileUrlPrefix = rawPath.replace(/^file:\/\/\/?/i, '');
+  try {
+    return decodeURIComponent(withoutFileUrlPrefix);
+  } catch {
+    return withoutFileUrlPrefix;
+  }
+}
+
+function parseFinalAnswerPathArtifacts(messages: CoworkMessage[], sessionId: string): Artifact[] {
+  const artifacts: Artifact[] = [];
+
+  for (const message of messages) {
+    const isFinalAnswer =
+      message.type === 'assistant' &&
+      !message.metadata?.isThinking &&
+      (message.metadata?.isFinalAnswer || message.metadata?.isFinal);
+    if (!isFinalAnswer || !message.content) continue;
+
+    for (const match of message.content.matchAll(FINAL_ANSWER_PATH_PATTERN)) {
+      const rawPath = match[1];
+      if (!rawPath) continue;
+      const filePath = normalizeDetectedPath(rawPath);
+      const artifactType = getArtifactTypeFromExtension(getFileExtension(filePath));
+      if (!artifactType) continue;
+
+      artifacts.push({
+        id: `artifact-final-path-${message.id}-${artifacts.length}`,
+        messageId: message.id,
+        sessionId,
+        type: artifactType,
+        title: getFileName(filePath),
+        content: '',
+        fileName: getFileName(filePath),
+        filePath,
+        source: 'tool',
+        role: ArtifactRole.Deliverable,
+        declared: false,
+        createdAt: message.timestamp || Date.now(),
+      });
+    }
+  }
+
+  return artifacts;
+}
+
 export function parseToolArtifact(
   toolUseMsg: CoworkMessage,
   toolResultMsg: CoworkMessage | undefined,
@@ -344,6 +367,13 @@ export function detectArtifactsFromMessages(
     () => ArtifactRole.Deliverable,
   );
   for (const artifact of declaredArtifacts) {
+    addPathArtifact(artifact, true);
+  }
+
+  // The final answer often names an output path without a preceding explicit
+  // declaration. Accept supported absolute paths there, but not paths from
+  // streamed reasoning or arbitrary tool output.
+  for (const artifact of parseFinalAnswerPathArtifacts(messages, sessionId)) {
     addPathArtifact(artifact, true);
   }
 

--- a/src/renderer/types/artifact.ts
+++ b/src/renderer/types/artifact.ts
@@ -5,6 +5,14 @@ import {
   type CoworkArtifactType,
 } from '../../shared/cowork/artifacts';
 
+export {
+  ArtifactPreviewMode,
+  getArtifactPreviewMode,
+  getArtifactTypeByExtension,
+  isBinaryArtifactFile,
+  type ArtifactPreviewMode as ArtifactPreviewModeValue,
+} from '../../shared/cowork/artifactPreview';
+
 export type ArtifactType = CoworkArtifactType;
 
 export const PREVIEWABLE_ARTIFACT_TYPES = new Set<ArtifactType>([

--- a/src/shared/cowork/artifactPreview.ts
+++ b/src/shared/cowork/artifactPreview.ts
@@ -1,0 +1,98 @@
+import type { CoworkArtifactType } from './artifacts';
+
+/**
+ * Canonical file-preview policy shared by artifact discovery and the renderer.
+ * Preview-only files are binary or structured documents; source-only files are
+ * intended to be read as text; the remaining formats support both views.
+ */
+export const ArtifactPreviewMode = {
+  Preview: 'preview',
+  Source: 'source',
+  PreviewAndSource: 'preview-and-source',
+} as const;
+
+export type ArtifactPreviewMode = (typeof ArtifactPreviewMode)[keyof typeof ArtifactPreviewMode];
+
+export const ArtifactTypeByExtension = {
+  '.html': 'html',
+  '.htm': 'html',
+  '.svg': 'svg',
+  '.png': 'image',
+  '.jpg': 'image',
+  '.jpeg': 'image',
+  '.gif': 'image',
+  '.webp': 'image',
+  '.mermaid': 'mermaid',
+  '.mmd': 'mermaid',
+  '.jsx': 'code',
+  '.tsx': 'code',
+  '.js': 'code',
+  '.mjs': 'code',
+  '.cjs': 'code',
+  '.ts': 'code',
+  '.mts': 'code',
+  '.cts': 'code',
+  '.css': 'code',
+  '.scss': 'code',
+  '.less': 'code',
+  '.json': 'code',
+  '.yaml': 'code',
+  '.yml': 'code',
+  '.xml': 'code',
+  '.py': 'code',
+  '.java': 'code',
+  '.go': 'code',
+  '.rs': 'code',
+  '.md': 'markdown',
+  '.txt': 'text',
+  '.log': 'text',
+  '.csv': 'document',
+  '.tsv': 'document',
+  '.xls': 'document',
+  '.docx': 'document',
+  '.xlsx': 'document',
+  '.pptx': 'document',
+  '.pdf': 'document',
+} as const satisfies Record<string, CoworkArtifactType>;
+
+const ARTIFACT_PREVIEW_MODE_BY_TYPE: Record<CoworkArtifactType, ArtifactPreviewMode> = {
+  html: ArtifactPreviewMode.PreviewAndSource,
+  svg: ArtifactPreviewMode.PreviewAndSource,
+  image: ArtifactPreviewMode.Preview,
+  mermaid: ArtifactPreviewMode.PreviewAndSource,
+  code: ArtifactPreviewMode.Source,
+  markdown: ArtifactPreviewMode.PreviewAndSource,
+  text: ArtifactPreviewMode.Source,
+  document: ArtifactPreviewMode.Preview,
+};
+
+const BINARY_ARTIFACT_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.xls',
+  '.xlsx',
+  '.docx',
+  '.pptx',
+  '.pdf',
+]);
+
+export function getArtifactExtension(filePath: string): string {
+  const lastDot = filePath.lastIndexOf('.');
+  return lastDot === -1 ? '' : filePath.slice(lastDot).toLowerCase();
+}
+
+export function getArtifactTypeByExtension(filePath: string): CoworkArtifactType | null {
+  const extension = getArtifactExtension(filePath) as keyof typeof ArtifactTypeByExtension;
+  return ArtifactTypeByExtension[extension] ?? null;
+}
+
+export function getArtifactPreviewMode(type: CoworkArtifactType): ArtifactPreviewMode {
+  return ARTIFACT_PREVIEW_MODE_BY_TYPE[type];
+}
+
+export function isBinaryArtifactFile(filePath: string): boolean {
+  return BINARY_ARTIFACT_EXTENSIONS.has(getArtifactExtension(filePath));
+}


### PR DESCRIPTION
## Summary

重构工件（artifact）渲染相关逻辑：将文件预览策略抽取为共享模块，统一路径规范化与去重逻辑，并完善文档工件渲染。

## Related Issue

<!-- Link to the related issue(s) if applicable -->

## Changes Made

- **新增共享模块** `src/shared/cowork/artifactPreview.ts`：统一 `ArtifactPreviewMode` 与 `ArtifactTypeByExtension` 扩展名映射，供工件发现与渲染层共用
- **路径去重规范化**（`artifactParser.ts`）：`normalizeFilePathForDedup` 增加 `file://` 前缀剥离与百分号编码解码，统一分隔符与大小写比较
- **工件检测精简**（`artifactDetectionService.ts`、`coworkArtifactCollector.ts`）：复用共享的扩展名映射，移除重复定义
- **工件面板与文档渲染**（`ArtifactPanel.tsx`、`DocumentRenderer.tsx`）：适配预览模式、预览/源码视图切换
- **测试补充**：`artifactDetectionService.test.ts`、`artifactParser.test.ts` 新增路径规范化与类型映射用例

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

改动集中在渲染层的工件解析、检测与渲染组件，并新增一个共享类型/常量模块。不涉及 Electron 主进程与 IPC。
