### PR TITLE
feat(cowork): 为 production reviewer 增加分段读取预算

### DIFF
--- a/src/main/libs/agentEngine/piExtensionTypes.ts
+++ b/src/main/libs/agentEngine/piExtensionTypes.ts
@@ -1,0 +1,37 @@
+export const PiExtensionEventType = {
+  ToolCall: 'tool_call',
+  ToolResult: 'tool_result',
+} as const;
+
+export interface PiToolCallEvent {
+  toolCallId: string;
+  toolName: string;
+  input?: unknown;
+}
+
+export interface PiToolResultEvent {
+  toolCallId: string;
+  toolName: string;
+  input?: unknown;
+  isError: boolean;
+}
+
+export interface PiToolCallEventResult {
+  block: true;
+  reason: string;
+}
+
+export interface PiExtensionApi {
+  on(
+    event: typeof PiExtensionEventType.ToolCall,
+    handler: (
+      event: PiToolCallEvent,
+    ) => PiToolCallEventResult | undefined | Promise<PiToolCallEventResult | undefined>,
+  ): void;
+  on(
+    event: typeof PiExtensionEventType.ToolResult,
+    handler: (event: PiToolResultEvent) => void | Promise<void>,
+  ): void;
+}
+
+export type PiExtensionFactory = (extensionApi: PiExtensionApi) => void;

