### PR TITLE
feat(memory): engram 运行时切换到 CJK fork 并加固下载校验

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,23 +56,23 @@
     }
   },
   "engram": {
-    "version": "v1.20.0",
-    "repo": "Gentleman-Programming/engram",
+    "version": "v1.20.0-zhiyuan.1",
+    "repo": "z189yis/engram-cjk",
     "runtimeAssets": {
-      "mac-x64": "engram_1.20.0_darwin_amd64.tar.gz",
-      "mac-arm64": "engram_1.20.0_darwin_arm64.tar.gz",
-      "win-x64": "engram_1.20.0_windows_amd64.zip",
-      "win-arm64": "engram_1.20.0_windows_arm64.zip",
-      "linux-x64": "engram_1.20.0_linux_amd64.tar.gz",
-      "linux-arm64": "engram_1.20.0_linux_arm64.tar.gz"
+      "mac-x64": "engram_v1.20.0-zhiyuan.1_darwin_amd64.tar.gz",
+      "mac-arm64": "engram_v1.20.0-zhiyuan.1_darwin_arm64.tar.gz",
+      "win-x64": "engram_v1.20.0-zhiyuan.1_windows_amd64.zip",
+      "win-arm64": "engram_v1.20.0-zhiyuan.1_windows_arm64.zip",
+      "linux-x64": "engram_v1.20.0-zhiyuan.1_linux_amd64.tar.gz",
+      "linux-arm64": "engram_v1.20.0-zhiyuan.1_linux_arm64.tar.gz"
     },
     "runtimeChecksums": {
-      "mac-x64": "3b9015dcfcdd9f823eb7ad0b590b1dbc4c25bb5d81dda3f84e623709815afe80",
-      "mac-arm64": "2363d5012f23e58878f86c3ddcc1f63cfe9dcf3eec7f413e70eaafcbb9d394cc",
-      "win-x64": "c945c47d58367f943642cb8451fa45f208174407839f1dda33a975a05d6e465b",
-      "win-arm64": "eb93c6d7d5a4020ddcf1ff956909f3e90694f6447519433316b10f964f8f37b5",
-      "linux-x64": "7dc3003318e303bee269a4772144f3ce01c8ec700bfd524aaec76770acd389ca",
-      "linux-arm64": "7eb815910a76ae6cfa9a5d0161d3701e293dcca71f7743cffa62e236e5af59af"
+      "mac-x64": "PENDING",
+      "mac-arm64": "PENDING",
+      "win-x64": "PENDING",
+      "win-arm64": "PENDING",
+      "linux-x64": "PENDING",
+      "linux-arm64": "PENDING"
     }
   },
   "main": "dist-electron/main.js",

--- a/scripts/download-engram-runtime.cjs
+++ b/scripts/download-engram-runtime.cjs
@@ -21,6 +21,16 @@ function readRuntimeConfig(rootDir) {
   if (!packageJson.engram?.version || !packageJson.engram?.repo) {
     throw new Error('package.json is missing the pinned memory runtime configuration.');
   }
+  // Fork 运行时校验：ZhiYuan 使用带 -zhiyuan 后缀的 fork 标签。
+  // 防呆——若配置回退到上游裸版本号（v1.20.0 无后缀），说明配置被
+  // 误改或 fork 发布未完成，此时应显式失败而不是静默下载上游二进制。
+  const version = packageJson.engram.version;
+  if (!/^v\d+\.\d+\.\d+-zhiyuan\.\d+$/.test(version)) {
+    throw new Error(
+      `Unsupported memory runtime version "${version}": expected a fork tag like v1.20.0-zhiyuan.1. ` +
+        'Publish the fork release first, then update package.json engram.version and runtimeChecksums.',
+    );
+  }
   return packageJson.engram;
 }
 
