### PR TITLE
feat(cowork): 限制 production reviewer 执行预算

### DIFF
--- a/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
@@ -221,6 +221,15 @@ describe('createZhiyuanEvaluationPolicy', () => {
       toolCallId: 'review-1',
       result: {
         content: [{ type: 'text', text: '{"verdict":"pass","findings":[]}' }],
+        details: {
+          execution: {
+            terminationReason: 'settled',
+            durationMs: 1_500,
+            assistantTurns: 2,
+            toolCalls: 1,
+            steerRequested: false,
+          },
+        },
       },
       isError: false,
     });
@@ -236,7 +245,14 @@ describe('createZhiyuanEvaluationPolicy', () => {
       expect.arrayContaining([
         expect.objectContaining({
           activation: ZhiyuanEvaluationActivation.CriticCompleted,
-          evidence: expect.objectContaining({ mode: 'isolated_reviewer_subsession' }),
+          evidence: expect.objectContaining({
+            mode: 'isolated_reviewer_subsession',
+            terminationReason: 'settled',
+            durationMs: 1_500,
+            assistantTurns: 2,
+            toolCalls: 1,
+            steerRequested: false,
+          }),
         }),
       ]),
     );

--- a/src/main/evaluation/zhiyuanEvaluationPolicy.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.ts
@@ -6,6 +6,7 @@ import { ProductionLoopAction, ProductionLoopPhase } from '../../shared/producti
 import { WorkbenchContractKind, type WorkbenchJsonObject } from '../../shared/workbenchTask';
 import { createPiWorkLoop } from '../libs/agentEngine/piWorkLoop';
 import { ProductionLoopController } from '../productionLoop/controller';
+import { extractPiSubagentExecutionMetadata } from '../libs/agentEngine/piSubagentExecution';
 import type { ProductionLoopMeasurement } from '../productionLoop/ports';
 import { ProductionLoopService } from '../productionLoop/service';
 import { buildProductionLoopTool } from '../productionLoop/tool';
@@ -195,10 +196,12 @@ export function createZhiyuanEvaluationPolicy(
     if (event.type === ZhiyuanEvaluationEventType.ToolExecutionStart) {
       controller.recordSubagentStart(toolCallId, event.args);
     } else if (event.type === ZhiyuanEvaluationEventType.ToolExecutionEnd) {
+      const execution = extractPiSubagentExecutionMetadata(event.result);
       controller.recordSubagentResult(
         toolCallId,
         toolResultText(event.result),
         event.isError === true,
+        execution,
       );
       criticAttempt += 1;
       const critic = controller.getState().critic;
@@ -208,6 +211,15 @@ export function createZhiyuanEvaluationPolicy(
         outputPresent: Boolean(toolResultText(event.result).trim()),
         passed: critic.passed,
         findingSeverities: critic.findings.map(finding => finding.severity),
+        ...(execution
+          ? {
+              terminationReason: execution.terminationReason,
+              durationMs: execution.durationMs,
+              assistantTurns: execution.assistantTurns,
+              toolCalls: execution.toolCalls,
+              steerRequested: execution.steerRequested,
+            }
+          : {}),
       });
     }
   };

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -88,6 +88,7 @@ import {
 } from './piShortcutWorkflow';
 import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool';
 import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
+import { extractPiSubagentExecutionMetadata } from './piSubagentExecution';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { buildPiSkillScriptTool } from './piSkillScriptTool';
 import { buildPiSkillRuntimeCapabilitiesTool } from './piSkillRuntimeCapabilitiesTool';
