### PR TITLE
feat(cowork): 生产循环支持任务跳过

### DIFF
--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -105,3 +105,27 @@ test('invalid critic output enters revision instead of silently passing', () => 
   expect(controller.getState().phase).toBe(ProductionLoopPhase.Revise);
   expect(controller.getState().critic.findings[0].summary).toContain('invalid structured response');
 });
+
+test('skip_workflow lets the agent finish without the completion gate', () => {
+  const { controller, downstream } = createController();
+  controller.skipWorkflow('Pure information request with no work to plan');
+  expect(controller.getState()).toMatchObject({
+    phase: ProductionLoopPhase.Plan,
+    status: ProductionLoopStatus.Completed,
+    skip: { reason: 'Pure information request with no work to plan' },
+  });
+
+  // Completion is no longer blocked.
+  expect(controller.requestCompletion('answered')).toBe('downstream requested');
+  expect(downstream.requestCompletion).toHaveBeenCalledOnce();
+
+  // Agent end finishes without a recovery prompt.
+  expect(controller.onAgentEnd()).toEqual({ shouldFinish: true, reason: 'Pure information request with no work to plan' });
+  expect(downstream.onAgentEnd).not.toHaveBeenCalled();
+});
+
+test('skip_workflow is rejected after a plan is committed', () => {
+  const { controller } = createController();
+  reachCritique(controller);
+  expect(() => controller.skipWorkflow('too late')).toThrow('before a plan is committed');
+});

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -80,6 +80,7 @@ export class ProductionLoopController {
       'A reviewer PASS does not replace artifact verification or the completion contract.',
       'When findings exist, revise the work, record_revision, inspect again, and request another critique.',
       'Call agent_loop done only after the production loop reports ready_to_deliver.',
+      'Pure information requests or trivial tasks with no work to plan (e.g. simple Q&A) may call skip_workflow with a reason instead, then answer directly.',
     ].join('\n');
   }
 
@@ -138,7 +139,16 @@ export class ProductionLoopController {
     return this.update(this.service.recordRevision(this.state.runId, summary, evidence));
   }
 
