### PR TITLE
fix(cowork): enforce production inspection evidence

### DIFF
--- a/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
@@ -93,7 +93,16 @@ describe('createZhiyuanEvaluationPolicy', () => {
       itemId: plan.details.planItems[0].id,
       status: ProductionPlanItemStatus.Completed,
     });
-    await productionTool.execute('inspect', { action: ProductionLoopAction.StartInspection });
+    await productionTool.execute('inspect', {
+      action: ProductionLoopAction.StartInspection,
+      verifierEvidence: [
+        {
+          name: 'official benchmark scorer',
+          passed: true,
+          evidence: 'Official benchmark scorer passed.',
+        },
+      ],
+    });
     await productionTool.execute('critic', { action: ProductionLoopAction.RequestCritique });
     policy.onEvent?.({
       type: 'tool_execution_end',
@@ -181,7 +190,16 @@ describe('createZhiyuanEvaluationPolicy', () => {
       itemId: plan.details.planItems[0].id,
       status: ProductionPlanItemStatus.Completed,
     });
-    await productionTool.execute('inspect', { action: ProductionLoopAction.StartInspection });
+    await productionTool.execute('inspect', {
+      action: ProductionLoopAction.StartInspection,
+      verifierEvidence: [
+        {
+          name: 'official benchmark scorer',
+          passed: true,
+          evidence: 'Official benchmark scorer passed.',
+        },
+      ],
+    });
     await productionTool.execute('critic', { action: ProductionLoopAction.RequestCritique });
     policy.onEvent?.({
       type: 'tool_execution_end',

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -64,7 +64,10 @@ const reachCritique = (controller: ProductionLoopController) => {
   for (const item of planned.planItems) {
     controller.updatePlanItem(item.id, 'completed');
   }
-  controller.startInspection();
+  controller.startInspection({
+    artifacts: [],
+    verifiers: [{ name: 'preview', passed: true, evidence: 'Preview completed successfully.' }],
+  });
   controller.requestCritique();
 };
 

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -79,7 +79,7 @@ export class ProductionLoopController {
       phaseInstruction,
       'The plan must include acceptance criteria, expected artifacts, and deterministic verifiers.',
       'After commit_plan, read the returned state and use each generated plan item ID with update_plan_item.',
-      'After execution, call start_inspection, then request_critique and delegate a read-only review to the reviewer subagent.',
+      'After execution, call start_inspection with evidence for every required artifact and deterministic verifier, then request_critique and delegate a read-only review to the reviewer subagent.',
       'A reviewer PASS does not replace artifact verification or the completion contract.',
       'When findings exist, revise the work, record_revision, inspect again, and request another critique.',
       'Call agent_loop done only after the production loop reports ready_to_deliver.',
@@ -119,8 +119,8 @@ export class ProductionLoopController {
     return this.update(this.service.updatePlanItem(this.state.runId, itemId, status));
   }
 
-  startInspection(): ProductionLoopState {
-    return this.update(this.service.startInspection(this.state.runId));
+  startInspection(input: Parameters<ProductionLoopService['startInspection']>[1]): ProductionLoopState {
+    return this.update(this.service.startInspection(this.state.runId, input));
   }
 
   requestCritique(): string {
@@ -236,7 +236,7 @@ export class ProductionLoopController {
       case ProductionLoopPhase.Critique:
         return this.requestCriticPrompt();
       case ProductionLoopPhase.Revise:
-        return 'Address the critic findings and record the revision before inspecting again.';
+        return 'Address the critic findings, record the revision, rerun deterministic checks, and submit fresh inspection evidence.';
       case ProductionLoopPhase.Deliver:
         return 'Call agent_loop done to request deterministic completion verification.';
     }

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -65,6 +65,14 @@ const commitPlan = (runId: string) =>
     selectedDirection: 'prototype-a',
   });
 
+const startInspection = (runId: string) =>
+  service.startInspection(runId, {
+    artifacts: [{ kind: 'file', reference: 'report.md' }],
+    verifiers: [
+      { name: 'artifact_verifier', passed: true, evidence: 'report.md exists and is valid.' },
+    ],
+  });
+
 test('requires a prototype only for explicitly high-ambiguity runs', () => {
   const { run, state } = begin(true);
   expect(state.phase).toBe(ProductionLoopPhase.Explore);
@@ -74,13 +82,54 @@ test('requires a prototype only for explicitly high-ambiguity runs', () => {
   expect(commitPlan(run.id).phase).toBe(ProductionLoopPhase.Execute);
 });
 
+test('requires deterministic verifier and artifact evidence before inspection', () => {
+  const { run } = begin();
+  expect(() =>
+    service.commitPlan(run.id, {
+      items: [{ title: 'Create artifact' }],
+      constraints: [],
+      acceptanceCriteria: ['Artifact exists'],
+      expectedArtifacts: [],
+      expectedVerifiers: [{ name: 'manual review', deterministic: false }],
+    }),
+  ).toThrow('deterministic verifier');
+
+  const planned = commitPlan(run.id);
+  for (const item of planned.planItems) {
+    service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
+  }
+  expect(() =>
+    service.startInspection(run.id, {
+      artifacts: [],
+      verifiers: [
+        { name: 'artifact_verifier', passed: true, evidence: 'Verifier passed.' },
+      ],
+    }),
+  ).toThrow('artifact evidence');
+  expect(() =>
+    service.startInspection(run.id, {
+      artifacts: [{ kind: 'file', reference: 'report.md' }],
+      verifiers: [
+        { name: 'artifact_verifier', passed: false, evidence: 'Verifier failed.' },
+      ],
+    }),
+  ).toThrow('Passing deterministic verifier evidence');
+
+  const inspecting = startInspection(run.id);
+  expect(inspecting.inspections).toHaveLength(1);
+  expect(inspecting.inspections[0].verifiers[0]).toMatchObject({
+    name: 'artifact_verifier',
+    passed: true,
+  });
+});
+
 test('persists plan, critic rejection, revision, and delivery readiness', () => {
   const { run } = begin();
   const planned = commitPlan(run.id);
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  service.startInspection(run.id);
+  startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review-1');
   const rejected = service.recordCriticResult(
@@ -96,6 +145,7 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
   expect(rejected.status).toBe(ProductionLoopStatus.NeedsRevision);
 
   service.recordRevision(run.id, 'Added test evidence', { command: 'npm test' });
+  startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review-2');
   const accepted = service.recordCriticResult(
@@ -147,7 +197,7 @@ test('accepts a critic verdict wrapped in a Markdown JSON fence', () => {
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  service.startInspection(run.id);
+  startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review');
 
@@ -168,7 +218,7 @@ test('deterministic verification failure overrides critic PASS and returns to re
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  service.startInspection(run.id);
+  startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review');
   service.recordCriticResult(
@@ -196,7 +246,7 @@ test('keeps acceptance-required work ready until the user accepts it', () => {
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  service.startInspection(run.id);
+  startInspection(run.id);
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review');
   service.recordCriticResult(

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -8,10 +8,13 @@ import {
   ProductionLoopStatus,
   ProductionPlanItemStatus,
   type ProductionCriticFinding,
+  type ProductionArtifactEvidence,
   type ProductionExpectedArtifact,
   type ProductionExpectedVerifier,
+  type ProductionInspectionEvidence,
   type ProductionLoopState,
   type ProductionPlanItem,
+  type ProductionVerifierEvidence,
 } from '../../shared/productionLoop';
 import {
   WorkbenchVerificationOutcome,
@@ -143,6 +146,7 @@ export class ProductionLoopService {
       acceptanceCriteria: previous?.acceptanceCriteria ?? [],
       expectedArtifacts: previous?.expectedArtifacts ?? [],
       expectedVerifiers: previous?.expectedVerifiers ?? [],
+      inspections: [],
       planItems:
         previous?.planItems.map(item => ({ ...item, status: ProductionPlanItemStatus.Pending })) ??
         [],
@@ -226,9 +230,13 @@ export class ProductionLoopService {
         return name ? [{ name, deterministic: verifier.deterministic === true }] : [];
       });
       const selectedDirection = input.selectedDirection?.trim() || null;
-      if (items.length === 0 || acceptanceCriteria.length === 0 || expectedVerifiers.length === 0) {
+      if (
+        items.length === 0 ||
+        acceptanceCriteria.length === 0 ||
+        !expectedVerifiers.some(verifier => verifier.deterministic)
+      ) {
         throw new Error(
-          'A plan requires at least one item, one acceptance criterion, and one expected verifier.',
+          'A plan requires at least one item, one acceptance criterion, and one deterministic verifier.',
         );
       }
       if (state.prototypeRequired && !selectedDirection) {
@@ -282,11 +290,51 @@ export class ProductionLoopService {
     });
   }
 
-  startInspection(runId: string): ProductionLoopState {
+  startInspection(
+    runId: string,
+    input: {
+      artifacts: ProductionArtifactEvidence[];
+      verifiers: ProductionVerifierEvidence[];
+    },
+  ): ProductionLoopState {
     return this.mutate(runId, state => {
       if (state.planItems.some(item => item.status !== ProductionPlanItemStatus.Completed)) {
         throw new Error('Every production plan item must be completed before inspection.');
       }
+      const artifacts = input.artifacts.flatMap(artifact => {
+        const kind = artifact.kind.trim();
+        const reference = artifact.reference.trim();
+        return kind && reference ? [{ kind, reference }] : [];
+      });
+      const verifiers = input.verifiers.flatMap(verifier => {
+        const name = verifier.name.trim();
+        const evidence = verifier.evidence.trim();
+        return name && evidence ? [{ name, passed: verifier.passed === true, evidence }] : [];
+      });
+      const missingArtifact = state.expectedArtifacts.find(
+        expected =>
+          expected.required && !artifacts.some(artifact => artifact.kind === expected.kind),
+      );
+      if (missingArtifact) {
+        throw new Error(`Required artifact evidence is missing for kind: ${missingArtifact.kind}`);
+      }
+      const failedVerifier = state.expectedVerifiers.find(
+        expected =>
+          expected.deterministic &&
+          !verifiers.some(verifier => verifier.name === expected.name && verifier.passed),
+      );
+      if (failedVerifier) {
+        throw new Error(
+          `Passing deterministic verifier evidence is missing for: ${failedVerifier.name}`,
+        );
+      }
+      const inspection: ProductionInspectionEvidence = {
+        artifacts,
+        verifiers,
+        createdAt: Date.now(),
+      };
+      state.inspections ??= [];
+      state.inspections.push(inspection);
       this.transition(state, ProductionLoopPhase.Inspect);
       state.progressVersion += 1;
     });
@@ -362,7 +410,6 @@ export class ProductionLoopService {
       state.revisions.push({ summary: normalizedSummary, evidence, createdAt: Date.now() });
       state.status = ProductionLoopStatus.Active;
       state.progressVersion += 1;
-      this.transition(state, ProductionLoopPhase.Inspect);
       this.measurement.recordActivation(runId, {
         activation: HarnessActivationType.RevisionApplied,
         mechanism: 'production_loop',

--- a/src/main/productionLoop/tool.ts
+++ b/src/main/productionLoop/tool.ts
@@ -2,8 +2,10 @@ import {
   ProductionLoopAction,
   ProductionLoopToolName,
   ProductionPlanItemStatus,
+  type ProductionArtifactEvidence,
   type ProductionExpectedArtifact,
   type ProductionExpectedVerifier,
+  type ProductionVerifierEvidence,
 } from '../../shared/productionLoop';
 import type { ProductionLoopController } from './controller';
 
@@ -39,6 +41,28 @@ const expectedVerifiers = (value: unknown): ProductionExpectedVerifier[] =>
         const raw = entry as Record<string, unknown>;
         return typeof raw.name === 'string'
           ? [{ name: raw.name, deterministic: raw.deterministic === true }]
+          : [];
+      })
+    : [];
+
+const artifactEvidence = (value: unknown): ProductionArtifactEvidence[] =>
+  Array.isArray(value)
+    ? value.flatMap(entry => {
+        if (!entry || typeof entry !== 'object') return [];
+        const raw = entry as Record<string, unknown>;
+        return typeof raw.kind === 'string' && typeof raw.reference === 'string'
+          ? [{ kind: raw.kind, reference: raw.reference }]
+          : [];
+      })
+    : [];
+
+const verifierEvidence = (value: unknown): ProductionVerifierEvidence[] =>
+  Array.isArray(value)
+    ? value.flatMap(entry => {
+        if (!entry || typeof entry !== 'object') return [];
+        const raw = entry as Record<string, unknown>;
+        return typeof raw.name === 'string' && typeof raw.evidence === 'string'
+          ? [{ name: raw.name, passed: raw.passed === true, evidence: raw.evidence }]
           : [];
       })
     : [];
@@ -113,6 +137,32 @@ export function buildProductionLoopTool(
             additionalProperties: false,
           },
         },
+        artifactEvidence: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              kind: { type: 'string' },
+              reference: { type: 'string' },
+            },
+            required: ['kind', 'reference'],
+            additionalProperties: false,
+          },
+        },
+        verifierEvidence: {
+          type: 'array',
+          minItems: 1,
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              passed: { type: 'boolean' },
+              evidence: { type: 'string' },
+            },
+            required: ['name', 'passed', 'evidence'],
+            additionalProperties: false,
+          },
+        },
         selectedDirection: { type: 'string' },
         itemId: { type: 'string' },
         status: { type: 'string', enum: Object.values(ProductionPlanItemStatus) },
@@ -172,7 +222,10 @@ export function buildProductionLoopTool(
             );
             return result('Plan item updated.');
           case ProductionLoopAction.StartInspection:
-            controller.startInspection();
+            controller.startInspection({
+              artifacts: artifactEvidence(params.artifactEvidence),
+              verifiers: verifierEvidence(params.verifierEvidence),
+            });
             return result(
               'Inspection phase started. Run deterministic checks, then request critique.',
             );

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -61,7 +61,16 @@ const prepareProductionDelivery = (
     planned.planItems[0].id,
     ProductionPlanItemStatus.Completed,
   );
-  service.productionLoop.startInspection(runId);
+  service.productionLoop.startInspection(runId, {
+    artifacts: [{ kind: 'result', reference: 'final-answer' }],
+    verifiers: [
+      {
+        name: 'completion_contract',
+        passed: true,
+        evidence: 'Completion contract passed.',
+      },
+    ],
+  });
   service.productionLoop.requestCritique(runId);
   service.productionLoop.recordCriticStart(runId, 'critic');
   service.productionLoop.recordCriticResult(

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -31,6 +31,23 @@ export interface ProductionExpectedVerifier {
   deterministic: boolean;
 }
 
+export interface ProductionArtifactEvidence {
+  kind: string;
+  reference: string;
+}
+
+export interface ProductionVerifierEvidence {
+  name: string;
+  passed: boolean;
+  evidence: string;
+}
+
+export interface ProductionInspectionEvidence {
+  artifacts: ProductionArtifactEvidence[];
+  verifiers: ProductionVerifierEvidence[];
+  createdAt: number;
+}
+
 export interface ProductionCriticFinding {
   severity: ProductionCriticSeverity;
   summary: string;
@@ -77,6 +94,7 @@ export interface ProductionLoopState {
   acceptanceCriteria: string[];
   expectedArtifacts: ProductionExpectedArtifact[];
   expectedVerifiers: ProductionExpectedVerifier[];
+  inspections: ProductionInspectionEvidence[];
   planItems: ProductionPlanItem[];
   critic: ProductionCriticState;
   revisions: ProductionRevision[];


### PR DESCRIPTION
## 阶段

第 1/4 阶段，基于 `main`。

## 变更摘要

- 每个生产计划必须至少声明一个确定性校验器
- 进入检查阶段前必须持久化产物证据和校验器证据
- 完成修订后必须重新提交检查证据

## 测试

- `npm.cmd test -- productionLoop taskService zhiyuanEvaluationPolicy`（48 个用例通过）