@@ -1797,10 +1798,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           );
         }
         if (event.toolName === PiSubagentToolName) {
+          const execution = extractPiSubagentExecutionMetadata(event.result);
           active.productionLoop?.recordSubagentResult(
             event.toolCallId,
             resultText,
             Boolean(event.isError),
+            execution,
           );
           active.researchRun?.recordSubagentResult(
             event.toolCallId,

--- a/src/main/libs/agentEngine/piSubagentConstants.ts
+++ b/src/main/libs/agentEngine/piSubagentConstants.ts
@@ -8,3 +8,11 @@ export const PiSubagentProfileId = {
 
 export type PiSubagentProfileId =
   (typeof PiSubagentProfileId)[keyof typeof PiSubagentProfileId];
+
+export const PiSubagentTerminationReason = {
+  Settled: 'settled',
+  Error: 'error',
+  HardTimeout: 'hard_timeout',
+} as const;
+export type PiSubagentTerminationReason =
+  (typeof PiSubagentTerminationReason)[keyof typeof PiSubagentTerminationReason];

--- a/src/main/libs/agentEngine/piSubagentExecution.test.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest';
 
 import {
+  extractPiSubagentExecutionMetadata,
   PiMessageRole,
   PiSubagentEventType,
   runPiSubagent,
@@ -11,6 +12,33 @@ import {
   PiBuiltinFileToolName,
   PiContentBlockType,
 } from './piWriteTokenLimit';
+
+test('extracts validated execution metadata from a subagent tool result', () => {
+  expect(
+    extractPiSubagentExecutionMetadata({
+      details: {
+        execution: {
+          terminationReason: 'hard_timeout',
+          durationMs: 180_000,
+          assistantTurns: 6,
+          toolCalls: 5,
+          steerRequested: true,
+        },
+      },
+    }),
+  ).toEqual({
+    terminationReason: 'hard_timeout',
+    durationMs: 180_000,
+    assistantTurns: 6,
+    toolCalls: 5,
+    steerRequested: true,
+  });
+  expect(
+    extractPiSubagentExecutionMetadata({
+      details: { execution: { terminationReason: 'unknown' } },
+    }),
+  ).toBeUndefined();
+});
 
 const createSession = () => {
   let listener: ((event: { type: string; message?: never }) => void) | undefined;
@@ -40,7 +68,7 @@ test('waits for agent_settled instead of returning after an intermediate assista
   let settled = false;
   const output = runPiSubagent(session, 'Implement it', {
     maxOutputTokens: 4096,
-    timeoutMs: 10_000,
+    hardTimeoutMs: 10_000,
   }).then(value => {
     settled = true;
     return value;
@@ -72,14 +100,20 @@ test('waits for agent_settled instead of returning after an intermediate assista
 
   emit({ type: PiSubagentEventType.AgentSettled });
 
-  await expect(output).resolves.toBe('Final answer');
+  await expect(output).resolves.toMatchObject({
+    output: 'Final answer',
+    terminationReason: 'settled',
+    assistantTurns: 2,
+    toolCalls: 0,
+    steerRequested: false,
+  });
 });
 
 test('queues Pi write recovery and keeps waiting after a truncated subagent write', async () => {
   const { session, emit, resolvePrompt } = createSession();
   const output = runPiSubagent(session, 'Write a large file', {
     maxOutputTokens: 4096,
-    timeoutMs: 10_000,
+    hardTimeoutMs: 10_000,
   });
 
   emit({
@@ -111,14 +145,14 @@ test('queues Pi write recovery and keeps waiting after a truncated subagent writ
   emit({ type: PiSubagentEventType.AgentSettled });
   resolvePrompt();
 
-  await expect(output).resolves.toBe('Completed');
+  await expect(output).resolves.toMatchObject({ output: 'Completed' });
 });
 
 test('returns a subagent error without waiting for agent_end', async () => {
   const { session, emit } = createSession();
   const output = runPiSubagent(session, 'Fail', {
     maxOutputTokens: 4096,
-    timeoutMs: 10_000,
+    hardTimeoutMs: 10_000,
   });
 
   emit({
@@ -131,7 +165,10 @@ test('returns a subagent error without waiting for agent_end', async () => {
     },
   });
 
-  await expect(output).resolves.toBe('Error: provider failed');
+  await expect(output).resolves.toMatchObject({
+    output: 'Error: provider failed',
+    terminationReason: 'error',
+  });
 });
 
 test('cleans up when subscribing throws synchronously', async () => {
@@ -145,7 +182,10 @@ test('cleans up when subscribing throws synchronously', async () => {
   };
 
   await expect(
-    runPiSubagent(session, 'Implement it', { maxOutputTokens: 4096, timeoutMs: 10_000 }),
+    runPiSubagent(session, 'Implement it', {
+      maxOutputTokens: 4096,
+      hardTimeoutMs: 10_000,
+    }),
   ).rejects.toBe(error);
   expect(session.prompt).not.toHaveBeenCalled();
 });
@@ -162,7 +202,73 @@ test('cleans up when prompting throws synchronously', async () => {
   };
 
   await expect(
-    runPiSubagent(session, 'Implement it', { maxOutputTokens: 4096, timeoutMs: 10_000 }),
+    runPiSubagent(session, 'Implement it', {
+      maxOutputTokens: 4096,
+      hardTimeoutMs: 10_000,
+    }),
   ).rejects.toBe(error);
   expect(unsubscribe).toHaveBeenCalledOnce();
+});
+
+test('requests at most one bounded steer when review budgets are exhausted', async () => {
+  const { session, emit, resolvePrompt } = createSession();
+  const output = runPiSubagent(session, 'Review it', {
+    maxOutputTokens: 4096,
+    hardTimeoutMs: 10_000,
+    maxAssistantTurns: 2,
+    maxToolCalls: 1,
+    steerPrompt: 'Return the verdict now.',
+  });
+
+  emit({ type: PiSubagentEventType.ToolExecutionStart });
+  emit({ type: PiSubagentEventType.ToolExecutionStart });
+  for (const text of ['First', 'Final']) {
+    emit({
+      type: PiSubagentEventType.MessageEnd,
+      message: {
+        role: PiMessageRole.Assistant,
+        stopReason: PiAssistantStopReason.Stop,
+        content: [{ type: PiContentBlockType.Text, text }],
+      },
+    });
+  }
+  emit({ type: PiSubagentEventType.AgentSettled });
+  resolvePrompt();
+
+  expect(session.steer).toHaveBeenCalledOnce();
+  await expect(output).resolves.toMatchObject({
+    output: 'Final',
+    terminationReason: 'settled',
+    assistantTurns: 2,
+    toolCalls: 2,
+    steerRequested: true,
+  });
+});
+
+test('steers at the soft timeout and returns structured hard-timeout metadata', async () => {
+  vi.useFakeTimers();
+  try {
+    const { session } = createSession();
+    const output = runPiSubagent(session, 'Review it', {
+      maxOutputTokens: 4096,
+      softTimeoutMs: 120_000,
+      hardTimeoutMs: 180_000,
+      steerPrompt: 'Return the verdict now.',
+    });
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(session.steer).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(output).resolves.toMatchObject({
+      output: '(subagent hard timeout after 180s)',
+      terminationReason: 'hard_timeout',
+      durationMs: 180_000,
+      assistantTurns: 0,
+      toolCalls: 0,
+      steerRequested: true,
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/src/main/libs/agentEngine/piSubagentExecution.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.ts
@@ -4,12 +4,17 @@ import {
   PiWriteTokenLimitRecovery,
   type PiWriteRecoveryMessage,
 } from './piWriteTokenLimit';
+import {
+  PiSubagentTerminationReason,
+  type PiSubagentTerminationReason as PiSubagentTerminationReasonValue,
+} from './piSubagentConstants';
 
 export const PiSubagentEventType = {
   AgentEnd: 'agent_end',
   AgentSettled: 'agent_settled',
   Error: 'error',
   MessageEnd: 'message_end',
+  ToolExecutionStart: 'tool_execution_start',
 } as const;
 
 export const PiMessageRole = {
@@ -34,8 +39,24 @@ export type PiSubagentSession = {
 
 export type RunPiSubagentOptions = {
   maxOutputTokens: number;
-  timeoutMs: number;
+  hardTimeoutMs: number;
+  softTimeoutMs?: number;
+  maxAssistantTurns?: number;
+  maxToolCalls?: number;
+  steerPrompt?: string;
 };
+
+export interface PiSubagentExecutionMetadata {
+  terminationReason: PiSubagentTerminationReasonValue;
+  durationMs: number;
+  assistantTurns: number;
+  toolCalls: number;
+  steerRequested: boolean;
+}
+
+export interface PiSubagentExecutionResult extends PiSubagentExecutionMetadata {
+  output: string;
+}
 
 const extractAssistantText = (message: PiSubagentMessage): string => {
   if (typeof message.content === 'string') return message.content.trim();
@@ -50,33 +71,66 @@ export const runPiSubagent = (
   session: PiSubagentSession,
   task: string,
   options: RunPiSubagentOptions,
-): Promise<string> =>
+): Promise<PiSubagentExecutionResult> =>
   new Promise((resolve, reject) => {
+    const startedAt = Date.now();
     const recovery = new PiWriteTokenLimitRecovery(options.maxOutputTokens);
     let latestAnswer = '';
     let settled = false;
+    let assistantTurns = 0;
+    let toolCalls = 0;
+    let steerRequested = false;
     let unsubscribe = (): void => {};
+    let softTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    const finish = (output: string): void => {
+    const finish = (output: string, terminationReason: PiSubagentTerminationReasonValue): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      clearTimeout(hardTimeout);
+      if (softTimeout) clearTimeout(softTimeout);
       unsubscribe();
-      resolve(output);
+      resolve({
+        output,
+        terminationReason,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        assistantTurns,
+        toolCalls,
+        steerRequested,
+      });
     };
 
     const fail = (error: unknown): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      clearTimeout(hardTimeout);
+      if (softTimeout) clearTimeout(softTimeout);
       unsubscribe();
       reject(error);
     };
 
-    const timeout = setTimeout(
-      () => finish(`(subagent timed out after ${Math.round(options.timeoutMs / 1000)}s)`),
-      options.timeoutMs,
+    const requestSteer = (): void => {
+      if (settled || steerRequested || !options.steerPrompt) return;
+      steerRequested = true;
+      try {
+        void session.steer(options.steerPrompt).catch(error => {
+          console.warn('[PiSubagent] failed to request a bounded final response:', error);
+        });
+      } catch (error) {
+        console.warn('[PiSubagent] failed to request a bounded final response:', error);
+      }
+    };
+
+    const hardTimeout = setTimeout(
+      () =>
+        finish(
+          `(subagent hard timeout after ${Math.round(options.hardTimeoutMs / 1000)}s)`,
+          PiSubagentTerminationReason.HardTimeout,
+        ),
+      options.hardTimeoutMs,
     );
+    if (options.softTimeoutMs !== undefined) {
+      softTimeout = setTimeout(requestSteer, options.softTimeoutMs);
+    }
 
     try {
       const subscribedUnsubscribe = session.subscribe(event => {
@@ -85,20 +139,38 @@ export const runPiSubagent = (
           event.type === PiSubagentEventType.MessageEnd &&
           message?.role === PiMessageRole.Assistant
         ) {
+          assistantTurns += 1;
           recovery.queueIfNeeded(message, session);
           if (message.stopReason === PiAssistantStopReason.Error) {
-            finish(`Error: ${message.errorMessage || 'Subagent encountered an error'}`);
+            finish(
+              `Error: ${message.errorMessage || 'Subagent encountered an error'}`,
+              PiSubagentTerminationReason.Error,
+            );
             return;
           }
 
           const answer = extractAssistantText(message);
           if (answer) latestAnswer = answer;
+          if (
+            options.maxAssistantTurns !== undefined &&
+            assistantTurns >= options.maxAssistantTurns
+          ) {
+            requestSteer();
+          }
         }
 
         if (event.type === PiSubagentEventType.Error) {
-          finish(`Error: ${message?.errorMessage || 'Subagent encountered an error'}`);
+          finish(
+            `Error: ${message?.errorMessage || 'Subagent encountered an error'}`,
+            PiSubagentTerminationReason.Error,
+          );
+        } else if (event.type === PiSubagentEventType.ToolExecutionStart) {
+          toolCalls += 1;
+          if (options.maxToolCalls !== undefined && toolCalls >= options.maxToolCalls) {
+            requestSteer();
+          }
         } else if (event.type === PiSubagentEventType.AgentSettled) {
-          finish(latestAnswer || '(no output)');
+          finish(latestAnswer || '(no output)', PiSubagentTerminationReason.Settled);
         }
       });
       unsubscribe = subscribedUnsubscribe;
@@ -116,3 +188,35 @@ export const runPiSubagent = (
       fail(error);
     }
   });
+
+const isFiniteNonNegativeNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0;
+
+export const extractPiSubagentExecutionMetadata = (
+  result: unknown,
+): PiSubagentExecutionMetadata | undefined => {
+  if (!result || typeof result !== 'object') return undefined;
+  const details = (result as Record<string, unknown>).details;
+  if (!details || typeof details !== 'object') return undefined;
+  const execution = (details as Record<string, unknown>).execution;
+  if (!execution || typeof execution !== 'object') return undefined;
+  const raw = execution as Record<string, unknown>;
+  if (
+    !Object.values(PiSubagentTerminationReason).includes(
+      raw.terminationReason as PiSubagentTerminationReasonValue,
+    ) ||
+    !isFiniteNonNegativeNumber(raw.durationMs) ||
+    !isFiniteNonNegativeNumber(raw.assistantTurns) ||
+    !isFiniteNonNegativeNumber(raw.toolCalls) ||
+    typeof raw.steerRequested !== 'boolean'
+  ) {
+    return undefined;
+  }
+  return {
+    terminationReason: raw.terminationReason as PiSubagentTerminationReasonValue,
+    durationMs: raw.durationMs,
+    assistantTurns: raw.assistantTurns,
+    toolCalls: raw.toolCalls,
+    steerRequested: raw.steerRequested,
+  };
+};

--- a/src/main/libs/agentEngine/piSubagentTool.test.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.test.ts
@@ -22,6 +22,7 @@ vi.mock('@earendil-works/pi-coding-agent', () => ({
 
 import {
   buildPiSubagentTool,
+  PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS,
   SUBAGENT_PARALLEL_LIMIT,
   type PiSubagentToolDeps,
 } from './piSubagentTool';
@@ -283,7 +284,7 @@ describe('buildPiSubagentTool', () => {
         expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
           '/tmp/workspace',
           expect.stringContaining('Respond with exactly one JSON object'),
-          4096,
+          PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS,
         );
       } finally {
         fs.rmSync(agentsDir, { recursive: true, force: true });
@@ -295,29 +296,52 @@ describe('buildPiSubagentTool', () => {
 
   describe('single mode', () => {
     it('runs one sub-session and returns its output', async () => {
-      const { tool } = buildTool();
+      const { tool, deps } = buildTool();
       const result = await tool.execute('call-1', { agent: 'scout', task: 'map the code' });
       expect(result.content[0].text).toBe('subagent output');
-      expect(result.details).toEqual({ agentId: 'scout' });
+      expect(result.details).toMatchObject({
+        agentId: 'scout',
+        execution: {
+          terminationReason: 'settled',
+          assistantTurns: 1,
+          toolCalls: 0,
+          steerRequested: false,
+        },
+      });
       expect(hoisted.mockCreateAgentSession).toHaveBeenCalledTimes(1);
       const options = hoisted.mockCreateAgentSession.mock.calls[0]?.[0] as Record<string, unknown>;
       expect(options).not.toHaveProperty('customTools');
       expect(options.tools).toEqual(['read', 'grep', 'find', 'ls']);
+      expect(options.model).toBe(deps.resolvedModel.model);
+      expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
+        '/tmp/workspace',
+        expect.any(String),
+        4096,
+      );
     });
 
     it('enforces the production reviewer contract and read-only tool allowlist', async () => {
       const { tool, deps } = buildTool();
-      await tool.execute('call-1', {
+      const result = await tool.execute('call-1', {
         agent: PiSubagentProfileId.ProductionReviewer,
         task: 'review the implementation',
       });
       const options = hoisted.mockCreateAgentSession.mock.calls[0]?.[0] as Record<string, unknown>;
       expect(options.tools).toEqual(['read', 'grep', 'find', 'ls']);
+      expect(options.model).toMatchObject({ maxTokens: PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS });
       expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
         '/tmp/workspace',
         expect.stringContaining('Respond with exactly one JSON object'),
-        4096,
+        PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS,
       );
+      expect(result.details).toMatchObject({
+        execution: {
+          terminationReason: 'settled',
+          assistantTurns: 1,
+          toolCalls: 0,
+          steerRequested: false,
+        },
+      });
     });
 
     it('surfaces a sub-session error as the tool output', async () => {

--- a/src/main/libs/agentEngine/piSubagentTool.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.ts
@@ -21,8 +21,15 @@ import * as fs from 'fs';
 import path from 'path';
 
 import { CoreSkillId } from '../../../shared/skills/constants';
-import { PiSubagentProfileId } from './piSubagentConstants';
-import { runPiSubagent, type PiSubagentSession } from './piSubagentExecution';
+import {
+  PiSubagentProfileId,
+  PiSubagentTerminationReason,
+} from './piSubagentConstants';
+import {
+  runPiSubagent,
+  type PiSubagentExecutionMetadata,
+  type PiSubagentSession,
+} from './piSubagentExecution';
 
 // ── Constants ──
 
@@ -30,6 +37,15 @@ export const PiSubagentToolName = 'subagent';
 
 /** Per-subagent run timeout. */
 export const SUBAGENT_TIMEOUT_MS = 600_000;
+
+export const PRODUCTION_REVIEWER_SOFT_TIMEOUT_MS = 120_000;
+export const PRODUCTION_REVIEWER_HARD_TIMEOUT_MS = 180_000;
+export const PRODUCTION_REVIEWER_MAX_ASSISTANT_TURNS = 6;
+export const PRODUCTION_REVIEWER_MAX_TOOL_CALLS = 6;
+export const PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS = 4_000;
+
+const PRODUCTION_REVIEWER_STEER_PROMPT =
+  'Stop investigating now. Return the best supported verdict immediately as exactly one JSON object matching the required production critic contract.';
 
 /** Maximum number of subagent sessions running at once in parallel mode. */
 export const SUBAGENT_PARALLEL_LIMIT = 4;
@@ -102,6 +118,7 @@ interface SubagentTaskSpec {
 interface SubagentRunResult {
   ok: boolean;
   output: string;
+  execution?: PiSubagentExecutionMetadata;
 }
 
 interface SubagentToolResult {
@@ -241,26 +258,35 @@ function resolveAgentProfiles(deps: PiSubagentToolDeps): SubagentProfile[] {
 
 // ── Sub-session execution ──
 
-/** runPiSubagent reports run failures inline; classify them for the ok flag. */
-const FAILURE_OUTPUT_PREFIXES = ['Error:', '(subagent timed out'] as const;
-
-function isFailureOutput(output: string): boolean {
-  return FAILURE_OUTPUT_PREFIXES.some(prefix => output.startsWith(prefix));
-}
-
 /** Run a single subagent profile on a task in an isolated Pi sub-session. */
 async function runSubagent(
   deps: PiSubagentToolDeps,
   profile: SubagentProfile,
   task: string,
 ): Promise<SubagentRunResult> {
+  const startedAt = Date.now();
   let subSession: PiSubagentSubSession | null = null;
   try {
     const pi = await getPiSubagentModules();
     const cwd = deps.workspaceRoot || process.cwd();
+    const isProductionReviewer = profile.id === PiSubagentProfileId.ProductionReviewer;
+    const maxOutputTokens = isProductionReviewer
+      ? Math.min(deps.resolvedModel.maxOutputTokens, PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS)
+      : deps.resolvedModel.maxOutputTokens;
+    const model = isProductionReviewer
+      ? {
+          ...deps.resolvedModel.model,
+          maxTokens: Math.min(
+            typeof deps.resolvedModel.model.maxTokens === 'number'
+              ? deps.resolvedModel.model.maxTokens
+              : maxOutputTokens,
+            maxOutputTokens,
+          ),
+        }
+      : deps.resolvedModel.model;
     const subOptions: Record<string, unknown> = {
       cwd,
-      model: deps.resolvedModel.model,
+      model,
       // No customTools: subagents must not recursively spawn sub-subagents,
       // and AskUserQuestion is reserved for the parent session.
     };
@@ -280,10 +306,10 @@ async function runSubagent(
         'Open the returned primary sources where possible. Never substitute model memory for a retrieved citation.'
       : profile.systemPrompt;
     const resourceLoader = researcherUsesWebSearch
-      ? await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens, [
+      ? await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens, [
           CoreSkillId.WebSearch,
         ])
-      : await deps.createPiResourceLoader(cwd, systemPrompt, deps.resolvedModel.maxOutputTokens);
+      : await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens);
     subOptions.resourceLoader = resourceLoader;
     if (
       resourceLoader &&
@@ -299,15 +325,37 @@ async function runSubagent(
 
     const { session } = await pi.createAgentSession(subOptions);
     subSession = session;
-    const output = await runPiSubagent(session, task, {
-      maxOutputTokens: deps.resolvedModel.maxOutputTokens,
-      timeoutMs: SUBAGENT_TIMEOUT_MS,
+    const result = await runPiSubagent(session, task, {
+      maxOutputTokens,
+      hardTimeoutMs: isProductionReviewer
+        ? PRODUCTION_REVIEWER_HARD_TIMEOUT_MS
+        : SUBAGENT_TIMEOUT_MS,
+      ...(isProductionReviewer
+        ? {
+            softTimeoutMs: PRODUCTION_REVIEWER_SOFT_TIMEOUT_MS,
+            maxAssistantTurns: PRODUCTION_REVIEWER_MAX_ASSISTANT_TURNS,
+            maxToolCalls: PRODUCTION_REVIEWER_MAX_TOOL_CALLS,
+            steerPrompt: PRODUCTION_REVIEWER_STEER_PROMPT,
+          }
+        : {}),
     });
-    return { ok: !isFailureOutput(output), output };
+    const { output, ...execution } = result;
+    return {
+      ok: execution.terminationReason === PiSubagentTerminationReason.Settled,
+      output,
+      execution,
+    };
   } catch (err) {
     return {
       ok: false,
       output: `Subagent "${profile.id}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      execution: {
+        terminationReason: PiSubagentTerminationReason.Error,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        assistantTurns: 0,
+        toolCalls: 0,
+        steerRequested: false,
+      },
     };
   } finally {
     if (subSession) {
@@ -421,7 +469,7 @@ export function buildPiSubagentTool(deps: PiSubagentToolDeps): Record<string, un
       return textResult(unknownAgentMessage(spec.agent));
     }
     const result = await runSubagent(deps, profile, spec.task);
-    return textResult(result.output, { agentId: spec.agent });
+    return textResult(result.output, { agentId: spec.agent, execution: result.execution });
   };
 
   const executeParallel = async (specs: SubagentTaskSpec[]): Promise<SubagentToolResult> => {

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -8,7 +8,10 @@ import {
   WorkbenchVerificationOutcome,
 } from '../../shared/workbenchTask';
 import { HarnessMeasurementService } from '../harness/measurementService';
-import { PiSubagentProfileId } from '../libs/agentEngine/piSubagentConstants';
+import {
+  PiSubagentProfileId,
+  PiSubagentTerminationReason,
+} from '../libs/agentEngine/piSubagentConstants';
 import { WorkbenchTaskRepository } from '../workbenchTask/repository';
 import { initializeWorkbenchTaskSchema } from '../workbenchTask/schema';
 import { ProductionLoopController } from './controller';
@@ -118,10 +121,26 @@ test('accepts only the requested read-only reviewer result before delivery', () 
     'review',
     JSON.stringify({ verdict: 'pass', findings: [] }),
     false,
+    {
+      terminationReason: PiSubagentTerminationReason.Settled,
+      durationMs: 1_200,
+      assistantTurns: 2,
+      toolCalls: 1,
+      steerRequested: false,
+    },
   );
   expect(controller.getState()).toMatchObject({
     phase: ProductionLoopPhase.Deliver,
     status: ProductionLoopStatus.ReadyToDeliver,
+    critic: {
+      execution: {
+        durationMs: 1_200,
+        assistantTurns: 2,
+        toolCalls: 1,
+        steerRequested: false,
+        timedOut: false,
+      },
+    },
   });
 
   expect(controller.requestCompletion('ready')).toBe('downstream requested');
@@ -140,6 +159,72 @@ test('invalid critic output enters revision instead of silently passing', () => 
   controller.recordSubagentResult('review', 'looks fine', false);
   expect(controller.getState().phase).toBe(ProductionLoopPhase.Revise);
   expect(controller.getState().critic.findings[0].summary).toContain('invalid structured response');
+});
+
+test('uses structured execution errors instead of parsing result text', () => {
+  const { controller } = createController();
+  reachCritique(controller);
+  controller.recordSubagentStart('review-error', {
+    agent: PiSubagentProfileId.ProductionReviewer,
+    task: 'review',
+  });
+  controller.recordSubagentResult('review-error', 'provider unavailable', false, {
+    terminationReason: PiSubagentTerminationReason.Error,
+    durationMs: 900,
+    assistantTurns: 0,
+    toolCalls: 0,
+    steerRequested: false,
+  });
+
+  expect(controller.getState().phase).toBe(ProductionLoopPhase.Revise);
+  expect(controller.getState().critic.findings[0].summary).toContain(
+    'did not complete successfully',
+  );
+});
+
+test('keeps infrastructure timeouts in critique so the reviewer can retry', () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const { controller } = createController();
+  reachCritique(controller);
+  controller.recordSubagentStart('review-timeout', {
+    agent: PiSubagentProfileId.ProductionReviewer,
+    task: 'review',
+  });
+  controller.recordSubagentResult('review-timeout', '(subagent hard timeout after 180s)', false, {
+    terminationReason: PiSubagentTerminationReason.HardTimeout,
+    durationMs: 180_000,
+    assistantTurns: 6,
+    toolCalls: 6,
+    steerRequested: true,
+  });
+
+  expect(controller.getState()).toMatchObject({
+    phase: ProductionLoopPhase.Critique,
+    status: ProductionLoopStatus.WaitingCritic,
+    critic: {
+      toolCallId: null,
+      passed: false,
+      findings: [],
+      execution: {
+        durationMs: 180_000,
+        assistantTurns: 6,
+        toolCalls: 6,
+        steerRequested: true,
+        timedOut: true,
+      },
+    },
+  });
+
+  controller.recordSubagentStart('review-retry', {
+    agent: PiSubagentProfileId.ProductionReviewer,
+    task: 'retry review',
+  });
+  controller.recordSubagentResult(
+    'review-retry',
+    JSON.stringify({ verdict: 'pass', findings: [] }),
+    false,
+  );
+  expect(controller.getState().phase).toBe(ProductionLoopPhase.Deliver);
 });
 
 test('does not bind grouped subagent calls as the independent reviewer', () => {

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -6,7 +6,11 @@ import {
 } from '../../shared/productionLoop';
 import type { WorkbenchContractKind, WorkbenchJsonObject } from '../../shared/workbenchTask';
 import type { PiAgentLoopEndSignal } from '../libs/agentEngine/piAgentLoop';
-import { PiSubagentProfileId } from '../libs/agentEngine/piSubagentConstants';
+import {
+  PiSubagentProfileId,
+  PiSubagentTerminationReason,
+} from '../libs/agentEngine/piSubagentConstants';
+import type { PiSubagentExecutionMetadata } from '../libs/agentEngine/piSubagentExecution';
 import type { ProductionLoopService } from './service';
 
 interface DownstreamCompletionWorkflow {
@@ -134,10 +138,34 @@ export class ProductionLoopController {
     this.update(this.service.recordCriticStart(this.state.runId, toolCallId));
   }
 
-  recordSubagentResult(toolCallId: string, output: string, isError: boolean): void {
+  recordSubagentResult(
+    toolCallId: string,
+    output: string,
+    isError: boolean,
+    execution?: PiSubagentExecutionMetadata,
+  ): void {
     this.refresh();
     if (this.state.critic.toolCallId !== toolCallId) return;
-    this.update(this.service.recordCriticResult(this.state.runId, toolCallId, output, isError));
+    const criticExecution = execution
+      ? {
+          durationMs: execution.durationMs,
+          assistantTurns: execution.assistantTurns,
+          toolCalls: execution.toolCalls,
+          steerRequested: execution.steerRequested,
+          timedOut: execution.terminationReason === PiSubagentTerminationReason.HardTimeout,
+        }
+      : undefined;
+    const criticFailed =
+      isError || execution?.terminationReason === PiSubagentTerminationReason.Error;
+    this.update(
+      this.service.recordCriticResult(
+        this.state.runId,
+        toolCallId,
+        output,
+        criticFailed,
+        criticExecution,
+      ),
+    );
   }
 
   recordRevision(summary: string, evidence: WorkbenchJsonObject): ProductionLoopState {

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -9,6 +9,7 @@ import {
   ProductionLoopStatus,
   ProductionPlanItemStatus,
   type ProductionCriticFinding,
+  type ProductionCriticExecution,
   type ProductionArtifactEvidence,
   type ProductionExpectedArtifact,
   type ProductionExpectedVerifier,
@@ -176,6 +177,7 @@ export class ProductionLoopService {
         passed: false,
         findings: [],
         outputSummary: null,
+        execution: null,
       },
       revisions: [],
       recoveries: [],
@@ -388,6 +390,7 @@ export class ProductionLoopService {
         passed: false,
         findings: [],
         outputSummary: null,
+        execution: null,
       };
       state.progressVersion += 1;
       this.measurement.recordActivation(runId, {
@@ -436,11 +439,34 @@ export class ProductionLoopService {
     toolCallId: string,
     output: string,
     isError: boolean,
+    execution?: ProductionCriticExecution,
   ): ProductionLoopState {
     return this.mutate(runId, state => {
       if (state.critic.toolCallId !== toolCallId) return;
-      const result = parseCriticPayload(output, isError);
       state.critic.outputSummary = output.slice(0, MAX_CRITIC_OUTPUT_LENGTH);
+      state.critic.execution = execution ?? null;
+      if (execution?.timedOut) {
+        state.critic.toolCallId = null;
+        state.critic.passed = false;
+        state.critic.findings = [];
+        state.progressVersion += 1;
+        console.warn(
+          `[ProductionLoop] critic timed out after ${execution.durationMs}ms; retaining critique phase for retry`,
+        );
+        this.measurement.recordActivation(runId, {
+          activation: HarnessActivationType.RecoveryTriggered,
+          mechanism: 'production_loop_reviewer',
+          evidence: {
+            durationMs: execution.durationMs,
+            assistantTurns: execution.assistantTurns,
+            toolCalls: execution.toolCalls,
+            steerRequested: execution.steerRequested,
+            timedOut: true,
+          },
+        });
+        return;
+      }
+      const result = parseCriticPayload(output, isError);
       state.critic.findings = result.findings;
       state.critic.passed = result.verdict === ProductionCriticVerdict.Pass;
       state.progressVersion += 1;
@@ -568,6 +594,7 @@ export class ProductionLoopService {
           },
         ],
         outputSummary: null,
+        execution: null,
       };
       state.deliveryReason = null;
     });

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -64,12 +64,21 @@ export interface ProductionCriticFinding {
   evidence?: string;
 }
 
+export interface ProductionCriticExecution {
+  durationMs: number;
+  assistantTurns: number;
+  toolCalls: number;
+  steerRequested: boolean;
+  timedOut: boolean;
+}
+
 export interface ProductionCriticState {
   requested: boolean;
   toolCallId: string | null;
   passed: boolean;
   findings: ProductionCriticFinding[];
   outputSummary: string | null;
+  execution: ProductionCriticExecution | null;
 }
 
 export interface ProductionRevision {


### PR DESCRIPTION
## 阶段说明

这是 production loop reviewer 优化的第 2/3 阶段，堆叠在 #397 之上。

本阶段为专用 reviewer 建立可控的执行上界和结构化终止语义；评审契约压缩与已执行证据注入将在第 3 阶段完成。

## 主要变更

- production reviewer 最多执行 6 个 assistant 回合和 6 次工具调用。
- 达到回合、工具或 120 秒软预算时，只触发一次收尾 steer，要求立即返回严格 JSON verdict。
- 180 秒硬超时后结束子会话；通用 subagent 仍保留原有 10 分钟时限。
- production reviewer 的模型输出预算限制为最多 4,000 token，并同步应用到模型和资源加载器。
- 子会话结果新增结构化执行元数据：终止原因、耗时、assistant 回合数、工具调用数和 steer 标记。
- Pi 运行时与评估策略透传执行元数据，production loop 持久化 reviewer 指标。
- reviewer 硬超时被视为基础设施恢复事件：保留在 critique 阶段并允许重试，不生成虚假的实现缺陷。
- reviewer 执行错误通过结构化终止原因识别，不再依赖输出文本前缀。

## 设计边界

- 不改变通用 `reviewer`、`researcher`、`scout`、`planner` 的执行预算。
- 不移除 artifact、verifier 或验收门禁。
- 不在本阶段改变评审上下文的内容与长度。

## 验证

- `npm.cmd test -- piSubagentExecution piSubagentTool productionLoop zhiyuanEvaluationPolicy`：63 个测试通过。
- `npm.cmd run lint`：通过。
- `npm.cmd run build:tsc`：通过。
- `git diff --check`：通过。

## 堆叠关系

- 前置：#397，第 1/3 阶段，专用 production reviewer 与严格协议
- 当前：第 2/3 阶段，结构化执行预算、超时恢复与指标
- 后续：第 3/3 阶段将压缩评审契约并注入有界、脱敏的已执行证据

> 请先审阅并合并 #397；本 PR 只需关注相对 `codex/production-reviewer-profile` 的增量。
