### PR TITLE
fix(cowork): 稳定历史会话首帧与向上滚动

### DIFF
--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -26,7 +26,7 @@ import {
   DefaultAgentAvatarIcon,
   encodeAgentAvatarIcon,
 } from '../shared/agent/avatar';
-import { CoworkSessionMode } from '../shared/cowork/constants';
+import { COWORK_MESSAGE_PAGE_SIZE, CoworkSessionMode } from '../shared/cowork/constants';
 import { CoworkSessionExpertSource } from '../shared/cowork/sessionExperts';
 import { initializeCoworkArtifactIndexSchema } from './coworkArtifactIndex';
 import { CoworkStore } from './coworkStore';
@@ -247,6 +247,31 @@ test('getSession lazily backfills artifacts from messages outside the loaded pag
       content: '<h1>old</h1>',
     }),
   ]);
+});
+
+test('getSession can return the complete transcript for a virtualized renderer', () => {
+  const sid = 'full-history-session';
+  insertSession(sid);
+  for (let sequence = 1; sequence <= 75; sequence += 1) {
+    insertMessage(
+      `message-${sequence}`,
+      sid,
+      sequence % 2 === 0 ? 'assistant' : 'user',
+      `message ${sequence}`,
+      null,
+      sequence,
+      sequence,
+    );
+  }
+
+  const pagedSession = store.getSession(sid);
+  const completeSession = store.getSession(sid, null);
+
+  expect(pagedSession?.messages).toHaveLength(COWORK_MESSAGE_PAGE_SIZE);
+  expect(pagedSession?.messagesOffset).toBe(45);
+  expect(completeSession?.messages).toHaveLength(75);
+  expect(completeSession?.messagesOffset).toBe(0);
+  expect(completeSession?.totalMessages).toBe(75);
 });
 
 test('sessions are grouped by workspace independently of their agent snapshot', () => {

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -651,7 +651,9 @@ export class CoworkStore {
       is_hidden: number;
       created_at: number;
       updated_at: number;
-    }>('SELECT id, name, path, is_hidden, created_at, updated_at FROM workspaces WHERE id = ?', [id]);
+    }>('SELECT id, name, path, is_hidden, created_at, updated_at FROM workspaces WHERE id = ?', [
+      id,
+    ]);
     if (!row) return null;
     return {
       id: row.id,
@@ -699,9 +701,7 @@ export class CoworkStore {
   }
 
   setWorkspaceHidden(id: string, isHidden: boolean): void {
-    this.db
-      .prepare('UPDATE workspaces SET is_hidden = ? WHERE id = ?')
-      .run(isHidden ? 1 : 0, id);
+    this.db.prepare('UPDATE workspaces SET is_hidden = ? WHERE id = ?').run(isHidden ? 1 : 0, id);
   }
 
   relocateWorkspace(id: string, workspacePath: string, name: string): Workspace | null {
@@ -841,7 +841,10 @@ export class CoworkStore {
     };
   }
 
-  getSession(id: string, messageLimit = COWORK_MESSAGE_PAGE_SIZE): CoworkSession | null {
+  getSession(
+    id: string,
+    messageLimit: number | null = COWORK_MESSAGE_PAGE_SIZE,
+  ): CoworkSession | null {
     interface SessionRow {
       id: string;
       title: string;
@@ -873,10 +876,11 @@ export class CoworkStore {
     if (!row) return null;
 
     const totalMessages = this.countSessionMessages(id);
-    const messageOffset = Math.max(0, totalMessages - messageLimit);
+    const resolvedMessageLimit = messageLimit === null ? totalMessages : Math.max(0, messageLimit);
+    const messageOffset = Math.max(0, totalMessages - resolvedMessageLimit);
     const messages =
       messageOffset > 0
-        ? this.getPagedSessionMessages(id, messageLimit, messageOffset)
+        ? this.getPagedSessionMessages(id, resolvedMessageLimit, messageOffset)
         : this.getSessionMessages(id);
 
     let activeSkillIds: string[] = [];

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4899,7 +4899,10 @@ if (!gotTheLock) {
   ipcMain.handle(CoworkSessionIpc.Get, async (_event, sessionId: string) => {
     try {
       const store = getCoworkStore();
-      const session = store.getSession(sessionId);
+      // The renderer virtualizes turns, so it needs the complete local data
+      // model up front to expose the full scroll range without mounting the
+      // entire transcript in the DOM.
+      const session = store.getSession(sessionId, null);
       if (!session) return { success: true, session: null };
 
       const reconciledSession = reconcileWorkSessionRuntimeState(

--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -63,3 +63,10 @@ test('keeps streaming controls gated without obscuring the prompt', () => {
   expect(source).toContain("status={isStreaming ? 'streaming' : 'ready'}");
   expect(source).toContain('onStop={isStreaming ? onStop : undefined}');
 });
+
+test('keeps text editing mounted while a target session context is pending', () => {
+  expect(source).toContain('disabled={disabled}');
+  expect(source).toContain('inert={sessionContextPending ? true : undefined}');
+  expect(source).toContain('disabled={sessionContextPending}');
+  expect(source).toContain('sessionContextPending ||');
+});

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -168,6 +168,8 @@ interface CoworkPromptInputProps {
   isStreaming?: boolean;
   placeholder?: string;
   disabled?: boolean;
+  /** Keeps text editing available while session-bound actions wait for the target session. */
+  sessionContextPending?: boolean;
   size?: 'normal' | 'large';
   workingDirectory?: string;
   workingDirectoryName?: string;
@@ -200,6 +202,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       isStreaming = false,
       placeholder = 'Enter your task...',
       disabled = false,
+      sessionContextPending = false,
       size = 'normal',
       workingDirectory = '',
       workingDirectoryName,
@@ -529,6 +532,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
         (!trimmedValue && attachments.length === 0) ||
         (isStreaming && !canQueueWhileStreaming) ||
         disabled ||
+        sessionContextPending ||
         isPatchingModel
       )
         return;
@@ -655,6 +659,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       value,
       isStreaming,
       disabled,
+      sessionContextPending,
       isPatchingModel,
       isDirectChat,
       hasUnavailableLlamaCppModel,
@@ -1178,7 +1183,14 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
             />
           </PromptInputBody>
           <PromptInputFooter className="flex-wrap">
-            <PromptInputTools className="min-w-0 flex-1 flex-wrap">
+            <PromptInputTools
+              className={cn(
+                'min-w-0 flex-1 flex-wrap',
+                sessionContextPending && 'pointer-events-none opacity-50',
+              )}
+              aria-disabled={sessionContextPending}
+              inert={sessionContextPending ? true : undefined}
+            >
               {!isPlusToolbar && showModelSelector && (
                 <>
                   <ContextUsageIndicator
@@ -1276,6 +1288,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
             )}
             <PromptInputSubmit
               className={isStreaming ? 'relative z-20' : undefined}
+              disabled={sessionContextPending}
               status={isStreaming ? 'streaming' : 'ready'}
               onStop={isStreaming ? onStop : undefined}
             />

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -63,6 +63,10 @@ import {
 } from './components/VirtualizedTurnList';
 import { type CoworkOpenShareOptionsEventDetail, CoworkUiEvent } from './constants';
 import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInput';
+import {
+  CoworkConversationLoadingSkeleton,
+  CoworkSessionTitleLoadingSkeleton,
+} from './CoworkSessionLoadingState';
 import PendingMessageQueue from './PendingMessageQueue';
 import type { CaptureRect } from './helpers/exportUtils';
 import {
@@ -105,6 +109,8 @@ const ArtifactPanelFrame = React.lazy(() =>
 );
 
 interface CoworkSessionDetailProps {
+  displayedSessionId?: string;
+  isSessionSwitching?: boolean;
   onManageSkills?: () => void;
   onManageConnectors?: () => void;
   permissionMode?: CoworkPermissionMode;
@@ -172,6 +178,8 @@ class ArtifactPanelErrorBoundary extends React.Component<
 }
 
 const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
+  displayedSessionId,
+  isSessionSwitching = false,
   onManageSkills,
   onManageConnectors,
   permissionMode,
@@ -1123,18 +1131,24 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               {updateBadge}
             </div>
           )}
-          <h1 className="text-sm leading-none font-medium text-foreground truncate max-w-[400px]">
-            {currentSession.title || i18nService.t('coworkNewSession')}
-            {process.env.NODE_ENV === 'development' && gatewaySessionId && (
-              <span
-                className="non-draggable text-[10px] text-muted-foreground ml-1.5 font-mono select-text cursor-text"
-                onPointerDown={e => e.stopPropagation()}
-              >
-                {gatewaySessionId.slice(0, 8)}
-              </span>
-            )}
-          </h1>
-          {sessionId && <WorkbenchTaskStatusBar sessionId={sessionId} />}
+          {isSessionSwitching ? (
+            <CoworkSessionTitleLoadingSkeleton />
+          ) : (
+            <>
+              <h1 className="text-sm leading-none font-medium text-foreground truncate max-w-[400px]">
+                {currentSession.title || i18nService.t('coworkNewSession')}
+                {process.env.NODE_ENV === 'development' && gatewaySessionId && (
+                  <span
+                    className="non-draggable text-[10px] text-muted-foreground ml-1.5 font-mono select-text cursor-text"
+                    onPointerDown={e => e.stopPropagation()}
+                  >
+                    {gatewaySessionId.slice(0, 8)}
+                  </span>
+                )}
+              </h1>
+              {sessionId && <WorkbenchTaskStatusBar sessionId={sessionId} />}
+            </>
+          )}
         </div>
 
         {/* Right side: Artifact toggle */}
@@ -1145,8 +1159,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             size="icon"
             onClick={() => dispatch(togglePanel())}
             aria-label={i18nService.t('artifactPanelToggle')}
+            disabled={isSessionSwitching}
           >
-            <ArtifactPanelIcon className="h-4 w-4" open={isPanelOpen} />
+            <ArtifactPanelIcon className="h-4 w-4" open={!isSessionSwitching && isPanelOpen} />
           </Button>
 
           <WindowTitleBar inline className="ml-1" />
@@ -1154,7 +1169,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
       </div>
 
       {/* Export Options Modal */}
-      {showExportOptions && (
+      {!isSessionSwitching && showExportOptions && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
           onClick={() => setShowExportOptions(false)}
@@ -1228,42 +1243,46 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         <div
           ref={detailRootRef}
           className={`relative min-w-0 flex-1 flex flex-col bg-background h-full ${
-            isArtifactWorkspace ? 'hidden' : ''
+            !isSessionSwitching && isArtifactWorkspace ? 'hidden' : ''
           }`}
-          aria-hidden={isArtifactWorkspace}
+          aria-hidden={!isSessionSwitching && isArtifactWorkspace}
         >
           <div className="relative flex-1 min-h-0">
-            <Conversation
-              className="h-full"
-              initial="instant"
-              resize={isStreaming ? 'smooth' : 'instant'}
-            >
-              <ConversationContent
-                className={`pt-3 ${turns.length > 1 ? 'pr-8' : 'pr-3'}`}
-                observeContentResize={false}
-                reverse={false}
-                scrollClassName="cowork-conversation-scroll"
+            {isSessionSwitching ? (
+              <CoworkConversationLoadingSkeleton />
+            ) : (
+              <Conversation
+                className="h-full"
+                initial="instant"
+                resize={isStreaming ? 'smooth' : 'instant'}
               >
-                <div ref={scrollContainerRef}>
-                  {renderConversationTurns()}
-                  {inlineQuestionPermission && onRespondToInlineQuestion && (
-                    <div className="px-3 pt-3">
-                      <AskUserQuestionCard
-                        permission={inlineQuestionPermission}
-                        onRespond={onRespondToInlineQuestion}
-                      />
-                    </div>
-                  )}
-                  <div className="h-20" />
-                </div>
-              </ConversationContent>
-              <ConversationScrollButton
-                className={todoQueue.todos.length > 0 ? 'bottom-14' : undefined}
-              />
-            </Conversation>
+                <ConversationContent
+                  className={`pt-3 ${turns.length > 1 ? 'pr-8' : 'pr-3'}`}
+                  observeContentResize={false}
+                  reverse={false}
+                  scrollClassName="cowork-conversation-scroll"
+                >
+                  <div ref={scrollContainerRef}>
+                    {renderConversationTurns()}
+                    {inlineQuestionPermission && onRespondToInlineQuestion && (
+                      <div className="px-3 pt-3">
+                        <AskUserQuestionCard
+                          permission={inlineQuestionPermission}
+                          onRespond={onRespondToInlineQuestion}
+                        />
+                      </div>
+                    )}
+                    <div className="h-20" />
+                  </div>
+                </ConversationContent>
+                <ConversationScrollButton
+                  className={todoQueue.todos.length > 0 ? 'bottom-14' : undefined}
+                />
+              </Conversation>
+            )}
 
             {/* Turn navigation rail removed: message content remains scrollable in the conversation. */}
-            {turns.length > 1 && (
+            {!isSessionSwitching && turns.length > 1 && (
               <div
                 className="hidden absolute right-[18px] top-1/2 -translate-y-1/2 w-5 flex flex-col items-end z-10"
                 style={{ maxHeight: 'calc(100% - 40px)' }}
@@ -1464,7 +1483,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               </div>
             )}
 
-            {railTooltip &&
+            {!isSessionSwitching &&
+              railTooltip &&
               createPortal(
                 <div
                   className={`fixed z-100 px-3.5 py-2 text-[13px] leading-snug pointer-events-none overflow-hidden
@@ -1503,7 +1523,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               )}
           </div>
 
-          {inlinePermission && onRespondToInlinePermission && (
+          {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
             <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4">
               <div className="w-full max-w-5xl mx-auto">
                 <CoworkPermissionModal
@@ -1521,31 +1541,41 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               <CoworkPromptInput
                 ref={promptInputRef}
                 topAccessory={
-                  <>
-                    {workMode === CoworkSessionMode.Work && !isDirectChat && currentSession?.id && (
-                      <PendingMessageQueue
-                        sessionId={currentSession.id}
-                        isStreaming={isStreaming}
-                      />
-                    )}
-                    <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
-                  </>
+                  isSessionSwitching ? null : (
+                    <>
+                      {workMode === CoworkSessionMode.Work &&
+                        !isDirectChat &&
+                        currentSession?.id && (
+                          <PendingMessageQueue
+                            sessionId={currentSession.id}
+                            isStreaming={isStreaming}
+                          />
+                        )}
+                      <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
+                    </>
+                  )
                 }
                 onSubmit={onContinue}
                 onStop={onStop}
-                isStreaming={isStreaming}
+                isStreaming={isSessionSwitching ? false : isStreaming}
                 placeholder={i18nService.t(
-                  remoteManaged
+                  !isSessionSwitching && remoteManaged
                     ? 'coworkRemoteManagedPlaceholder'
                     : workMode === 'chat'
                       ? 'chatPlaceholder'
                       : 'coworkContinuePlaceholder',
                 )}
-                disabled={remoteManaged || isAwaitingInlineQuestion || Boolean(inlinePermission)}
+                disabled={
+                  !isSessionSwitching &&
+                  (remoteManaged || isAwaitingInlineQuestion || Boolean(inlinePermission))
+                }
+                sessionContextPending={isSessionSwitching}
                 size="large"
-                remoteManaged={remoteManaged}
-                onManageSkills={remoteManaged ? undefined : onManageSkills}
-                onManageConnectors={remoteManaged ? undefined : onManageConnectors}
+                remoteManaged={!isSessionSwitching && remoteManaged}
+                onManageSkills={!isSessionSwitching && remoteManaged ? undefined : onManageSkills}
+                onManageConnectors={
+                  !isSessionSwitching && remoteManaged ? undefined : onManageConnectors
+                }
                 showPermissionModeSelector={workMode === 'work'}
                 permissionMode={permissionMode}
                 onPermissionModeChange={onPermissionModeChange}
@@ -1554,7 +1584,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 showLocalThinkingToggle={isDirectChat}
                 localThinkingEnabled={localThinkingEnabled}
                 onLocalThinkingEnabledChange={onLocalThinkingEnabledChange}
-                sessionId={currentSession?.id}
+                sessionId={displayedSessionId ?? currentSession?.id}
               />
               <p className="text-center text-[11px] text-muted opacity-85 mt-2 mb-[-8px] select-none">
                 {i18nService.t('aiGeneratedDisclaimer')}
@@ -1562,7 +1592,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             </div>
           </div>
         </div>
-        {shouldRenderArtifactPanel && (
+        {!isSessionSwitching && shouldRenderArtifactPanel && (
           <ArtifactPanelErrorBoundary onClose={() => dispatch(closePanel())}>
             <React.Suspense
               fallback={

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -949,10 +949,9 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const rawTurns = useMemo(() => buildConversationTurns(displayItems), [displayItems]);
   // Stabilize turn object identity so completed turns do not re-render on
   // every streaming token (issue #141).
-  const turns = useStableConversationTurns(rawTurns);
+  const turns = useStableConversationTurns(rawTurns, sessionId);
   const turnArtifactsMap = useTurnArtifacts(turns, sessionArtifacts, PREVIEWABLE_ARTIFACT_TYPES);
-  // Scope persisted collapsible state to this session (orphan turn ids are
-  // positional and would collide across sessions). Rendered sessions are
+  // Scope persisted collapsible state to this session. Rendered sessions are
   // shown one at a time, so a render-time namespace assignment is safe.
   setPersistentToggleNamespace(currentSession?.id ?? '');
   // Rail indices come from data, not DOM, so virtualized (unmounted) turns

--- a/src/renderer/components/cowork/CoworkSessionLoadingState.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionLoadingState.test.ts
@@ -12,13 +12,27 @@ import {
 test('builds the conversation loading state from shared Skeleton primitives', () => {
   const view = render(React.createElement(CoworkConversationLoadingSkeleton));
 
-  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
-  expect(view.container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
+  const loadingState = screen.getByRole('status');
+  const skeletons = view.container.querySelectorAll('[data-slot="skeleton"]');
+
+  expect(loadingState).toHaveAttribute('aria-busy', 'true');
+  expect(loadingState).toHaveClass('h-full', 'justify-between', 'overflow-hidden');
+  expect(view.container.querySelectorAll('[data-slot="session-loading-turn"]')).toHaveLength(4);
+  expect(skeletons).toHaveLength(14);
+  skeletons.forEach(skeleton => {
+    expect(skeleton).toHaveClass('skeleton', 'animate-none');
+    expect(skeleton).not.toHaveClass('animate-pulse');
+  });
 });
 
 test('adds an input placeholder only when no session shell exists yet', () => {
   const view = render(React.createElement(CoworkSessionColdStartSkeleton));
+  const skeletons = view.container.querySelectorAll('[data-slot="skeleton"]');
 
   expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
-  expect(view.container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(7);
+  expect(skeletons).toHaveLength(17);
+  skeletons.forEach(skeleton => {
+    expect(skeleton).toHaveClass('skeleton', 'animate-none');
+    expect(skeleton).not.toHaveClass('animate-pulse');
+  });
 });

--- a/src/renderer/components/cowork/CoworkSessionLoadingState.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionLoadingState.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { expect, test } from 'vitest';
+
+import {
+  CoworkConversationLoadingSkeleton,
+  CoworkSessionColdStartSkeleton,
+} from './CoworkSessionLoadingState';
+
+test('builds the conversation loading state from shared Skeleton primitives', () => {
+  const view = render(React.createElement(CoworkConversationLoadingSkeleton));
+
+  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  expect(view.container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(4);
+});
+
+test('adds an input placeholder only when no session shell exists yet', () => {
+  const view = render(React.createElement(CoworkSessionColdStartSkeleton));
+
+  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  expect(view.container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(7);
+});

--- a/src/renderer/components/cowork/CoworkSessionLoadingState.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLoadingState.tsx
@@ -1,21 +1,53 @@
 import { Skeleton } from '@shared/components/ui/skeleton';
+import { cn } from '@shared/lib/utils';
 
-export const CoworkSessionTitleLoadingSkeleton = () => <Skeleton className="h-4 w-48" />;
+const shimmerClassName = 'skeleton animate-none';
+
+const conversationLoadingTurns = [
+  {
+    userClassName: 'h-12 w-2/5',
+    assistantLineClassNames: ['w-4/5', 'w-2/3', 'w-1/2'],
+  },
+  {
+    userClassName: 'h-10 w-1/3',
+    assistantLineClassNames: ['w-3/4', 'w-1/2'],
+  },
+  {
+    userClassName: 'h-16 w-1/2',
+    assistantLineClassNames: ['w-5/6', 'w-3/4', 'w-2/5'],
+  },
+  {
+    userClassName: 'h-12 w-2/5',
+    assistantLineClassNames: ['w-2/3', 'w-1/2'],
+  },
+] as const;
+
+export const CoworkSessionTitleLoadingSkeleton = () => (
+  <Skeleton className={cn(shimmerClassName, 'h-4 w-48')} />
+);
 
 export const CoworkConversationLoadingSkeleton = () => (
   <div
-    className="mx-auto flex h-full w-full max-w-5xl flex-col justify-end gap-6 px-8 py-6"
+    className="mx-auto flex h-full w-full max-w-5xl flex-col justify-between gap-6 overflow-hidden px-8 py-6"
     role="status"
     aria-busy="true"
   >
-    <div className="flex justify-end">
-      <Skeleton className="h-16 w-2/3 rounded-lg" />
-    </div>
-    <div className="flex flex-col gap-2">
-      <Skeleton className="h-4 w-3/4" />
-      <Skeleton className="h-4 w-2/3" />
-      <Skeleton className="h-4 w-1/2" />
-    </div>
+    {conversationLoadingTurns.map(turn => (
+      <div
+        key={`${turn.userClassName}-${turn.assistantLineClassNames.length}`}
+        className="flex flex-col gap-4"
+        data-slot="session-loading-turn"
+      >
+        <div className="flex justify-end">
+          <Skeleton className={cn(shimmerClassName, 'rounded-lg', turn.userClassName)} />
+        </div>
+        <div className="flex flex-col gap-2">
+          {turn.assistantLineClassNames.map(lineClassName => (
+            <Skeleton key={lineClassName} className={cn(shimmerClassName, 'h-4', lineClassName)} />
+          ))}
+        </div>
+      </div>
+    ))}
   </div>
 );
 
@@ -23,7 +55,7 @@ export const CoworkSessionColdStartSkeleton = () => (
   <div className="flex min-h-0 flex-1 flex-col bg-background">
     <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
       <CoworkSessionTitleLoadingSkeleton />
-      <Skeleton className="size-8" />
+      <Skeleton className={cn(shimmerClassName, 'size-8')} />
     </div>
 
     <div className="flex min-h-0 flex-1 flex-col">
@@ -31,7 +63,7 @@ export const CoworkSessionColdStartSkeleton = () => (
         <CoworkConversationLoadingSkeleton />
       </div>
       <div className="shrink-0 px-4 pb-4">
-        <Skeleton className="mx-auto h-24 w-full max-w-5xl rounded-xl" />
+        <Skeleton className={cn(shimmerClassName, 'mx-auto h-24 w-full max-w-5xl rounded-xl')} />
       </div>
     </div>
   </div>

--- a/src/renderer/components/cowork/CoworkSessionLoadingState.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLoadingState.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from '@shared/components/ui/skeleton';
+
+export const CoworkSessionTitleLoadingSkeleton = () => <Skeleton className="h-4 w-48" />;
+
+export const CoworkConversationLoadingSkeleton = () => (
+  <div
+    className="mx-auto flex h-full w-full max-w-5xl flex-col justify-end gap-6 px-8 py-6"
+    role="status"
+    aria-busy="true"
+  >
+    <div className="flex justify-end">
+      <Skeleton className="h-16 w-2/3 rounded-lg" />
+    </div>
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  </div>
+);
+
+export const CoworkSessionColdStartSkeleton = () => (
+  <div className="flex min-h-0 flex-1 flex-col bg-background">
+    <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
+      <CoworkSessionTitleLoadingSkeleton />
+      <Skeleton className="size-8" />
+    </div>
+
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1">
+        <CoworkConversationLoadingSkeleton />
+      </div>
+      <div className="shrink-0 px-4 pb-4">
+        <Skeleton className="mx-auto h-24 w-full max-w-5xl rounded-xl" />
+      </div>
+    </div>
+  </div>
+);

--- a/src/renderer/components/cowork/CoworkSessionViewport.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionViewport.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import CoworkSessionViewport from './CoworkSessionViewport';
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    cowork: {
+      currentSession: null as { id: string } | null,
+      loadingSessionId: null as string | null,
+    },
+  },
+}));
+
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+}));
+
+vi.mock('@shared/components/ui/spinner', () => ({
+  Spinner: () => React.createElement('div', { 'data-testid': 'session-spinner' }),
+}));
+
+vi.mock('./CoworkSessionDetail', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'session-detail' }),
+}));
+
+beforeEach(() => {
+  mocks.state.cowork.currentSession = null;
+  mocks.state.cowork.loadingSessionId = null;
+});
+
+test('keeps the current detail tree mounted while another session loads', () => {
+  mocks.state.cowork.currentSession = { id: 'session-a' };
+  mocks.state.cowork.loadingSessionId = 'session-b';
+
+  const view = render(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  const retainedDetail = screen.getByTestId('session-detail');
+  expect(retainedDetail.parentElement).toHaveAttribute('inert');
+  expect(retainedDetail.parentElement?.parentElement).toHaveAttribute('aria-busy', 'true');
+  expect(screen.queryByTestId('session-spinner')).not.toBeInTheDocument();
+
+  mocks.state.cowork.currentSession = { id: 'session-b' };
+  mocks.state.cowork.loadingSessionId = null;
+  view.rerender(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  expect(screen.getByTestId('session-detail')).toBe(retainedDetail);
+  expect(retainedDetail.parentElement).not.toHaveAttribute('inert');
+  expect(retainedDetail.parentElement?.parentElement).toHaveAttribute('aria-busy', 'false');
+});
+
+test('uses a loading state only when no previous session can be retained', () => {
+  mocks.state.cowork.loadingSessionId = 'session-b';
+
+  render(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  expect(screen.getByTestId('session-spinner')).toBeInTheDocument();
+  expect(screen.queryByTestId('session-detail')).not.toBeInTheDocument();
+});

--- a/src/renderer/components/cowork/CoworkSessionViewport.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionViewport.test.ts
@@ -19,8 +19,8 @@ vi.mock('react-redux', () => ({
   useSelector: (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
 }));
 
-vi.mock('@shared/components/ui/spinner', () => ({
-  Spinner: () => React.createElement('div', { 'data-testid': 'session-spinner' }),
+vi.mock('@shared/components/ui/skeleton', () => ({
+  Skeleton: () => React.createElement('div', { 'data-testid': 'session-skeleton' }),
 }));
 
 vi.mock('./CoworkSessionDetail', () => ({
@@ -32,39 +32,8 @@ beforeEach(() => {
   mocks.state.cowork.loadingSessionId = null;
 });
 
-test('keeps the current detail tree mounted while another session loads', () => {
+test('replaces the previous session with a loading skeleton while another session loads', () => {
   mocks.state.cowork.currentSession = { id: 'session-a' };
-  mocks.state.cowork.loadingSessionId = 'session-b';
-
-  const view = render(
-    React.createElement(CoworkSessionViewport, {
-      sessionId: 'session-b',
-      onContinue: () => undefined,
-      onStop: () => undefined,
-    }),
-  );
-
-  const retainedDetail = screen.getByTestId('session-detail');
-  expect(retainedDetail.parentElement).toHaveAttribute('inert');
-  expect(retainedDetail.parentElement?.parentElement).toHaveAttribute('aria-busy', 'true');
-  expect(screen.queryByTestId('session-spinner')).not.toBeInTheDocument();
-
-  mocks.state.cowork.currentSession = { id: 'session-b' };
-  mocks.state.cowork.loadingSessionId = null;
-  view.rerender(
-    React.createElement(CoworkSessionViewport, {
-      sessionId: 'session-b',
-      onContinue: () => undefined,
-      onStop: () => undefined,
-    }),
-  );
-
-  expect(screen.getByTestId('session-detail')).toBe(retainedDetail);
-  expect(retainedDetail.parentElement).not.toHaveAttribute('inert');
-  expect(retainedDetail.parentElement?.parentElement).toHaveAttribute('aria-busy', 'false');
-});
-
-test('uses a loading state only when no previous session can be retained', () => {
   mocks.state.cowork.loadingSessionId = 'session-b';
 
   render(
@@ -75,6 +44,55 @@ test('uses a loading state only when no previous session can be retained', () =>
     }),
   );
 
-  expect(screen.getByTestId('session-spinner')).toBeInTheDocument();
+  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  expect(screen.getAllByTestId('session-skeleton')).not.toHaveLength(0);
+  expect(screen.queryByTestId('session-detail')).not.toBeInTheDocument();
+});
+
+test('renders the target session as soon as its data is ready', () => {
+  mocks.state.cowork.currentSession = { id: 'session-b' };
+  mocks.state.cowork.loadingSessionId = 'session-b';
+
+  render(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  expect(screen.getByTestId('session-detail')).toBeInTheDocument();
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('session-skeleton')).not.toBeInTheDocument();
+});
+
+test('renders the current session when no switch is pending', () => {
+  mocks.state.cowork.currentSession = { id: 'session-b' };
+
+  render(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  expect(screen.getByTestId('session-detail')).toBeInTheDocument();
+  expect(screen.queryByRole('status')).not.toBeInTheDocument();
+});
+
+test('uses the same loading skeleton when there is no previous session', () => {
+  mocks.state.cowork.loadingSessionId = 'session-b';
+
+  render(
+    React.createElement(CoworkSessionViewport, {
+      sessionId: 'session-b',
+      onContinue: () => undefined,
+      onStop: () => undefined,
+    }),
+  );
+
+  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  expect(screen.getAllByTestId('session-skeleton')).not.toHaveLength(0);
   expect(screen.queryByTestId('session-detail')).not.toBeInTheDocument();
 });

--- a/src/renderer/components/cowork/CoworkSessionViewport.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionViewport.test.ts
@@ -24,7 +24,18 @@ vi.mock('@shared/components/ui/skeleton', () => ({
 }));
 
 vi.mock('./CoworkSessionDetail', () => ({
-  default: () => React.createElement('div', { 'data-testid': 'session-detail' }),
+  default: ({
+    displayedSessionId,
+    isSessionSwitching,
+  }: {
+    displayedSessionId: string;
+    isSessionSwitching: boolean;
+  }) =>
+    React.createElement('div', {
+      'data-testid': 'session-detail',
+      'data-displayed-session-id': displayedSessionId,
+      'data-session-switching': String(isSessionSwitching),
+    }),
 }));
 
 beforeEach(() => {
@@ -32,7 +43,7 @@ beforeEach(() => {
   mocks.state.cowork.loadingSessionId = null;
 });
 
-test('replaces the previous session with a loading skeleton while another session loads', () => {
+test('keeps the detail shell mounted while its conversation switches sessions', () => {
   mocks.state.cowork.currentSession = { id: 'session-a' };
   mocks.state.cowork.loadingSessionId = 'session-b';
 
@@ -44,9 +55,10 @@ test('replaces the previous session with a loading skeleton while another sessio
     }),
   );
 
-  expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
-  expect(screen.getAllByTestId('session-skeleton')).not.toHaveLength(0);
-  expect(screen.queryByTestId('session-detail')).not.toBeInTheDocument();
+  const detail = screen.getByTestId('session-detail');
+  expect(detail).toHaveAttribute('data-displayed-session-id', 'session-b');
+  expect(detail).toHaveAttribute('data-session-switching', 'true');
+  expect(screen.queryByTestId('session-skeleton')).not.toBeInTheDocument();
 });
 
 test('renders the target session as soon as its data is ready', () => {
@@ -62,6 +74,7 @@ test('renders the target session as soon as its data is ready', () => {
   );
 
   expect(screen.getByTestId('session-detail')).toBeInTheDocument();
+  expect(screen.getByTestId('session-detail')).toHaveAttribute('data-session-switching', 'false');
   expect(screen.queryByRole('status')).not.toBeInTheDocument();
   expect(screen.queryByTestId('session-skeleton')).not.toBeInTheDocument();
 });
@@ -78,6 +91,7 @@ test('renders the current session when no switch is pending', () => {
   );
 
   expect(screen.getByTestId('session-detail')).toBeInTheDocument();
+  expect(screen.getByTestId('session-detail')).toHaveAttribute('data-session-switching', 'false');
   expect(screen.queryByRole('status')).not.toBeInTheDocument();
 });
 

--- a/src/renderer/components/cowork/CoworkSessionViewport.tsx
+++ b/src/renderer/components/cowork/CoworkSessionViewport.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@shared/components/ui/spinner';
+import { Skeleton } from '@shared/components/ui/skeleton';
 import type { ComponentProps } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -12,29 +12,45 @@ type CoworkSessionViewportProps = ComponentProps<typeof CoworkSessionDetail> & {
   sessionId: string;
 };
 
+const CoworkSessionLoadingSkeleton = () => (
+  <div className="flex min-h-0 flex-1 flex-col bg-background" role="status" aria-busy="true">
+    <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
+      <Skeleton className="h-4 w-48" />
+      <Skeleton className="size-8" />
+    </div>
+
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col justify-end gap-6 px-8 py-6">
+        <div className="flex justify-end">
+          <Skeleton className="h-16 w-2/3 rounded-lg" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-4 w-2/3" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      </div>
+
+      <div className="shrink-0 px-4 pb-4">
+        <Skeleton className="mx-auto h-24 w-full max-w-5xl rounded-xl" />
+      </div>
+    </div>
+  </div>
+);
+
 const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportProps) => {
   const loadingSessionId = useSelector(selectLoadingSessionId);
   const currentSession = useSelector(selectCurrentSession);
   const isLoadingTargetSession = loadingSessionId === sessionId;
+  const isWaitingForTargetSession = isLoadingTargetSession && currentSession?.id !== sessionId;
 
-  // Keep the current detail tree mounted until the target session is ready.
-  // Replacing it during the async load creates a blank frame and throws away
-  // the measured virtual-list state that can still be displayed safely.
-  if (isLoadingTargetSession && !currentSession) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center bg-background">
-        <Spinner className="size-5 text-muted-foreground" />
-      </div>
-    );
+  if (isWaitingForTargetSession) {
+    return <CoworkSessionLoadingSkeleton />;
   }
 
-  const isShowingPreviousSession = isLoadingTargetSession && currentSession?.id !== sessionId;
-
   return (
-    <div className="flex min-h-0 flex-1" aria-busy={isShowingPreviousSession}>
-      <div className="flex min-h-0 flex-1" inert={isShowingPreviousSession}>
-        <CoworkSessionDetail {...props} />
-      </div>
+    <div className="flex min-h-0 flex-1">
+      <CoworkSessionDetail {...props} />
     </div>
   );
 };

--- a/src/renderer/components/cowork/CoworkSessionViewport.tsx
+++ b/src/renderer/components/cowork/CoworkSessionViewport.tsx
@@ -15,11 +15,12 @@ type CoworkSessionViewportProps = ComponentProps<typeof CoworkSessionDetail> & {
 const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportProps) => {
   const loadingSessionId = useSelector(selectLoadingSessionId);
   const currentSession = useSelector(selectCurrentSession);
+  const isLoadingTargetSession = loadingSessionId === sessionId;
 
-  // If a live streaming snapshot has already been restored for this session,
-  // show it immediately instead of a blank loading spinner. This keeps the
-  // stream visible when switching back to a running session.
-  if (loadingSessionId === sessionId && currentSession?.id !== sessionId) {
+  // Keep the current detail tree mounted until the target session is ready.
+  // Replacing it during the async load creates a blank frame and throws away
+  // the measured virtual-list state that can still be displayed safely.
+  if (isLoadingTargetSession && !currentSession) {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center bg-background">
         <Spinner className="size-5 text-muted-foreground" />
@@ -27,10 +28,15 @@ const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportPro
     );
   }
 
-  // Keep the detail tree mounted while switching sessions. In particular, this
-  // preserves expensive document and PPT preview renderers instead of rebuilding
-  // them whenever the selected session changes.
-  return <CoworkSessionDetail {...props} />;
+  const isShowingPreviousSession = isLoadingTargetSession && currentSession?.id !== sessionId;
+
+  return (
+    <div className="flex min-h-0 flex-1" aria-busy={isShowingPreviousSession}>
+      <div className="flex min-h-0 flex-1" inert={isShowingPreviousSession}>
+        <CoworkSessionDetail {...props} />
+      </div>
+    </div>
+  );
 };
 
 export default CoworkSessionViewport;

--- a/src/renderer/components/cowork/CoworkSessionViewport.tsx
+++ b/src/renderer/components/cowork/CoworkSessionViewport.tsx
@@ -1,4 +1,3 @@
-import { Skeleton } from '@shared/components/ui/skeleton';
 import type { ComponentProps } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -7,36 +6,14 @@ import {
   selectLoadingSessionId,
 } from '../../store/selectors/coworkSelectors';
 import CoworkSessionDetail from './CoworkSessionDetail';
+import { CoworkSessionColdStartSkeleton } from './CoworkSessionLoadingState';
 
-type CoworkSessionViewportProps = ComponentProps<typeof CoworkSessionDetail> & {
+type CoworkSessionViewportProps = Omit<
+  ComponentProps<typeof CoworkSessionDetail>,
+  'displayedSessionId' | 'isSessionSwitching'
+> & {
   sessionId: string;
 };
-
-const CoworkSessionLoadingSkeleton = () => (
-  <div className="flex min-h-0 flex-1 flex-col bg-background" role="status" aria-busy="true">
-    <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
-      <Skeleton className="h-4 w-48" />
-      <Skeleton className="size-8" />
-    </div>
-
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col justify-end gap-6 px-8 py-6">
-        <div className="flex justify-end">
-          <Skeleton className="h-16 w-2/3 rounded-lg" />
-        </div>
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-4 w-3/4" />
-          <Skeleton className="h-4 w-2/3" />
-          <Skeleton className="h-4 w-1/2" />
-        </div>
-      </div>
-
-      <div className="shrink-0 px-4 pb-4">
-        <Skeleton className="mx-auto h-24 w-full max-w-5xl rounded-xl" />
-      </div>
-    </div>
-  </div>
-);
 
 const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportProps) => {
   const loadingSessionId = useSelector(selectLoadingSessionId);
@@ -44,13 +21,17 @@ const CoworkSessionViewport = ({ sessionId, ...props }: CoworkSessionViewportPro
   const isLoadingTargetSession = loadingSessionId === sessionId;
   const isWaitingForTargetSession = isLoadingTargetSession && currentSession?.id !== sessionId;
 
-  if (isWaitingForTargetSession) {
-    return <CoworkSessionLoadingSkeleton />;
+  if (isWaitingForTargetSession && !currentSession) {
+    return <CoworkSessionColdStartSkeleton />;
   }
 
   return (
     <div className="flex min-h-0 flex-1">
-      <CoworkSessionDetail {...props} />
+      <CoworkSessionDetail
+        {...props}
+        displayedSessionId={sessionId}
+        isSessionSwitching={isWaitingForTargetSession}
+      />
     </div>
   );
 };

--- a/src/renderer/components/cowork/components/VirtualizedTurnList.integration.test.ts
+++ b/src/renderer/components/cowork/components/VirtualizedTurnList.integration.test.ts
@@ -249,6 +249,7 @@ test('preserves the visible turn and viewport offset when older turns are prepen
   await waitFor(() => expect(onInitialTailPositioned).toHaveBeenCalledOnce());
 
   await act(async () => {
+    viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
     viewport.scrollTop = 15_000;
     viewport.dispatchEvent(new Event('scroll'));
   });
@@ -281,6 +282,97 @@ test('preserves the visible turn and viewport offset when older turns are prepen
     expect(Number.parseFloat(anchoredRow?.style.top ?? '0') - viewport.scrollTop).toBe(
       anchorOffset,
     );
+  });
+});
+
+test('preserves visible content when a missing turn prefix is prepended', async () => {
+  const viewport = installViewport();
+  const turns = makeTurns(100, 'existing').map(turn => ({
+    ...turn,
+    assistantItems: [
+      {
+        type: 'assistant' as const,
+        message: {
+          id: `${turn.id}-content`,
+          type: 'assistant' as const,
+          content: 'existing content',
+          timestamp: 1,
+        },
+      },
+    ],
+  }));
+  const heights = new Map(turns.map(turn => [turn.id, 200]));
+  const prefixHeights = new Map<string, number>();
+  const renderTurn = (turn: ConversationTurn) =>
+    React.createElement('div', {
+      'data-turn-height': String(heights.get(turn.id)),
+      'data-turn-id': turn.id,
+    });
+  const view = render(
+    React.createElement(VirtualizedTurnList, {
+      isStreaming: false,
+      turns,
+      renderAll: false,
+      renderTurn,
+    }),
+    { container: viewport },
+  );
+  await flushResizeObservers();
+
+  await act(async () => {
+    viewport.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
+    viewport.scrollTop = 15_000;
+    viewport.dispatchEvent(new Event('scroll'));
+  });
+  await flushResizeObservers();
+
+  const anchorRow = Array.from(viewport.querySelectorAll<HTMLElement>('[data-index]')).find(row => {
+    const start = Number.parseFloat(row.style.top);
+    return start <= viewport.scrollTop && start + row.offsetHeight > viewport.scrollTop;
+  });
+  const anchorId = anchorRow?.querySelector<HTMLElement>('[data-turn-id]')?.dataset.turnId;
+  const originalContentOffset = Number.parseFloat(anchorRow?.style.top ?? '0') - viewport.scrollTop;
+  expect(anchorId).toBeTruthy();
+
+  heights.set(anchorId!, (heights.get(anchorId!) ?? 0) + 400);
+  prefixHeights.set(anchorId!, 400);
+  const expandedTurns = turns.map(turn =>
+    turn.id === anchorId
+      ? {
+          ...turn,
+          assistantItems: [
+            {
+              type: 'assistant' as const,
+              message: {
+                id: `${turn.id}-prefix`,
+                type: 'assistant' as const,
+                content: 'newly loaded prefix',
+                timestamp: 1,
+              },
+            },
+            ...turn.assistantItems,
+          ],
+        }
+      : turn,
+  );
+  view.rerender(
+    React.createElement(VirtualizedTurnList, {
+      isStreaming: false,
+      turns: [...makeTurns(50, 'older'), ...expandedTurns],
+      renderAll: false,
+      renderTurn,
+    }),
+  );
+  await flushResizeObservers();
+
+  await waitFor(() => {
+    const anchoredContent = viewport.querySelector<HTMLElement>(`[data-turn-id="${anchorId}"]`);
+    const anchoredRow = anchoredContent?.closest<HTMLElement>('[data-index]');
+    const retainedContentOffset =
+      Number.parseFloat(anchoredRow?.style.top ?? '0') +
+      (prefixHeights.get(anchorId!) ?? 0) -
+      viewport.scrollTop;
+    expect(retainedContentOffset).toBe(originalContentOffset);
   });
 });
 

--- a/src/renderer/components/cowork/components/VirtualizedTurnList.test.ts
+++ b/src/renderer/components/cowork/components/VirtualizedTurnList.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -8,6 +8,7 @@ import type { ConversationTurn } from '../helpers/messageGrouping';
 import { VirtualizedTurnList } from './VirtualizedTurnList';
 
 const mocks = vi.hoisted(() => ({
+  elementScroll: vi.fn(),
   measureElement: vi.fn(),
   scrollRef: { current: null as HTMLElement | null },
   scrollToEnd: vi.fn(),
@@ -20,11 +21,13 @@ vi.mock('use-stick-to-bottom', () => ({
 }));
 
 vi.mock('@tanstack/react-virtual', () => ({
+  elementScroll: mocks.elementScroll,
   useVirtualizer: (options: unknown) => mocks.useVirtualizer(options),
 }));
 
 beforeEach(() => {
   mocks.scrollRef.current = document.createElement('div');
+  mocks.elementScroll.mockReset();
   mocks.measureElement.mockReset();
   mocks.scrollToEnd.mockReset();
   mocks.scrollToIndex.mockReset();
@@ -84,15 +87,10 @@ test('positions a newly mounted virtualizer at the end before paint', () => {
   expect(mocks.scrollToEnd).toHaveBeenCalledTimes(2);
 });
 
-test('enables history pagination only after the rendered tail is stable', () => {
-  const frameCallbacks: FrameRequestCallback[] = [];
-  const requestFrame = vi
-    .spyOn(window, 'requestAnimationFrame')
-    .mockImplementation(callback => frameCallbacks.push(callback));
-  const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
+test('positions the initial tail once before enabling history pagination', () => {
   const onInitialTailPositioned = vi.fn();
 
-  const view = render(
+  render(
     React.createElement(VirtualizedTurnList, {
       isStreaming: false,
       turns: [],
@@ -103,58 +101,39 @@ test('enables history pagination only after the rendered tail is stable', () => 
   );
 
   expect(mocks.scrollToEnd).toHaveBeenCalledTimes(1);
-  expect(onInitialTailPositioned).not.toHaveBeenCalled();
-
-  act(() => frameCallbacks.shift()?.(0));
-  expect(onInitialTailPositioned).not.toHaveBeenCalled();
-
-  act(() => frameCallbacks.shift()?.(16));
-  expect(mocks.scrollToEnd).toHaveBeenCalledTimes(3);
   expect(onInitialTailPositioned).toHaveBeenCalledOnce();
-
-  view.unmount();
-  requestFrame.mockRestore();
-  cancelFrame.mockRestore();
 });
 
-test('releases history pagination when a dynamic tail does not settle', () => {
-  const frameCallbacks: FrameRequestCallback[] = [];
-  const requestFrame = vi
-    .spyOn(window, 'requestAnimationFrame')
-    .mockImplementation(callback => frameCallbacks.push(callback));
-  const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined);
-  const onInitialTailPositioned = vi.fn();
-  const turns: ConversationTurn[] = [
-    {
-      id: 'turn-1',
-      userMessage: null,
-      assistantItems: [],
-    },
-  ];
+test('does not retry internal anchor adjustments while the user scrolls upward', () => {
+  const scrollElement = mocks.scrollRef.current!;
+  Object.defineProperties(scrollElement, {
+    clientHeight: { configurable: true, value: 600 },
+    scrollHeight: { configurable: true, value: 2_000 },
+    scrollTop: { configurable: true, writable: true, value: 500 },
+  });
+  const requestFrame = vi.spyOn(window, 'requestAnimationFrame');
 
-  const view = render(
+  render(
     React.createElement(VirtualizedTurnList, {
       isStreaming: false,
-      turns,
-      onInitialTailPositioned,
+      turns: [],
       renderAll: false,
       renderTurn: () => null,
     }),
   );
 
-  act(() => {
-    for (let frame = 0; frame < 12; frame += 1) {
-      frameCallbacks.shift()?.(frame * 16);
-    }
-  });
+  const options = mocks.useVirtualizer.mock.calls[0]?.[0] as {
+    scrollToFn: (
+      offset: number,
+      options: { adjustments?: number; behavior?: ScrollBehavior },
+      instance: { scrollElement: HTMLElement },
+    ) => void;
+  };
+  options.scrollToFn(1_000, { adjustments: 200 }, { scrollElement });
 
-  expect(mocks.scrollToEnd).toHaveBeenCalledTimes(13);
-  expect(onInitialTailPositioned).toHaveBeenCalledOnce();
-  expect(frameCallbacks).toHaveLength(0);
-
-  view.unmount();
+  expect(mocks.elementScroll).toHaveBeenCalledOnce();
+  expect(requestFrame).not.toHaveBeenCalled();
   requestFrame.mockRestore();
-  cancelFrame.mockRestore();
 });
 
 test('lets a short session clamp its estimated end to the top of a non-overflowing viewport', () => {
@@ -219,7 +198,7 @@ test('positions only the virtual tail window instead of rendering the full sessi
   );
 });
 
-test('leaves row measurement and positioning exclusively to the virtualizer', () => {
+test('synchronizes measured layout before the following React commit', () => {
   const turns: ConversationTurn[] = [
     {
       id: 'turn-1',
@@ -256,4 +235,22 @@ test('leaves row measurement and positioning exclusively to the virtualizer', ()
   expect(mocks.measureElement).toHaveBeenCalledTimes(1);
   expect(row?.style.top).toBe('0px');
   expect(row?.style.transform).toBe('');
+
+  const options = mocks.useVirtualizer.mock.calls[0]?.[0] as {
+    onChange: (instance: {
+      elementsCache: Map<React.Key, HTMLElement>;
+      getTotalSize: () => number;
+      getVirtualItems: () => Array<{ key: React.Key; start: number }>;
+    }) => void;
+  };
+  options.onChange({
+    elementsCache: new Map([['turn-1', row!]]),
+    getTotalSize: () => 480,
+    getVirtualItems: () => [{ key: 'turn-1', start: 120 }],
+  });
+
+  expect(
+    view.container.querySelector<HTMLElement>('[data-virtualized-turn-list]')?.style.height,
+  ).toBe('480px');
+  expect(row?.style.top).toBe('120px');
 });

--- a/src/renderer/components/cowork/components/VirtualizedTurnList.tsx
+++ b/src/renderer/components/cowork/components/VirtualizedTurnList.tsx
@@ -1,8 +1,16 @@
 import { elementScroll, useVirtualizer } from '@tanstack/react-virtual';
-import React, { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { useStickToBottomContext } from 'use-stick-to-bottom';
 
-import type { ConversationTurn } from '../helpers/messageGrouping';
+import { estimateConversationTurnHeight } from '../helpers/conversationTurnHeight';
+import { getConversationTurnMessageIds, type ConversationTurn } from '../helpers/messageGrouping';
 
 export interface VirtualizedTurnListHandle {
   scrollToTurn: (index: number) => void;
@@ -18,12 +26,9 @@ interface VirtualizedTurnListProps {
   renderAll: boolean;
 }
 
-/** Fallback height estimate for turns that were never measured. */
-const TURN_HEIGHT_ESTIMATE_PX = 300;
 const INITIAL_VIEWPORT_HEIGHT_PX = 1200;
 const INITIAL_VIEWPORT_RECT = { width: 0, height: INITIAL_VIEWPORT_HEIGHT_PX };
-const INITIAL_TAIL_STABLE_FRAMES = 2;
-const INITIAL_TAIL_MAX_POSITIONING_FRAMES = 12;
+const TURN_OVERSCAN = 8;
 
 /**
  * Renders only the visible window of conversation turns (issue #141
@@ -38,54 +43,118 @@ export const VirtualizedTurnList = React.forwardRef<
 >(({ isStreaming, turns, onInitialTailPositioned, renderTurn, renderAll }, ref) => {
   const { scrollRef } = useStickToBottomContext();
   const hasPositionedInitialTailRef = useRef(false);
-  const scrollRetryFrameRef = useRef<number | null>(null);
-  const scrollRetryWindowRef = useRef<Window | null>(null);
+  const shouldFollowInitialTailRef = useRef(true);
+  const virtualSizerRef = useRef<HTMLDivElement>(null);
+  const measuredTurnSizesRef = useRef(new Map<string, number>());
+  const previousMessageIdsByTurnRef = useRef(new Map<string, string[]>());
+  const measureElementRefsRef = useRef(
+    new Map<React.Key, (element: HTMLDivElement | null) => void>(),
+  );
+  const tailRetryFrameRef = useRef<number | null>(null);
+  const tailRetryWindowRef = useRef<Window | null>(null);
+  const estimatedTurnSizes = useMemo(() => turns.map(estimateConversationTurnHeight), [turns]);
+
+  const { internallyPrependedTurnSizes, nextMessageIdsByTurn } = useMemo(() => {
+    const nextIdsByTurn = new Map<string, string[]>();
+    const prependedSizes = new Map<string, number>();
+    for (const turn of turns) {
+      const nextMessageIds = getConversationTurnMessageIds(turn);
+      const previousMessageIds = previousMessageIdsByTurnRef.current.get(turn.id);
+      if (previousMessageIds?.[0] && nextMessageIds.indexOf(previousMessageIds[0]) > 0) {
+        const previousSize = measuredTurnSizesRef.current.get(turn.id);
+        if (previousSize !== undefined) {
+          prependedSizes.set(turn.id, previousSize);
+        }
+      }
+      nextIdsByTurn.set(turn.id, nextMessageIds);
+    }
+    return {
+      internallyPrependedTurnSizes: prependedSizes,
+      nextMessageIdsByTurn: nextIdsByTurn,
+    };
+  }, [turns]);
   const scrollToFn = useCallback<typeof elementScroll>((offset, options, instance) => {
     const scrollElement = instance.scrollElement as HTMLElement | null;
     const targetWindow = scrollElement?.ownerDocument.defaultView;
+    const wasAtTail = scrollElement
+      ? Math.abs(
+          scrollElement.scrollTop -
+            Math.max(scrollElement.scrollHeight - scrollElement.clientHeight, 0),
+        ) < 1
+      : false;
 
     elementScroll(offset, options, instance);
     if (!scrollElement || !targetWindow) return;
+
+    // Internal anchor adjustments during upward scrolling must never schedule
+    // a later scroll write. Retry only a clamped tail update or an explicit
+    // programmatic scroll such as the initial jump to the end.
+    if (!wasAtTail && options.behavior === undefined) return;
 
     const requestedOffset = offset + (options.adjustments ?? 0);
     const clampedOffset = scrollElement.scrollTop;
     if (requestedOffset - clampedOffset < 1) return;
 
-    if (scrollRetryFrameRef.current !== null && scrollRetryWindowRef.current) {
-      scrollRetryWindowRef.current.cancelAnimationFrame(scrollRetryFrameRef.current);
+    if (tailRetryFrameRef.current !== null && tailRetryWindowRef.current) {
+      tailRetryWindowRef.current.cancelAnimationFrame(tailRetryFrameRef.current);
     }
 
-    // A ResizeObserver batch can grow several tail rows before React commits
-    // the new sizer height. Retry only a browser-clamped correction after that
-    // commit, and abandon it if another scroll changed the DOM position.
-    scrollRetryWindowRef.current = targetWindow;
-    scrollRetryFrameRef.current = targetWindow.requestAnimationFrame(() => {
-      scrollRetryFrameRef.current = null;
-      scrollRetryWindowRef.current = null;
+    tailRetryWindowRef.current = targetWindow;
+    tailRetryFrameRef.current = targetWindow.requestAnimationFrame(() => {
+      tailRetryFrameRef.current = null;
+      tailRetryWindowRef.current = null;
       const currentScrollElement = instance.scrollElement as HTMLElement | null;
       if (currentScrollElement === scrollElement && scrollElement.scrollTop === clampedOffset) {
         scrollElement.scrollTo({ top: requestedOffset, behavior: 'auto' });
       }
     });
   }, []);
-  const initialOffset = turns.length * TURN_HEIGHT_ESTIMATE_PX;
+  const initialOffset = estimatedTurnSizes.reduce((total, size) => total + size, 0);
   const virtualizer = useVirtualizer({
     count: turns.length,
     getScrollElement: () => scrollRef.current,
     getItemKey: index => turns[index]?.id ?? index,
-    estimateSize: () => TURN_HEIGHT_ESTIMATE_PX,
-    overscan: 4,
+    estimateSize: index => estimatedTurnSizes[index] ?? 300,
+    overscan: TURN_OVERSCAN,
     initialOffset,
     initialRect: INITIAL_VIEWPORT_RECT,
     anchorTo: 'end',
     followOnAppend: isStreaming ? 'auto' : false,
     scrollToFn,
+    onChange: instance => {
+      // ResizeObserver corrections happen before React can commit the new
+      // virtual positions. Apply the sizer height and mounted row offsets in
+      // that same callback so the corrected scrollTop and layout reach the
+      // browser together instead of painting a transient frame.
+      const sizer = virtualSizerRef.current;
+      if (!sizer) return;
+
+      sizer.style.height = `${instance.getTotalSize()}px`;
+      for (const item of instance.getVirtualItems()) {
+        const element = instance.elementsCache.get(item.key) as HTMLElement | undefined;
+        if (element) element.style.top = `${item.start}px`;
+      }
+    },
   });
+  const getMeasureElementRef = useCallback(
+    (key: React.Key) => {
+      const existing = measureElementRefsRef.current.get(key);
+      if (existing) return existing;
+
+      const measure = (element: HTMLDivElement | null) => {
+        virtualizer.measureElement(element);
+        if (element) measuredTurnSizesRef.current.set(String(key), element.offsetHeight);
+      };
+      measureElementRefsRef.current.set(key, measure);
+      return measure;
+    },
+    [virtualizer],
+  );
 
   useEffect(
     () => () => {
-      if (scrollRetryFrameRef.current !== null && scrollRetryWindowRef.current) {
-        scrollRetryWindowRef.current.cancelAnimationFrame(scrollRetryFrameRef.current);
+      if (tailRetryFrameRef.current !== null && tailRetryWindowRef.current) {
+        tailRetryWindowRef.current.cancelAnimationFrame(tailRetryFrameRef.current);
       }
     },
     [],
@@ -103,63 +172,74 @@ export const VirtualizedTurnList = React.forwardRef<
     };
   }, [scrollRef]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const scrollElement = scrollRef.current;
-    if (!scrollElement || renderAll || hasPositionedInitialTailRef.current) return;
+    const ownerDocument = scrollElement?.ownerDocument;
+    if (!scrollElement || !ownerDocument) return;
 
-    const targetWindow = scrollElement.ownerDocument.defaultView;
-    if (!targetWindow) {
-      virtualizer.scrollToEnd({ behavior: 'auto' });
-      hasPositionedInitialTailRef.current = true;
-      onInitialTailPositioned?.();
-      return;
-    }
-
-    let stableFrames = 0;
-    let positioningFrames = 0;
-    let previousScrollHeight = scrollElement.scrollHeight;
-    let previousTotalSize = virtualizer.getTotalSize();
-    let settleFrame: number;
-
-    const positionTail = () => {
-      positioningFrames += 1;
-      virtualizer.scrollToEnd({ behavior: 'auto' });
-
-      const virtualItems = virtualizer.getVirtualItems();
-      const lastVirtualItem = virtualItems[virtualItems.length - 1];
-      const lastTurnIsRendered = turns.length === 0 || lastVirtualItem?.index === turns.length - 1;
-      const maxScrollOffset = Math.max(scrollElement.scrollHeight - scrollElement.clientHeight, 0);
-      const isAtTail = Math.abs(scrollElement.scrollTop - maxScrollOffset) < 1;
-      const totalSize = virtualizer.getTotalSize();
-      const sizeIsStable =
-        scrollElement.scrollHeight === previousScrollHeight && totalSize === previousTotalSize;
-
-      stableFrames = lastTurnIsRendered && isAtTail && sizeIsStable ? stableFrames + 1 : 0;
-      previousScrollHeight = scrollElement.scrollHeight;
-      previousTotalSize = totalSize;
-
-      if (
-        stableFrames >= INITIAL_TAIL_STABLE_FRAMES ||
-        positioningFrames >= INITIAL_TAIL_MAX_POSITIONING_FRAMES
-      ) {
-        hasPositionedInitialTailRef.current = true;
-        onInitialTailPositioned?.();
-        return;
+    const stopFollowingInitialTail = () => {
+      shouldFollowInitialTailRef.current = false;
+    };
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) stopFollowingInitialTail();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (['ArrowUp', 'Home', 'PageUp'].includes(event.key)) {
+        stopFollowingInitialTail();
       }
-
-      settleFrame = targetWindow.requestAnimationFrame(positionTail);
     };
 
-    virtualizer.scrollToEnd({ behavior: 'auto' });
-    settleFrame = targetWindow.requestAnimationFrame(positionTail);
+    scrollElement.addEventListener('wheel', handleWheel, { passive: true });
+    scrollElement.addEventListener('touchstart', stopFollowingInitialTail, { passive: true });
+    scrollElement.addEventListener('pointerdown', stopFollowingInitialTail, { passive: true });
+    ownerDocument.addEventListener('keydown', handleKeyDown);
 
-    return () => targetWindow.cancelAnimationFrame(settleFrame);
-  }, [onInitialTailPositioned, renderAll, scrollRef, turns.length, virtualizer]);
+    return () => {
+      scrollElement.removeEventListener('wheel', handleWheel);
+      scrollElement.removeEventListener('touchstart', stopFollowingInitialTail);
+      scrollElement.removeEventListener('pointerdown', stopFollowingInitialTail);
+      ownerDocument.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [scrollRef]);
+
+  useLayoutEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    const rows = scrollElement.querySelectorAll<HTMLElement>('[data-turn-key]');
+    for (const row of rows) {
+      const key = row.dataset.turnKey;
+      if (!key) continue;
+
+      const previousSize = internallyPrependedTurnSizes.get(key);
+      if (previousSize !== undefined && virtualizer.scrollDirection === 'backward') {
+        const delta = row.offsetHeight - previousSize;
+        const rowStart = Number.parseFloat(row.style.top);
+        if (delta > 0 && rowStart <= scrollElement.scrollTop) {
+          scrollElement.scrollTop += delta;
+        }
+      }
+      measuredTurnSizesRef.current.set(key, row.offsetHeight);
+    }
+    previousMessageIdsByTurnRef.current = nextMessageIdsByTurn;
+  }, [internallyPrependedTurnSizes, nextMessageIdsByTurn, scrollRef, turns, virtualizer]);
+
+  useLayoutEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement || renderAll || !shouldFollowInitialTailRef.current) return;
+
+    virtualizer.scrollToEnd({ behavior: 'auto' });
+    if (!hasPositionedInitialTailRef.current) {
+      hasPositionedInitialTailRef.current = true;
+      onInitialTailPositioned?.();
+    }
+  });
 
   useImperativeHandle(
     ref,
     () => ({
       scrollToTurn: index => {
+        shouldFollowInitialTailRef.current = false;
         virtualizer.scrollToIndex(index, { align: 'start', behavior: 'smooth' });
       },
     }),
@@ -171,12 +251,17 @@ export const VirtualizedTurnList = React.forwardRef<
   }
 
   return (
-    <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+    <div
+      data-virtualized-turn-list
+      ref={virtualSizerRef}
+      style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}
+    >
       {virtualizer.getVirtualItems().map(virtualItem => (
         <div
           key={virtualItem.key}
           data-index={virtualItem.index}
-          ref={virtualizer.measureElement}
+          data-turn-key={String(virtualItem.key)}
+          ref={getMeasureElementRef(virtualItem.key)}
           style={{
             position: 'absolute',
             top: virtualItem.start,

--- a/src/renderer/components/cowork/helpers/conversationTurnHeight.test.ts
+++ b/src/renderer/components/cowork/helpers/conversationTurnHeight.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest';
+
+import type { CoworkMessage } from '../../../types/cowork';
+import type { ConversationTurn } from './messageGrouping';
+import { estimateConversationTurnHeight } from './conversationTurnHeight';
+
+const message = (id: string, content: string): CoworkMessage => ({
+  id,
+  type: 'assistant',
+  content,
+  timestamp: 1,
+});
+
+const turn = (content: string): ConversationTurn => ({
+  id: 'turn-1',
+  userMessage: null,
+  assistantItems: [{ type: 'assistant', message: message('assistant-1', content) }],
+});
+
+test('estimates content-heavy turns above the empty-turn fallback', () => {
+  const shortEstimate = estimateConversationTurnHeight(turn('short response'));
+  const codeLines = Array.from(
+    { length: 80 },
+    (_, index) => `const value${index} = ${index};`,
+  ).join('\n');
+  const codeEstimate = estimateConversationTurnHeight(turn(`\`\`\`ts\n${codeLines}\n\`\`\``));
+
+  expect(shortEstimate).toBeLessThan(300);
+  expect(codeEstimate).toBeGreaterThan(1_500);
+});

--- a/src/renderer/components/cowork/helpers/conversationTurnHeight.ts
+++ b/src/renderer/components/cowork/helpers/conversationTurnHeight.ts
@@ -1,0 +1,49 @@
+import type { ConversationTurn } from './messageGrouping';
+
+const DEFAULT_TURN_HEIGHT_PX = 300;
+const TURN_BASE_HEIGHT_PX = 72;
+const TEXT_LINE_HEIGHT_PX = 22;
+const APPROXIMATE_UNITS_PER_LINE = 72;
+const MAX_ESTIMATED_TEXT_LINES = 800;
+const TOOL_GROUP_HEIGHT_PX = 84;
+const MIN_TURN_HEIGHT_PX = 180;
+const MAX_TURN_HEIGHT_PX = 18_000;
+
+const estimateLineUnits = (line: string): number => {
+  let units = 0;
+  for (const character of line) {
+    units += character.codePointAt(0)! > 0xff ? 2 : 1;
+  }
+  return units;
+};
+
+const estimateTextLines = (content: string): number => {
+  if (!content) return 0;
+  let lines = 0;
+  for (const line of content.split('\n')) {
+    lines += Math.max(1, Math.ceil(estimateLineUnits(line) / APPROXIMATE_UNITS_PER_LINE));
+    if (lines >= MAX_ESTIMATED_TEXT_LINES) return MAX_ESTIMATED_TEXT_LINES;
+  }
+  return lines;
+};
+
+const estimateTextHeight = (content: string): number =>
+  estimateTextLines(content) * TEXT_LINE_HEIGHT_PX + (content ? 24 : 0);
+
+export const estimateConversationTurnHeight = (turn: ConversationTurn): number => {
+  let height = TURN_BASE_HEIGHT_PX;
+  let hasContent = false;
+  if (turn.userMessage) {
+    height += estimateTextHeight(turn.userMessage.content);
+    hasContent = true;
+  }
+
+  for (const item of turn.assistantItems) {
+    hasContent = true;
+    height +=
+      item.type === 'tool_group' ? TOOL_GROUP_HEIGHT_PX : estimateTextHeight(item.message.content);
+  }
+
+  if (!hasContent) return DEFAULT_TURN_HEIGHT_PX;
+  return Math.min(MAX_TURN_HEIGHT_PX, Math.max(MIN_TURN_HEIGHT_PX, height));
+};

--- a/src/renderer/components/cowork/helpers/messageGrouping.test.ts
+++ b/src/renderer/components/cowork/helpers/messageGrouping.test.ts
@@ -161,7 +161,48 @@ test('pagination prepend keeps existing turn references', () => {
   const initialById = new Map(initial.map(turn => [turn.id, turn]));
   for (const turn of prepended) {
     const previous = initialById.get(turn.id);
-    if (previous) expect(turn).toBe(previous);
+    if (previous?.userMessage) expect(turn).toBe(previous);
   }
   expect(prepended.length).toBe(50);
+});
+
+test('pagination keeps a partial turn key when its user message is prepended', () => {
+  const completeMessages = [
+    message('user-1', 'user', 'question'),
+    message('assistant-1', 'assistant', 'first answer block'),
+    message('tool-1', 'tool_use', 'read file'),
+    message('tool-result-1', 'tool_result', 'file contents'),
+    message('assistant-2', 'assistant', 'final answer block'),
+  ];
+  const partial = buildTurns(completeMessages.slice(2));
+
+  expect(partial).toHaveLength(1);
+  expect(partial[0]?.id).toBe('orphan:tool-1');
+
+  const prepended = stabilizeConversationTurns(partial, buildTurns(completeMessages));
+
+  expect(prepended).toHaveLength(1);
+  expect(prepended[0]?.id).toBe('orphan:tool-1');
+  expect(prepended[0]?.userMessage?.id).toBe('user-1');
+});
+
+test('pagination assigns unique keys when an earlier page also starts mid-turn', () => {
+  const currentPage = buildTurns([
+    message('assistant-b', 'assistant', 'partial B'),
+    message('user-c', 'user', 'question C'),
+    message('assistant-c', 'assistant', 'answer C'),
+  ]);
+  const withEarlierPage = buildTurns([
+    message('assistant-a', 'assistant', 'partial A'),
+    message('user-b', 'user', 'question B'),
+    message('assistant-b', 'assistant', 'partial B'),
+    message('user-c', 'user', 'question C'),
+    message('assistant-c', 'assistant', 'answer C'),
+  ]);
+
+  const stabilized = stabilizeConversationTurns(currentPage, withEarlierPage);
+  const turnIds = stabilized.map(turn => turn.id);
+
+  expect(turnIds).toEqual(['orphan:assistant-a', 'orphan:assistant-b', 'user-c']);
+  expect(new Set(turnIds).size).toBe(turnIds.length);
 });

--- a/src/renderer/components/cowork/helpers/messageGrouping.ts
+++ b/src/renderer/components/cowork/helpers/messageGrouping.ts
@@ -73,10 +73,10 @@ export const buildConversationTurns = (items: DisplayItem[]): ConversationTurn[]
   let currentTurn: ConversationTurn | null = null;
   let orphanIndex = 0;
 
-  const ensureTurn = (): ConversationTurn => {
+  const ensureTurn = (anchorMessageId: string): ConversationTurn => {
     if (currentTurn) return currentTurn;
     const orphanTurn: ConversationTurn = {
-      id: `orphan-${orphanIndex++}`,
+      id: anchorMessageId ? `orphan:${anchorMessageId}` : `orphan-${orphanIndex++}`,
       userMessage: null,
       assistantItems: [],
     };
@@ -96,7 +96,8 @@ export const buildConversationTurns = (items: DisplayItem[]): ConversationTurn[]
       continue;
     }
 
-    const turn = ensureTurn();
+    const anchorMessageId = item.type === 'tool_group' ? item.toolUse.id : item.message.id;
+    const turn = ensureTurn(anchorMessageId);
     if (item.type === 'tool_group') {
       turn.assistantItems.push({ type: 'tool_group', group: item });
       continue;
@@ -157,6 +158,20 @@ const reuseConversationTurn = (
   return allReused ? previous : { ...next, assistantItems: items };
 };
 
+export const getConversationTurnMessageIds = (turn: ConversationTurn): string[] => {
+  const ids: string[] = [];
+  if (turn.userMessage) ids.push(turn.userMessage.id);
+  for (const item of turn.assistantItems) {
+    if (item.type === 'tool_group') {
+      ids.push(item.group.toolUse.id);
+      if (item.group.toolResult) ids.push(item.group.toolResult.id);
+    } else {
+      ids.push(item.message.id);
+    }
+  }
+  return ids;
+};
+
 /**
  * Rebuilds the turn list while preserving object identity for every turn
  * whose messages did not change. Streaming deltas only alter the active
@@ -168,10 +183,39 @@ export const stabilizeConversationTurns = (
   nextTurns: ConversationTurn[],
 ): ConversationTurn[] => {
   const previousById = new Map(previousTurns.map(turn => [turn.id, turn]));
+  const previousByMessageId = new Map<string, ConversationTurn>();
+  for (const turn of previousTurns) {
+    for (const messageId of getConversationTurnMessageIds(turn)) {
+      previousByMessageId.set(messageId, turn);
+    }
+  }
+
+  const claimedTurnIds = new Set<string>();
   let allReused = previousTurns.length === nextTurns.length;
-  const stabilized = nextTurns.map(nextTurn => {
-    const turn = reuseConversationTurn(previousById.get(nextTurn.id), nextTurn);
-    if (turn !== previousById.get(nextTurn.id)) allReused = false;
+  const stabilized = nextTurns.map((nextTurn, index) => {
+    const exactPrevious = previousById.get(nextTurn.id);
+    const previous =
+      (exactPrevious && !claimedTurnIds.has(exactPrevious.id) ? exactPrevious : undefined) ??
+      getConversationTurnMessageIds(nextTurn)
+        .map(messageId => previousByMessageId.get(messageId))
+        .find((candidate): candidate is ConversationTurn =>
+          Boolean(candidate && !claimedTurnIds.has(candidate.id)),
+        );
+    const preferredTurnId = previous?.id ?? nextTurn.id;
+    let uniqueTurnId = preferredTurnId;
+    if (claimedTurnIds.has(uniqueTurnId)) {
+      const messageAnchor = getConversationTurnMessageIds(nextTurn)[0] ?? String(index);
+      uniqueTurnId = `${preferredTurnId}:${messageAnchor}`;
+      let duplicateIndex = 1;
+      while (claimedTurnIds.has(uniqueTurnId)) {
+        uniqueTurnId = `${preferredTurnId}:${messageAnchor}:${duplicateIndex++}`;
+      }
+    }
+    const normalizedNext =
+      uniqueTurnId === nextTurn.id ? nextTurn : { ...nextTurn, id: uniqueTurnId };
+    const turn = reuseConversationTurn(previous, normalizedNext);
+    claimedTurnIds.add(turn.id);
+    if (turn !== previousTurns[index]) allReused = false;
     return turn;
   });
   return allReused ? previousTurns : stabilized;

--- a/src/renderer/components/cowork/helpers/useStableConversationTurns.test.ts
+++ b/src/renderer/components/cowork/helpers/useStableConversationTurns.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import type { ConversationTurn } from './messageGrouping';
+import { useStableConversationTurns } from './useStableConversationTurns';
+
+const turn = (id: string): ConversationTurn => ({
+  id,
+  userMessage: null,
+  assistantItems: [],
+});
+
+test('does not reuse positional turn state across sessions', () => {
+  const sessionATurn = turn('orphan:message-a');
+  const sessionBTurn = turn('orphan:message-b');
+  const view = renderHook(({ sessionId, turns }) => useStableConversationTurns(turns, sessionId), {
+    initialProps: { sessionId: 'session-a', turns: [sessionATurn] },
+  });
+
+  view.rerender({ sessionId: 'session-b', turns: [sessionBTurn] });
+
+  expect(view.result.current[0]).toBe(sessionBTurn);
+  expect(view.result.current[0]).not.toBe(sessionATurn);
+});

--- a/src/renderer/components/cowork/helpers/useStableConversationTurns.ts
+++ b/src/renderer/components/cowork/helpers/useStableConversationTurns.ts
@@ -8,10 +8,19 @@ import { stabilizeConversationTurns } from './messageGrouping';
  * whose messages actually changed get new references, so memoized turn
  * subtrees skip re-rendering on every token (issue #141).
  */
-export const useStableConversationTurns = (turns: ConversationTurn[]): ConversationTurn[] => {
-  const stableTurnsRef = useRef<ConversationTurn[]>([]);
+export const useStableConversationTurns = (
+  turns: ConversationTurn[],
+  sessionId: string | undefined,
+): ConversationTurn[] => {
+  const stableTurnsRef = useRef<{ sessionId: string | undefined; turns: ConversationTurn[] }>({
+    sessionId,
+    turns: [],
+  });
   return useMemo(() => {
-    stableTurnsRef.current = stabilizeConversationTurns(stableTurnsRef.current, turns);
-    return stableTurnsRef.current;
-  }, [turns]);
+    const previousTurns =
+      stableTurnsRef.current.sessionId === sessionId ? stableTurnsRef.current.turns : [];
+    const stableTurns = stabilizeConversationTurns(previousTurns, turns);
+    stableTurnsRef.current = { sessionId, turns: stableTurns };
+    return stableTurns;
+  }, [sessionId, turns]);
 };

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -55,6 +55,7 @@ import type {
 } from '../types/cowork';
 import { i18nService } from './i18n';
 import { respondToPermissionByOrigin } from './coworkPermissionRouting';
+import { prepareCoworkSessionRender } from './coworkSessionRenderPreparation';
 import { RafMessageUpdateBatcher } from './rafMessageUpdateBatcher';
 import { workspaceService } from './workspace';
 
@@ -726,6 +727,10 @@ class CoworkService {
     const result = await cowork.getSession(sessionId);
     if (result.success && result.session) {
       // Keep only the latest session load result to avoid stale async overwrites.
+      if (requestId !== this.latestLoadSessionRequestId) {
+        return result.session;
+      }
+      await prepareCoworkSessionRender(result.session);
       if (requestId !== this.latestLoadSessionRequestId) {
         return result.session;
       }

--- a/src/renderer/services/coworkSessionRenderPreparation.ts
+++ b/src/renderer/services/coworkSessionRenderPreparation.ts
@@ -1,0 +1,11 @@
+import {
+  hasRichMessageContent,
+  loadRichMessageResponse,
+} from '../../shared/components/ai-elements/richMessageResponseLoader';
+import type { CoworkSession } from '../types/cowork';
+
+/** Loads the rich Markdown pipeline before a historical session reaches the DOM. */
+export async function prepareCoworkSessionRender(session: CoworkSession): Promise<void> {
+  if (!session.messages.some(message => hasRichMessageContent(message.content))) return;
+  await loadRichMessageResponse();
+}

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -353,6 +353,53 @@ test('keeps streaming messages when another session is selected', () => {
   expect(restoredState.currentSession?.messages[0]?.content).toBe('still streaming');
 });
 
+test('merges complete loaded history into a tracked streaming session', () => {
+  const recentMessage = {
+    id: 'assistant-live',
+    type: 'assistant' as const,
+    content: 'partial',
+    timestamp: 3,
+  };
+  const runningSession = makeSession({
+    status: CoworkSessionStatusValue.Running,
+    messages: [recentMessage],
+    messagesOffset: 30,
+    totalMessages: 31,
+  });
+  const streamingState = coworkReducer(undefined, addSession(runningSession));
+  const updatedState = coworkReducer(
+    streamingState,
+    updateMessageContents([
+      {
+        sessionId: runningSession.id,
+        messageId: recentMessage.id,
+        content: 'complete live response',
+      },
+    ]),
+  );
+  const completeHistory = makeSession({
+    status: CoworkSessionStatusValue.Completed,
+    messages: [
+      { id: 'user-old', type: 'user', content: 'old question', timestamp: 1 },
+      { id: 'assistant-old', type: 'assistant', content: 'old answer', timestamp: 2 },
+      recentMessage,
+    ],
+    messagesOffset: 0,
+    totalMessages: 3,
+  });
+
+  const restoredState = coworkReducer(updatedState, setCurrentSession(completeHistory));
+
+  expect(restoredState.currentSession?.messages.map(message => message.id)).toEqual([
+    'user-old',
+    'assistant-old',
+    'assistant-live',
+  ]);
+  expect(restoredState.currentSession?.messages[2]?.content).toBe('complete live response');
+  expect(restoredState.currentSession?.messagesOffset).toBe(0);
+  expect(restoredState.currentSession?.status).toBe(CoworkSessionStatusValue.Running);
+});
+
 test('tracks parallel transient tool activities by session and call id', () => {
   const runningState = coworkReducer(
     undefined,

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -125,6 +125,36 @@ const cacheStreamingSession = (state: CoworkState, session: CoworkSession) => {
   };
 };
 
+const mergeSessionWithLiveSnapshot = (
+  session: CoworkSession,
+  liveSession: CoworkSession,
+): CoworkSession => {
+  const liveMessagesById = new Map(liveSession.messages.map(message => [message.id, message]));
+  const mergedMessages = session.messages.map(
+    message => liveMessagesById.get(message.id) ?? message,
+  );
+  const mergedMessageIds = new Set(mergedMessages.map(message => message.id));
+
+  for (const message of liveSession.messages) {
+    if (!mergedMessageIds.has(message.id)) {
+      mergedMessages.push(message);
+      mergedMessageIds.add(message.id);
+    }
+  }
+
+  return {
+    ...session,
+    ...liveSession,
+    messages: mergedMessages,
+    messagesOffset: session.messagesOffset ?? 0,
+    totalMessages: Math.max(
+      session.totalMessages ?? session.messages.length,
+      liveSession.totalMessages ?? liveSession.messages.length,
+      mergedMessages.length,
+    ),
+  };
+};
+
 const toSessionSummary = (session: CoworkSession): CoworkSessionSummary => ({
   id: session.id,
   title: session.title,
@@ -304,7 +334,9 @@ const coworkSlice = createSlice({
         // messages would cause streaming content and user messages to vanish
         // when switching sessions and coming back.
         const liveSession = state.streamingSessions[session.id];
-        const effectiveSession = liveSession ?? session;
+        const effectiveSession = liveSession
+          ? mergeSessionWithLiveSnapshot(session, liveSession)
+          : session;
 
         state.currentSession = {
           ...effectiveSession,

--- a/src/shared/components/ai-elements/message.tsx
+++ b/src/shared/components/ai-elements/message.tsx
@@ -24,9 +24,15 @@ import React, {
 } from 'react';
 import { Streamdown } from 'streamdown';
 
+import {
+  getLoadedRichMessageResponse,
+  hasRichMessageContent,
+  loadRichMessageResponse,
+} from './richMessageResponseLoader';
+
 // Code/math/mermaid plugins (and their Shiki/KaTeX/Mermaid runtimes) load
 // on demand when the content actually needs them (issue #141).
-const RichMessageResponse = React.lazy(() => import('./richMessageResponse'));
+const RichMessageResponse = React.lazy(loadRichMessageResponse);
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage['role'];
@@ -286,9 +292,6 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const basePlugins = { cjk };
 
-// Fenced code, math or mermaid content needs the rich plugin pipeline.
-const RICH_CONTENT_PATTERN = /```|~~~|\$\$|\\\(|\\\[|\$[^$\n]+?\$|(?:^|\n)(?: {4,}|\t+)\S/;
-
 export const MessageResponse = memo(
   ({ className, children, ...props }: MessageResponseProps) => {
     const base = (
@@ -301,8 +304,16 @@ export const MessageResponse = memo(
       </Streamdown>
     );
     const text = typeof children === 'string' ? children : '';
-    if (!RICH_CONTENT_PATTERN.test(text)) {
+    if (!hasRichMessageContent(text)) {
       return base;
+    }
+    const LoadedRichMessageResponse = getLoadedRichMessageResponse();
+    if (LoadedRichMessageResponse) {
+      return (
+        <LoadedRichMessageResponse className={className} {...props}>
+          {children}
+        </LoadedRichMessageResponse>
+      );
     }
     return (
       <React.Suspense fallback={base}>

--- a/src/shared/components/ai-elements/richMessageResponseLoader.ts
+++ b/src/shared/components/ai-elements/richMessageResponseLoader.ts
@@ -1,0 +1,19 @@
+const RICH_CONTENT_PATTERN = /```|~~~|\$\$|\\\(|\\\[|\$[^$\n]+?\$|(?:^|\n)(?: {4,}|\t+)\S/;
+
+export const hasRichMessageContent = (content: string): boolean =>
+  RICH_CONTENT_PATTERN.test(content);
+
+type RichMessageResponseModule = typeof import('./richMessageResponse');
+
+let loadedModule: RichMessageResponseModule | null = null;
+let pendingModule: Promise<RichMessageResponseModule> | null = null;
+
+export const loadRichMessageResponse = (): Promise<RichMessageResponseModule> => {
+  pendingModule ??= import('./richMessageResponse').then(module => {
+    loadedModule = module;
+    return module;
+  });
+  return pendingModule;
+};
+
+export const getLoadedRichMessageResponse = () => loadedModule?.default ?? null;


### PR DESCRIPTION
## 背景

在 #141 的长会话虚拟化基础上，历史会话进入与向上滚动仍存在以下问题：

- 首次只读取末尾分页，滚动范围需要等待历史逐页补入；
- 会话切换时可能出现空白帧、首帧跳动或未停留在末尾；
- 复杂 Markdown、代码块和边界 turn 在动态测量时可能造成内容抖动；
- 运行中会话的实时快照可能覆盖数据库中的完整历史。

## 修复方案

### 1. 完整历史进入数据模型

- 会话 IPC 打开时读取完整本地消息，并将 `messagesOffset` 固定为 `0`；
- 完整历史仅进入 Redux 数据模型，DOM 继续由 turn 虚拟列表按需挂载；
- 运行中会话按消息 ID 合并数据库历史与实时尾部，避免重新截断。

### 2. 稳定首帧与会话切换

- 切换目标会话时立即撤下旧消息 DOM，标题与消息区使用共享 shadcn `Skeleton` 明确表示加载中；
- 消息区使用 4 组交错的用户/助手 turn 骨架覆盖整个可用视窗，首尾占位固定分布在视窗上下边界，不再只显示少量骨架行；
- 所有加载占位复用项目既有 `.skeleton` shimmer，并覆盖共享组件默认 pulse；全局 `prefers-reduced-motion` 规则继续生效；
- 保持 `CoworkSessionDetail` 与真实 `CoworkPromptInput` 持续挂载，骨架不会替换或遮挡输入框；
- 输入框在加载期间直接绑定目标会话草稿，允许继续编辑；发送按钮和会话相关工具在目标上下文就绪前禁用，避免误操作旧会话；
- 目标会话数据写入 Redux 后立即挂载，不等待后续状态收尾请求；
- 修复 orphan turn、分页边界 turn 和重复 React key；
- 初始阶段持续跟随尾部，用户主动向上滚动后立即解除；
- 移除多帧重复滚底造成的首帧闪烁。

### 3. 降低复杂内容的动态高度误差

- 根据文本长度、换行、中文宽度、代码行数和工具块估算 turn 高度；
- 将虚拟列表 overscan 从 4 提升到 8，让复杂内容提前挂载测量；
- 历史会话提交到 DOM 前预加载富 Markdown 渲染模块，避免基础渲染器与富渲染器二次替换；
- 在虚拟化测量回调中同步更新容器高度与已挂载行位置，使 `scrollTop` 补偿和布局修正在同一帧生效；
- 保留边界 turn 内补入内容时的滚动锚点补偿。

## 行为与约束

- 保留 `@tanstack/react-virtual` 虚拟化，不会一次挂载完整长会话；
- 首帧即可基于全部 turn 建立完整滚动范围；
- 图片导出仍可切换到完整 DOM 渲染；
- 不再依赖分页请求逐步扩展向上滚动上限；
- 会话切换时不复用旧消息 DOM 或旧虚拟列表测量结果，仅保留稳定的会话外壳与真实输入框；
- 加载骨架只占用消息区域，不改变输入框挂载、草稿状态或发送禁用策略。

## 验证

- [x] 历史渲染相关回归：9 个测试文件，33 项通过
- [x] 加载态组件：视窗铺满、4 轮占位、shimmer 启用、pulse 移除
- [x] CoworkStore：22 项通过（Electron ABI）
- [x] `npm run build:tsc`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 本次涉及文件 `oxfmt --check`
- [x] `git diff --check`

## 手动验证重点

- 长会话进入后首帧停留在末尾；
- 连续向上滚动可立即访问完整历史；
- 含长代码块、数学公式或复杂 Markdown 的会话滚动时无明显内容抖动；
- 在多个长短会话之间快速切换时，标题与消息区显示铺满视窗的 shimmer 骨架，输入框保持原位且草稿不中断；
- 目标会话就绪后直接显示末尾内容，不残留旧消息、不出现白屏或错误定位。