--- a/src/main/libs/agentEngine/piReviewerReadBudget.test.ts
+++ b/src/main/libs/agentEngine/piReviewerReadBudget.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  PiExtensionEventType,
+  type PiExtensionApi,
+  type PiToolCallEvent,
+  type PiToolResultEvent,
+} from './piExtensionTypes';
+import {
+  createPiReviewerReadBudgetExtension,
+  PiReviewerReadBudget,
+  PiReviewerReadToolName,
+} from './piReviewerReadBudget';
+
+const temporaryDirectories: string[] = [];
+
+const createWorkspace = (): string => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-reviewer-read-budget-'));
+  temporaryDirectories.push(workspace);
+  return workspace;
+};
+
+const readCall = (toolCallId: string, input: Record<string, unknown>): PiToolCallEvent => ({
+  toolCallId,
+  toolName: PiReviewerReadToolName.Read,
+  input,
+});
+
+const readResult = (toolCallId: string, isError = false): PiToolResultEvent => ({
+  toolCallId,
+  toolName: PiReviewerReadToolName.Read,
+  isError,
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('PiReviewerReadBudget', () => {
+  it('blocks an exact file range after its first request', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { path: 'src/app.ts', offset: 10, limit: 50 })),
+    ).toBeUndefined();
+    expect(
+      budget.handleToolCall(readCall('read-2', { path: 'src/app.ts', offset: 10, limit: 50 })),
+    ).toMatchObject({ block: true, reason: expect.stringContaining('exact file range') });
+  });
+
+  it('allows distinct ranges from the same file', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { path: 'src/app.ts', offset: 1, limit: 100 })),
+    ).toBeUndefined();
+    expect(
+      budget.handleToolCall(readCall('read-2', { path: 'src/app.ts', offset: 101, limit: 100 })),
+    ).toBeUndefined();
+  });
+
+  it('supports path aliases and canonicalizes relative and absolute paths', () => {
+    const workspace = createWorkspace();
+    const sourceDirectory = path.join(workspace, 'src');
+    const filePath = path.join(sourceDirectory, 'app.ts');
+    fs.mkdirSync(sourceDirectory);
+    fs.writeFileSync(filePath, 'export const app = true;');
+    const budget = new PiReviewerReadBudget(workspace);
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { file_path: path.join('src', 'app.ts') })),
+    ).toBeUndefined();
+    expect(
+      budget.handleToolCall(readCall('read-2', { path: filePath, offset: 1, limit: 2_000 })),
+    ).toMatchObject({ block: true });
+  });
+
+  it('normalizes path casing when the filesystem is case-insensitive', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace(), {
+      caseInsensitivePaths: true,
+    });
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { path: path.join('src', 'File.ts') })),
+    ).toBeUndefined();
+    expect(
+      budget.handleToolCall(readCall('read-2', { path: path.join('SRC', 'file.ts') })),
+    ).toMatchObject({ block: true });
+  });
+
+  it('blocks a fourth range from the same file', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+    for (let index = 0; index < 3; index += 1) {
+      expect(
+        budget.handleToolCall(
+          readCall(`read-${index}`, {
+            path: 'src/app.ts',
+            offset: index * 100 + 1,
+            limit: 100,
+          }),
+        ),
+      ).toBeUndefined();
+    }
+
+    expect(
+      budget.handleToolCall(readCall('read-4', { path: 'src/app.ts', offset: 301, limit: 100 })),
+    ).toMatchObject({ block: true, reason: expect.stringContaining('per-file read budget') });
+  });
+
+  it('blocks ranges that exceed the cumulative requested-line budget', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { path: 'src/app.ts', offset: 1, limit: 4_000 })),
+    ).toBeUndefined();
+    expect(
+      budget.handleToolCall(
+        readCall('read-2', { path: 'src/app.ts', offset: 4_001, limit: 2_001 }),
+      ),
+    ).toMatchObject({ block: true, reason: expect.stringContaining('requested-line') });
+  });
+
+  it('rolls back a failed read so the same range can be retried', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+
+    expect(
+      budget.handleToolCall(readCall('read-1', { path: 'src/app.ts', offset: 1, limit: 100 })),
+    ).toBeUndefined();
+    budget.handleToolResult(readResult('read-1', true));
+
+    expect(
+      budget.handleToolCall(readCall('read-2', { path: 'src/app.ts', offset: 1, limit: 100 })),
+    ).toBeUndefined();
+  });
+
+  it('does not budget non-read tools', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+    const event = { toolCallId: 'grep-1', toolName: 'grep', input: { path: 'src/app.ts' } };
+
+    expect(budget.handleToolCall(event)).toBeUndefined();
+    expect(budget.handleToolCall(event)).toBeUndefined();
+  });
+
+  it('signals budget exhaustion once and registers both extension hooks', () => {
+    const budget = new PiReviewerReadBudget(createWorkspace());
+    const listener = vi.fn();
+    budget.subscribeLimitExceeded(listener);
+    const handlers = new Map<string, (event: PiToolCallEvent | PiToolResultEvent) => unknown>();
+
+    createPiReviewerReadBudgetExtension(budget)({
+      on: (event: string, handler: (value: never) => unknown) => {
+        handlers.set(event, handler as (value: PiToolCallEvent | PiToolResultEvent) => unknown);
+      },
+    } as unknown as PiExtensionApi);
+
+    expect(handlers.has(PiExtensionEventType.ToolCall)).toBe(true);
+    expect(handlers.has(PiExtensionEventType.ToolResult)).toBe(true);
+    handlers.get(PiExtensionEventType.ToolCall)?.(readCall('read-1', { path: 'src/app.ts' }));
+    handlers.get(PiExtensionEventType.ToolCall)?.(readCall('read-2', { path: 'src/app.ts' }));
+    handlers.get(PiExtensionEventType.ToolCall)?.(readCall('read-3', { path: 'src/app.ts' }));
+
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});

