### PR TITLE
fix(cowork): refresh persisted production state

### DIFF
--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -2,7 +2,11 @@ import Database from 'better-sqlite3';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { ProductionLoopPhase, ProductionLoopStatus } from '../../shared/productionLoop';
-import { WorkbenchContractKind, WorkbenchRunTrigger } from '../../shared/workbenchTask';
+import {
+  WorkbenchContractKind,
+  WorkbenchRunTrigger,
+  WorkbenchVerificationOutcome,
+} from '../../shared/workbenchTask';
 import { HarnessMeasurementService } from '../harness/measurementService';
 import { WorkbenchTaskRepository } from '../workbenchTask/repository';
 import { initializeWorkbenchTaskSchema } from '../workbenchTask/schema';
@@ -49,6 +53,7 @@ const createController = () => {
       },
       downstream,
     ),
+    service,
     downstream,
   };
 };
@@ -142,6 +147,29 @@ test('does not bind grouped subagent calls as the independent reviewer', () => {
 
   controller.recordSubagentStart('standalone-review', { agent: 'reviewer', task: 'review' });
   expect(controller.getState().critic.toolCallId).toBe('standalone-review');
+});
+
+test('refreshes externally persisted verification state before making decisions', () => {
+  const { controller, service } = createController();
+  reachCritique(controller);
+  controller.recordSubagentStart('review', { agent: 'reviewer', task: 'review' });
+  controller.recordSubagentResult(
+    'review',
+    JSON.stringify({ verdict: 'pass', findings: [] }),
+    false,
+  );
+  controller.requestCompletion('ready');
+  const runId = controller.getState().runId;
+
+  service.recordVerificationResult(runId, WorkbenchVerificationOutcome.Failed, 'checks failed');
+
+  expect(controller.getState()).toMatchObject({
+    phase: ProductionLoopPhase.Revise,
+    status: ProductionLoopStatus.NeedsRevision,
+  });
+  expect(controller.onAgentEnd({ next: false })).toMatchObject({
+    shouldFinish: false,
+  });
 });
 
 test('skip_workflow lets the agent finish without the completion gate', () => {

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -41,10 +41,12 @@ export class ProductionLoopController {
   }
 
   get goal(): string {
+    this.refresh();
     return this.downstream?.goal || this.state.goal;
   }
 
   getState(): ProductionLoopState {
+    this.refresh();
     return structuredClone(this.state);
   }
 
@@ -60,6 +62,7 @@ export class ProductionLoopController {
   }
 
   buildInitialPrompt(): string {
+    this.refresh();
     const phaseInstruction = this.state.prototypeRequired
       ? 'Begin by creating a concrete prototype or materially distinct direction, then record it with production_loop record_prototype.'
       : 'Begin by committing an executable plan with production_loop commit_plan before making changes.';
@@ -78,6 +81,7 @@ export class ProductionLoopController {
   }
 
   requestCriticPrompt(): string {
+    this.refresh();
     return [
       'Call the subagent tool with agent "reviewer". The reviewer must remain read-only.',
       'Ask it to inspect the implementation and available evidence against this persisted plan:',
@@ -119,11 +123,13 @@ export class ProductionLoopController {
   }
 
   recordSubagentStart(toolCallId: string, args: unknown): void {
+    this.refresh();
     if (!isStandaloneReviewer(args) || this.state.phase !== ProductionLoopPhase.Critique) return;
     this.update(this.service.recordCriticStart(this.state.runId, toolCallId));
   }
 
   recordSubagentResult(toolCallId: string, output: string, isError: boolean): void {
+    this.refresh();
     if (this.state.critic.toolCallId !== toolCallId) return;
     this.update(this.service.recordCriticResult(this.state.runId, toolCallId, output, isError));
   }
@@ -137,6 +143,7 @@ export class ProductionLoopController {
   }
 
   requestCompletion(reason: string): string {
+    this.refresh();
     if (this.state.skip) {
       return this.downstream
         ? this.downstream.requestCompletion(reason)
@@ -161,8 +168,15 @@ export class ProductionLoopController {
   onAgentEnd(
     signal: PiAgentLoopEndSignal,
   ): { shouldFinish: boolean; reason?: string; nextPrompt?: string } {
+    this.refresh();
     if (this.state.skip) {
       return { shouldFinish: true, reason: this.state.skip.reason };
+    }
+    if (this.state.status === ProductionLoopStatus.Completed) {
+      return {
+        shouldFinish: true,
+        reason: this.state.deliveryReason || 'Production workflow completed.',
+      };
     }
     if (this.state.status === ProductionLoopStatus.ReadyToDeliver && this.state.deliveryReason) {
       if (this.downstream) {
@@ -235,5 +249,9 @@ export class ProductionLoopController {
   private update(state: ProductionLoopState): ProductionLoopState {
     this.state = state;
     return this.getState();
+  }
+
+  private refresh(): void {
+    this.state = this.service.getState(this.state.runId);
   }
 }

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -133,6 +133,12 @@ export class ProductionLoopService {
     this.repository = repository;
   }
 
+  getState(runId: string): ProductionLoopState {
+    const state = this.repository.get(runId);
+    if (!state) throw new Error(`Production loop not found: ${runId}`);
+    return state;
+  }
+
   beginRun(input: {
     taskId: string;
     runId: string;


### PR DESCRIPTION
## 阶段

第 3/4 阶段，依赖 `codex/production-critic-validation`。

## 变更摘要

- controller 作出决策前从持久化存储刷新 production loop 状态
- 正确感知验证流程触发的 `completed` 或 `revise` 状态转换
- 防止过期的 `ready_to_deliver` 内存快照错误结束失败任务

## 测试

- `npm.cmd test -- productionLoop taskService zhiyuanEvaluationPolicy`（52 个用例通过）
