### PR TITLE
修复生产循环的流式消息时间线

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1645,6 +1645,63 @@ describe('PiRuntimeAdapter', () => {
       });
     });
 
+    it('does not mark intermediate loop answers as final', async () => {
+      const updates: Array<{
+        messageId: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }> = [];
+      adapter.on('messageUpdate', (_sid, messageId, content, metadata) =>
+        updates.push({ messageId, content, metadata }),
+      );
+
+      await adapter.startSession('test', 'Produce two iterations');
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools?: Array<{
+          name: string;
+          execute: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
+        }>;
+      };
+      const loopTool = sessionOptions.customTools?.find(tool => tool.name === PiAgentLoopToolName);
+      await loopTool!.execute('loop-start', {
+        action: PiAgentLoopAction.Start,
+        mode: PiAgentLoopMode.Passes,
+        passes: 2,
+      });
+
+      driveAssistantTurn('First iteration answer');
+      await loopTool!.execute('loop-next-1', {
+        action: PiAgentLoopAction.Next,
+        summary: 'First iteration complete',
+      });
+      listener!({ type: 'agent_end' });
+
+      expect(
+        updates.some(
+          update =>
+            update.content === 'First iteration answer' && update.metadata?.isFinalAnswer === true,
+        ),
+      ).toBe(false);
+
+      driveAssistantTurn('Second iteration answer');
+      await loopTool!.execute('loop-next-2', {
+        action: PiAgentLoopAction.Next,
+        summary: 'Second iteration complete',
+      });
+      listener!({ type: 'agent_end' });
+
+      const finalAnswers = updates.filter(update => update.metadata?.isFinalAnswer === true);
+      expect(finalAnswers).toHaveLength(1);
+      expect(finalAnswers[0].content).toBe('Second iteration answer');
+      expect(
+        new Set(
+          updates
+            .filter(update => update.content.endsWith('iteration answer'))
+            .map(update => update.messageId),
+        ).size,
+      ).toBe(2);
+    });
+
     it('should preserve the latest answer across a trailing thinking-only internal turn', async () => {
       const updates: Array<{
         messageId: string;

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1909,7 +1909,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
       case 'agent_end': {
         this.finalizeActiveThinking(sessionId, active);
-        this.markFinalAnswer(sessionId, active);
         const clearActivity = active.toolActivityTracker.clear();
         if (clearActivity) this.emit('toolActivity', sessionId, clearActivity);
         // Failed attempt (deferred error pending): do not continue the agent
@@ -1937,6 +1936,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             });
           break;
         }
+        this.markFinalAnswer(sessionId, active);
         active.isRunning = false;
         // Pi versions differ in whether they emit agent_settled after agent_end.
         // Drain queued Work follow-ups here so completion never leaves them stuck.


### PR DESCRIPTION
## 背景

`agent_end` 原先在判断 agent loop 是否需要继续之前就调用 `markFinalAnswer()`。因此每个 production iteration 的中间回答都会被标记为最终回答；续跑后该标记仍保留，渲染层会把多轮内容当作同一最终区域更新，表现为中间 answer 和步骤互相顶替。

## 变更内容

- `agent_end` 先计算 agent loop decision，再决定是否标记最终回答
- `shouldContinue=true` 时，中间 answer 仅完成当前消息，不添加 `isFinalAnswer`
- run 真正结束时，才将最后一条回答标记为最终回答
- 增加双 iteration 回归测试，验证两轮回答使用独立消息 ID，且只有终止轮次带最终回答标记

## 测试

- [x] PiRuntimeAdapter 78 个定向测试通过
- [x] 修改文件通过 oxlint 与 oxfmt 检查
- [x] Electron TypeScript `noEmit` 编译检查通过

## Electron 行为变化

本 PR 修改主进程流事件的消息元数据语义，不涉及 IPC 协议、SQLite schema 或 UI 组件。