--- a/src/main/libs/agentEngine/piReviewerReadBudget.ts
+++ b/src/main/libs/agentEngine/piReviewerReadBudget.ts
@@ -1,0 +1,169 @@
+import * as fs from 'fs';
+import path from 'path';
+
+import {
+  PiExtensionEventType,
+  type PiExtensionFactory,
+  type PiToolCallEvent,
+  type PiToolCallEventResult,
+  type PiToolResultEvent,
+} from './piExtensionTypes';
+
+export const PiReviewerReadBudgetLimit = {
+  DefaultRangeLines: 2_000,
+  MaxRangesPerFile: 3,
+  MaxRequestedLinesPerFile: 6_000,
+} as const;
+
+export const PiReviewerReadToolName = {
+  Read: 'read',
+} as const;
+
+const PiReviewerReadBudgetBlockReason = {
+  DuplicateRange:
+    'This exact file range was already read. Reuse the existing evidence or inspect a different range, then return the verdict.',
+  RangeLimit:
+    'The per-file read budget is exhausted. Reuse the existing evidence and return the best-supported verdict now.',
+  LineLimit:
+    'The per-file requested-line budget is exhausted. Reuse the existing evidence and return the best-supported verdict now.',
+} as const;
+
+interface ReviewerReadRequest {
+  pathKey: string;
+  rangeKey: string;
+  requestedLines: number;
+}
+
+interface ReviewerFileReadState {
+  rangeKeys: Set<string>;
+  requestedLines: number;
+}
+
+export interface PiReviewerReadBudgetOptions {
+  caseInsensitivePaths?: boolean;
+}
+
+const readPositiveInteger = (value: unknown, fallback: number): number | undefined => {
+  if (value === undefined) return fallback;
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+};
+
+const extractReadRequest = (
+  workspaceRoot: string,
+  input: unknown,
+  caseInsensitivePaths: boolean,
+): ReviewerReadRequest | undefined => {
+  if (!input || typeof input !== 'object') return undefined;
+  const rawInput = input as Record<string, unknown>;
+  const rawPath =
+    typeof rawInput.path === 'string'
+      ? rawInput.path
+      : typeof rawInput.file_path === 'string'
+        ? rawInput.file_path
+        : undefined;
+  if (!rawPath) return undefined;
+
+  const offset = readPositiveInteger(rawInput.offset, 1);
+  const limit = readPositiveInteger(rawInput.limit, PiReviewerReadBudgetLimit.DefaultRangeLines);
+  if (offset === undefined || limit === undefined) return undefined;
+
+  let resolvedPath = path.normalize(path.resolve(workspaceRoot, rawPath));
+  try {
+    if (fs.existsSync(resolvedPath)) {
+      resolvedPath = path.normalize(fs.realpathSync.native(resolvedPath));
+    }
+  } catch {
+    // Let the read tool report filesystem errors; budget identity falls back to the resolved path.
+  }
+  const pathKey = caseInsensitivePaths ? resolvedPath.toLowerCase() : resolvedPath;
+  return {
+    pathKey,
+    rangeKey: `${offset}:${limit}`,
+    requestedLines: limit,
+  };
+};
+
+export class PiReviewerReadBudget {
+  private readonly fileStates = new Map<string, ReviewerFileReadState>();
+  private readonly pendingRequests = new Map<string, ReviewerReadRequest>();
+  private readonly limitListeners = new Set<() => void>();
+  private readonly caseInsensitivePaths: boolean;
+  private limitSignalled = false;
+
+  constructor(
+    private readonly workspaceRoot: string,
+    options: PiReviewerReadBudgetOptions = {},
+  ) {
+    this.caseInsensitivePaths = options.caseInsensitivePaths ?? process.platform === 'win32';
+  }
+
+  subscribeLimitExceeded(listener: () => void): () => void {
+    this.limitListeners.add(listener);
+    return () => this.limitListeners.delete(listener);
+  }
+
+  handleToolCall(event: PiToolCallEvent): PiToolCallEventResult | undefined {
+    if (event.toolName.toLowerCase() !== PiReviewerReadToolName.Read) return undefined;
+    const request = extractReadRequest(this.workspaceRoot, event.input, this.caseInsensitivePaths);
+    if (!request) return undefined;
+
+    const state = this.fileStates.get(request.pathKey) ?? {
+      rangeKeys: new Set<string>(),
+      requestedLines: 0,
+    };
+    if (state.rangeKeys.has(request.rangeKey)) {
+      return this.block(PiReviewerReadBudgetBlockReason.DuplicateRange);
+    }
+    if (state.rangeKeys.size >= PiReviewerReadBudgetLimit.MaxRangesPerFile) {
+      return this.block(PiReviewerReadBudgetBlockReason.RangeLimit);
+    }
+    if (
+      state.requestedLines + request.requestedLines >
+      PiReviewerReadBudgetLimit.MaxRequestedLinesPerFile
+    ) {
+      return this.block(PiReviewerReadBudgetBlockReason.LineLimit);
+    }
+
+    state.rangeKeys.add(request.rangeKey);
+    state.requestedLines += request.requestedLines;
+    this.fileStates.set(request.pathKey, state);
+    this.pendingRequests.set(event.toolCallId, request);
+    return undefined;
+  }
+
+  handleToolResult(event: PiToolResultEvent): void {
+    const request = this.pendingRequests.get(event.toolCallId);
+    if (!request) return;
+    this.pendingRequests.delete(event.toolCallId);
+    if (!event.isError) return;
+
+    const state = this.fileStates.get(request.pathKey);
+    if (!state) return;
+    state.rangeKeys.delete(request.rangeKey);
+    state.requestedLines = Math.max(0, state.requestedLines - request.requestedLines);
+    if (state.rangeKeys.size === 0) {
+      this.fileStates.delete(request.pathKey);
+    }
+  }
+
+  private block(reason: string): PiToolCallEventResult {
+    if (!this.limitSignalled) {
+      this.limitSignalled = true;
+      for (const listener of this.limitListeners) {
+        try {
+          listener();
+        } catch (error) {
+          console.warn('[PiReviewerReadBudget] failed to signal the read limit:', error);
+        }
+      }
+    }
+    return { block: true, reason };
+  }
+}
+
+export const createPiReviewerReadBudgetExtension =
+  (budget: PiReviewerReadBudget): PiExtensionFactory =>
+  extensionApi => {
+    extensionApi.on(PiExtensionEventType.ToolCall, event => budget.handleToolCall(event));
+    extensionApi.on(PiExtensionEventType.ToolResult, event => budget.handleToolResult(event));
+  };

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -89,6 +89,11 @@ import {
 } from './piShortcutWorkflow';
 import { buildPiShortcutWorkflowStateTool } from './piShortcutWorkflowStateTool';
 import { registerPiOpenAICompatUpstream } from './piOpenAICompatProxy';