@@ -62,7 +72,11 @@ function downloadWithAgent(url, destination, proxyUrl) {
           response.pipe(fs.createWriteStream(destination));
           response.on('end', resolve);
           response.on('error', reject);
-        } else if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        } else if (
+          response.statusCode >= 300 &&
+          response.statusCode < 400 &&
+          response.headers.location
+        ) {
           // Follow a single redirect (GitHub release URLs redirect to objects.githubusercontent.com).
           const nextUrl = new URL(response.headers.location, url).toString();
           reject(new Error(`Redirect to ${nextUrl} is not supported in proxy mode.`));
@@ -173,53 +187,149 @@ async function extractZipArchive(archivePath, destination) {
   await extractZip(archivePath, { dir: destination });
 }
 
-async function main() {
-  const rootDir = path.resolve(__dirname, '..');
-  const targetId = process.argv[2]?.trim() || resolveHostTargetId();
-  const config = readRuntimeConfig(rootDir);
+function readBuildInfo(buildInfoPath) {
+  try {
+    return JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function runtimeMatchesConfig(buildInfo, config, targetId, assetName, checksum) {
+  return (
+    buildInfo?.target === targetId &&
+    buildInfo?.version === config.version &&
+    buildInfo?.repo === config.repo &&
+    buildInfo?.assetName === assetName &&
+    buildInfo?.checksum === checksum
+  );
+}
+
+function replaceDirectoryAtomically(stagedDirectory, targetDirectory, fileSystem = fs) {
+  const parentDirectory = path.dirname(targetDirectory);
+  const backupDirectory = path.join(
+    parentDirectory,
+    `.${path.basename(targetDirectory)}.backup-${crypto.randomUUID()}`,
+  );
+  const hadTarget = fileSystem.existsSync(targetDirectory);
+
+  try {
+    if (hadTarget) fileSystem.renameSync(targetDirectory, backupDirectory);
+    fileSystem.renameSync(stagedDirectory, targetDirectory);
+  } catch (error) {
+    if (fileSystem.existsSync(targetDirectory)) {
+      fileSystem.rmSync(targetDirectory, { recursive: true, force: true });
+    }
+    if (hadTarget && fileSystem.existsSync(backupDirectory)) {
+      fileSystem.renameSync(backupDirectory, targetDirectory);
+    }
+    throw error;
+  }
+
+  if (hadTarget) fileSystem.rmSync(backupDirectory, { recursive: true, force: true });
+}
+
+async function prepareRuntimeDirectory(options) {
+  const { rootDir, runtimeRoot, targetId, executableName, config, assetName, checksum } = options;
+  const downloadRuntime = options.downloadRuntime ?? download;
+  const extractRuntime = options.extractRuntime ?? extract;
+  const temporaryRoot = options.temporaryRoot ?? os.tmpdir();
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(temporaryRoot, 'zhiyuan-memory-runtime-download-'),
+  );
+  const stagedDirectory = fs.mkdtempSync(path.join(runtimeRoot, `.${targetId}.staging-`));
+
+  try {
+    const archivePath = path.join(temporaryDirectory, assetName);
+    const extractDirectory = path.join(temporaryDirectory, 'extract');
+    const url = `https://github.com/${config.repo}/releases/download/${config.version}/${assetName}`;
+    fs.mkdirSync(extractDirectory, { recursive: true });
+    await downloadRuntime(url, archivePath);
+    const actualChecksum = sha256(archivePath);
+    if (actualChecksum !== checksum) {
+      throw new Error(`Memory runtime checksum mismatch for ${assetName}.`);
+    }
+    await extractRuntime(archivePath, extractDirectory);
+    const sourceExecutable = findExecutable(extractDirectory, executableName);
+    if (!sourceExecutable) throw new Error(`Archive does not contain ${executableName}.`);
+
+    fs.copyFileSync(sourceExecutable, path.join(stagedDirectory, executableName));
+    if (process.platform !== 'win32') {
+      fs.chmodSync(path.join(stagedDirectory, executableName), 0o755);
+    }
+    fs.copyFileSync(
+      path.join(rootDir, 'third_party', 'engram.LICENSE'),
+      path.join(stagedDirectory, 'LICENSE'),
+    );
+    fs.writeFileSync(
+      path.join(stagedDirectory, 'runtime-build-info.json'),
+      `${JSON.stringify({ target: targetId, version: config.version, repo: config.repo, assetName, checksum }, null, 2)}\n`,
+    );
+    return stagedDirectory;
+  } catch (error) {
+    fs.rmSync(stagedDirectory, { recursive: true, force: true });
+    throw error;
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function ensureMemoryRuntime(rootDir, targetId, options = {}) {
+  const config = options.config ?? readRuntimeConfig(rootDir);
   const assetName = config.runtimeAssets?.[targetId];
   const checksum = config.runtimeChecksums?.[targetId];
   if (!assetName || !checksum) throw new Error(`Unsupported memory runtime target: ${targetId}`);
+  if (!/^[a-f0-9]{64}$/i.test(checksum)) {
+    throw new Error(`Memory runtime checksum is not finalized for ${targetId}.`);
+  }
 
   const executableName = targetId.startsWith('win-') ? 'engram.exe' : 'engram';
   const runtimeRoot = path.join(rootDir, 'vendor', 'engram-runtime');
   const targetDirectory = path.join(runtimeRoot, targetId);
   const targetExecutable = path.join(targetDirectory, executableName);
-  if (!fs.existsSync(targetExecutable)) {
-    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-memory-runtime-'));
+  const buildInfo = readBuildInfo(path.join(targetDirectory, 'runtime-build-info.json'));
+  const cacheIsValid =
+    fs.existsSync(targetExecutable) &&
+    runtimeMatchesConfig(buildInfo, config, targetId, assetName, checksum);
+
+  fs.mkdirSync(runtimeRoot, { recursive: true });
+  if (!cacheIsValid) {
+    console.log(`[MemoryRuntime] Downloading and verifying ${assetName}.`);
+    const stagedDirectory = await prepareRuntimeDirectory({
+      ...options,
+      rootDir,
+      runtimeRoot,
+      targetId,
+      executableName,
+      config,
+      assetName,
+      checksum,
+    });
     try {
-      const archivePath = path.join(temporaryDirectory, assetName);
-      const extractDirectory = path.join(temporaryDirectory, 'extract');
-      const url = `https://github.com/${config.repo}/releases/download/${config.version}/${assetName}`;
-      console.log(`[MemoryRuntime] Downloading ${assetName}.`);
-      await download(url, archivePath);
-      const actualChecksum = sha256(archivePath);
-      if (actualChecksum !== checksum) {
-        throw new Error(`Memory runtime checksum mismatch for ${assetName}.`);
-      }
-      fs.mkdirSync(extractDirectory, { recursive: true });
-      await extract(archivePath, extractDirectory);
-      const sourceExecutable = findExecutable(extractDirectory, executableName);
-      if (!sourceExecutable) throw new Error(`Archive does not contain ${executableName}.`);
-      fs.mkdirSync(targetDirectory, { recursive: true });
-      fs.copyFileSync(sourceExecutable, targetExecutable);
-      if (process.platform !== 'win32') fs.chmodSync(targetExecutable, 0o755);
-      fs.copyFileSync(
-        path.join(rootDir, 'third_party', 'engram.LICENSE'),
-        path.join(targetDirectory, 'LICENSE'),
-      );
-      fs.writeFileSync(
-        path.join(targetDirectory, 'runtime-build-info.json'),
-        `${JSON.stringify({ target: targetId, version: config.version, assetName, checksum }, null, 2)}\n`,
-      );
-    } finally {
-      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+      replaceDirectoryAtomically(stagedDirectory, targetDirectory);
+    } catch (error) {
+      fs.rmSync(stagedDirectory, { recursive: true, force: true });
+      throw error;
     }
   }
 
   const currentDirectory = path.join(runtimeRoot, 'current');
-  fs.rmSync(currentDirectory, { recursive: true, force: true });
-  fs.cpSync(targetDirectory, currentDirectory, { recursive: true });
+  const stagedCurrentDirectory = fs.mkdtempSync(path.join(runtimeRoot, '.current.staging-'));
+  try {
+    fs.cpSync(targetDirectory, stagedCurrentDirectory, { recursive: true });
+    replaceDirectoryAtomically(stagedCurrentDirectory, currentDirectory);
+  } catch (error) {
+    fs.rmSync(stagedCurrentDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return targetDirectory;
+}
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const targetId = process.argv[2]?.trim() || resolveHostTargetId();
+  await ensureMemoryRuntime(rootDir, targetId);
   console.log(`[MemoryRuntime] Runtime ready for ${targetId}.`);
 }
 
@@ -230,4 +340,12 @@ if (require.main === module) {
   });
 }
 
-module.exports = { resolveHostTargetId, readRuntimeConfig, sha256 };
+module.exports = {
+  ensureMemoryRuntime,
+  readBuildInfo,
+  readRuntimeConfig,
+  replaceDirectoryAtomically,
+  resolveHostTargetId,
+  runtimeMatchesConfig,
+  sha256,
+};

--- a/scripts/download-engram-runtime.test.ts
+++ b/scripts/download-engram-runtime.test.ts
@@ -1,0 +1,195 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { ensureMemoryRuntime, replaceDirectoryAtomically } =
+  require('./download-engram-runtime.cjs') as {
+    ensureMemoryRuntime: (
+      rootDir: string,
+      targetId: string,
+      options: {
+        config: RuntimeConfig;
+        temporaryRoot: string;
+        downloadRuntime: (url: string, destination: string) => Promise<void>;
+        extractRuntime: (archive: string, destination: string) => Promise<void>;
+      },
+    ) => Promise<string>;
+    replaceDirectoryAtomically: (
+      stagedDirectory: string,
+      targetDirectory: string,
+      fileSystem?: Pick<typeof fs, 'existsSync' | 'renameSync' | 'rmSync'>,
+    ) => void;
+  };
+
+interface RuntimeConfig {
+  version: string;
+  repo: string;
+  runtimeAssets: Record<string, string>;
+  runtimeChecksums: Record<string, string>;
+}
+
+const targetId = 'win-x64';
+const executableName = 'engram.exe';
+const archiveContent = 'verified archive';
+const checksum = crypto.createHash('sha256').update(archiveContent).digest('hex');
+
+describe('Engram runtime downloader', () => {
+  let rootDir: string;
+  let temporaryRoot: string;
+  let config: RuntimeConfig;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'engram-downloader-root-'));
+    temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'engram-downloader-temp-'));
+    fs.mkdirSync(path.join(rootDir, 'third_party'), { recursive: true });
+    fs.writeFileSync(path.join(rootDir, 'third_party', 'engram.LICENSE'), 'license');
+    config = {
+      version: 'v1.20.0-zhiyuan.1',
+      repo: 'z189yis/engram-cjk',
+      runtimeAssets: { [targetId]: 'engram.zip' },
+      runtimeChecksums: { [targetId]: checksum },
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDir, { recursive: true, force: true });
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  });
+
+  function targetDirectory() {
+    return path.join(rootDir, 'vendor', 'engram-runtime', targetId);
+  }
+
+  function writeCachedRuntime(buildInfo?: Record<string, string>) {
+    fs.mkdirSync(targetDirectory(), { recursive: true });
+    fs.writeFileSync(path.join(targetDirectory(), executableName), 'old runtime');
+    if (buildInfo) {
+      fs.writeFileSync(
+        path.join(targetDirectory(), 'runtime-build-info.json'),
+        JSON.stringify(buildInfo),
+      );
+    }
+  }
+
+  function options(downloadedContent = archiveContent) {
+    return {
+      config,
+      temporaryRoot,
+      downloadRuntime: async (_url: string, destination: string) => {
+        fs.writeFileSync(destination, downloadedContent);
+      },
+      extractRuntime: async (_archive: string, destination: string) => {
+        fs.writeFileSync(path.join(destination, executableName), 'new runtime');
+      },
+    };
+  }
+
+  test('replaces an executable whose build metadata is missing', async () => {
+    writeCachedRuntime();
+
+    await ensureMemoryRuntime(rootDir, targetId, options());
+
+    expect(fs.readFileSync(path.join(targetDirectory(), executableName), 'utf8')).toBe(
+      'new runtime',
+    );
+    const buildInfo = JSON.parse(
+      fs.readFileSync(path.join(targetDirectory(), 'runtime-build-info.json'), 'utf8'),
+    );
+    expect(buildInfo.repo).toBe(config.repo);
+  });
+
+  test('replaces a cache created from a different repository', async () => {
+    writeCachedRuntime({
+      target: targetId,
+      version: config.version,
+      repo: 'Gentleman-Programming/engram',
+      assetName: config.runtimeAssets[targetId],
+      checksum,
+    });
+
+    await ensureMemoryRuntime(rootDir, targetId, options());
+
+    expect(fs.readFileSync(path.join(targetDirectory(), executableName), 'utf8')).toBe(
+      'new runtime',
+    );
+  });
+
+  test('keeps the previous runtime when checksum verification fails', async () => {
+    writeCachedRuntime();
+
+    await expect(
+      ensureMemoryRuntime(rootDir, targetId, options('corrupted archive')),
+    ).rejects.toThrow('checksum mismatch');
+
+    expect(fs.readFileSync(path.join(targetDirectory(), executableName), 'utf8')).toBe(
+      'old runtime',
+    );
+  });
+
+  test('reuses a cache only when all provenance fields match', async () => {
+    writeCachedRuntime({
+      target: targetId,
+      version: config.version,
+      repo: config.repo,
+      assetName: config.runtimeAssets[targetId],
+      checksum,
+    });
+    let downloadCount = 0;
+    const validOptions = options();
+    validOptions.downloadRuntime = async () => {
+      downloadCount += 1;
+    };
+
+    await ensureMemoryRuntime(rootDir, targetId, validOptions);
+
+    expect(downloadCount).toBe(0);
+    expect(
+      fs.readFileSync(
+        path.join(rootDir, 'vendor', 'engram-runtime', 'current', executableName),
+        'utf8',
+      ),
+    ).toBe('old runtime');
+  });
+
+  test('rejects placeholder checksums before downloading', async () => {
+    config.runtimeChecksums[targetId] = 'PENDING';
+    let downloadCount = 0;
+    const pendingOptions = options();
+    pendingOptions.downloadRuntime = async () => {
+      downloadCount += 1;
+    };
+
+    await expect(ensureMemoryRuntime(rootDir, targetId, pendingOptions)).rejects.toThrow(
+      'checksum is not finalized',
+    );
+    expect(downloadCount).toBe(0);
+  });
+
+  test('restores the previous runtime when the directory swap fails', () => {
+    writeCachedRuntime();
+    const stagedDirectory = path.join(rootDir, 'vendor', 'engram-runtime', '.staged-test');
+    fs.mkdirSync(stagedDirectory, { recursive: true });
+    fs.writeFileSync(path.join(stagedDirectory, executableName), 'new runtime');
+    let renameCount = 0;
+    const fileSystem = {
+      existsSync: fs.existsSync,
+      rmSync: fs.rmSync,
+      renameSync(source: fs.PathLike, destination: fs.PathLike) {
+        renameCount += 1;
+        if (renameCount === 2) throw new Error('simulated swap failure');
+        fs.renameSync(source, destination);
+      },
+    };
+
+    expect(() =>
+      replaceDirectoryAtomically(stagedDirectory, targetDirectory(), fileSystem),
+    ).toThrow('simulated swap failure');
+    expect(fs.readFileSync(path.join(targetDirectory(), executableName), 'utf8')).toBe(
+      'old runtime',
+    );
+  });
+});


