### PR TITLE
fix(cowork): bind verifier evidence to tool results

### DIFF
--- a/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
@@ -93,23 +93,23 @@ describe('createZhiyuanEvaluationPolicy', () => {
       itemId: plan.details.planItems[0].id,
       status: ProductionPlanItemStatus.Completed,
     });
+    policy.onEvent?.({
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      toolCallId: 'benchmark-check',
+      result: { content: [{ type: 'text', text: 'checks passed' }] },
+      isError: false,
+    });
     await productionTool.execute('inspect', {
       action: ProductionLoopAction.StartInspection,
       verifierEvidence: [
         {
           name: 'official benchmark scorer',
-          passed: true,
-          evidence: 'Official benchmark scorer passed.',
+          toolCallId: 'benchmark-check',
         },
       ],
     });
     await productionTool.execute('critic', { action: ProductionLoopAction.RequestCritique });
-    policy.onEvent?.({
-      type: 'tool_execution_end',
-      toolName: 'bash',
-      result: { content: [{ type: 'text', text: 'checks passed' }] },
-      isError: false,
-    });
 
     const criticTurn = await policy.onAgentEnd?.({ iteration: 1, messages: [], usage: {} });
     expect(criticTurn?.nextPrompt).toContain('read-only');
@@ -190,23 +190,23 @@ describe('createZhiyuanEvaluationPolicy', () => {
       itemId: plan.details.planItems[0].id,
       status: ProductionPlanItemStatus.Completed,
     });
+    policy.onEvent?.({
+      type: 'tool_execution_end',
+      toolName: 'bash',
+      toolCallId: 'benchmark-check',
+      result: { content: [{ type: 'text', text: 'checks passed' }] },
+      isError: false,
+    });
     await productionTool.execute('inspect', {
       action: ProductionLoopAction.StartInspection,
       verifierEvidence: [
         {
           name: 'official benchmark scorer',
-          passed: true,
-          evidence: 'Official benchmark scorer passed.',
+          toolCallId: 'benchmark-check',
         },
       ],
     });
     await productionTool.execute('critic', { action: ProductionLoopAction.RequestCritique });
-    policy.onEvent?.({
-      type: 'tool_execution_end',
-      toolName: 'bash',
-      result: { content: [{ type: 'text', text: 'checks passed' }] },
-      isError: false,
-    });
 
     const delegation = await policy.onAgentEnd?.({ iteration: 1, messages: [], usage: {} });
     expect(delegation?.nextPrompt).toContain('isolated context and no tools');