+import {
+  PiExtensionEventType,
+  type PiExtensionApi,
+  type PiExtensionFactory,
+} from './piExtensionTypes';
 import { extractPiSubagentExecutionMetadata } from './piSubagentExecution';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { buildPiSkillScriptTool } from './piSkillScriptTool';
@@ -277,19 +282,6 @@ interface PiResourceLoader {
 interface PiSettingsManager {
   applyOverrides(overrides: { shellPath?: string }): void;
   getShellPath?(): string | undefined;
-}
-
-interface PiToolCallEvent {
-  toolCallId: string;
-  toolName: string;
-  input?: unknown;
-}
-
-interface PiExtensionApi {
-  on(
-    event: 'tool_call',
-    handler: (event: PiToolCallEvent) => Promise<{ block: true; reason: string } | undefined>,
-  ): void;
 }
 
 interface PiResourceState {
@@ -730,7 +722,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           researchRun || shortcutKind === ShortcutWorkflowKind.DeepResearch
             ? path.join(getSkillsRoot(), 'web-search')
             : undefined,
-        createPiResourceLoader: (cwd, systemPrompt, maxOutputTokens, skillIds) =>
+        createPiResourceLoader: (
+          cwd,
+          systemPrompt,
+          maxOutputTokens,
+          skillIds,
+          extensionFactories,
+        ) =>
           this.createPiResourceLoader(
             pi,
             cwd,
@@ -746,6 +744,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               getAutoApprove: () =>
                 this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
             },
+            extensionFactories,
           ),
       });
       if (subagentTool) {
@@ -1511,6 +1510,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       settingsManager?: PiSettingsManager | null;
       getAutoApprove: () => boolean;
     },
+    additionalExtensionFactories: PiExtensionFactory[] = [],
   ): Promise<PiResourceLoader> {
     const settingsManager =
       approvalContext?.settingsManager ?? this.createPiSettingsManager(pi, cwd);
@@ -1548,39 +1548,42 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           : []),
         DeclareArtifactSystemPrompt,
       ],
