### PR TITLE
fix(release): validate electron updater generation

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -476,10 +476,11 @@ jobs:
           mkdir -p manifest/electron
           while IFS=$'\t' read -r key target filename; do
             target_file="${target//:/-}"
-            output="manifest/electron/${target_file}-${filename}"
+            mkdir -p "manifest/electron/${target_file}"
+            output="manifest/electron/${target_file}/${filename}"
             aws s3api get-object --bucket "$R2_BUCKET" --key "$key" "$output" > /dev/null
           done < <(
-            jq -rsr '
+            jq -s -r '
               [.[].artifacts[] | select(.kind == "metadata")]
               | sort_by(.platform, .arch, .variant)
               | .[]
@@ -489,10 +490,10 @@ jobs:
           )
           node scripts/release/verify-electron-updater-generation.mjs \
             '${{ needs.prepare-release.outputs.version }}' \
-            manifest/electron/win32-x64-lite-latest.yml:win32:x64:lite \
-            manifest/electron/darwin-arm64-default-latest-mac.yml:darwin:arm64:default \
-            manifest/electron/linux-x64-appimage-latest-linux.yml:linux:x64:appimage \
-            manifest/electron/linux-x64-deb-latest-linux.yml:linux:x64:deb \
+            manifest/electron/win32-x64-lite/latest.yml:win32:x64:lite \
+            manifest/electron/darwin-arm64-default/latest-mac.yml:darwin:arm64:default \
+            manifest/electron/linux-x64-appimage/latest-linux.yml:linux:x64:appimage \
+            manifest/electron/linux-x64-deb/latest-linux.yml:linux:x64:deb \
             --artifact-metadata "${metadata[@]}"
           generation_key='generations/${{ needs.prepare-release.outputs.version }}/legacy/stable.json'
           set +e

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -78,6 +78,14 @@ test('publish verification uses portable jq flags and preserves updater filename
   assert.doesNotMatch(workflow, /jq -rsr/);
   assert.match(workflow, /output="manifest\/electron\/\$\{target_file\}\/\$\{filename\}"/);
   assert.match(workflow, /manifest\/electron\/win32-x64-lite\/latest\.yml:win32:x64:lite/);
+  assert.match(
+    workflow,
+    /manifest\/electron\/darwin-arm64-default\/latest-mac\.yml:darwin:arm64:default/,
+  );
+  assert.match(
+    workflow,
+    /manifest\/electron\/linux-x64-appimage\/latest-linux\.yml:linux:x64:appimage/,
+  );
   assert.match(workflow, /manifest\/electron\/linux-x64-deb\/latest-linux\.yml:linux:x64:deb/);
 });
 

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -69,6 +69,18 @@ test('stable release metadata does not inherit the build prerelease channel', ()
   }
 });
 
+test('publish verification uses portable jq flags and preserves updater filenames per target', () => {
+  const workflow = readFileSync(
+    path.join(root, '.github', 'workflows', 'online-update-release.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /jq -s -r/);
+  assert.doesNotMatch(workflow, /jq -rsr/);
+  assert.match(workflow, /output="manifest\/electron\/\$\{target_file\}\/\$\{filename\}"/);
+  assert.match(workflow, /manifest\/electron\/win32-x64-lite\/latest\.yml:win32:x64:lite/);
+  assert.match(workflow, /manifest\/electron\/linux-x64-deb\/latest-linux\.yml:linux:x64:deb/);
+});
+
 test('unsigned macOS release builds do not receive empty signing credentials', () => {
   const workflow = readFileSync(
     path.join(root, '.github', 'workflows', 'online-update-release.yml'),


### PR DESCRIPTION
## Summary
- use jq portable long-form flags when aggregating platform metadata
- stage each electron-updater manifest under its target directory while preserving the standard filename
- add regression assertions for the publish workflow shape

## Root cause
v2026.8.6-build.5 completed all three platform builds, Windows clean-PATH smoke, and R2 uploads, but the publish job failed in Verify and publish the immutable update generation. Ubuntu jq rejected the combined -rsr option, and the generated local paths were win32-x64-lite-latest.yml instead of the standard latest.yml basename required by verify-electron-updater-generation.mjs. Linux appimage and deb would also collide under a shared basename.

## Validation
- bun test tests/runtimePackagingConfig.test.ts (8/8)
- bun x oxfmt --check tests/runtimePackagingConfig.test.ts
- git diff --check
- independent review requested for jq, YAML, and target-path correctness

This is a workflow-only release fix; the next tag will rerun the complete Publish online update pipeline.