### PR TITLE
fix(release): retry transient range probes

### DIFF
--- a/scripts/release/published-update-smoke-lib.mjs
+++ b/scripts/release/published-update-smoke-lib.mjs
@@ -4,6 +4,26 @@ export const ONE_BYTE_RANGE_HEADERS = Object.freeze({
   'cache-control': 'no-cache',
 });
 
+export async function fetchOneByteRange({
+  fetchImpl = fetch,
+  url,
+  timeoutMs = 15_000,
+  attempts = 3,
+}) {
+  let response;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    response = await fetchImpl(url, {
+      headers: ONE_BYTE_RANGE_HEADERS,
+      redirect: 'error',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (response.status === 206 || attempt === attempts - 1) return response;
+    await response.body?.cancel();
+    await new Promise(resolve => setTimeout(resolve, 250 * (attempt + 1)));
+  }
+  return response;
+}
+
 export function redirectMatches(location, baseUrl, expectedUrl) {
   try {
     return new URL(location, baseUrl).toString() === new URL(expectedUrl).toString();
@@ -48,10 +68,10 @@ export async function verifyPublishedBlockmap({
     throw new Error(`${target} blockmap HEAD did not return a valid object size`);
   }
 
-  const rangeResponse = await fetchImpl(immutableBlockmapUrl, {
-    headers: ONE_BYTE_RANGE_HEADERS,
-    redirect: 'error',
-    signal: AbortSignal.timeout(timeoutMs),
+  const rangeResponse = await fetchOneByteRange({
+    fetchImpl,
+    url: immutableBlockmapUrl,
+    timeoutMs,
   });
   await rangeResponse.body?.cancel();
   if (

--- a/scripts/release/published-update-smoke-lib.test.ts
+++ b/scripts/release/published-update-smoke-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import {
   ONE_BYTE_RANGE_HEADERS,
+  fetchOneByteRange,
   redirectMatches,
   verifyPublishedBlockmap,
 } from './published-update-smoke-lib.mjs';
@@ -12,6 +13,27 @@ describe('published update smoke helpers', () => {
       range: 'bytes=0-0',
       'cache-control': 'no-cache',
     });
+  });
+
+  test('retries a transient full-body response before requiring partial content', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(new Uint8Array([1, 2]), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([1]), {
+          status: 206,
+          headers: { 'content-range': 'bytes 0-0/2' },
+        }),
+      );
+
+    const response = await fetchOneByteRange({
+      fetchImpl,
+      url: new URL('https://downloads.rongxzyai.com/file.exe'),
+    });
+
+    expect(response.status).toBe(206);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({ headers: ONE_BYTE_RANGE_HEADERS });
   });
 
   test('compares redirects after URL normalization for Unicode filenames', () => {

--- a/scripts/release/verify-published-update.mjs
+++ b/scripts/release/verify-published-update.mjs
@@ -4,7 +4,7 @@ import {
   verifyEnvelope,
 } from './update-manifest-lib.mjs';
 import {
-  ONE_BYTE_RANGE_HEADERS,
+  fetchOneByteRange,
   redirectMatches,
   verifyPublishedBlockmap,
 } from './published-update-smoke-lib.mjs';
@@ -62,11 +62,7 @@ for (const target of targets) {
     throw new Error(`${target} artifact size does not match the signed manifest`);
   }
 
-  const rangeResponse = await fetch(payload.artifact.url, {
-    headers: ONE_BYTE_RANGE_HEADERS,
-    redirect: 'error',
-    signal: AbortSignal.timeout(15_000),
-  });
+  const rangeResponse = await fetchOneByteRange({ url: payload.artifact.url });
   await rangeResponse.body?.cancel();
   if (
     rangeResponse.status !== 206 ||
@@ -157,11 +153,7 @@ for (const target of targets) {
   ) {
     throw new Error(`${target} updater artifact size does not match the signed manifest`);
   }
-  const updaterRangeResponse = await fetch(signedUpdater.url, {
-    headers: ONE_BYTE_RANGE_HEADERS,
-    redirect: 'error',
-    signal: AbortSignal.timeout(15_000),
-  });
+  const updaterRangeResponse = await fetchOneByteRange({ url: signedUpdater.url });
   await updaterRangeResponse.body?.cancel();
   if (
     updaterRangeResponse.status !== 206 ||


### PR DESCRIPTION
## Summary
- centralize one-byte Range probes with a bounded three-attempt retry
- retain no-cache headers and strict 206 plus exact Content-Range validation
- use the helper for legacy artifacts, electron-updater artifacts, and blockmaps
- cover transient 200 then 206 behavior in tests

## Verification
- bun test scripts/release/published-update-smoke-lib.test.ts tests/runtimePackagingConfig.test.ts
- node --check scripts/release/verify-published-update.mjs
- node --check scripts/release/published-update-smoke-lib.mjs
- git diff --check
- public build.8 Windows artifact returned 206 after the helper retry

Context: build.8 still saw a transient cached 200 on the updater Range probe even with no-cache; the next probe returned 206 for the same immutable URL.