### PR TITLE
第一阶段：阻止技能泄漏到空白新会话

### DIFF
--- a/src/renderer/App.newConversation.test.ts
+++ b/src/renderer/App.newConversation.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const appSource = readFileSync(fileURLToPath(new URL('./App.tsx', import.meta.url)), 'utf8');
+const sidebarSource = readFileSync(
+  fileURLToPath(new URL('./components/SidebarNavigationControls.tsx', import.meta.url)),
+  'utf8',
+);
+
+const callbackBody = (source: string, name: string, nextName: string) => {
+  const start = source.indexOf(`const ${name} = useCallback`);
+  const end = source.indexOf(`const ${nextName} = useCallback`, start);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+test('resets active skills for every blank conversation entry point', () => {
+  const handleNewChat = callbackBody(appSource, 'handleNewChat', 'handleTryMcp');
+
+  expect(handleNewChat).toContain('dispatch(clearActiveSkills());');
+  expect(handleNewChat).toContain('openNewConversation();');
+  expect(sidebarSource).not.toContain('clearActiveSkills');
+  expect(sidebarSource).not.toContain('workMode === WorkMode.Chat) dispatch');
+});
+
+test('preserves the selected skill when starting from use-this-skill', () => {
+  const handleTrySkill = callbackBody(appSource, 'handleTrySkill', 'dismissToast');
+
+  expect(handleTrySkill).toContain('dispatch(setActiveSkillIds([skillId]));');
+  expect(handleTrySkill).toContain('openNewConversation();');
+  expect(handleTrySkill).not.toContain('handleNewChat();');
+});
+
+test('routes specialized blank conversation entries through the reset boundary', () => {
+  const handleTryMcp = callbackBody(appSource, 'handleTryMcp', 'handleCreateSkillByChat');
+  const handleCreateSkillByChat = callbackBody(
+    appSource,
+    'handleCreateSkillByChat',
+    'handleTrySkill',
+  );
+
+  expect(handleTryMcp).toContain('handleNewChat();');
+  expect(handleCreateSkillByChat).toContain('handleNewChat();');
+});

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,7 +39,7 @@ import {
 import { setDraftPrompt } from './store/slices/coworkSlice';
 import { setAvailableModels, setDefaultSelectedModel } from './store/slices/modelSlice';
 import { clearSelection } from './store/slices/quickActionSlice';
-import { setActiveSkillIds } from './store/slices/skillSlice';
+import { clearActiveSkills, setActiveSkillIds } from './store/slices/skillSlice';
 import { WorkMode } from './store/workMode/constants';
 import { setWorkMode } from './store/workMode/workModeSlice';
 import type { CoworkPermissionResult } from './types/cowork';
@@ -410,7 +410,7 @@ const App: React.FC = () => {
     setIsSidebarCollapsed(prev => !prev);
   }, []);
 
-  const handleNewChat = useCallback(() => {
+  const openNewConversation = useCallback(() => {
     // Only clear when already on home (no session) — preserve __home__ draft when returning from a session
     const shouldClearInput = mainView === 'cowork' && !currentSessionId;
     if (currentWorkspaceIsHidden) void workspaceService.clearWorkspaceSelection();
@@ -426,6 +426,11 @@ const App: React.FC = () => {
     }, 0);
   }, [currentSessionId, currentWorkspaceIsHidden, dispatch, mainView]);
 
+  const handleNewChat = useCallback(() => {
+    dispatch(clearActiveSkills());
+    openNewConversation();
+  }, [dispatch, openNewConversation]);
+
   const handleTryMcp = useCallback(
     (prompt?: string) => {
       if (prompt?.trim()) {
@@ -439,18 +444,16 @@ const App: React.FC = () => {
 
   const handleCreateSkillByChat = useCallback(() => {
     dispatch(setDraftPrompt({ sessionId: '__home__', draft: i18nService.t('skillCreatorPrompt') }));
-    coworkService.clearSession();
-    dispatch(clearSelection());
-    setMainView('cowork');
-  }, [dispatch]);
+    handleNewChat();
+  }, [dispatch, handleNewChat]);
 
   const handleTrySkill = useCallback(
     (skillId: string) => {
       dispatch(setActiveSkillIds([skillId]));
       dispatch(setWorkMode(WorkMode.Work));
-      handleNewChat();
+      openNewConversation();
     },
-    [dispatch, handleNewChat],
+    [dispatch, openNewConversation],
   );
 
   const dismissToast = useCallback(() => {

--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -3,13 +3,12 @@ import { Switch } from '@shared/components/ui/switch';
 import { cn } from '@shared/lib/utils';
 import { useReducedMotion } from 'motion/react';
 import { type RefObject, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { i18nService } from '../services/i18n';
 import { workspaceService } from '../services/workspace';
 import type { RootState } from '../store';
 import { selectHasActiveChannelRun } from '../store/selectors/activitySelectors';
-import { clearActiveSkills } from '../store/slices/skillSlice';
 import { WorkMode } from '../store/workMode/constants';
 import type { PrefetchableFeatureView } from './featureViewPrefetch';
 import {
@@ -79,7 +78,6 @@ export const SidebarNavigationControls = ({
   workMode,
   onPrefetchView,
 }: SidebarNavigationControlsProps) => {
-  const dispatch = useDispatch();
   const hasActiveChannelRun = useSelector((state: RootState) => selectHasActiveChannelRun(state));
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
   const scheduledTasksIconRef = useRef<SidebarAnimatedAlarmClockIconHandle>(null);
@@ -95,7 +93,6 @@ export const SidebarNavigationControls = ({
     if (!prefersReducedMotion) iconRef.current?.startAnimation();
   };
   const handleNewConversation = () => {
-    if (workMode === WorkMode.Chat) dispatch(clearActiveSkills());
     if (workMode === WorkMode.Work) void workspaceService.clearWorkspaceSelection();
     onNewChat();
   };


### PR DESCRIPTION
## 背景

Work 模式创建空白会话时未清理当前技能，导致上一会话的 PPT 等技能被复制到新会话。不同入口各自维护清理逻辑，也使快捷键、托盘和功能页入口存在遗漏风险。

## 修改内容

- 将空白新会话的技能重置统一收敛到 App 入口。
- Sidebar 不再按 Chat/Work 模式分别清理技能。
- MCP 使用、技能创建等空白会话入口统一经过重置边界。
- “使用此技能”绕过空白重置，仅复用导航核心，保留用户刚选择的技能。
- 增加入口边界回归测试，覆盖普通新建、特殊入口和“使用此技能”。

## 行为变化

- Work 与 Chat 模式创建空白会话时都会清空上一会话的普通技能。
- 从技能市场点击“使用此技能”创建会话时，指定技能仍会保留。
- 专家技能与工作区逻辑未改变。

## 验证

- [x] `npm test -- App.newConversation`
- [x] `npm run lint`
- [x] `npm run build`

## Electron 影响

仅调整 renderer 侧新会话导航与 Redux 状态边界，不涉及 IPC、SQLite 或窗口生命周期。
