### PR TITLE
第二阶段：修复会话技能复活与跨轮丢失

### DIFF
--- a/src/main/coworkSessionSkills.test.ts
+++ b/src/main/coworkSessionSkills.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'vitest';
+
+import { resolveCoworkContinuationSkillState } from './coworkSessionSkills';
+
+test('treats an explicit empty array as clearing saved session skills', () => {
+  const state = resolveCoworkContinuationSkillState({
+    activeSkillIds: [],
+    savedSkillIds: ['pptx'],
+    expertSkillIds: [],
+  });
+
+  expect(state.sessionSkillIds).toEqual([]);
+  expect(state.runtimeSkillIds).toEqual([]);
+});
+
+test('falls back to saved session skills only when the field is omitted', () => {
+  const state = resolveCoworkContinuationSkillState({
+    activeSkillIds: undefined,
+    savedSkillIds: ['pptx'],
+    expertSkillIds: [],
+  });
+
+  expect(state.sessionSkillIds).toBeUndefined();
+  expect(state.runtimeSkillIds).toEqual(['pptx']);
+});
+
+test('keeps explicit session skills active across continuations', () => {
+  const state = resolveCoworkContinuationSkillState({
+    activeSkillIds: ['pptx'],
+    savedSkillIds: [],
+    expertSkillIds: [],
+  });
+
+  expect(state.sessionSkillIds).toEqual(['pptx']);
+  expect(state.runtimeSkillIds).toEqual(['pptx']);
+});
+
+test('keeps expert skills independent from ordinary session skill clearing', () => {
+  const state = resolveCoworkContinuationSkillState({
+    activeSkillIds: [],
+    savedSkillIds: ['pptx'],
+    expertSkillIds: ['research', 'research'],
+  });
+
+  expect(state.sessionSkillIds).toEqual([]);
+  expect(state.runtimeSkillIds).toEqual(['research']);
+});

--- a/src/main/coworkSessionSkills.ts
+++ b/src/main/coworkSessionSkills.ts
@@ -1,0 +1,23 @@
+interface CoworkContinuationSkillInput {
+  activeSkillIds: string[] | undefined;
+  expertSkillIds: string[];
+  savedSkillIds: string[] | undefined;
+}
+
+export interface CoworkContinuationSkillState {
+  runtimeSkillIds: string[];
+  sessionSkillIds: string[] | undefined;
+}
+
+export const resolveCoworkContinuationSkillState = ({
+  activeSkillIds,
+  expertSkillIds,
+  savedSkillIds,
+}: CoworkContinuationSkillInput): CoworkContinuationSkillState => {
+  const sessionSkillIds = activeSkillIds === undefined ? undefined : [...activeSkillIds];
+  const runtimeSkillIds = [
+    ...new Set([...(sessionSkillIds ?? savedSkillIds ?? []), ...expertSkillIds]),
+  ];
+
+  return { runtimeSkillIds, sessionSkillIds };
+};

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -97,6 +97,7 @@ import { getChangedSessionPermissionModes } from './coworkPermissionModeChanges'
 import type { CoworkPromptLanguage } from './coworkLanguagePrompt';
 import { composeCoworkSystemPrompt } from './coworkPrompt/composer';
 import { reconcileWorkSessionRuntimeState } from './coworkSessionRuntimeState';
+import { resolveCoworkContinuationSkillState } from './coworkSessionSkills';
 import {
   type CoworkExecutionMode,
   type CoworkMessageType,
@@ -4288,27 +4289,24 @@ if (!gotTheLock) {
           });
         }
 
