### PR TITLE
fix(release): normalize updater redirect URLs

### DIFF
--- a/scripts/release/published-update-smoke-lib.mjs
+++ b/scripts/release/published-update-smoke-lib.mjs
@@ -1,5 +1,13 @@
 const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
 
+export function redirectMatches(location, baseUrl, expectedUrl) {
+  try {
+    return new URL(location, baseUrl).toString() === new URL(expectedUrl).toString();
+  } catch {
+    return false;
+  }
+}
+
 export async function verifyPublishedBlockmap({
   fetchImpl = fetch,
   target,
@@ -21,7 +29,7 @@ export async function verifyPublishedBlockmap({
   if (
     !REDIRECT_STATUSES.has(redirectResponse.status) ||
     !location ||
-    new URL(location, blockmapUrl).toString() !== immutableBlockmapUrl.toString()
+    !redirectMatches(location, blockmapUrl, immutableBlockmapUrl)
   ) {
     throw new Error(`${target} blockmap did not redirect to the immutable download`);
   }

--- a/scripts/release/published-update-smoke-lib.test.ts
+++ b/scripts/release/published-update-smoke-lib.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
+import { redirectMatches, verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
 
 describe('published update smoke helpers', () => {
+  test('compares redirects after URL normalization for Unicode filenames', () => {
+    const signedUrl =
+      'https://downloads.rongxzyai.com/releases/2026.8.6-build.6/win32-x64-lite/知远-Setup-2026.8.6-build.6.exe';
+    const encodedLocation =
+      'https://downloads.rongxzyai.com/releases/2026.8.6-build.6/win32-x64-lite/%E7%9F%A5%E8%BF%9C-Setup-2026.8.6-build.6.exe';
+
+    expect(redirectMatches(encodedLocation, new URL('https://updates.rongxzyai.com/'), signedUrl)).toBe(
+      true,
+    );
+  });
+
   test('verifies the versioned redirect and Range support for differential blockmaps', async () => {
     const immutable =
       'https://downloads.rongxzyai.com/releases/2026.8.6/win32-x64-lite/ZhiYuan.exe.blockmap';

--- a/scripts/release/verify-published-update.mjs
+++ b/scripts/release/verify-published-update.mjs
@@ -3,7 +3,7 @@ import {
   loadTrustedReleaseKey,
   verifyEnvelope,
 } from './update-manifest-lib.mjs';
-import { verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
+import { redirectMatches, verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
 import yaml from 'js-yaml';
 
 const [expectedVersion, ...targets] = process.argv.slice(2);
@@ -137,7 +137,7 @@ for (const target of targets) {
   if (
     ![301, 302, 307, 308].includes(redirectResponse.status) ||
     !location ||
-    new URL(location, updaterUrl).toString() !== signedUpdater.url
+    !redirectMatches(location, updaterUrl, signedUpdater.url)
   ) {
     throw new Error(`${target} electron-updater artifact did not redirect to the immutable download`);
   }


### PR DESCRIPTION
## Summary
- compare Worker redirects and signed updater URLs after URL normalization
- cover Windows Unicode installer filenames in smoke helper tests
- reuse the normalized comparison for blockmap redirect checks

## Verification
- bun test scripts/release/published-update-smoke-lib.test.ts tests/runtimePackagingConfig.test.ts
- node --check scripts/release/verify-published-update.mjs
- git diff --check

Context: build.6 published generation verification passed, but the final smoke test rejected the valid Windows redirect because the installer filename contains Chinese characters.