-      extensionFactories: approvalContext?.getRunId()
-        ? [
-            (extensionApi: PiExtensionApi) => {
-              extensionApi.on('tool_call', async event => {
-                const runId = approvalContext.getRunId();
-                if (!runId) {
-                  return {
-                    block: true as const,
-                    reason: 'No active workbench run is available.',
-                  };
-                }
-                const toolInput =
-                  event.input && typeof event.input === 'object'
-                    ? (event.input as Record<string, unknown>)
-                    : {};
-                const authorization = await this.workbenchTaskService?.authorizeToolCall({
-                  sessionId: approvalContext.sessionId,
-                  runId,
-                  toolCallId: event.toolCallId,
-                  toolName: event.toolName,
-                  toolInput,
-                  autoApprove: approvalContext.getAutoApprove(),
-                });
-                return authorization && !authorization.allow
-                  ? {
+      extensionFactories: [
+        ...(approvalContext?.getRunId()
+          ? [
+              (extensionApi: PiExtensionApi) => {
+                extensionApi.on(PiExtensionEventType.ToolCall, async event => {
+                  const runId = approvalContext.getRunId();
+                  if (!runId) {
+                    return {
                       block: true as const,
-                      reason: authorization.reason || 'The action was not approved.',
-                    }
-                  : undefined;
-              });
-            },
-          ]
-        : [],
+                      reason: 'No active workbench run is available.',
+                    };
+                  }
+                  const toolInput =
+                    event.input && typeof event.input === 'object'
+                      ? (event.input as Record<string, unknown>)
+                      : {};
+                  const authorization = await this.workbenchTaskService?.authorizeToolCall({
+                    sessionId: approvalContext.sessionId,
+                    runId,
+                    toolCallId: event.toolCallId,
+                    toolName: event.toolName,
+                    toolInput,
+                    autoApprove: approvalContext.getAutoApprove(),
+                  });
+                  return authorization && !authorization.allow
+                    ? {
+                        block: true as const,
+                        reason: authorization.reason || 'The action was not approved.',
+                      }
+                    : undefined;
+                });
+              },
+            ]
+          : []),
+        ...additionalExtensionFactories,
+      ],
     });
     await resourceLoader.reload();
     // Pi's resource reload refreshes settings from disk, so apply the resolved

--- a/src/main/libs/agentEngine/piSubagentExecution.test.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.test.ts
@@ -245,6 +245,35 @@ test('requests at most one bounded steer when review budgets are exhausted', asy
   });
 });
 
