### PR TITLE
fix(release): bypass cache for range smoke probes

### DIFF
--- a/scripts/release/published-update-smoke-lib.mjs
+++ b/scripts/release/published-update-smoke-lib.mjs
@@ -1,4 +1,8 @@
 const REDIRECT_STATUSES = new Set([301, 302, 307, 308]);
+export const ONE_BYTE_RANGE_HEADERS = Object.freeze({
+  range: 'bytes=0-0',
+  'cache-control': 'no-cache',
+});
 
 export function redirectMatches(location, baseUrl, expectedUrl) {
   try {
@@ -45,7 +49,7 @@ export async function verifyPublishedBlockmap({
   }
 
   const rangeResponse = await fetchImpl(immutableBlockmapUrl, {
-    headers: { range: 'bytes=0-0' },
+    headers: ONE_BYTE_RANGE_HEADERS,
     redirect: 'error',
     signal: AbortSignal.timeout(timeoutMs),
   });

--- a/scripts/release/published-update-smoke-lib.test.ts
+++ b/scripts/release/published-update-smoke-lib.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { redirectMatches, verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
+import {
+  ONE_BYTE_RANGE_HEADERS,
+  redirectMatches,
+  verifyPublishedBlockmap,
+} from './published-update-smoke-lib.mjs';
 
 describe('published update smoke helpers', () => {
+  test('disables cache for one-byte Range probes', () => {
+    expect(ONE_BYTE_RANGE_HEADERS).toEqual({
+      range: 'bytes=0-0',
+      'cache-control': 'no-cache',
+    });
+  });
+
   test('compares redirects after URL normalization for Unicode filenames', () => {
     const signedUrl =
       'https://downloads.rongxzyai.com/releases/2026.8.6-build.6/win32-x64-lite/知远-Setup-2026.8.6-build.6.exe';
@@ -48,7 +59,7 @@ describe('published update smoke helpers', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(fetchImpl.mock.calls[0]?.[0].toString()).toMatch(/ZhiYuan\.exe\.blockmap$/);
     expect(fetchImpl.mock.calls[2]?.[1]).toMatchObject({
-      headers: { range: 'bytes=0-0' },
+      headers: ONE_BYTE_RANGE_HEADERS,
     });
   });
 

--- a/scripts/release/verify-published-update.mjs
+++ b/scripts/release/verify-published-update.mjs
@@ -3,7 +3,11 @@ import {
   loadTrustedReleaseKey,
   verifyEnvelope,
 } from './update-manifest-lib.mjs';
-import { redirectMatches, verifyPublishedBlockmap } from './published-update-smoke-lib.mjs';
+import {
+  ONE_BYTE_RANGE_HEADERS,
+  redirectMatches,
+  verifyPublishedBlockmap,
+} from './published-update-smoke-lib.mjs';
 import yaml from 'js-yaml';
 
 const [expectedVersion, ...targets] = process.argv.slice(2);
@@ -59,7 +63,7 @@ for (const target of targets) {
   }
 
   const rangeResponse = await fetch(payload.artifact.url, {
-    headers: { range: 'bytes=0-0' },
+    headers: ONE_BYTE_RANGE_HEADERS,
     redirect: 'error',
     signal: AbortSignal.timeout(15_000),
   });
@@ -154,7 +158,7 @@ for (const target of targets) {
     throw new Error(`${target} updater artifact size does not match the signed manifest`);
   }
   const updaterRangeResponse = await fetch(signedUpdater.url, {
-    headers: { range: 'bytes=0-0' },
+    headers: ONE_BYTE_RANGE_HEADERS,
     redirect: 'error',
     signal: AbortSignal.timeout(15_000),
   });


### PR DESCRIPTION
## Summary
- send Cache-Control: no-cache on all one-byte Range smoke requests
- reuse the shared Range headers for legacy artifacts, electron-updater artifacts, and blockmaps
- add regression coverage for the cache-bypass contract

## Verification
- bun test scripts/release/published-update-smoke-lib.test.ts tests/runtimePackagingConfig.test.ts
- node --check scripts/release/verify-published-update.mjs
- node --check scripts/release/published-update-smoke-lib.mjs
- git diff --check
- public build.7 Windows artifact returned 206 bytes 0-0 with the no-cache header

Context: build.7 platform builds and Windows smoke passed, but the publish smoke saw a cached 200 response for the same immutable Windows artifact during the updater Range probe.