### PR TITLE
fix(cowork): validate independent critic results

### DIFF
--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -129,6 +129,21 @@ test('invalid critic output enters revision instead of silently passing', () => 
   expect(controller.getState().critic.findings[0].summary).toContain('invalid structured response');
 });
 
+test('does not bind grouped subagent calls as the independent reviewer', () => {
+  const { controller } = createController();
+  reachCritique(controller);
+  controller.recordSubagentStart('parallel-review', {
+    parallel: [
+      { agent: 'reviewer', task: 'review' },
+      { agent: 'scout', task: 'inspect files' },
+    ],
+  });
+  expect(controller.getState().critic.toolCallId).toBeNull();
+
+  controller.recordSubagentStart('standalone-review', { agent: 'reviewer', task: 'review' });
+  expect(controller.getState().critic.toolCallId).toBe('standalone-review');
+});
+
 test('skip_workflow lets the agent finish without the completion gate', () => {
   const { controller, downstream } = createController();
   controller.skipWorkflow('Pure information request with no work to plan');

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -17,20 +17,10 @@ interface DownstreamCompletionWorkflow {
   ): { shouldFinish: boolean; reason?: string; nextPrompt?: string };
 }
 
-const hasReviewer = (args: unknown): boolean => {
+const isStandaloneReviewer = (args: unknown): boolean => {
   if (!args || typeof args !== 'object') return false;
   const raw = args as Record<string, unknown>;
-  if (raw.agent === 'reviewer') return true;
-  for (const key of ['parallel', 'chain']) {
-    const values = raw[key];
-    if (
-      Array.isArray(values) &&
-      values.some(value => value && typeof value === 'object' && value.agent === 'reviewer')
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return raw.agent === 'reviewer' && raw.parallel === undefined && raw.chain === undefined;
 };
 
 export class ProductionLoopController {
@@ -129,7 +119,7 @@ export class ProductionLoopController {
   }
 
   recordSubagentStart(toolCallId: string, args: unknown): void {
-    if (!hasReviewer(args) || this.state.phase !== ProductionLoopPhase.Critique) return;
+    if (!isStandaloneReviewer(args) || this.state.phase !== ProductionLoopPhase.Critique) return;
     this.update(this.service.recordCriticStart(this.state.runId, toolCallId));
   }
 

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -212,6 +212,49 @@ test('accepts a critic verdict wrapped in a Markdown JSON fence', () => {
   expect(accepted.status).toBe(ProductionLoopStatus.ReadyToDeliver);
 });
 
+test('fails closed when critic output omits required schema fields', () => {
+  const { run } = begin();
+  const planned = commitPlan(run.id);
+  for (const item of planned.planItems) {
+    service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
+  }
+  startInspection(run.id);
+  service.requestCritique(run.id);
+  service.recordCriticStart(run.id, 'review');
+
+  const rejected = service.recordCriticResult(
+    run.id,
+    'review',
+    JSON.stringify({ verdict: 'pass' }),
+    false,
+  );
+  expect(rejected).toMatchObject({
+    phase: ProductionLoopPhase.Revise,
+    status: ProductionLoopStatus.NeedsRevision,
+    critic: { passed: false },
+  });
+  expect(rejected.critic.findings[0].summary).toContain('invalid structured response');
+});
+
+test('requires a finding for a revise critic verdict', () => {
+  const { run } = begin();
+  const planned = commitPlan(run.id);
+  for (const item of planned.planItems) {
+    service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
+  }
+  startInspection(run.id);
+  service.requestCritique(run.id);
+  service.recordCriticStart(run.id, 'review');
+
+  const rejected = service.recordCriticResult(
+    run.id,
+    'review',
+    JSON.stringify({ verdict: 'revise', findings: [] }),
+    false,
+  );
+  expect(rejected.critic.findings[0].summary).toContain('invalid structured response');
+});
+
 test('deterministic verification failure overrides critic PASS and returns to revision', () => {
   const { run } = begin();
   const planned = commitPlan(run.id);

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { HarnessActivationType } from '../../shared/harness';
 import {
   ProductionCriticSeverity,
+  ProductionCriticVerdict,
   ProductionLoopPhase,
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
@@ -27,7 +28,7 @@ import { assertProductionLoopTransition } from './stateMachine';
 const MAX_CRITIC_OUTPUT_LENGTH = 8_000;
 
 interface CriticPayload {
-  verdict: 'pass' | 'revise';
+  verdict: ProductionCriticVerdict;
   findings: ProductionCriticFinding[];
 }
 
@@ -62,7 +63,7 @@ const parseJsonRecord = (output: string): Record<string, unknown> => {
 const parseCriticPayload = (output: string, isError: boolean): CriticPayload => {
   if (isError) {
     return {
-      verdict: 'revise',
+      verdict: ProductionCriticVerdict.Revise,
       findings: [
         {
           severity: ProductionCriticSeverity.Major,
@@ -74,31 +75,43 @@ const parseCriticPayload = (output: string, isError: boolean): CriticPayload => 
   }
   try {
     const parsed = parseJsonRecord(output);
-    const verdict = parsed.verdict === 'pass' ? 'pass' : 'revise';
-    const findings = Array.isArray(parsed.findings)
-      ? parsed.findings.flatMap(value => {
-          if (!value || typeof value !== 'object') return [];
-          const raw = value as Record<string, unknown>;
-          if (typeof raw.summary !== 'string' || !raw.summary.trim()) return [];
-          const severity = Object.values(ProductionCriticSeverity).includes(
-            raw.severity as ProductionCriticSeverity,
-          )
-            ? (raw.severity as ProductionCriticSeverity)
-            : ProductionCriticSeverity.Major;
-          return [
-            {
-              severity,
-              summary: raw.summary.trim(),
-              evidence: typeof raw.evidence === 'string' ? raw.evidence.trim() : undefined,
-            },
-          ];
-        })
-      : [];
-    if (verdict === 'pass' && findings.length > 0) return { verdict: 'revise', findings };
+    if (!Object.values(ProductionCriticVerdict).includes(parsed.verdict as ProductionCriticVerdict)) {
+      throw new Error('Critic verdict is missing or invalid.');
+    }
+    if (!Array.isArray(parsed.findings)) {
+      throw new Error('Critic findings must be an array.');
+    }
+    const verdict = parsed.verdict as ProductionCriticVerdict;
+    const findings = parsed.findings.map(value => {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new Error('Critic finding must be an object.');
+      }
+      const raw = value as Record<string, unknown>;
+      if (typeof raw.summary !== 'string' || !raw.summary.trim()) {
+        throw new Error('Critic finding summary is required.');
+      }
+      if (!Object.values(ProductionCriticSeverity).includes(raw.severity as ProductionCriticSeverity)) {
+        throw new Error('Critic finding severity is invalid.');
+      }
+      if (raw.evidence !== undefined && typeof raw.evidence !== 'string') {
+        throw new Error('Critic finding evidence must be a string.');
+      }
+      return {
+        severity: raw.severity as ProductionCriticSeverity,
+        summary: raw.summary.trim(),
+        evidence: typeof raw.evidence === 'string' ? raw.evidence.trim() : undefined,
+      };
+    });
+    if (verdict === ProductionCriticVerdict.Pass && findings.length > 0) {
+      return { verdict: ProductionCriticVerdict.Revise, findings };
+    }
+    if (verdict === ProductionCriticVerdict.Revise && findings.length === 0) {
+      throw new Error('A revise verdict requires at least one finding.');
+    }
     return { verdict, findings };
   } catch {
     return {
-      verdict: 'revise',
+      verdict: ProductionCriticVerdict.Revise,
       findings: [
         {
           severity: ProductionCriticSeverity.Major,
@@ -379,9 +392,9 @@ export class ProductionLoopService {
       const result = parseCriticPayload(output, isError);
       state.critic.outputSummary = output.slice(0, MAX_CRITIC_OUTPUT_LENGTH);
       state.critic.findings = result.findings;
-      state.critic.passed = result.verdict === 'pass';
+      state.critic.passed = result.verdict === ProductionCriticVerdict.Pass;
       state.progressVersion += 1;
-      if (result.verdict === 'pass') {
+      if (result.verdict === ProductionCriticVerdict.Pass) {
         this.transition(state, ProductionLoopPhase.Deliver);
         state.status = ProductionLoopStatus.ReadyToDeliver;
         return;

--- a/src/shared/productionLoop/constants.ts
+++ b/src/shared/productionLoop/constants.ts
@@ -36,6 +36,13 @@ export const ProductionCriticSeverity = {
 export type ProductionCriticSeverity =
   (typeof ProductionCriticSeverity)[keyof typeof ProductionCriticSeverity];
 
+export const ProductionCriticVerdict = {
+  Pass: 'pass',
+  Revise: 'revise',
+} as const;
+export type ProductionCriticVerdict =
+  (typeof ProductionCriticVerdict)[keyof typeof ProductionCriticVerdict];
+
 export const ProductionLoopRecoveryReason = {
   MissingSignal: 'missing_signal',
   PrematureFinalize: 'premature_finalize',


### PR DESCRIPTION
## 阶段

第 2/4 阶段，依赖 `codex/production-gate-evidence`。

## 变更摘要

- critic 输出不满足完整 JSON 协议时按失败处理
- `revise` 必须包含 finding，`pass` 不允许携带 finding
- 仅允许独立、只读的 reviewer 调用满足审查门禁

## 测试

- `npm.cmd test -- productionLoop taskService zhiyuanEvaluationPolicy`（51 个用例通过）
