### PR TITLE
ci: gate releases on dependency provenance

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -54,8 +54,43 @@ jobs:
   quality:
     uses: ./.github/workflows/ci.yml
 
-  build-platforms:
+  supply-chain-gate:
     needs: prepare-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.commit }}
+      - uses: actions/setup-node@v6
+        with: { node-version: '24.x' }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: '1.3.14' }
+      # Installs only the exact Bun lockfile graph and never runs dependency
+      # lifecycle scripts. This catches a lockfile/integrity mismatch before
+      # a release build begins.
+      - name: Verify frozen Bun dependency graph
+        run: bun install --frozen-lockfile --ignore-scripts
+      # Verifies npm registry signatures for every checked-in npm lockfile.
+      # This is intentionally not `npm audit`: known CVEs are not a release
+      # gate here; registry provenance and tampered package metadata are.
+      - name: Verify npm package signatures
+        shell: bash
+        run: |
+          set -euo pipefail
+          for lockfile in \
+            package-lock.json \
+            SKILLs/presentation-studio/package-lock.json \
+            SKILLs/web-search/package-lock.json \
+            scripts/release/package-lock.json; do
+            npm --prefix "$(dirname "$lockfile")" audit signatures --package-lock-only --ignore-scripts
+          done
+      - name: Enforce approved package sources
+        run: bun run check:supply-chain-inputs
+
+  build-platforms:
+    needs: [prepare-release, supply-chain-gate]
     strategy:
       # A release is only valid when every platform artifact is available.
       # Cancel sibling builds as soon as one platform fails.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "prepare": "husky",
     "test": "node scripts/test-with-native-restore.cjs",
     "test:bundle-budget": "node scripts/check-renderer-bundle-budget.cjs",
+    "check:supply-chain-inputs": "node scripts/ci/check-supply-chain-inputs.mjs",
     "test:visual-blind-review": "node tests/visualBlindReview.test.mjs",
     "test:sqlite-backup:seed": "node tests/sqlite-backup/generate-large-db.cjs",
     "preview": "vite preview",

--- a/scripts/ci/check-supply-chain-inputs.mjs
+++ b/scripts/ci/check-supply-chain-inputs.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const npmLockfiles = [
+  'package-lock.json',
+  'SKILLs/presentation-studio/package-lock.json',
+  'SKILLs/web-search/package-lock.json',
+  'scripts/release/package-lock.json',
+]
+
+const pythonRequirements = [
+  'SKILLs/code-safety-audit/requirements.txt',
+  'SKILLs/database-inspector/requirements.txt',
+  'SKILLs/pdf/requirements.txt',
+  'SKILLs/programming-tutor/requirements.txt',
+  'SKILLs/py-perf-analyzer/requirements.txt',
+  'SKILLs/regression-insight/requirements.txt',
+  'SKILLs/sql-tutor/requirements.txt',
+  'SKILLs/xlsx/requirements.txt',
+  'SKILLs/zhiyuan-expert-manager/requirements.txt',
+]
+
+// Keep this list deliberately small. A new registry, Git dependency, or URL
+// dependency must be explicitly reviewed before it can enter a release.
+const approvedNpmRegistries = new Set([
+  'https://registry.npmjs.org',
+  'https://registry.npmmirror.com',
+])
+
+const violations = []
+
+for (const lockfile of npmLockfiles) {
+  const raw = await readFile(resolve(lockfile), 'utf8')
+  const lock = JSON.parse(raw)
+
+  for (const [packagePath, entry] of Object.entries(lock.packages ?? {})) {
+    if (!entry?.resolved) continue
+
+    let origin
+    try {
+      origin = new URL(entry.resolved).origin
+    } catch {
+      violations.push(`${lockfile}: ${packagePath || '<root>'} has a non-HTTPS package source`)
+      continue
+    }
+
+    if (!approvedNpmRegistries.has(origin)) {
+      violations.push(`${lockfile}: ${packagePath || '<root>'} resolves from unapproved registry ${origin}`)
+    }
+
+    if (!entry.integrity) {
+      violations.push(`${lockfile}: ${packagePath || '<root>'} is missing an integrity hash`)
+    }
+  }
+}
+
+for (const requirementsFile of pythonRequirements) {
+  const lines = (await readFile(resolve(requirementsFile), 'utf8')).split(/\r?\n/)
+
+  for (const [index, rawLine] of lines.entries()) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const hasUnapprovedSource =
+      /^(?:-i|--index-url|--extra-index-url|--find-links|--trusted-host)\b/i.test(line) ||
+      /^(?:git\+|https?:\/\/|file:|\.\.?[\\/])/i.test(line) ||
+      /\s@\s(?:git\+|https?:\/\/|file:)/i.test(line)
+
+    if (hasUnapprovedSource) {
+      violations.push(`${requirementsFile}:${index + 1} introduces a non-default Python package source`)
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Supply-chain input policy failed:')
+  for (const violation of violations) console.error(`- ${violation}`)
+  process.exit(1)
+}
+
+console.log(`Supply-chain input policy passed: ${npmLockfiles.length} npm lockfiles and ${pythonRequirements.length} Python requirement files checked.`)


### PR DESCRIPTION
Summary: add a release-only supply-chain gate before platform packaging. It verifies frozen Bun lockfile integrity and npm registry signatures without lifecycle scripts, and rejects unapproved npm registries, Git/URL package sources, missing integrity hashes, and Python alternate sources. Deliberate boundary: it does not fail releases because of ordinary CVEs. Verified locally with the input policy, npm signature checks for all four checked-in npm lockfiles, and a clean diff check.