### PR TITLE
修复生产循环的无效续跑与审批拒绝失控

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -20,6 +20,7 @@ import {
   ProviderModelPiMaxTokensField,
 } from '../../../shared/providers';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
+import { WorkbenchRunStatus } from '../../../shared/workbenchTask';
 
 const hoisted = vi.hoisted(() => {
   const mockSession = {
@@ -437,6 +438,64 @@ describe('PiRuntimeAdapter', () => {
         expect(
           db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
         ).toEqual({ count: 1 });
+      } finally {
+        db.close();
+      }
+    });
+
+    it('does not continue after the owning workbench run is paused', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+
+      try {
+        await adapter.startSession('paused-production', 'Create and validate a release report', {
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+          type: string;
+        }) => void;
+        service.pauseRun('paused-production', 'Paused for test.');
+
+        listener({ type: 'agent_end' });
+
+        expect(mockSession.prompt).toHaveBeenCalledTimes(1);
+        expect(mockSession.abort).toHaveBeenCalledOnce();
+        expect(adapter.isSessionRunning('paused-production')).toBe(false);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('pauses production after three stale continuations', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+
+      try {
+        await adapter.startSession('stale-production', 'Create and validate a release report', {
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+          type: string;
+        }) => void;
+
+        listener({ type: 'agent_end' });
+        listener({ type: 'agent_end' });
+        listener({ type: 'agent_end' });
+
+        expect(mockSession.prompt).toHaveBeenCalledTimes(3);
+        expect(mockSession.abort).toHaveBeenCalledOnce();
+        expect(service.getCurrent('stale-production')?.runs[0].status).toBe(
+          WorkbenchRunStatus.Paused,
+        );
+        expect(adapter.isSessionRunning('stale-production')).toBe(false);
       } finally {
         db.close();
       }
@@ -1197,6 +1256,51 @@ describe('PiRuntimeAdapter', () => {
       expect(() =>
         adapter.respondToPermission('unknown', { behavior: 'deny', message: 'no' }),
       ).not.toThrow();
+    });
+
+    it('aborts the active Pi turn when a workbench approval is denied', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const requests: string[] = [];
+      adapter.on('permissionRequest', (_sessionId, request) => requests.push(request.requestId));
+
+      try {
+        await adapter.startSession('denied-workbench', 'Create and validate a release report', {
+          sessionMode: 'work',
+          workspaceRoot: createTemporaryWorkspace(),
+        });
+        const detail = service.getCurrent('denied-workbench');
+        const authorization = service.authorizeToolCall({
+          sessionId: 'denied-workbench',
+          runId: detail!.task.activeRunId!,
+          toolCallId: 'write-call',
+          toolName: 'write',
+          toolInput: { path: 'release.md', content: 'draft' },
+          autoApprove: false,
+        });
+        await vi.waitFor(() => expect(requests).toHaveLength(1));
+
+        adapter.respondToPermission(requests[0], {
+          behavior: 'deny',
+          message: 'Do not write this file.',
+        });
+
+        await expect(authorization).resolves.toEqual({
+          allow: false,
+          reason: 'Do not write this file.',
+        });
+        expect(mockSession.abortBash).toHaveBeenCalledOnce();
+        expect(mockSession.abort).toHaveBeenCalledOnce();
+        expect(adapter.isSessionRunning('denied-workbench')).toBe(false);
+        expect(service.getCurrent('denied-workbench')?.runs[0].status).toBe(
+          WorkbenchRunStatus.Paused,
+        );
+      } finally {
+        db.close();
+      }
     });
 
     it('appends the AskUserQuestion policy when a custom system prompt is configured', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -34,6 +34,7 @@ import {
   type HarnessActivationEvent,
   type HarnessModelProfileInput,
 } from '../../../shared/harness';
+import { MAX_STALE_PRODUCTION_ITERATIONS } from '../../../shared/productionLoop';
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
@@ -1202,10 +1203,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   stopSession(sessionId: string): void {
+    this.stopActiveSession(sessionId, 'The user stopped this run.', true);
+  }
+
+  private stopActiveSession(sessionId: string, reason: string, drainQueuedFollowUp: boolean): void {
     this.dismissAskUserQuestionsBySession(sessionId);
     const active = this.activeSessions.get(sessionId);
     if (!active) {
-      this.workbenchTaskService?.pauseRun?.(sessionId, 'The user stopped this run.');
+      this.workbenchTaskService?.pauseRun?.(sessionId, reason);
       this.clearApprovalsBySession(sessionId);
       return;
     }
@@ -1231,7 +1236,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.abortController.abort();
     active.unsubscribe();
     void active.piSession.abort();
-    this.workbenchTaskService?.pauseRun?.(sessionId, 'The user stopped this run.');
+    this.workbenchTaskService?.pauseRun?.(sessionId, reason);
     this.clearApprovalsBySession(sessionId);
     this.emit('sessionStopped', sessionId);
 
@@ -1241,6 +1246,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     // recursively drain the queue.
     if (
       wasRunning &&
+      drainQueuedFollowUp &&
       active.workbenchContract.kind !== WorkbenchContractKind.Chat &&
       this.pendingMessageQueue.hasPendingFollowUp(sessionId)
     ) {
@@ -1281,11 +1287,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     this.approvalSessionMap.delete(requestId);
 
     if (this.workbenchTaskService?.repository.getApproval(requestId)) {
+      const denied = result.behavior === 'deny';
       this.workbenchTaskService.respondToApproval({
         approvalId: requestId,
-        approved: result.behavior === 'allow',
-        reason: result.behavior === 'deny' ? result.message : undefined,
+        approved: !denied,
+        reason: denied ? result.message : undefined,
       });
+      if (denied) {
+        this.stopActiveSession(sessionId, result.message || 'The user denied this action.', false);
+      }
       return;
     }
 
@@ -1916,10 +1926,29 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         // loop, mark completed, or emit complete. flushPendingError surfaces
         // the error when the run settles (auto_retry_end / agent_settled).
         if (active.pendingError) break;
+        if (
+          active.workbenchRunId &&
+          this.workbenchTaskService &&
+          !this.workbenchTaskService.isRunRunning(active.workbenchRunId)
+        ) {
+          this.stopActiveSession(sessionId, 'The workbench run is no longer active.', false);
+          break;
+        }
         // Agent loop: when the finished iteration signaled "next", continue
         // the session with the next iteration prompt instead of completing.
         const loopDecision = active.agentLoop.handleAgentEnd();
         if (loopDecision.shouldContinue && loopDecision.nextPrompt) {
+          if (
+            active.productionLoop &&
+            active.productionLoop.getState().staleCount >= MAX_STALE_PRODUCTION_ITERATIONS
+          ) {
+            this.stopActiveSession(
+              sessionId,
+              `Production workflow made no progress for ${MAX_STALE_PRODUCTION_ITERATIONS} consecutive iterations.`,
+              false,
+            );
+            break;
+          }
           // Reset turn state (same as continueSession).
           active.answerText = '';
           active.thinkingText = '';

--- a/src/main/workbenchTask/riskClassifier.test.ts
+++ b/src/main/workbenchTask/riskClassifier.test.ts
@@ -31,18 +31,12 @@ test('idempotency hashing is stable across object key order', () => {
   );
 });
 
-test('only skip_workflow bypasses production loop approval', () => {
-  expect(
-    classifyWorkbenchToolRisk(ProductionLoopToolName, {
-      action: ProductionLoopAction.SkipWorkflow,
-      reason: 'Simple information request',
-    }),
-  ).toBe(WorkbenchApprovalRiskLevel.ReadOnly);
-  expect(
-    classifyWorkbenchToolRisk(ProductionLoopToolName, {
-      action: ProductionLoopAction.CommitPlan,
-    }),
-  ).toBe(WorkbenchApprovalRiskLevel.Unknown);
+test('all production loop control actions bypass user approval', () => {
+  for (const action of Object.values(ProductionLoopAction)) {
+    expect(classifyWorkbenchToolRisk(ProductionLoopToolName, { action })).toBe(
+      WorkbenchApprovalRiskLevel.ReadOnly,
+    );
+  }
 });
 
 test('only explicitly read-only shell commands qualify for allow-all auto approval', () => {

--- a/src/main/workbenchTask/riskClassifier.ts
+++ b/src/main/workbenchTask/riskClassifier.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 
 import { WorkbenchApprovalRiskLevel } from '../../shared/workbenchTask';
-import { ProductionLoopAction, ProductionLoopToolName } from '../../shared/productionLoop';
+import { ProductionLoopToolName } from '../../shared/productionLoop';
 
 const readOnlyTools = new Set(['read', 'grep', 'find', 'ls', 'skill_runtime_capabilities']);
 const internalControlTools = new Set([
@@ -34,10 +34,7 @@ export function classifyWorkbenchToolRisk(
   input: Record<string, unknown>,
 ): WorkbenchApprovalRiskLevel {
   const normalizedName = toolName.trim().toLowerCase();
-  if (
-    normalizedName === ProductionLoopToolName &&
-    input.action === ProductionLoopAction.SkipWorkflow
-  ) {
+  if (normalizedName === ProductionLoopToolName) {
     return WorkbenchApprovalRiskLevel.ReadOnly;
   }
   if (readOnlyTools.has(normalizedName) || internalControlTools.has(normalizedName)) {

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -479,6 +479,24 @@ test('agent end does not verify a run paused by a denied approval', async () => 
   }
 });
 
+test('reports only running workbench runs as eligible for continuation', () => {
+  const { db, service } = createService();
+  try {
+    const { run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'write',
+      contract: chatContract,
+    });
+
+    expect(service.isRunRunning(run.id)).toBe(true);
+    service.pauseRun('session', 'Paused for test.');
+    expect(service.isRunRunning(run.id)).toBe(false);
+    expect(service.isRunRunning('missing-run')).toBe(false);
+  } finally {
+    db.close();
+  }
+});
+
 test('pausing a run expires and resolves its pending approval', async () => {
   const { db, service } = createService();
   try {

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -463,6 +463,10 @@ export class WorkbenchTaskService extends EventEmitter {
     return updated;
   }
 
+  isRunRunning(runId: string): boolean {
+    return this.repository.getRun(runId)?.status === WorkbenchRunStatus.Running;
+  }
+
   recordToolResult(runId: string, toolCallId: string, result: unknown, isError: boolean): void {
     const approval = this.repository.getApprovalByToolCall(runId, toolCallId);
     if (!approval || approval.effectStatus !== WorkbenchApprovalEffectStatus.Executing) return;

--- a/src/shared/productionLoop/constants.ts
+++ b/src/shared/productionLoop/constants.ts
@@ -65,3 +65,6 @@ export const ProductionLoopAction = {
 export type ProductionLoopAction = (typeof ProductionLoopAction)[keyof typeof ProductionLoopAction];
 
 export const ProductionLoopToolName = 'production_loop';
+
+/** Stop automatic continuation after repeated turns make no production progress. */
+export const MAX_STALE_PRODUCTION_ITERATIONS = 3;


### PR DESCRIPTION
## 背景

审批被拒绝后，Workbench run 虽已暂停，但 Pi turn 和 agent loop 仍可能继续执行；production loop 连续无进展时也只累计 staleCount，不会熔断。这会造成工具报错后反复重试和无效续跑。

## 变更内容

- 将 `production_loop` 的所有 action 视为内部控制操作，不再触发用户审批
- 审批拒绝后立即停止 agent loop，并终止当前 Pi turn 与 Bash 执行
- `agent_end` 续跑前校验所属 Workbench run 必须仍为 `Running`
- production loop 连续 3 次无进展时暂停 run 并停止自动 continuation
- 内部终止不会自动消费排队中的后续消息

## 测试

- [x] Workbench 风险分类与 task service 单元测试
- [x] PiRuntimeAdapter 审批拒绝、run 活性和 stale 熔断回归测试
- [x] 103 个定向测试通过
- [x] 修改文件通过 oxlint 与 oxfmt 检查
- [x] Electron TypeScript `noEmit` 编译检查通过

## Electron 行为变化

本 PR 修改主进程中的执行生命周期和工具审批语义，不涉及 IPC 协议、SQLite schema 或 UI。
