### PR TITLE
隔离用户消息对应的Workbench任务

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -20,7 +20,11 @@ import {
   ProviderModelPiMaxTokensField,
 } from '../../../shared/providers';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
-import { WorkbenchRunStatus } from '../../../shared/workbenchTask';
+import {
+  WorkbenchContractKind,
+  WorkbenchRunStatus,
+  WorkbenchTaskStatus,
+} from '../../../shared/workbenchTask';
 
 const hoisted = vi.hoisted(() => {
   const mockSession = {
@@ -1141,6 +1145,54 @@ describe('PiRuntimeAdapter', () => {
       expect(greetingOptions.customTools?.map(tool => tool.name) || []).not.toContain(
         'workflow_state',
       );
+    });
+
+    it('starts a fresh generic task after a shortcut approval is denied', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const workspaceRoot = createTemporaryWorkspace();
+
+      try {
+        await adapter.startSession('denied-shortcut', 'Create a 10-page presentation', {
+          skillIds: ['presentation-studio'],
+          sessionMode: 'work',
+          workspaceRoot,
+        });
+        const first = service.getCurrent('denied-shortcut')!;
+        const authorization = service.authorizeToolCall({
+          sessionId: 'denied-shortcut',
+          runId: first.task.activeRunId!,
+          toolCallId: 'write-call',
+          toolName: 'write',
+          toolInput: { path: 'slides.md', content: 'draft' },
+          autoApprove: false,
+        });
+        const approval = service.getDetail(first.task.id)?.approvals[0];
+        service.respondToApproval({ approvalId: approval!.id, approved: false });
+        await authorization;
+
+        await adapter.continueSession('denied-shortcut', 'Hello', {
+          skillIds: ['presentation-studio'],
+          sessionMode: 'work',
+          workspaceRoot,
+        });
+
+        const current = service.getCurrent('denied-shortcut')!;
+        expect(current.task.id).not.toBe(first.task.id);
+        expect(current.task.contract.kind).toBe(WorkbenchContractKind.GenericWork);
+        expect(service.getDetail(first.task.id)?.task.status).toBe(WorkbenchTaskStatus.Cancelled);
+        const greetingOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        expect(greetingOptions.customTools?.map(tool => tool.name) || []).not.toContain(
+          'production_loop',
+        );
+      } finally {
+        db.close();
+      }
     });
 
     it('should recreate the session when expert tool topology changes', async () => {

--- a/src/main/workbenchTask/stateMachine.test.ts
+++ b/src/main/workbenchTask/stateMachine.test.ts
@@ -95,7 +95,12 @@ test('guards every run status transition', () => {
     ],
     [
       WorkbenchRunStatus.Verifying,
-      [WorkbenchRunStatus.Succeeded, WorkbenchRunStatus.NeedsReview, WorkbenchRunStatus.Failed],
+      [
+        WorkbenchRunStatus.Succeeded,
+        WorkbenchRunStatus.NeedsReview,
+        WorkbenchRunStatus.Failed,
+        WorkbenchRunStatus.Cancelled,
+      ],
     ],
     [WorkbenchRunStatus.Paused, []],
     [WorkbenchRunStatus.NeedsReview, [WorkbenchRunStatus.Succeeded]],

--- a/src/main/workbenchTask/stateMachine.ts
+++ b/src/main/workbenchTask/stateMachine.ts
@@ -61,6 +61,7 @@ const runTransitions: Record<WorkbenchRunStatusType, ReadonlySet<WorkbenchRunSta
     WorkbenchRunStatus.Succeeded,
     WorkbenchRunStatus.NeedsReview,
     WorkbenchRunStatus.Failed,
+    WorkbenchRunStatus.Cancelled,
   ]),
   [WorkbenchRunStatus.Paused]: new Set(),
   [WorkbenchRunStatus.NeedsReview]: new Set([WorkbenchRunStatus.Succeeded]),

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -7,6 +7,7 @@ import {
   WorkbenchApprovalEffectStatus,
   WorkbenchApprovalRiskLevel,
   WorkbenchContractKind,
+  WorkbenchRunEventType,
   WorkbenchRunTrigger,
   WorkbenchRunStatus,
   WorkbenchTaskStatus,
@@ -219,23 +220,98 @@ test('keeps acceptance-required production work ready until explicit user accept
   }
 });
 
-test('reuses a nonterminal task and creates a new task after completion', () => {
+test('creates a new task for each ordinary user message', () => {
   const { db, service } = createService();
   try {
     const first = service.beginRun({ sessionId: 'session', goal: 'first', contract: chatContract });
-    service.completeRun({
-      sessionId: 'session',
-      runId: first.run.id,
-      workspaceRoot: process.cwd(),
-      finalAnswer: 'done',
-    });
     const second = service.beginRun({
       sessionId: 'session',
       goal: 'second',
       contract: chatContract,
     });
+
     expect(second.task.id).not.toBe(first.task.id);
     expect(second.run.attempt).toBe(1);
+    const superseded = service.getDetail(first.task.id);
+    expect(superseded?.task.status).toBe(WorkbenchTaskStatus.Cancelled);
+    expect(superseded?.task.activeRunId).toBeNull();
+    expect(superseded?.runs[0].status).toBe(WorkbenchRunStatus.Cancelled);
+    expect(superseded?.events).toContainEqual(
+      expect.objectContaining({ type: WorkbenchRunEventType.RunCancelled }),
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test('supersedes a paused task instead of reusing its contract', async () => {
+  const { db, service } = createService();
+  try {
+    const first = service.beginRun({
+      sessionId: 'session',
+      goal: 'create a presentation',
+      contract: {
+        kind: WorkbenchContractKind.Shortcut,
+        requiresUserAcceptance: false,
+      },
+    });
+    const authorization = service.authorizeToolCall({
+      sessionId: 'session',
+      runId: first.run.id,
+      toolCallId: 'write-call',
+      toolName: 'write',
+      toolInput: { path: 'slides.md', content: 'draft' },
+      autoApprove: false,
+    });
+    const approval = service.getDetail(first.task.id)?.approvals[0];
+    service.respondToApproval({ approvalId: approval!.id, approved: false });
+    await authorization;
+
+    const second = service.beginRun({
+      sessionId: 'session',
+      goal: 'hello',
+      contract: {
+        kind: WorkbenchContractKind.GenericWork,
+        requiresUserAcceptance: true,
+      },
+    });
+
+    expect(second.task.id).not.toBe(first.task.id);
+    expect(second.task.contract.kind).toBe(WorkbenchContractKind.GenericWork);
+    expect(service.getDetail(first.task.id)?.task.status).toBe(WorkbenchTaskStatus.Cancelled);
+    expect(service.getDetail(first.task.id)?.runs[0].status).toBe(WorkbenchRunStatus.Paused);
+  } finally {
+    db.close();
+  }
+});
+
+test('expires pending approvals when a new message supersedes the task', async () => {
+  const { db, service } = createService();
+  try {
+    const first = service.beginRun({
+      sessionId: 'session',
+      goal: 'write',
+      contract: chatContract,
+    });
+    const authorization = service.authorizeToolCall({
+      sessionId: 'session',
+      runId: first.run.id,
+      toolCallId: 'write-call',
+      toolName: 'write',
+      toolInput: { path: 'result.txt', content: 'draft' },
+      autoApprove: false,
+    });
+
+    service.beginRun({ sessionId: 'session', goal: 'new request', contract: chatContract });
+
+    await expect(authorization).resolves.toEqual({
+      allow: false,
+      reason: 'Superseded by a new user message.',
+    });
+    const superseded = service.getDetail(first.task.id);
+    expect(superseded?.approvals[0].decision).toBe(WorkbenchApprovalDecision.Expired);
+    expect(superseded?.runs[0].status).toBe(WorkbenchRunStatus.Cancelled);
+    expect(superseded?.task.status).toBe(WorkbenchTaskStatus.Cancelled);
   } finally {
     db.close();
   }

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -101,23 +101,55 @@ export class WorkbenchTaskService extends EventEmitter {
     trigger?: WorkbenchRunTrigger;
     preparedRunId?: string;
   }): { task: WorkbenchTask; run: WorkbenchRun } {
+    const supersededReason = 'Superseded by a new user message.';
     const result = this.repository.transaction(() => {
       let run = input.preparedRunId ? this.repository.getRun(input.preparedRunId) : null;
-      let task = run
-        ? this.repository.getTask(run.taskId)
-        : this.repository.getActiveTaskForSession(input.sessionId);
-      if (!task) task = this.repository.createTask(input.sessionId, input.goal, input.contract);
-      if (run && run.taskId !== task.id) throw new Error('Prepared run does not belong to task.');
+      let task = run ? this.repository.getTask(run.taskId) : null;
+      let supersededTask: WorkbenchTask | null = null;
+      let expiredApprovals: WorkbenchApproval[] = [];
+      if (run) {
+        if (!task) throw new Error('Prepared run task not found.');
+        if (task.sessionId !== input.sessionId) {
+          throw new Error('Prepared run does not belong to this session.');
+        }
+      } else {
+        const activeTask = this.repository.getActiveTaskForSession(input.sessionId);
+        if (activeTask) {
+          expiredApprovals = this.expirePendingApprovalsForSession(
+            input.sessionId,
+            supersededReason,
+          );
+          if (activeTask.activeRunId) {
+            const activeRun = this.repository.getRun(activeTask.activeRunId);
+            if (activeRun && this.isRunActive(activeRun.status)) {
+              this.repository.updateRunStatus(activeRun.id, WorkbenchRunStatus.Cancelled);
+            }
+            if (activeRun) {
+              this.repository.appendRunEvent(activeRun.id, WorkbenchRunEventType.RunCancelled, {
+                reason: supersededReason,
+              });
+            }
+          }
+          supersededTask = this.repository.updateTaskStatus(
+            activeTask.id,
+            WorkbenchTaskStatus.Cancelled,
+            null,
+          );
+        }
+        task = this.repository.createTask(input.sessionId, input.goal, input.contract);
+      }
       if (!run) {
         run = this.repository.createRun(task.id, input.trigger ?? WorkbenchRunTrigger.Message);
       }
       task = this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Running, run.id);
       run = this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Running);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.RunStarted);
-      return { task, run };
+      return { task, run, supersededTask, expiredApprovals };
     });
+    this.resolvePendingApprovals(result.expiredApprovals, supersededReason);
+    if (result.supersededTask) this.emitChanged(result.supersededTask);
     this.emitChanged(result.task);
-    return result;
+    return { task: result.task, run: result.run };
   }
 
   prepareRun(

--- a/src/shared/workbenchTask/constants.ts
+++ b/src/shared/workbenchTask/constants.ts
@@ -126,6 +126,7 @@ export const WorkbenchRunEventType = {
   VerificationStarted: 'verification_started',
   VerificationFinished: 'verification_finished',
   RunPaused: 'run_paused',
+  RunCancelled: 'run_cancelled',
   RunFailed: 'run_failed',
   RecoveryRequired: 'recovery_required',
   HarnessProfiled: 'harness_profiled',


### PR DESCRIPTION
## 背景

Workbench 原先把 `paused` 和 `needs_review` task 视为可复用的 active task。审批拒绝后再发送简单消息时，新 run 会继承旧 task 的目标和 shortcut contract，导致普通问候仍进入旧工作流门禁并出现错误。

## 变更内容

- 普通用户消息始终创建独立的新 task，不复用旧 task
- 新消息到来时，将旧的非终态 task 标记为 `Cancelled`
- 仍在执行、等待审批或验证中的旧 run 标记为 `Cancelled`，并记录 `run_cancelled` 审计事件
- 已暂停或待审的旧 run 保留原状态，避免覆盖原始终止原因
- 新消息会过期并释放旧 task 的未决审批
- 仅 `preparedRunId` 路径复用既有 task，显式 Resume/Retry 语义保持不变
- 增加“快捷任务拒绝审批后发送 Hello”的端到端回归测试，确认新 task 为 `GenericWork` 且不注册 `production_loop`

## 测试

- [x] Workbench state machine 与 task service 单元测试
- [x] PiRuntimeAdapter task 隔离回归测试
- [x] 103 个定向测试通过
- [x] 修改文件通过 oxlint 与 oxfmt 检查
- [x] Electron TypeScript `noEmit` 编译检查通过

## Electron 行为变化

本 PR 修改主进程中的 Workbench task/run 生命周期和审计事件，不涉及 SQLite schema、IPC 协议或 UI。
