### PR TITLE
修复轻量会话误触发生产门禁和假错误提示

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -300,6 +300,7 @@ describe('PiRuntimeAdapter', () => {
 
         expect(mockSession.prompt).toHaveBeenLastCalledWith(
           expect.stringContaining('workflow continuation'),
+          { streamingBehavior: 'followUp' },
         );
       } finally {
         fs.rmSync(workspaceRoot, { recursive: true, force: true });
@@ -312,11 +313,15 @@ describe('PiRuntimeAdapter', () => {
       adapter.on('permissionRequest', onPermissionRequest);
       adapter.on('complete', onComplete);
 
-      await adapter.startSession('generic-work-skill', 'Analyze this codebase', {
-        skillIds: ['code-review'],
-        sessionMode: 'work',
-        workspaceRoot: createTemporaryWorkspace(),
-      });
+      await adapter.startSession(
+        'generic-work-skill',
+        'Analyze this codebase, write a review report, and verify the findings',
+        {
+          skillIds: ['code-review'],
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        },
+      );
 
       expect(mockSession.prompt).toHaveBeenCalledWith(
         expect.stringContaining('Loop started. Iteration 1. Goal:'),
@@ -353,6 +358,7 @@ describe('PiRuntimeAdapter', () => {
       await Promise.resolve();
       expect(mockSession.prompt).toHaveBeenLastCalledWith(
         expect.stringContaining('has not received explicit user acceptance'),
+        { streamingBehavior: 'followUp' },
       );
       expect(onComplete).not.toHaveBeenCalled();
 
@@ -378,14 +384,14 @@ describe('PiRuntimeAdapter', () => {
       expect(onComplete).toHaveBeenCalledOnce();
     });
 
-    it('registers the production loop only for nontrivial Work sessions', async () => {
+    it('registers the production workflow only for nontrivial Work turns', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
       adapter.setWorkbenchTaskService(new RealWorkbenchTaskService(db));
 
       try {
-        await adapter.startSession('production-work', 'Build', {
+        await adapter.startSession('production-work', 'Create and validate a release report', {
           sessionMode: 'work',
           workspaceRoot: createTemporaryWorkspace(),
         });
@@ -393,7 +399,12 @@ describe('PiRuntimeAdapter', () => {
           sessionMode: 'work',
           workspaceRoot: createTemporaryWorkspace(),
         });
-        await adapter.startSession('production-chat', 'Chat', {
+        await adapter.startSession('production-light', '你好', {
+          sessionMode: 'work',
+          skillIds: ['presentation-studio'],
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        await adapter.startSession('production-chat', 'Create and validate a release report', {
           sessionMode: 'chat',
           workspaceRoot: createTemporaryWorkspace(),
         });
@@ -404,22 +415,34 @@ describe('PiRuntimeAdapter', () => {
         const simpleOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
           customTools?: Array<{ name: string }>;
         };
-        const chatOptions = mockCreateAgentSession.mock.calls[2]?.[0] as {
+        const lightOptions = mockCreateAgentSession.mock.calls[2]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        const chatOptions = mockCreateAgentSession.mock.calls[3]?.[0] as {
           customTools?: Array<{ name: string }>;
         };
         expect(workOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
         expect(simpleOptions.customTools?.map(tool => tool.name) || []).not.toContain(
           'production_loop',
         );
+        expect(lightOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+          'production_loop',
+        );
+        expect(lightOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+          'workflow_state',
+        );
         expect(chatOptions.customTools?.map(tool => tool.name) || []).not.toContain(
           'production_loop',
         );
+        expect(
+          db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
+        ).toEqual({ count: 1 });
       } finally {
         db.close();
       }
     });
 
-    it('rebuilds the production loop topology when follow-up complexity changes', async () => {
+    it('rebuilds the production workflow topology when follow-up complexity changes', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
@@ -1008,19 +1031,56 @@ describe('PiRuntimeAdapter', () => {
       );
     });
 
-    it('uses the durable acceptance loop when an arbitrary skill is added to a Work session', async () => {
+    it('keeps a lightweight turn outside the durable loop when a skill is added', async () => {
       const workspaceRoot = createTemporaryWorkspace();
       await adapter.startSession('dynamic-skill', 'First', { sessionMode: 'work', workspaceRoot });
 
-      await adapter.continueSession('dynamic-skill', 'Use code review', {
+      await adapter.continueSession('dynamic-skill', 'Read package.json', {
         skillIds: ['code-review'],
         sessionMode: 'work',
         workspaceRoot,
       });
       expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
       expect(mockSession.abort).toHaveBeenCalledOnce();
-      expect(mockSession.prompt).toHaveBeenLastCalledWith(
-        expect.stringContaining('Persistent Work execution'),
+      expect(mockSession.prompt).toHaveBeenLastCalledWith('Read package.json');
+      const recreatedOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(recreatedOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+        'work_acceptance',
+      );
+    });
+
+    it('removes completed production controllers before a greeting in the same session', async () => {
+      const workspaceRoot = createTemporaryWorkspace();
+      await adapter.startSession('production-to-greeting', 'Create a 10-page PPT', {
+        skillIds: ['presentation-studio'],
+        sessionMode: 'work',
+        workspaceRoot,
+      });
+      const activeSessions = (
+        adapter as unknown as {
+          activeSessions: Map<string, { agentLoop: { stop(): void } }>;
+        }
+      ).activeSessions;
+      activeSessions.get('production-to-greeting')?.agentLoop.stop();
+
+      await adapter.continueSession('production-to-greeting', '你好', {
+        skillIds: ['presentation-studio'],
+        sessionMode: 'work',
+        workspaceRoot,
+      });
+
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      const greetingOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(greetingOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+        'production_loop',
+      );
+      expect(greetingOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+        'workflow_state',
       );
     });
 
@@ -1979,6 +2039,7 @@ describe('PiRuntimeAdapter', () => {
       failedAttempt('429 Too Many Requests: overloaded');
       listener!({ type: 'auto_retry_start' });
       successfulTurn('Recovered answer');
+      listener!({ type: 'auto_retry_end', success: true, attempt: 1 });
       listener!({ type: 'agent_settled' });
 
       expect(errors).toHaveLength(0);
@@ -1997,7 +2058,16 @@ describe('PiRuntimeAdapter', () => {
       for (let attempt = 0; attempt < 3; attempt++) {
         listener!({ type: 'turn_start' });
         failedAttempt('429 Too Many Requests: overloaded');
-        listener!({ type: attempt < 2 ? 'auto_retry_start' : 'auto_retry_end' });
+        if (attempt < 2) {
+          listener!({ type: 'auto_retry_start', attempt: attempt + 1 });
+        } else {
+          listener!({
+            type: 'auto_retry_end',
+            success: false,
+            attempt: attempt + 1,
+            finalError: '429 Too Many Requests: overloaded',
+          });
+        }
       }
       listener!({ type: 'agent_settled' });
 
@@ -2042,7 +2112,12 @@ describe('PiRuntimeAdapter', () => {
 
       listener!({ type: 'turn_start' });
       failedAttempt('429 Too Many Requests: overloaded');
-      listener!({ type: 'auto_retry_end' });
+      listener!({
+        type: 'auto_retry_end',
+        success: false,
+        attempt: 3,
+        finalError: '429 Too Many Requests: overloaded',
+      });
 
       // No continuation prompt beyond the initial startSession prompt.
       expect(mockSession.prompt).toHaveBeenCalledTimes(1);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -60,7 +60,7 @@ import type {
   WorkbenchTaskService,
 } from '../../workbenchTask/taskService';
 import { ProductionLoopController } from '../../productionLoop/controller';
-import { shouldEnableProductionLoop } from '../../productionLoop/entryPolicy';
+import { shouldEnableProductionWorkflow } from '../../productionLoop/entryPolicy';
 import { buildProductionLoopTool } from '../../productionLoop/tool';
 import {
   type ApiConfigResolution,
@@ -160,6 +160,9 @@ interface PiUsage {
 
 interface PiEvent {
   type: string;
+  success?: boolean;
+  attempt?: number;
+  finalError?: string;
   message?: {
     id?: string;
     role: string;
@@ -231,6 +234,8 @@ interface ActivePiSession {
   /** Present for arbitrary skills loaded in Work mode. */
   workExecution: PiWorkExecutionController | null;
   productionLoop: ProductionLoopController | null;
+  /** Whether the current turn owns durable completion and production gates. */
+  productionWorkflowEnabled: boolean;
   /** Whether this Work session was explicitly started in Goal mode. */
   goalMode: boolean;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
@@ -517,11 +522,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const shortcutKindForContract = isAcademicResearchSkillSet(resourceState.skillIds)
         ? null
         : resolveShortcutWorkflowKind(resourceState.skillIds);
-      const workbenchContract = this.createWorkbenchContract(
-        options.sessionMode,
-        resourceState.skillIds,
-      );
-      const productionLoopEnabled = shouldEnableProductionLoop({
+      const productionWorkflowEnabled = shouldEnableProductionWorkflow({
         sessionMode: options.sessionMode,
         prompt,
         goalMode: options.goalMode,
@@ -530,6 +531,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         imageAttachmentCount: options.imageAttachments?.length,
         resumeRun: Boolean(options._workbenchRunId),
       });
+      const workbenchContract = this.createWorkbenchContract(
+        options.sessionMode,
+        resourceState.skillIds,
+        productionWorkflowEnabled,
+      );
       if (this.workbenchTaskService) {
         const workbench = this.workbenchTaskService.beginRun({
           sessionId,
@@ -636,30 +642,32 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // Academic research is a controlled workflow, not a prompt-only label.
       // It owns durable state and completion gates for the lifetime of this
       // session (and reloads the same state directory after a session restart).
-      const researchRun = isAcademicResearchSkillSet(resourceState.skillIds)
-        ? new PiResearchRunController({
-            sessionId,
-            workspaceRoot,
-            task: prompt,
-            onActivation: recordActivation,
-          })
-        : null;
+      const researchRun =
+        productionWorkflowEnabled && isAcademicResearchSkillSet(resourceState.skillIds)
+          ? new PiResearchRunController({
+              sessionId,
+              workspaceRoot,
+              task: prompt,
+              onActivation: recordActivation,
+            })
+          : null;
       if (researchRun) {
         researchRun.resumeForPrompt(prompt);
         customTools.push(buildPiResearchStateTool(researchRun));
       }
       const shortcutKind = researchRun ? null : shortcutKindForContract;
-      const shortcutWorkflow = shortcutKind
-        ? new PiShortcutWorkflowController({
-            sessionId,
-            workspaceRoot,
-            task: prompt,
-            kind: shortcutKind,
-            validateRasterPreview: isRasterPreviewDecodable,
-            renderOfficePreview,
-            onActivation: recordActivation,
-          })
-        : null;
+      const shortcutWorkflow =
+        shortcutKind && productionWorkflowEnabled
+          ? new PiShortcutWorkflowController({
+              sessionId,
+              workspaceRoot,
+              task: prompt,
+              kind: shortcutKind,
+              validateRasterPreview: isRasterPreviewDecodable,
+              renderOfficePreview,
+              onActivation: recordActivation,
+            })
+          : null;
       if (shortcutWorkflow) {
         shortcutWorkflow.resumeForPrompt(prompt);
         customTools.push(buildPiShortcutWorkflowStateTool(shortcutWorkflow));
@@ -674,11 +682,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           }),
         );
       }
-      // A selected skill in Work mode is an execution request, not a one-turn
-      // chat hint. Run it through Pi's durable loop by default; completion
-      // still requires explicit user acceptance because arbitrary skills do
-      // not share a safe universal semantic validator.
+      // Complex Work turns with arbitrary skills use the durable acceptance
+      // loop because they do not share a safe universal semantic validator.
       const shouldManageSkillExecution =
+        productionWorkflowEnabled &&
         options.sessionMode === 'work' &&
         Boolean(resourceState.skillIds?.length) &&
         !researchRun &&
@@ -719,7 +726,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         resolvedModel,
         workspaceRoot,
         webSearchSkillPath:
-          researchRun || shortcutKind === ShortcutWorkflowKind.DeepResearch
+          researchRun ||
+          (productionWorkflowEnabled && shortcutKind === ShortcutWorkflowKind.DeepResearch)
             ? path.join(getSkillsRoot(), 'web-search')
             : undefined,
         createPiResourceLoader: (
@@ -755,7 +763,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // loops; the controller continues the session on agent_end.
       const completionWorkflow = researchRun || shortcutWorkflow || workExecution;
       const productionLoop =
-        productionLoopEnabled &&
+        productionWorkflowEnabled &&
         workbenchTaskId &&
         workbenchRunId &&
         this.workbenchTaskService?.productionLoop
@@ -824,6 +832,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         shortcutWorkflow,
         workExecution,
         productionLoop,
+        productionWorkflowEnabled,
         goalMode: options.goalMode === true,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
@@ -938,22 +947,21 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       (active.workbenchContract.kind === WorkbenchContractKind.Chat
         ? CoworkSessionMode.Chat
         : CoworkSessionMode.Work);
-    const productionLoopEnabled = Boolean(
-      this.workbenchTaskService &&
-      shouldEnableProductionLoop({
-        sessionMode: requestedSessionMode,
-        prompt,
-        goalMode: options.goalMode ?? active.goalMode,
-        skillIds: requestedSkillIds,
-        expertIds: requestedExpertIds,
-        imageAttachmentCount: options.imageAttachments?.length,
-        resumeRun: Boolean(options._workbenchRunId),
-      }),
-    );
-    const productionLoopTopologyChanged = productionLoopEnabled !== Boolean(active.productionLoop);
+    const nextGoalMode = options.goalMode ?? active.goalMode;
+    const productionWorkflowEnabled = shouldEnableProductionWorkflow({
+      sessionMode: requestedSessionMode,
+      prompt,
+      goalMode: nextGoalMode,
+      skillIds: requestedSkillIds,
+      expertIds: requestedExpertIds,
+      imageAttachmentCount: options.imageAttachments?.length,
+      resumeRun: Boolean(options._workbenchRunId),
+    });
+    const productionWorkflowTopologyChanged =
+      productionWorkflowEnabled !== active.productionWorkflowEnabled;
     if (
       !haveSameStringList(requestedExpertIds, active.requestedExpertIds) ||
-      productionLoopTopologyChanged
+      productionWorkflowTopologyChanged
     ) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
       this.disposeSessionForRecreation(sessionId, active);
@@ -963,7 +971,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         systemPrompt: requestedSystemPrompt ?? active.requestedSystemPrompt,
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
-        goalMode: options.goalMode ?? active.goalMode,
+        goalMode: nextGoalMode,
         _piPromptOverride: buildPiConversationPrompt(history, prompt),
       });
     }
@@ -980,10 +988,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         systemPrompt: nextSystemPrompt,
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
-        goalMode: options.goalMode ?? active.goalMode,
+        goalMode: nextGoalMode,
         _piPromptOverride: buildPiConversationPrompt(history, prompt),
       });
     }
+
+    active.goalMode = nextGoalMode;
+
     if (promptChanged) {
       const previousSystemPrompt = active.resourceState.systemPrompt;
       const previousSkillIds = active.resourceState.skillIds;
@@ -1013,6 +1024,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const workbenchContract = this.createWorkbenchContract(
         requestedSessionMode,
         requestedSkillIds,
+        productionWorkflowEnabled,
       );
       const workbench = this.workbenchTaskService.beginRun({
         sessionId,
@@ -1031,7 +1043,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workbench.run.id,
         active.harnessModelProfile,
       );
-      if (workbench.task?.id) {
+      if (productionWorkflowEnabled && workbench.task?.id) {
         active.productionLoop?.startRun({
           taskId: workbench.task.id,
           runId: workbench.run.id,
@@ -1078,9 +1090,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     let nextPrompt = prompt;
-    const domainCompletionWorkflow =
-      active.researchRun || active.shortcutWorkflow || active.workExecution;
-    const completionWorkflow = active.productionLoop || domainCompletionWorkflow;
+    const domainCompletionWorkflow = active.productionWorkflowEnabled
+      ? active.researchRun || active.shortcutWorkflow || active.workExecution
+      : null;
+    const completionWorkflow = active.productionWorkflowEnabled
+      ? active.productionLoop || domainCompletionWorkflow
+      : null;
     if (options.goalMode !== undefined && !completionWorkflow) {
       active.goalMode = options.goalMode;
       if (!active.goalMode && active.agentLoop.getState().active) {
@@ -1914,10 +1929,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           active.lastCompletedAnswerMessageId = null;
           active.lastCompletedAnswerText = '';
           active.toolResultMessageIdByCallId.clear();
-          active.piSession.prompt(loopDecision.nextPrompt).catch(error => {
-            const message = error instanceof Error ? error.message : String(error);
-            this.emit('error', sessionId, classifyCoworkError(message));
-          });
+          active.piSession
+            .prompt(loopDecision.nextPrompt, { streamingBehavior: 'followUp' })
+            .catch(error => {
+              const message = error instanceof Error ? error.message : String(error);
+              this.emit('error', sessionId, classifyCoworkError(message));
+            });
           break;
         }
         active.isRunning = false;
@@ -1942,11 +1959,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           }
         }
         if (active.workbenchRunId && this.workbenchTaskService) {
-          const workflowSnapshot = active.researchRun
-            ? active.researchRun.getSnapshot()
-            : active.shortcutWorkflow
-              ? active.shortcutWorkflow.getSnapshot()
-              : active.workExecution?.getSnapshot() || null;
+          const workflowSnapshot = active.productionWorkflowEnabled
+            ? active.researchRun
+              ? active.researchRun.getSnapshot()
+              : active.shortcutWorkflow
+                ? active.shortcutWorkflow.getSnapshot()
+                : active.workExecution?.getSnapshot() || null
+            : null;
           this.workbenchTaskService.completeRun({
             sessionId,
             runId: active.workbenchRunId,
@@ -1954,7 +1973,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             finalAnswer: active.lastCompletedAnswerText,
             finalMessageId: active.lastCompletedAnswerMessageId,
             workflowCompleted:
-              !active.researchRun && !active.shortcutWorkflow && !active.workExecution
+              !active.productionWorkflowEnabled ||
+              (!active.researchRun && !active.shortcutWorkflow && !active.workExecution)
                 ? undefined
                 : active.agentLoop.getState().done,
             workflowSnapshot,
@@ -1969,7 +1989,18 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         break;
 
       case 'auto_retry_end':
-        // Retries exhausted — surface the deferred error, if any.
+        // Pi reports both recovered retries and final exhaustion here.
+        if (event.success === true) {
+          active.pendingError = null;
+          active.turnFailed = false;
+          break;
+        }
+        if (event.finalError) {
+          active.pendingError = {
+            message: event.finalError,
+            classified: classifyCoworkError(event.finalError),
+          };
+        }
         this.flushPendingError(sessionId, active);
         break;
 
@@ -2629,8 +2660,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private createWorkbenchContract(
     sessionMode: PiStartOptions['sessionMode'],
     skillIds: string[] | undefined,
+    managedWorkflow = true,
   ): WorkbenchTaskContract {
-    const research = isAcademicResearchSkillSet(skillIds);
+    const research = managedWorkflow && isAcademicResearchSkillSet(skillIds);
     const shortcut = research ? null : resolveShortcutWorkflowKind(skillIds);
     return {
       kind:
@@ -2638,10 +2670,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           ? WorkbenchContractKind.Chat
           : research
             ? WorkbenchContractKind.Research
-            : shortcut
+            : managedWorkflow && shortcut
               ? WorkbenchContractKind.Shortcut
               : WorkbenchContractKind.GenericWork,
-      requiresUserAcceptance: sessionMode !== 'chat' && !research && !shortcut,
+      requiresUserAcceptance: sessionMode !== 'chat' && !research && !(managedWorkflow && shortcut),
       metadata: skillIds?.length ? { skillIds } : undefined,
     };
   }

--- a/src/main/productionLoop/entryPolicy.test.ts
+++ b/src/main/productionLoop/entryPolicy.test.ts
@@ -1,49 +1,82 @@
 import { expect, test } from 'vitest';
 
 import { CoworkSessionMode } from '../../shared/cowork/constants';
-import { shouldEnableProductionLoop } from './entryPolicy';
+import { shouldEnableProductionWorkflow } from './entryPolicy';
 
 const workRequest = (prompt: string) => ({ sessionMode: CoworkSessionMode.Work, prompt });
 
-test('bypasses production loop for Chat mode and empty Work prompts', () => {
+test('bypasses production workflow for Chat mode and empty Work prompts', () => {
   expect(
-    shouldEnableProductionLoop({ sessionMode: CoworkSessionMode.Chat, prompt: 'Build an app' }),
+    shouldEnableProductionWorkflow({ sessionMode: CoworkSessionMode.Chat, prompt: 'Build an app' }),
   ).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('  '))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('  '))).toBe(false);
+  expect(shouldEnableProductionWorkflow({ prompt: 'Build an app' })).toBe(true);
 });
 
-test('bypasses production loop for simple conversation and information requests', () => {
-  expect(shouldEnableProductionLoop(workRequest('你好'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('为什么天空是蓝色的？'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('Explain how event loops work.'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('什么是单元测试？'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('How do I fix a stale closure?'))).toBe(false);
+test('bypasses production workflow for simple conversation and information requests', () => {
+  expect(shouldEnableProductionWorkflow(workRequest('你好'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('为什么天空是蓝色的？'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('Explain how event loops work.'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('什么是单元测试？'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('How do I fix a stale closure?'))).toBe(false);
 });
 
-test('bypasses production loop for explicit lightweight one-step tasks', () => {
-  expect(shouldEnableProductionLoop(workRequest('计算 17 * 23'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('列出当前目录'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('Translate this sentence to Chinese.'))).toBe(
+test('bypasses production workflow for explicit lightweight one-step tasks', () => {
+  expect(shouldEnableProductionWorkflow(workRequest('计算 17 * 23'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('列出当前目录'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('Translate this sentence to Chinese.'))).toBe(
     false,
   );
-  expect(shouldEnableProductionLoop(workRequest('你好，帮我翻译这句话'))).toBe(false);
-  expect(shouldEnableProductionLoop(workRequest('当前时间'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('你好，帮我翻译这句话'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('当前时间'))).toBe(false);
 });
 
-test('retains production loop for changes and scoped reviews', () => {
-  expect(shouldEnableProductionLoop(workRequest('修复登录流程中的刷新问题'))).toBe(true);
-  expect(shouldEnableProductionLoop(workRequest('Review this repository for regressions.'))).toBe(
-    true,
-  );
-  expect(shouldEnableProductionLoop(workRequest('先修改配置，然后运行测试'))).toBe(true);
-  expect(shouldEnableProductionLoop(workRequest('Can you fix the stale closure?'))).toBe(true);
+test('retains production workflow for changes and scoped reviews', () => {
+  expect(shouldEnableProductionWorkflow(workRequest('修复登录流程中的刷新问题'))).toBe(true);
+  expect(
+    shouldEnableProductionWorkflow(workRequest('Review this repository for regressions.')),
+  ).toBe(true);
+  expect(shouldEnableProductionWorkflow(workRequest('先修改配置，然后运行测试'))).toBe(true);
+  expect(shouldEnableProductionWorkflow(workRequest('Can you fix the stale closure?'))).toBe(true);
 });
 
-test('retains production loop for explicit workflow signals and ambiguous Work requests', () => {
-  expect(shouldEnableProductionLoop({ ...workRequest('你好'), goalMode: true })).toBe(true);
-  expect(shouldEnableProductionLoop({ ...workRequest('你好'), skillIds: ['code-review'] })).toBe(
+test('retains production workflow for explicit signals and ambiguous Work requests', () => {
+  expect(shouldEnableProductionWorkflow({ ...workRequest('你好'), goalMode: true })).toBe(true);
+  expect(
+    shouldEnableProductionWorkflow({
+      ...workRequest('Review this repository'),
+      skillIds: ['code-review'],
+    }),
+  ).toBe(true);
+  expect(shouldEnableProductionWorkflow({ ...workRequest('Continue'), resumeRun: true })).toBe(
     true,
   );
-  expect(shouldEnableProductionLoop({ ...workRequest('Continue'), resumeRun: true })).toBe(true);
-  expect(shouldEnableProductionLoop(workRequest('Handle the request'))).toBe(true);
+  expect(shouldEnableProductionWorkflow(workRequest('Handle the request'))).toBe(true);
+});
+
+test('does not let a selected skill override an explicitly lightweight turn', () => {
+  expect(
+    shouldEnableProductionWorkflow({ ...workRequest('你好'), skillIds: ['presentation-studio'] }),
+  ).toBe(false);
+  expect(
+    shouldEnableProductionWorkflow({
+      ...workRequest('Read package.json'),
+      skillIds: ['code-review'],
+    }),
+  ).toBe(false);
+});
+
+test('keeps continuations and revisions inside an existing skilled workflow', () => {
+  expect(
+    shouldEnableProductionWorkflow({
+      ...workRequest('继续'),
+      skillIds: ['presentation-studio'],
+    }),
+  ).toBe(true);
+  expect(
+    shouldEnableProductionWorkflow({
+      ...workRequest('把标题改成蓝色'),
+      skillIds: ['presentation-studio'],
+    }),
+  ).toBe(true);
 });

--- a/src/main/productionLoop/entryPolicy.ts
+++ b/src/main/productionLoop/entryPolicy.ts
@@ -16,7 +16,7 @@ const EXECUTION_REQUEST_PATTERN =
 const MULTI_STEP_PATTERN =
   /\b(?:multi[- ]step|end[- ]to[- ]end|first.+then|and then)\b|(?:多步骤|完整流程|端到端|先.+再|然后)/i;
 
-export interface ProductionLoopEntryInput {
+export interface ProductionWorkflowEntryInput {
   sessionMode?: CoworkSessionModeValue;
   prompt: string;
   goalMode?: boolean;
@@ -26,25 +26,25 @@ export interface ProductionLoopEntryInput {
   resumeRun?: boolean;
 }
 
-export const shouldEnableProductionLoop = (input: ProductionLoopEntryInput): boolean => {
-  if (input.sessionMode !== CoworkSessionMode.Work) return false;
-  if (input.goalMode || input.skillIds?.length || input.resumeRun) return true;
+export const shouldEnableProductionWorkflow = (input: ProductionWorkflowEntryInput): boolean => {
+  if (input.sessionMode === CoworkSessionMode.Chat) return false;
+  if (input.goalMode || input.resumeRun) return true;
 
   const prompt = input.prompt.replace(/\s+/g, ' ').trim();
   if (!prompt) return false;
   const intentPrompt = prompt.replace(/^(?:hi|hello|hey|你好|您好|嗨)[,，!！\s]+/i, '');
+  if (SIMPLE_CONVERSATION_PATTERN.test(prompt)) return false;
   if (EXECUTION_REQUEST_PATTERN.test(intentPrompt) || MULTI_STEP_PATTERN.test(intentPrompt)) {
     return true;
   }
-  if (SIMPLE_CONVERSATION_PATTERN.test(prompt)) return false;
   if (
     prompt.length <= MAX_LIGHTWEIGHT_PROMPT_LENGTH &&
     (INFORMATION_REQUEST_PATTERN.test(intentPrompt) || LIGHTWEIGHT_TASK_PATTERN.test(intentPrompt))
   ) {
     return false;
   }
-  if (input.expertIds?.length || input.imageAttachmentCount) return true;
+  if (input.skillIds?.length || input.expertIds?.length || input.imageAttachmentCount) return true;
 
-  // Ambiguous Work requests retain the production gate.
+  // Ambiguous Work requests retain the workflow gate.
   return true;
 };

--- a/tests/__mocks__/electron.ts
+++ b/tests/__mocks__/electron.ts
@@ -1,6 +1,10 @@
 // Vitest mock for electron — CI runs without electron binary (ELECTRON_SKIP_BINARY_DOWNLOAD=1)
 import { EventEmitter } from 'events';
 
+if (!process.resourcesPath) {
+  Object.defineProperty(process, 'resourcesPath', { value: process.cwd() });
+}
+
 export const app = {
   getPath: () => '',
   getName: () => 'RongxinAI',


### PR DESCRIPTION
## 问题背景

部分轻量会话（例如在演示文稿技能上下文中输入“你好”）仍会初始化 shortcut、research 或 work-execution 等持久控制器。即使 `production_loop` 本身已由 #401 绕过，这些控制器仍可能在 `agent_end` 后续跑；旧实现又以普通 prompt 写入仍处于 streaming 状态的 Pi 会话，最终回答和产物已经正常生成，界面却收到并展示“任务执行出错”。

此外，运行时将成功恢复的 `auto_retry_end` 误当作重试耗尽，也会产生同类假错误。

## 与 #401 / #402 的整合

- 基于最新 `main` 完成 rebase，保留 #401 的入口策略、`skip_workflow` 免审批和 #402 的 reviewer 读取预算。
- 不再新增第二套门禁模块；升级 `productionLoop/entryPolicy.ts` 作为唯一 production workflow 入口策略。
- 同一个门禁结果统一控制 production、shortcut、research 和 work-execution 控制器，避免工具门禁与持久控制器拓扑状态不一致。

## 门禁规则

- Chat 模式始终绕过。
- Goal 和 Resume/Retry 明确信号始终启用。
- 问候、致谢、普通问答以及读取、翻译、计算等明确轻量任务优先绕过，即使当前已选择技能。
- 创建、修改、修复、实现、测试、审查、多步骤任务以及继续/修订已有产物仍启用完整工作流。
- 模糊 Work 请求保守启用，避免复杂任务被误判为轻量任务。
- 同一会话的请求复杂度跨档变化时重建 Pi 会话，清除旧控制器拓扑。

## 错误处理修复

- 内部工作流续跑改用 `streamingBehavior: 'followUp'`，遵循 Pi 的 streaming 时序。
- 按真实协议处理 `auto_retry_end` 的 `success`、`attempt` 和 `finalError`：成功恢复时清除延迟错误，仅在最终失败时上报。
- 完善 Electron 测试 mock 的 `process.resourcesPath`。

## Electron 行为影响

本次变更仅影响主进程中的 Pi 会话调度、production workflow 初始化和错误事件判定，不修改 IPC 协议、数据库结构或用户数据，也不包含 UI 改动。

## 验证

- `npm test -- entryPolicy piRuntimeAdapter piReviewerReadBudget piSubagentExecution piSubagentTool riskClassifier taskService productionLoop`：12 个测试文件、179 个用例通过
- `npm run lint`：通过
- `npx oxfmt --check ...`：通过
- `npm run compile:electron`：通过
- `git diff --check`：通过