### PR DESCRIPTION
## 概述

将 engram 记忆运行时切换到 **CJK 搜索 fork**（`z189yis/engram-cjk`），使中文、日文、韩文搜索可用，并加固运行时下载校验。

## 背景

上游 engram v1.20.0 的 FTS5 默认分词器无法可靠检索 CJK 文本。fork 已实现 trigram 子串索引 + 混合查询规划 + 性能优化（长词查询 2.1s → 526µs），发布为 `v1.20.0-zhiyuan.1`。

## 改动内容

### 1. `package.json` — engram 块切换到 fork

- `repo`: `Gentleman-Programming/engram` → `z189yis/engram-cjk`
- `version`: `v1.20.0` → `v1.20.0-zhiyuan.1`（fork 专属标签）
- `runtimeAssets`: 更新为 fork 资产命名（`engram_v1.20.0-zhiyuan.1_*`）
- `runtimeChecksums`: **置 `PENDING`**——fork 发布完成后填入真实 SHA-256 后再合并本 PR

### 2. `scripts/download-engram-runtime.cjs` — 下载校验加固

**fork 标签防呆**（`readRuntimeConfig`）：

- 仅接受 `vX.Y.Z-zhiyuan.N` 格式版本号
- 误配上游裸版本号（`v1.20.0`）时显式失败，而非静默下载上游二进制

**缓存一致性校验**：

- 运行时缓存（`runtime-build-info.json`）与配置不匹配（版本/资产/checksum 任一不同）时强制重新下载
- 防止切换 fork 标签或升级后静默使用旧二进制

**替换顺序修复**：

- 下载成功并校验通过后才删除旧缓存
- 下载/校验失败时保留旧二进制（优雅降级：`current/` 仍指向旧版本可运行）

## 验证

- 内存模块测试：**11 文件 27 测试全部通过**
- fork 标签正则边界用例：`v1.20.0`❌ / `v1.20.0-zhiyuan.1`✅ / `v1.21.0-zhiyuan.2`✅ / `dev`❌
- 缓存不匹配 → 重新下载 → 下载失败 → **旧二进制保留**（已实测）

## 合并前置条件

1. **`v1.20.0-zhiyuan.1` fork 发布完成**（资产 + checksums 就绪）
2. package.json `runtimeChecksums` 从 `PENDING` 替换为真实值
3. 本 PR 合并后执行 `bun run engram:runtime:host` 验证端到端下载

## 变更文件

- `package.json`（engram 块）
- `scripts/download-engram-runtime.cjs`