+test('steers once without terminating when an external review budget is exhausted', async () => {
+  const { session, emit, resolvePrompt } = createSession();
+  let signalLimitExceeded = (): void => {};
+  const unsubscribeSignal = vi.fn();
+  const output = runPiSubagent(session, 'Review it', {
+    maxOutputTokens: 4096,
+    hardTimeoutMs: 10_000,
+    steerPrompt: 'Return the verdict now.',
+    steerSignal: {
+      subscribeLimitExceeded: listener => {
+        signalLimitExceeded = listener;
+        return unsubscribeSignal;
+      },
+    },
+  });
+
+  signalLimitExceeded();
+  signalLimitExceeded();
+  expect(session.steer).toHaveBeenCalledOnce();
+
+  emit({ type: PiSubagentEventType.AgentSettled });
+  resolvePrompt();
+  await expect(output).resolves.toMatchObject({
+    terminationReason: 'settled',
+    steerRequested: true,
+  });
+  expect(unsubscribeSignal).toHaveBeenCalledOnce();
+});
+
 test('steers at the soft timeout and returns structured hard-timeout metadata', async () => {
   vi.useFakeTimers();
   try {

--- a/src/main/libs/agentEngine/piSubagentExecution.ts
+++ b/src/main/libs/agentEngine/piSubagentExecution.ts
@@ -44,6 +44,9 @@ export type RunPiSubagentOptions = {
   maxAssistantTurns?: number;
   maxToolCalls?: number;
   steerPrompt?: string;
+  steerSignal?: {
+    subscribeLimitExceeded(listener: () => void): () => void;
+  };
 };
 
 export interface PiSubagentExecutionMetadata {
@@ -81,6 +84,7 @@ export const runPiSubagent = (
     let toolCalls = 0;
     let steerRequested = false;
     let unsubscribe = (): void => {};
+    let unsubscribeSteerSignal = (): void => {};
     let softTimeout: ReturnType<typeof setTimeout> | undefined;
 
     const finish = (output: string, terminationReason: PiSubagentTerminationReasonValue): void => {
@@ -89,6 +93,7 @@ export const runPiSubagent = (
       clearTimeout(hardTimeout);
       if (softTimeout) clearTimeout(softTimeout);
       unsubscribe();
+      unsubscribeSteerSignal();
       resolve({
         output,
         terminationReason,
@@ -105,6 +110,7 @@ export const runPiSubagent = (
       clearTimeout(hardTimeout);
       if (softTimeout) clearTimeout(softTimeout);
       unsubscribe();
+      unsubscribeSteerSignal();
       reject(error);
     };
 
@@ -174,7 +180,13 @@ export const runPiSubagent = (
         }
       });
       unsubscribe = subscribedUnsubscribe;
-      if (settled) subscribedUnsubscribe();
+      if (settled) {
+        subscribedUnsubscribe();
+        return;
+      }
+      if (options.steerSignal) {
+        unsubscribeSteerSignal = options.steerSignal.subscribeLimitExceeded(requestSteer);
+      }
     } catch (error) {
       fail(error);
       return;

--- a/src/main/libs/agentEngine/piSubagentTool.test.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.test.ts
@@ -285,6 +285,8 @@ describe('buildPiSubagentTool', () => {
           '/tmp/workspace',
           expect.stringContaining('Respond with exactly one JSON object'),
           PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS,
+          undefined,
+          [expect.any(Function)],
         );
       } finally {
         fs.rmSync(agentsDir, { recursive: true, force: true });
@@ -331,8 +333,10 @@ describe('buildPiSubagentTool', () => {
       expect(options.model).toMatchObject({ maxTokens: PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS });
       expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
         '/tmp/workspace',
-        expect.stringContaining('Respond with exactly one JSON object'),
+        expect.stringContaining('Do not repeat an exact range'),
         PRODUCTION_REVIEWER_MAX_OUTPUT_TOKENS,
+        undefined,
+        [expect.any(Function)],
       );
       expect(result.details).toMatchObject({
         execution: {
@@ -342,6 +346,21 @@ describe('buildPiSubagentTool', () => {
           steerRequested: false,
         },
       });
+    });
+
+    it('does not apply the production read budget to the ordinary reviewer', async () => {
+      const { tool, deps } = buildTool();
+
+      await tool.execute('call-1', {
+        agent: PiSubagentProfileId.Reviewer,
+        task: 'review the implementation',
+      });
+
+      expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
+        '/tmp/workspace',
+        expect.stringContaining('code review subagent'),
+        4096,
+      );
     });
 
     it('surfaces a sub-session error as the tool output', async () => {

--- a/src/main/libs/agentEngine/piSubagentTool.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.ts
@@ -31,6 +31,8 @@ import {
   type PiSubagentExecutionMetadata,
   type PiSubagentSession,
 } from './piSubagentExecution';
+import type { PiExtensionFactory } from './piExtensionTypes';
+import { createPiReviewerReadBudgetExtension, PiReviewerReadBudget } from './piReviewerReadBudget';
 
 // ── Constants ──
 
@@ -101,6 +103,7 @@ export interface PiSubagentToolDeps {
     systemPrompt: string,
     maxOutputTokens: number,
     skillIds?: string[],
+    extensionFactories?: PiExtensionFactory[],
   ): Promise<unknown>;
 }
 
@@ -171,6 +174,7 @@ const BUILTIN_AGENT_PROFILES: ReadonlyArray<Omit<SubagentProfile, 'source'>> = [
       'Review the implementation and supplied execution evidence against the assigned contract.',
       'Check correctness, required artifacts, deterministic verification, edge cases, and regressions.',
       'Prioritize the supplied contract and execution evidence. Inspect at most 3 files, and only when evidence is insufficient.',
+      'Read files in targeted ranges. Do not repeat an exact range; each file allows at most 3 ranges and 6000 requested lines.',
       'Never modify files. If evidence is insufficient, return revise with a concrete finding.',
       'Respond with exactly one JSON object and no Markdown or surrounding text:',
       '{"verdict":"pass"|"revise","findings":[{"severity":"critical"|"major"|"minor","summary":"...","evidence":"..."}]}',
@@ -302,16 +306,21 @@ async function runSubagent(
     }
     const researcherUsesWebSearch =
       profile.id === PiSubagentProfileId.Researcher && Boolean(deps.webSearchSkillPath);
+    const reviewerReadBudget = isProductionReviewer ? new PiReviewerReadBudget(cwd) : undefined;
     const systemPrompt = researcherUsesWebSearch
       ? `${profile.systemPrompt}\n\nYou have an explicit retrieval capability. Before reporting a web claim, run the bundled web-search skill with Bash:\n` +
         `bash "${path.join(deps.webSearchSkillPath || '', 'scripts/search.sh')}" "<query>" 10\n` +
         'Open the returned primary sources where possible. Never substitute model memory for a retrieved citation.'
       : profile.systemPrompt;
-    const resourceLoader = researcherUsesWebSearch
-      ? await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens, [
-          CoreSkillId.WebSearch,
+    const resourceLoader = reviewerReadBudget
+      ? await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens, undefined, [
+          createPiReviewerReadBudgetExtension(reviewerReadBudget),
         ])
-      : await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens);
+      : researcherUsesWebSearch
+        ? await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens, [
+            CoreSkillId.WebSearch,
+          ])
+        : await deps.createPiResourceLoader(cwd, systemPrompt, maxOutputTokens);
     subOptions.resourceLoader = resourceLoader;
     if (
       resourceLoader &&
@@ -338,6 +347,7 @@ async function runSubagent(
             maxAssistantTurns: PRODUCTION_REVIEWER_MAX_ASSISTANT_TURNS,
             maxToolCalls: PRODUCTION_REVIEWER_MAX_TOOL_CALLS,
             steerPrompt: PRODUCTION_REVIEWER_STEER_PROMPT,
+            steerSignal: reviewerReadBudget,
           }
         : {}),
     });


### PR DESCRIPTION
## 阶段定位

这是 production loop 收敛工作的第二阶段，堆叠在 #401 之上。本阶段只约束 `production-reviewer` 的文件读取行为，不改变通用 researcher、scout、planner 和 reviewer。

## 背景

“每个文件最多 read 一次”会把合理的分段复查与无效重复读取混为一谈：大文件无法按区间补证，首次读取失败也可能永久失去重试机会。另一方面，完全不限制重复读取又会浪费 reviewer 的工具轮次，拖慢门禁结论。

本 PR 改为基于规范化路径和读取区间的前置预算控制，在工具真正执行前阻止完全重复或超预算读取。

## 主要变更

- 新增 production reviewer 专用读取预算控制器，并通过 Pi extension 的 `tool_call` / `tool_result` 生命周期接入。
- 使用规范化绝对路径识别文件；文件存在时解析真实路径，Windows 下统一路径大小写，同时兼容 `path` 与 `file_path` 参数。
- 以 `offset + limit` 作为读取区间签名；相同区间禁止重复执行，不同区间仍可继续补证。
- 每个文件最多读取 3 个区间，累计最多请求 6000 行；未指定 `limit` 时按 Pi 默认的 2000 行计入。
- 在工具调用阶段预留额度，读取失败后通过 `tool_result` 回滚，允许同一区间重新尝试。
- 预算耗尽时只触发一次既有 bounded steer，要求 reviewer 基于现有证据立即返回 JSON verdict；不会新增硬终止原因。
- 资源加载器会合并预算 extension 与现有审批 extension，保持原授权顺序和行为。
- reviewer 系统提示同步说明分段读取规则和预算边界。

## 行为边界

| 场景 | 结果 |
| --- | --- |
| 同一文件、相同 `offset/limit` | 执行前阻止，并触发一次 steer |
| 同一文件、不同区间 | 在预算内允许 |
| 第 4 个区间 | 执行前阻止 |
| 累计请求超过 6000 行 | 执行前阻止 |
| 首次读取失败 | 回滚额度，允许重试 |
| 非 `read` 工具 | 不受读取预算影响 |
| 普通 reviewer / 其他 subagent | 不注入该机制 |

该实现不伪装缓存命中：当前 Pi API 只能在执行前阻止工具，无法在不执行工具的情况下安全返回历史结果。

## 验证

- 相关测试：`113 passed`
- 完整构建：通过
- Electron 主进程编译：通过
- TypeScript 检查：通过
- `npm run lint`：通过
- `git diff --check`：通过
- 全量测试：`2084 passed, 1 skipped, 7 failed`

全量测试中的 7 个失败与 #401 基线同类，均为既有 Windows 环境问题：缺少 `python3` 的 PDF/XLSX smoke、release manifest 对 Windows 盘符的解析，以及 skill runtime 测试中的 Electron mock 缺少 `process.resourcesPath`。

## 合并顺序

1. 先合并 #401。
2. 再将本 PR 合并到 `main`，或在 #401 合并后将本分支变基到最新 `main`。