+  skipWorkflow(reason: string): ProductionLoopState {
+    return this.update(this.service.skipWorkflow(this.state.runId, reason));
+  }
+
   requestCompletion(reason: string): string {
+    if (this.state.skip) {
+      return this.downstream
+        ? this.downstream.requestCompletion(reason)
+        : 'Workflow skipped. End the turn now so verification can run.';
+    }
     if (this.state.status !== ProductionLoopStatus.ReadyToDeliver) {
       this.update(
         this.service.recordRecovery(
@@ -156,6 +166,9 @@ export class ProductionLoopController {
   }
 
   onAgentEnd(): { shouldFinish: boolean; reason?: string; nextPrompt?: string } {
+    if (this.state.skip) {
+      return { shouldFinish: true, reason: this.state.skip.reason };
+    }
     if (this.state.status === ProductionLoopStatus.ReadyToDeliver && this.state.deliveryReason) {
       if (this.downstream) {
         const decision = this.downstream.onAgentEnd();

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -113,6 +113,34 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
   ).toBe(ProductionLoopStatus.Completed);
 });
 
+test('skip_workflow marks the loop completed and skips the completion gate', () => {
+  const { run } = begin();
+  const skipped = service.skipWorkflow(run.id, 'Pure information request');
+  expect(skipped).toMatchObject({
+    status: ProductionLoopStatus.Completed,
+    skip: { reason: 'Pure information request' },
+  });
+
+  // Verification on a skipped loop is a no-op, not an error.
+  expect(
+    service.recordVerificationResult(run.id, WorkbenchVerificationOutcome.Failed, 'n/a'),
+  ).toMatchObject({ status: ProductionLoopStatus.Completed });
+});
+
+test('skip_workflow requires a reason and is only allowed before a plan', () => {
+  const { run } = begin();
+  expect(() => service.skipWorkflow(run.id, '  ')).toThrow('skip reason');
+  commitPlan(run.id);
+  expect(() => service.skipWorkflow(run.id, 'too late')).toThrow('before a plan is committed');
+});
+
+test('verification on a loop that never reached delivery readiness is a no-op', () => {
+  const { run } = begin();
+  expect(
+    service.recordVerificationResult(run.id, WorkbenchVerificationOutcome.Failed, 'never ready'),
+  ).toMatchObject({ status: ProductionLoopStatus.Active });
+});
+
 test('accepts a critic verdict wrapped in a Markdown JSON fence', () => {
   const { run } = begin();
   const planned = commitPlan(run.id);

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -155,6 +155,7 @@ export class ProductionLoopService {
       },
       revisions: [],
       recoveries: [],
+      skip: null,
       deliveryReason: null,
       progressVersion: 0,
       lastObservedProgressVersion: 0,
@@ -400,6 +401,31 @@ export class ProductionLoopService {
     });
   }
 
+  /**
+   * Declare that this task needs no production workflow (pure information
+   * requests, trivial edits). Only valid before a plan is committed. The loop
+   * is marked completed so the agent may end the turn without a completion
+   * gate; deterministic verification still applies on run completion.
+   */
+  skipWorkflow(runId: string, reason: string): ProductionLoopState {
+    return this.mutate(runId, state => {
+      if (state.skip) return;
+      if (state.phase !== ProductionLoopPhase.Explore && state.phase !== ProductionLoopPhase.Plan) {
+        throw new Error('The workflow can only be skipped before a plan is committed.');
+      }
+      const normalized = reason.trim();
+      if (!normalized) throw new Error('A skip reason is required.');
+      state.skip = { reason: normalized, createdAt: Date.now() };
+      state.status = ProductionLoopStatus.Completed;
+      state.progressVersion += 1;
+      this.measurement.recordActivation(runId, {
+        activation: HarnessActivationType.WorkflowSkipped,
+        mechanism: 'production_loop',
+        evidence: { reason: normalized },
+      });
+    });
+  }
+
   recordVerificationResult(
     runId: string,
     outcome: WorkbenchVerificationOutcome,
@@ -407,8 +433,11 @@ export class ProductionLoopService {
   ): ProductionLoopState | null {
     if (!this.repository.get(runId)) return null;
     return this.mutate(runId, state => {
+      // The loop may have been skipped or never reached delivery readiness
+      // (e.g. the run settled outside the workflow). That is not an error:
+      // verification outcome still applies to the underlying run.
       if (state.status !== ProductionLoopStatus.ReadyToDeliver || !state.deliveryReason) {
-        throw new Error('The production loop cannot complete before delivery is requested.');
+        return;
       }
       if (outcome === WorkbenchVerificationOutcome.Passed) {
         state.status = ProductionLoopStatus.Completed;

--- a/src/main/productionLoop/tool.test.ts
+++ b/src/main/productionLoop/tool.test.ts
@@ -22,6 +22,7 @@ const createTool = () => {
     getState: vi.fn(() => state),
     commitPlan: vi.fn(),
     updatePlanItem: vi.fn(),
+    skipWorkflow: vi.fn(),
   } as unknown as ProductionLoopController;
   const tool = buildProductionLoopTool(controller) as {
     execute(
@@ -106,4 +107,16 @@ test('does not dispatch unknown actions', async () => {
   expect(output.content[0].text).toBe('Unknown production_loop action: delete_everything');
   expect(controller.commitPlan).not.toHaveBeenCalled();
   expect(controller.updatePlanItem).not.toHaveBeenCalled();
+});
+
+test('skip_workflow forwards the reason to the controller', async () => {
+  const { controller, tool } = createTool();
+
+  const output = await tool.execute('call', {
+    action: ProductionLoopAction.SkipWorkflow,
+    reason: 'Pure information request',
+  });
+
+  expect(controller.skipWorkflow).toHaveBeenCalledWith('Pure information request');
+  expect(output.content[0].text).toContain('skipped');
 });

--- a/src/main/productionLoop/tool.ts
+++ b/src/main/productionLoop/tool.ts
@@ -117,6 +117,10 @@ export function buildProductionLoopTool(
         itemId: { type: 'string' },
         status: { type: 'string', enum: Object.values(ProductionPlanItemStatus) },
         evidence: { type: 'object' },
+        reason: {
+          type: 'string',
+          description: 'Required for skip_workflow: why this task needs no production workflow.',
+        },
       },
       required: ['action'],
       additionalProperties: false,
@@ -185,6 +189,11 @@ export function buildProductionLoopTool(
             );
             return result(
               'Revision recorded. Inspect the revised result and request critique again.',
+            );
+          case ProductionLoopAction.SkipWorkflow:
+            controller.skipWorkflow(String(params.reason || ''));
+            return result(
+              'Production workflow skipped for this task. Answer directly and end the turn.',
             );
           case ProductionLoopAction.GetState:
             return result(stateForModel());

--- a/src/shared/harness/constants.ts
+++ b/src/shared/harness/constants.ts
@@ -37,6 +37,7 @@ export const HarnessActivationType = {
   CriticRequested: 'critic_requested',
   CriticRejected: 'critic_rejected',
   RevisionApplied: 'revision_applied',
+  WorkflowSkipped: 'workflow_skipped',
   RecoveryTriggered: 'recovery_triggered',
 } as const;
 export type HarnessActivationType =

--- a/src/shared/productionLoop/constants.ts
+++ b/src/shared/productionLoop/constants.ts
@@ -52,6 +52,7 @@ export const ProductionLoopAction = {
   StartInspection: 'start_inspection',
   RequestCritique: 'request_critique',
   RecordRevision: 'record_revision',
+  SkipWorkflow: 'skip_workflow',
   GetState: 'get_state',
 } as const;
 export type ProductionLoopAction = (typeof ProductionLoopAction)[keyof typeof ProductionLoopAction];

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -57,6 +57,11 @@ export interface ProductionRecovery {
   createdAt: number;
 }
 
+export interface ProductionSkip {
+  reason: string;
+  createdAt: number;
+}
+
 export interface ProductionLoopState {
   version: 1;
   taskId: string;
@@ -76,6 +81,8 @@ export interface ProductionLoopState {
   critic: ProductionCriticState;
   revisions: ProductionRevision[];
   recoveries: ProductionRecovery[];
+  /** Set when the model declares the task needs no production workflow. */
+  skip: ProductionSkip | null;
   deliveryReason: string | null;
   progressVersion: number;
   lastObservedProgressVersion: number;


### PR DESCRIPTION
## 背景

生产循环(production_loop)在 Work 模式下对所有任务强制生效:即使纯信息咨询(如"1+1=?"),模型若不调用生产循环工具,回合结束会被 `onAgentEnd` 强制续跑,导致:
- 模型被迫反复被提示"未交付"而陷入无意义循环
- 简单任务出现"任务执行出错,请重试"报错(强制续跑与 Pi 回合错误叠加)

## 改动

1. **新增 `skip_workflow` 动作**:纯信息咨询/无需规划的任务,模型可显式声明跳过生产工作流并直接回答
   - `ProductionLoopAction` 新增 `skip_workflow`
   - `ProductionLoopState` 新增 `skip` 字段,skip 后状态置为 `completed`
   - `requestCompletion` / `onAgentEnd` 对已跳过循环放行
   - 工具 schema 增加 `reason` 参数
   - 提示词告知模型该出口
2. **`recordVerificationResult` 非就绪不再抛错**:循环未就绪(如被跳过)时静默返回,避免抛出异常回滚 `completeRun` 事务
3. **harness 新增 `workflow_skipped` 激活事件**用于遥测

## 验证

- productionLoop 测试 23/23 通过
- workbenchTask 测试 35/35 通过
- `tsc` 类型检查通过
- `oxlint` 通过
- 5 个失败测试文件(piRuntimeAdapter、pdf/xlsxSkillSmoke、skillRuntimeRunner、update-manifest-lib)均确认为基线环境问题(python3 缺失、Windows 路径、native 模块),与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)