### PR TITLE
feat(cowork): 收窄 production loop 入口门禁

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -189,6 +189,14 @@ vi.mock('./piOpenAICompatProxy', () => ({
   registerPiOpenAICompatUpstream: hoisted.mockRegisterPiOpenAICompatUpstream,
 }));
 
+vi.mock('../coworkUtil', async importOriginal => {
+  const actual = await importOriginal<typeof import('../coworkUtil')>();
+  return {
+    ...actual,
+    resolveGitBashPathForPi: vi.fn(() => undefined),
+  };
+});
+
 import { PiRuntimeAdapter } from './piRuntimeAdapter';
 import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
 import { DeclareArtifactSystemPrompt } from '../../declareArtifact/tool';
@@ -370,7 +378,7 @@ describe('PiRuntimeAdapter', () => {
       expect(onComplete).toHaveBeenCalledOnce();
     });
 
-    it('registers the production loop for Work sessions but not Chat sessions', async () => {
+    it('registers the production loop only for nontrivial Work sessions', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
@@ -378,6 +386,10 @@ describe('PiRuntimeAdapter', () => {
 
       try {
         await adapter.startSession('production-work', 'Build', {
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        await adapter.startSession('production-simple', '为什么天空是蓝色的？', {
           sessionMode: 'work',
           workspaceRoot: createTemporaryWorkspace(),
         });
@@ -389,13 +401,59 @@ describe('PiRuntimeAdapter', () => {
         const workOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
           customTools?: Array<{ name: string }>;
         };
-        const chatOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+        const simpleOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        const chatOptions = mockCreateAgentSession.mock.calls[2]?.[0] as {
           customTools?: Array<{ name: string }>;
         };
         expect(workOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
+        expect(simpleOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+          'production_loop',
+        );
         expect(chatOptions.customTools?.map(tool => tool.name) || []).not.toContain(
           'production_loop',
         );
+      } finally {
+        db.close();
+      }
+    });
+
+    it('rebuilds the production loop topology when follow-up complexity changes', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      adapter.setWorkbenchTaskService(new RealWorkbenchTaskService(db));
+
+      try {
+        await adapter.startSession('adaptive-gate', '你好', {
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        await adapter.continueSession('adaptive-gate', '修复登录流程中的刷新问题', {
+          sessionMode: 'work',
+        });
+        await adapter.continueSession('adaptive-gate', '解释一下事件循环', {
+          sessionMode: 'work',
+        });
+
+        const simpleStart = mockCreateAgentSession.mock.calls[0]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        const complexFollowUp = mockCreateAgentSession.mock.calls[1]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        const simpleFollowUp = mockCreateAgentSession.mock.calls[2]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        expect(simpleStart.customTools?.map(tool => tool.name) || []).not.toContain(
+          'production_loop',
+        );
+        expect(complexFollowUp.customTools?.map(tool => tool.name)).toContain('production_loop');
+        expect(simpleFollowUp.customTools?.map(tool => tool.name) || []).not.toContain(
+          'production_loop',
+        );
+        expect(mockSession.abort).toHaveBeenCalledTimes(2);
       } finally {
         db.close();
       }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -60,6 +60,7 @@ import type {
   WorkbenchTaskService,
 } from '../../workbenchTask/taskService';
 import { ProductionLoopController } from '../../productionLoop/controller';
+import { shouldEnableProductionLoop } from '../../productionLoop/entryPolicy';
 import { buildProductionLoopTool } from '../../productionLoop/tool';
 import {
   type ApiConfigResolution,
@@ -528,6 +529,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         options.sessionMode,
         resourceState.skillIds,
       );
+      const productionLoopEnabled = shouldEnableProductionLoop({
+        sessionMode: options.sessionMode,
+        prompt,
+        goalMode: options.goalMode,
+        skillIds: resourceState.skillIds,
+        expertIds: normalizeExpertIds(options.expertIds),
+        imageAttachmentCount: options.imageAttachments?.length,
+        resumeRun: Boolean(options._workbenchRunId),
+      });
       if (this.workbenchTaskService) {
         const workbench = this.workbenchTaskService.beginRun({
           sessionId,
@@ -746,7 +756,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // loops; the controller continues the session on agent_end.
       const completionWorkflow = researchRun || shortcutWorkflow || workExecution;
       const productionLoop =
-        options.sessionMode === CoworkSessionMode.Work &&
+        productionLoopEnabled &&
         workbenchTaskId &&
         workbenchRunId &&
         this.workbenchTaskService?.productionLoop
@@ -924,11 +934,33 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       options.expertIds === undefined
         ? active.requestedExpertIds
         : normalizeExpertIds(options.expertIds);
-    if (!haveSameStringList(requestedExpertIds, active.requestedExpertIds)) {
+    const requestedSessionMode =
+      options.sessionMode ??
+      (active.workbenchContract.kind === WorkbenchContractKind.Chat
+        ? CoworkSessionMode.Chat
+        : CoworkSessionMode.Work);
+    const productionLoopEnabled = Boolean(
+      this.workbenchTaskService &&
+      shouldEnableProductionLoop({
+        sessionMode: requestedSessionMode,
+        prompt,
+        goalMode: options.goalMode ?? active.goalMode,
+        skillIds: requestedSkillIds,
+        expertIds: requestedExpertIds,
+        imageAttachmentCount: options.imageAttachments?.length,
+        resumeRun: Boolean(options._workbenchRunId),
+      }),
+    );
+    const productionLoopTopologyChanged = productionLoopEnabled !== Boolean(active.productionLoop);
+    if (
+      !haveSameStringList(requestedExpertIds, active.requestedExpertIds) ||
+      productionLoopTopologyChanged
+    ) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
       this.disposeSessionForRecreation(sessionId, active);
       return this.startSession(sessionId, prompt, {
         ...options,
+        sessionMode: requestedSessionMode,
         systemPrompt: requestedSystemPrompt ?? active.requestedSystemPrompt,
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
@@ -945,6 +977,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       this.disposeSessionForRecreation(sessionId, active);
       return this.startSession(sessionId, prompt, {
         ...options,
+        sessionMode: requestedSessionMode,
         systemPrompt: nextSystemPrompt,
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
@@ -978,10 +1011,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     if (this.workbenchTaskService) {
-      const sessionMode =
-        options.sessionMode ??
-        (active.workbenchContract.kind === WorkbenchContractKind.Chat ? 'chat' : 'work');
-      const workbenchContract = this.createWorkbenchContract(sessionMode, requestedSkillIds);
+      const workbenchContract = this.createWorkbenchContract(
+        requestedSessionMode,
+        requestedSkillIds,
+      );
       const workbench = this.workbenchTaskService.beginRun({
         sessionId,
         goal: prompt,

--- a/src/main/productionLoop/entryPolicy.test.ts
+++ b/src/main/productionLoop/entryPolicy.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest';
+
+import { CoworkSessionMode } from '../../shared/cowork/constants';
+import { shouldEnableProductionLoop } from './entryPolicy';
+
+const workRequest = (prompt: string) => ({ sessionMode: CoworkSessionMode.Work, prompt });
+
+test('bypasses production loop for Chat mode and empty Work prompts', () => {
+  expect(
+    shouldEnableProductionLoop({ sessionMode: CoworkSessionMode.Chat, prompt: 'Build an app' }),
+  ).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('  '))).toBe(false);
+});
+
+test('bypasses production loop for simple conversation and information requests', () => {
+  expect(shouldEnableProductionLoop(workRequest('你好'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('为什么天空是蓝色的？'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('Explain how event loops work.'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('什么是单元测试？'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('How do I fix a stale closure?'))).toBe(false);
+});
+
+test('bypasses production loop for explicit lightweight one-step tasks', () => {
+  expect(shouldEnableProductionLoop(workRequest('计算 17 * 23'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('列出当前目录'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('Translate this sentence to Chinese.'))).toBe(
+    false,
+  );
+  expect(shouldEnableProductionLoop(workRequest('你好，帮我翻译这句话'))).toBe(false);
+  expect(shouldEnableProductionLoop(workRequest('当前时间'))).toBe(false);
+});
+
+test('retains production loop for changes and scoped reviews', () => {
+  expect(shouldEnableProductionLoop(workRequest('修复登录流程中的刷新问题'))).toBe(true);
+  expect(shouldEnableProductionLoop(workRequest('Review this repository for regressions.'))).toBe(
+    true,
+  );
+  expect(shouldEnableProductionLoop(workRequest('先修改配置，然后运行测试'))).toBe(true);
+  expect(shouldEnableProductionLoop(workRequest('Can you fix the stale closure?'))).toBe(true);
+});
+
+test('retains production loop for explicit workflow signals and ambiguous Work requests', () => {
+  expect(shouldEnableProductionLoop({ ...workRequest('你好'), goalMode: true })).toBe(true);
+  expect(shouldEnableProductionLoop({ ...workRequest('你好'), skillIds: ['code-review'] })).toBe(
+    true,
+  );
+  expect(shouldEnableProductionLoop({ ...workRequest('Continue'), resumeRun: true })).toBe(true);
+  expect(shouldEnableProductionLoop(workRequest('Handle the request'))).toBe(true);
+});

--- a/src/main/productionLoop/entryPolicy.ts
+++ b/src/main/productionLoop/entryPolicy.ts
@@ -1,0 +1,50 @@
+import {
+  CoworkSessionMode,
+  type CoworkSessionMode as CoworkSessionModeValue,
+} from '../../shared/cowork/constants';
+
+const MAX_LIGHTWEIGHT_PROMPT_LENGTH = 600;
+
+const SIMPLE_CONVERSATION_PATTERN =
+  /^(?:hi|hello|hey|thanks|thank you|ok|okay|你好|您好|嗨|谢谢|多谢|好的|收到|聊聊|随便聊聊)[!.。！?？\s]*$/i;
+const INFORMATION_REQUEST_PATTERN =
+  /^(?:please\s+)?(?:what|why|when|where|who|how|explain|describe|tell me|is|are|can|could|would)\b|^(?:请问|请)?(?:什么|为什么|何时|哪里|谁|怎么|如何|解释|介绍|说明|告诉我|是否|能否|可以|你能)/i;
+const LIGHTWEIGHT_TASK_PATTERN =
+  /^(?:please\s+)?(?:show|list|read|find|search|count|calculate|translate|rewrite|summarize|proofread)\b|^(?:请)?(?:帮我)?(?:查看|列出|读取|查找|搜索|统计|计算|翻译|改写|总结|校对)|^(?:current time|today's date|现在几点|当前时间|今天几号|今天日期)/i;
+const EXECUTION_REQUEST_PATTERN =
+  /^(?:(?:please|can you|could you|would you)\s+)?(?:build|create|write|edit|modify|fix|implement|refactor|develop|test|deploy|install|configure|migrate|optimize|publish|generate|review|audit|inspect)\b|^(?:(?:请|能否|可以|你能)(?:帮我)?)?(?:构建|创建|写|编写|编辑|修改|修复|实现|重构|开发|测试|部署|安装|配置|迁移|优化|发布|生成|审查|审核|检查)|^(?:把|将).+(?:编辑|修改|修复|重构|迁移|优化|发布)/i;
+const MULTI_STEP_PATTERN =
+  /\b(?:multi[- ]step|end[- ]to[- ]end|first.+then|and then)\b|(?:多步骤|完整流程|端到端|先.+再|然后)/i;
+
+export interface ProductionLoopEntryInput {
+  sessionMode?: CoworkSessionModeValue;
+  prompt: string;
+  goalMode?: boolean;
+  skillIds?: string[];
+  expertIds?: string[];
+  imageAttachmentCount?: number;
+  resumeRun?: boolean;
+}
+
+export const shouldEnableProductionLoop = (input: ProductionLoopEntryInput): boolean => {
+  if (input.sessionMode !== CoworkSessionMode.Work) return false;
+  if (input.goalMode || input.skillIds?.length || input.resumeRun) return true;
+
+  const prompt = input.prompt.replace(/\s+/g, ' ').trim();
+  if (!prompt) return false;
+  const intentPrompt = prompt.replace(/^(?:hi|hello|hey|你好|您好|嗨)[,，!！\s]+/i, '');
+  if (EXECUTION_REQUEST_PATTERN.test(intentPrompt) || MULTI_STEP_PATTERN.test(intentPrompt)) {
+    return true;
+  }
+  if (SIMPLE_CONVERSATION_PATTERN.test(prompt)) return false;
+  if (
+    prompt.length <= MAX_LIGHTWEIGHT_PROMPT_LENGTH &&
+    (INFORMATION_REQUEST_PATTERN.test(intentPrompt) || LIGHTWEIGHT_TASK_PATTERN.test(intentPrompt))
+  ) {
+    return false;
+  }
+  if (input.expertIds?.length || input.imageAttachmentCount) return true;
+
+  // Ambiguous Work requests retain the production gate.
+  return true;
+};

--- a/src/main/workbenchTask/riskClassifier.test.ts
+++ b/src/main/workbenchTask/riskClassifier.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest';
 
 import { WorkbenchApprovalRiskLevel } from '../../shared/workbenchTask';
+import { ProductionLoopAction, ProductionLoopToolName } from '../../shared/productionLoop';
 import {
   classifyWorkbenchToolRisk,
   createToolIdempotencyKey,
@@ -28,6 +29,20 @@ test('idempotency hashing is stable across object key order', () => {
   expect(createToolIdempotencyKey('run', 'call', { a: 1, b: 2 })).toBe(
     createToolIdempotencyKey('run', 'call', { b: 2, a: 1 }),
   );
+});
+
+test('only skip_workflow bypasses production loop approval', () => {
+  expect(
+    classifyWorkbenchToolRisk(ProductionLoopToolName, {
+      action: ProductionLoopAction.SkipWorkflow,
+      reason: 'Simple information request',
+    }),
+  ).toBe(WorkbenchApprovalRiskLevel.ReadOnly);
+  expect(
+    classifyWorkbenchToolRisk(ProductionLoopToolName, {
+      action: ProductionLoopAction.CommitPlan,
+    }),
+  ).toBe(WorkbenchApprovalRiskLevel.Unknown);
 });
 
 test('only explicitly read-only shell commands qualify for allow-all auto approval', () => {

--- a/src/main/workbenchTask/riskClassifier.ts
+++ b/src/main/workbenchTask/riskClassifier.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 
 import { WorkbenchApprovalRiskLevel } from '../../shared/workbenchTask';
+import { ProductionLoopAction, ProductionLoopToolName } from '../../shared/productionLoop';
 
 const readOnlyTools = new Set(['read', 'grep', 'find', 'ls', 'skill_runtime_capabilities']);
 const internalControlTools = new Set([
@@ -33,6 +34,12 @@ export function classifyWorkbenchToolRisk(
   input: Record<string, unknown>,
 ): WorkbenchApprovalRiskLevel {
   const normalizedName = toolName.trim().toLowerCase();
+  if (
+    normalizedName === ProductionLoopToolName &&
+    input.action === ProductionLoopAction.SkipWorkflow
+  ) {
+    return WorkbenchApprovalRiskLevel.ReadOnly;
+  }
   if (readOnlyTools.has(normalizedName) || internalControlTools.has(normalizedName)) {
     return WorkbenchApprovalRiskLevel.ReadOnly;
   }

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -13,8 +13,10 @@ import {
   WorkbenchVerificationOutcome,
 } from '../../shared/workbenchTask';
 import {
+  ProductionLoopAction,
   ProductionLoopPhase,
   ProductionLoopStatus,
+  ProductionLoopToolName,
   ProductionPlanItemStatus,
 } from '../../shared/productionLoop';
 import { initializeWorkbenchTaskSchema } from './schema';
@@ -287,6 +289,37 @@ test('successful side effects are not authorized twice', async () => {
     const duplicate = await service.authorizeToolCall(input);
     expect(duplicate.allow).toBe(false);
     expect(duplicate.reason).toContain('Reuse the persisted result: {"ok":true}');
+  } finally {
+    db.close();
+  }
+});
+
+test('skip_workflow executes without creating a user approval', async () => {
+  const { db, service } = createService();
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'Explain the current state',
+      contract: {
+        kind: WorkbenchContractKind.GenericWork,
+        requiresUserAcceptance: true,
+      },
+    });
+
+    await expect(
+      service.authorizeToolCall({
+        sessionId: 'session',
+        runId: run.id,
+        toolCallId: 'skip-call',
+        toolName: ProductionLoopToolName,
+        toolInput: {
+          action: ProductionLoopAction.SkipWorkflow,
+          reason: 'Simple information request',
+        },
+        autoApprove: false,
+      }),
+    ).resolves.toEqual({ allow: true });
+    expect(service.getDetail(task.id)?.approvals).toEqual([]);
   } finally {
     db.close();
   }


### PR DESCRIPTION
## 阶段说明

这是 production loop 优化的独立入口门禁阶段，堆叠在 #399 之上。

本阶段解决 Work 模式一律注册 `production_loop` 导致简单对话和简单任务进入完整生产流程的问题，同时让 `skip_workflow` 作为无副作用控制动作直接执行，不再弹出用户审批。

## 主要变更

- 新增独立、可测试的 production loop 入口策略。
- Chat 模式始终不注册 production loop。
- Work 模式中的明确轻量请求直接绕过：
  - 问候、致谢和普通闲聊。
  - 事实问答、概念解释和咨询类问题。
  - 计算、翻译、改写、总结、读取、列出、搜索等明确单步任务。
- 下列请求仍强制进入 production loop：
  - 明确要求创建、修改、修复、实现、测试、部署、审查等执行动作。
  - 多步骤或端到端任务。
  - Goal 模式、显式技能工作流和 Resume/Retry 运行。
- 模糊的 Work 请求默认保留 production loop，避免复杂任务被误判为简单任务。
- 首轮与续聊使用同一入口策略；请求复杂度跨档变化时重建 Pi 工具拓扑，覆盖“简单 → 复杂”和“复杂 → 简单”。
- 仅将 `production_loop` 的 `skip_workflow` 动作分类为只读内部控制调用，因此无需用户审批。
- `commit_plan`、`start_inspection`、`request_critique` 等其他 production loop 动作的审批语义保持不变。

## 判定边界

- 判定不只依赖文本长度，而是组合会话模式、Goal、技能、恢复运行和明确意图。
- “什么是单元测试”“如何修复 stale closure”属于咨询，直接回答。
- “请修复 stale closure”“审查这个仓库”属于执行请求，进入 production loop。
- 明确轻量请求最长允许 600 字符；超过上限或语义模糊时保守进入门禁。
- 选择专家或携带图片本身不会覆盖明确的简单问答，但会使其他模糊请求保守进入门禁。

## 审批边界

- `skip_workflow` 只改变内部 workflow 状态，不写文件、不执行命令、不产生外部副作用，因此可安全免审批。
- 免审批匹配同时校验工具名和 action，不能被其他 production loop 动作复用。
- 写入、shell、MCP 和其他未知风险工具仍使用原授权策略。

## 验证

### 通过

- `npm.cmd test -- entryPolicy riskClassifier taskService productionLoop piRuntimeAdapter zhiyuanEvaluationPolicy`：10 个测试文件、144 个测试通过。
- `npm.cmd run build`：完整 TypeScript、renderer、Electron main/preload 构建通过。
- `npm.cmd run lint`：通过。
- `git diff --check`：通过。

### 全量测试

`npm.cmd test`：2,073 通过、1 跳过、7 失败。

剩余 7 个失败均为当前 Windows 环境的既有问题：

- 缺少 `python3`，导致 PDF/XLSX skill smoke 测试失败。
- release manifest 测试错误解析 Windows 盘符路径。
- skill runtime 测试的 Electron mock 缺少 `process.resourcesPath`。

## 堆叠关系

- 前置：#399，紧凑评审契约与有界执行证据。
- 当前：production loop 入口收窄与 `skip_workflow` 免审批。

> 请在 #399 之后审阅和合并；本 PR 只需关注相对 `codex/production-reviewer-contract` 的增量。