--- a/src/main/evaluation/zhiyuanEvaluationPolicy.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.ts
@@ -188,6 +188,19 @@ export function createZhiyuanEvaluationPolicy(
 
   const onEvent = (event: Record<string, unknown>): void => {
     const toolName = typeof event.toolName === 'string' ? event.toolName : '';
+    const toolCallId = typeof event.toolCallId === 'string' ? event.toolCallId : '';
+    if (
+      event.type === ZhiyuanEvaluationEventType.ToolExecutionEnd &&
+      toolName &&
+      toolCallId
+    ) {
+      controller.recordToolResult(
+        toolCallId,
+        toolName,
+        toolResultText(event.result),
+        event.isError === true,
+      );
+    }
     if (
       event.type === ZhiyuanEvaluationEventType.ToolExecutionEnd &&
       inspectToolNames.has(toolName)
@@ -200,7 +213,6 @@ export function createZhiyuanEvaluationPolicy(
       if (toolEvidence.length > 20) toolEvidence.shift();
     }
     if (toolName !== ZhiyuanEvaluationCriticToolName) return;
-    const toolCallId = typeof event.toolCallId === 'string' ? event.toolCallId : '';
     if (!toolCallId) return;
     if (event.type === ZhiyuanEvaluationEventType.ToolExecutionStart) {
       controller.recordSubagentStart(toolCallId, event.args);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1788,6 +1788,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             Boolean(event.isError),
           );
         }
+        if (event.toolName) {
+          active.productionLoop?.recordToolResult(
+            event.toolCallId,
+            event.toolName,
+            resultText,
+            Boolean(event.isError),
+          );
+        }
         if (event.toolName === PiSubagentToolName) {
           active.productionLoop?.recordSubagentResult(
             event.toolCallId,

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -69,9 +69,10 @@ const reachCritique = (controller: ProductionLoopController) => {
   for (const item of planned.planItems) {
     controller.updatePlanItem(item.id, 'completed');
   }
+  controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
   controller.startInspection({
     artifacts: [],
-    verifiers: [{ name: 'preview', passed: true, evidence: 'Preview completed successfully.' }],
+    verifiers: [{ name: 'preview', toolCallId: 'preview-check' }],
   });
   controller.requestCritique();
 };

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -72,7 +72,7 @@ export class ProductionLoopController {
       phaseInstruction,
       'The plan must include acceptance criteria, expected artifacts, and deterministic verifiers.',
       'After commit_plan, read the returned state and use each generated plan item ID with update_plan_item.',
-      'After execution, call start_inspection with evidence for every required artifact and deterministic verifier, then request_critique and delegate a read-only review to the reviewer subagent.',
+      'After execution, call start_inspection with every required artifact and the successful tool call ID for each deterministic verifier, then request_critique and delegate a read-only review to the reviewer subagent.',
       'A reviewer PASS does not replace artifact verification or the completion contract.',
       'When findings exist, revise the work, record_revision, inspect again, and request another critique.',
       'Call agent_loop done only after the production loop reports ready_to_deliver.',
@@ -249,6 +249,22 @@ export class ProductionLoopController {
   private update(state: ProductionLoopState): ProductionLoopState {
     this.state = state;
     return this.getState();
+  }
+
+  recordToolResult(
+    toolCallId: string,
+    toolName: string,
+    output: string,
+    isError: boolean,
+  ): void {
+    this.update(
+      this.service.recordToolResult(this.state.runId, {
+        toolCallId,
+        toolName,
+        output,
+        isError,
+      }),
+    );
   }
 
   private refresh(): void {

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -65,13 +65,24 @@ const commitPlan = (runId: string) =>
     selectedDirection: 'prototype-a',
   });
 
-const startInspection = (runId: string) =>
-  service.startInspection(runId, {
-    artifacts: [{ kind: 'file', reference: 'report.md' }],
-    verifiers: [
-      { name: 'artifact_verifier', passed: true, evidence: 'report.md exists and is valid.' },
-    ],
+const recordVerifier = (runId: string, isError = false) => {
+  const toolCallId = `artifact-verifier-${service.repository.get(runId)?.observedToolResults.length ?? 0}`;
+  service.recordToolResult(runId, {
+    toolCallId,
+    toolName: 'bash',
+    output: isError ? 'Verifier failed.' : 'report.md exists and is valid.',
+    isError,
   });
+  return toolCallId;
+};
+
+const startInspection = (runId: string) => {
+  const toolCallId = recordVerifier(runId);
+  return service.startInspection(runId, {
+    artifacts: [{ kind: 'file', reference: 'report.md' }],
+    verifiers: [{ name: 'artifact_verifier', toolCallId }],
+  });
+};
 
 test('requires a prototype only for explicitly high-ambiguity runs', () => {
   const { run, state } = begin(true);
@@ -98,20 +109,18 @@ test('requires deterministic verifier and artifact evidence before inspection', 
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
+  const successfulToolCallId = recordVerifier(run.id);
   expect(() =>
     service.startInspection(run.id, {
       artifacts: [],
-      verifiers: [
-        { name: 'artifact_verifier', passed: true, evidence: 'Verifier passed.' },
-      ],
+      verifiers: [{ name: 'artifact_verifier', toolCallId: successfulToolCallId }],
     }),
   ).toThrow('artifact evidence');
+  const failedToolCallId = recordVerifier(run.id, true);
   expect(() =>
     service.startInspection(run.id, {
       artifacts: [{ kind: 'file', reference: 'report.md' }],
-      verifiers: [
-        { name: 'artifact_verifier', passed: false, evidence: 'Verifier failed.' },
-      ],
+      verifiers: [{ name: 'artifact_verifier', toolCallId: failedToolCallId }],
     }),
   ).toThrow('Passing deterministic verifier evidence');
 
@@ -119,7 +128,8 @@ test('requires deterministic verifier and artifact evidence before inspection', 
   expect(inspecting.inspections).toHaveLength(1);
   expect(inspecting.inspections[0].verifiers[0]).toMatchObject({
     name: 'artifact_verifier',
-    passed: true,
+    toolName: 'bash',
+    evidence: 'report.md exists and is valid.',
   });
 });
 
@@ -129,7 +139,7 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  startInspection(run.id);
+  const firstInspection = startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review-1');
   const rejected = service.recordCriticResult(
@@ -145,6 +155,17 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
   expect(rejected.status).toBe(ProductionLoopStatus.NeedsRevision);
 
   service.recordRevision(run.id, 'Added test evidence', { command: 'npm test' });
+  expect(() =>
+    service.startInspection(run.id, {
+      artifacts: [{ kind: 'file', reference: 'report.md' }],
+      verifiers: [
+        {
+          name: 'artifact_verifier',
+          toolCallId: firstInspection.inspections[0].verifiers[0].toolCallId,
+        },
+      ],
+    }),
+  ).toThrow('Passing deterministic verifier evidence');
   startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review-2');

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -14,8 +14,8 @@ import {
   type ProductionExpectedVerifier,
   type ProductionInspectionEvidence,
   type ProductionLoopState,
+  type ProductionObservedToolResult,
   type ProductionPlanItem,
-  type ProductionVerifierEvidence,
 } from '../../shared/productionLoop';
 import {
   WorkbenchVerificationOutcome,
@@ -165,6 +165,7 @@ export class ProductionLoopService {
       acceptanceCriteria: previous?.acceptanceCriteria ?? [],
       expectedArtifacts: previous?.expectedArtifacts ?? [],
       expectedVerifiers: previous?.expectedVerifiers ?? [],
+      observedToolResults: [],
       inspections: [],
       planItems:
         previous?.planItems.map(item => ({ ...item, status: ProductionPlanItemStatus.Pending })) ??
@@ -313,7 +314,7 @@ export class ProductionLoopService {
     runId: string,
     input: {
       artifacts: ProductionArtifactEvidence[];
-      verifiers: ProductionVerifierEvidence[];
+      verifiers: Array<{ name: string; toolCallId: string }>;
     },
   ): ProductionLoopState {
     return this.mutate(runId, state => {
@@ -325,10 +326,28 @@ export class ProductionLoopService {
         const reference = artifact.reference.trim();
         return kind && reference ? [{ kind, reference }] : [];
       });
+      const observedToolResults = state.observedToolResults ?? [];
       const verifiers = input.verifiers.flatMap(verifier => {
         const name = verifier.name.trim();
-        const evidence = verifier.evidence.trim();
-        return name && evidence ? [{ name, passed: verifier.passed === true, evidence }] : [];
+        const toolCallId = verifier.toolCallId.trim();
+        const observed = observedToolResults.find(result => result.toolCallId === toolCallId);
+        if (
+          !name ||
+          !observed ||
+          observed.isError ||
+          observed.progressVersion !== state.progressVersion
+        ) {
+          return [];
+        }
+        return [
+          {
+            name,
+            toolCallId,
+            toolName: observed.toolName,
+            evidence:
+              observed.output.trim() || `Tool ${observed.toolName} completed successfully.`,
+          },
+        ];
       });
       const missingArtifact = state.expectedArtifacts.find(
         expected =>
@@ -340,7 +359,7 @@ export class ProductionLoopService {
       const failedVerifier = state.expectedVerifiers.find(
         expected =>
           expected.deterministic &&
-          !verifiers.some(verifier => verifier.name === expected.name && verifier.passed),
+          !verifiers.some(verifier => verifier.name === expected.name),
       );
       if (failedVerifier) {
         throw new Error(
@@ -375,6 +394,31 @@ export class ProductionLoopService {
         activation: HarnessActivationType.CriticRequested,
         mechanism: 'production_loop_reviewer',
       });
+    });
+  }
+
+  recordToolResult(
+    runId: string,
+    input: Omit<ProductionObservedToolResult, 'createdAt' | 'progressVersion'>,
+  ): ProductionLoopState {
+    return this.mutate(runId, state => {
+      const toolCallId = input.toolCallId.trim();
+      const toolName = input.toolName.trim();
+      if (!toolCallId || !toolName) return;
+      state.observedToolResults ??= [];
+      const result: ProductionObservedToolResult = {
+        toolCallId,
+        toolName,
+        output: input.output.slice(0, MAX_CRITIC_OUTPUT_LENGTH),
+        isError: input.isError,
+        progressVersion: state.progressVersion,
+        createdAt: Date.now(),
+      };
+      const existingIndex = state.observedToolResults.findIndex(
+        existing => existing.toolCallId === toolCallId,
+      );
+      if (existingIndex >= 0) state.observedToolResults[existingIndex] = result;
+      else state.observedToolResults.push(result);
     });
   }
 

--- a/src/main/productionLoop/tool.test.ts
+++ b/src/main/productionLoop/tool.test.ts
@@ -47,6 +47,7 @@ test('publishes concrete nested schemas for model-generated plans', () => {
     'name',
     'deterministic',
   ]);
+  expect(parameters.properties.verifierEvidence.items?.required).toEqual(['name', 'toolCallId']);
 });
 
 test('normalizes a plan payload before passing it to the controller', async () => {

--- a/src/main/productionLoop/tool.ts
+++ b/src/main/productionLoop/tool.ts
@@ -5,7 +5,6 @@ import {
   type ProductionArtifactEvidence,
   type ProductionExpectedArtifact,
   type ProductionExpectedVerifier,
-  type ProductionVerifierEvidence,
 } from '../../shared/productionLoop';
 import type { ProductionLoopController } from './controller';
 
@@ -56,13 +55,13 @@ const artifactEvidence = (value: unknown): ProductionArtifactEvidence[] =>
       })
     : [];
 
-const verifierEvidence = (value: unknown): ProductionVerifierEvidence[] =>
+const verifierEvidence = (value: unknown): Array<{ name: string; toolCallId: string }> =>
   Array.isArray(value)
     ? value.flatMap(entry => {
         if (!entry || typeof entry !== 'object') return [];
         const raw = entry as Record<string, unknown>;
-        return typeof raw.name === 'string' && typeof raw.evidence === 'string'
-          ? [{ name: raw.name, passed: raw.passed === true, evidence: raw.evidence }]
+        return typeof raw.name === 'string' && typeof raw.toolCallId === 'string'
+          ? [{ name: raw.name, toolCallId: raw.toolCallId }]
           : [];
       })
     : [];
@@ -152,14 +151,15 @@ export function buildProductionLoopTool(
         verifierEvidence: {
           type: 'array',
           minItems: 1,
+          description:
+            'Map each deterministic verifier name to the successful tool call that ran it in the current workflow revision.',
           items: {
             type: 'object',
             properties: {
               name: { type: 'string' },
-              passed: { type: 'boolean' },
-              evidence: { type: 'string' },
+              toolCallId: { type: 'string' },
             },
-            required: ['name', 'passed', 'evidence'],
+            required: ['name', 'toolCallId'],
             additionalProperties: false,
           },
         },

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -61,15 +61,15 @@ const prepareProductionDelivery = (
     planned.planItems[0].id,
     ProductionPlanItemStatus.Completed,
   );
+  service.productionLoop.recordToolResult(runId, {
+    toolCallId: 'completion-contract-check',
+    toolName: 'bash',
+    output: 'Completion contract passed.',
+    isError: false,
+  });
   service.productionLoop.startInspection(runId, {
     artifacts: [{ kind: 'result', reference: 'final-answer' }],
-    verifiers: [
-      {
-        name: 'completion_contract',
-        passed: true,
-        evidence: 'Completion contract passed.',
-      },
-    ],
+    verifiers: [{ name: 'completion_contract', toolCallId: 'completion-contract-check' }],
   });
   service.productionLoop.requestCritique(runId);
   service.productionLoop.recordCriticStart(runId, 'critic');

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -38,8 +38,18 @@ export interface ProductionArtifactEvidence {
 
 export interface ProductionVerifierEvidence {
   name: string;
-  passed: boolean;
+  toolCallId: string;
+  toolName: string;
   evidence: string;
+}
+
+export interface ProductionObservedToolResult {
+  toolCallId: string;
+  toolName: string;
+  output: string;
+  isError: boolean;
+  progressVersion: number;
+  createdAt: number;
 }
 
 export interface ProductionInspectionEvidence {
@@ -94,6 +104,7 @@ export interface ProductionLoopState {
   acceptanceCriteria: string[];
   expectedArtifacts: ProductionExpectedArtifact[];
   expectedVerifiers: ProductionExpectedVerifier[];
+  observedToolResults: ProductionObservedToolResult[];
   inspections: ProductionInspectionEvidence[];
   planItems: ProductionPlanItem[];
   critic: ProductionCriticState;


### PR DESCRIPTION
## 阶段

第 4/4 阶段，依赖 `codex/production-state-refresh`。

## 变更摘要

- 将工具执行结果记录为系统观测到的校验器证据
- 校验器证据必须引用当前 revision 中真实成功的工具调用
- 拒绝伪造、执行失败或来自旧 revision 的校验器证据

## 测试

- `npm.cmd run lint`
- `npm.cmd run build`
- `npm.cmd test -- productionLoop taskService zhiyuanEvaluationPolicy`（52 个用例通过）
- `npm.cmd test`（1970 个通过、1 个跳过、74 个无关环境失败：缺少 `python3`、Windows release 测试盘符路径解析异常、Electron mock 未定义 `process.resourcesPath`）