-        // Persist active skill selection to session record
-        if (options.activeSkillIds !== undefined) {
+        const continuationSkillState = resolveCoworkContinuationSkillState({
+          activeSkillIds: options.activeSkillIds,
+          savedSkillIds: existingSession?.activeSkillIds,
+          expertSkillIds: (existingSession?.experts || []).flatMap(expert => expert.skillIds),
+        });
+
+        // Persist explicit selections, including [] when the user clears session skills.
+        if (continuationSkillState.sessionSkillIds !== undefined) {
           try {
             store.updateSession(options.sessionId, {
-              activeSkillIds: options.activeSkillIds,
+              activeSkillIds: continuationSkillState.sessionSkillIds,
             });
           } catch (error) {
             console.error('[Cowork:ContinueSession] failed to persist activeSkillIds:', error);
           }
         }
 
-        const runtimeSkillIds = [
-          ...new Set([
-            // A continuation normally arrives after the input cleared its
-            // one-shot skill chips. Preserve the session's saved workflow
-            // skills in that case so controlled academic research resumes
-            // with the same state and completion gates.
-            ...(options.activeSkillIds ?? existingSession?.activeSkillIds ?? []),
-            ...(existingSession?.experts || []).flatMap(expert => expert.skillIds),
-          ]),
-        ];
+        const runtimeSkillIds = continuationSkillState.runtimeSkillIds;
 
         const runtimeSystemPrompt = existingSession
           ? existingSession.systemPrompt

--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -37,6 +37,12 @@ test('mounts ActiveSkillBadge inside the prompt toolbar', () => {
   expect(badge).toBeLessThan(toolsClose);
 });
 
+test('keeps active skills attached after submitting within a session', () => {
+  expect(source).not.toContain('dispatch(clearActiveSkills())');
+  expect(source).not.toContain('submittedSkillIds');
+  expect(source).not.toContain('dispatch(setActiveSkillIds(');
+});
+
 test('does not reintroduce the PR #184 textarea-token implementation', () => {
   // ResizeObserver-driven width measurement for the inline tokens.
   expect(source).not.toContain('skillTokensRef');

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -38,12 +38,7 @@ import {
   setDefaultSelectedModel,
   setSelectedModel,
 } from '../../store/slices/modelSlice';
-import {
-  clearActiveSkills,
-  setActiveSkillIds,
-  setSkills,
-  toggleActiveSkill,
-} from '../../store/slices/skillSlice';
+import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { WorkMode } from '../../store/workMode/constants';
 import { CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
@@ -640,20 +635,16 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       dispatch(setDraftPrompt({ sessionId: draftKey, draft: '' }));
       dispatch(clearDraftAttachments(draftKey));
       setImageVisionHint(false);
-      const submittedSkillIds = [...activeSkillIds];
-      const submission = onSubmit(
+      const result = await onSubmit(
         finalPrompt,
         skillPrompt,
         imageAtts.length > 0 ? imageAtts : undefined,
         selectedExpertIds,
         goalMode,
       );
-      dispatch(clearActiveSkills());
-      const result = await submission;
       if (result === false) {
         // Submission rejected — restore the prompt so the user can retry.
         setValue(finalPrompt);
-        dispatch(setActiveSkillIds(submittedSkillIds));
       }
     }, [
       value,

--- a/src/renderer/components/cowork/CoworkView.sessionSkills.test.ts
+++ b/src/renderer/components/cowork/CoworkView.sessionSkills.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./CoworkView.tsx', import.meta.url)), 'utf8');
+
+test('sends the current session skill array on every engine continuation', () => {
+  const continuationStart = source.indexOf('const handleContinueSession = async');
+  const continuationEnd = source.indexOf('const handleStopSession = async', continuationStart);
+  const continuation = source.slice(continuationStart, continuationEnd);
+
+  expect(continuationStart).toBeGreaterThanOrEqual(0);
+  expect(continuationEnd).toBeGreaterThan(continuationStart);
+  expect(continuation).toContain('activeSkillIds: sessionSkillIds,');
+  expect(continuation).not.toContain(
+    'activeSkillIds: sessionSkillIds.length > 0 ? sessionSkillIds : undefined',
+  );
+});

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1235,7 +1235,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         sessionId: currentSession.id,
         prompt,
         systemPrompt: currentSession.systemPrompt || combinedSystemPrompt,
-        activeSkillIds: sessionSkillIds.length > 0 ? sessionSkillIds : undefined,
+        activeSkillIds: sessionSkillIds,
         expertIds,
         permissionMode: sessionPermissionMode,
         goalMode,


### PR DESCRIPTION
## 背景

当前输入组件在每次提交后都会清空技能徽标，继续会话又把空数组转换为 `undefined`。这使用户主动移除技能时无法把清空状态传给主进程，主进程随后会回退到会话记录中的旧技能，表现为技能“复活”。

## 修改内容

- 技能调整为可见的会话级状态，提交后不再自动清空技能徽标。
- 继续会话始终发送当前技能数组，包括表示明确清空的 `[]`。
- 提取主进程 continuation 技能解析函数，集中定义 `[]` 与 `undefined` 的不同语义。
- `[]` 覆盖会话记录中的普通技能；只有字段缺省时才回退已保存技能。
- 专家技能继续独立合并，不受普通技能清空影响。
- 增加 renderer 边界测试和主进程纯函数测试。

## 行为变化

- 同一会话未移除技能时，技能徽标持续显示并跨轮生效。
- 用户移除技能并继续发送后，SQLite 中的 `activeSkillIds` 会更新为 `[]`，旧技能不会再次恢复。
- 专家会话清空普通技能时，专家自带技能仍正常生效。
- IPC 数据结构未变化，仅明确传输并持久化空数组。

## 分阶段关系

配套第一阶段为 #414。两个 PR 修改不同文件、没有代码依赖，建议按 #414 → 本 PR 的顺序合并，便于按行为边界审阅。

## 验证

- [x] `npm test -- coworkSessionSkills CoworkPromptInput.structure CoworkView.sessionSkills`（3 个测试文件，11 个测试通过）
- [x] `npm run lint`
- [x] `npm run build`

## Electron 影响

调整 renderer → main 的 continuation 参数语义，并更新现有 SQLite 会话字段；未新增 IPC channel，未修改数据库结构或窗口生命周期。
