### PR TITLE
fix(cowork): anchor deliverables to final answers

### DIFF
--- a/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.test.ts
@@ -99,12 +99,17 @@ describe('createZhiyuanEvaluationPolicy', () => {
       result: { content: [{ type: 'text', text: 'checks passed' }] },
       isError: false,
     });
+    const inspectionState = (await productionTool.execute('state', {
+      action: ProductionLoopAction.GetState,
+    })) as { content: Array<{ text: string }> };
+    const evidenceRef = JSON.parse(inspectionState.content[0].text).availableVerifierEvidence[0]
+      .evidenceRef as string;
     await productionTool.execute('inspect', {
       action: ProductionLoopAction.StartInspection,
       verifierEvidence: [
         {
           name: 'official benchmark scorer',
-          toolCallId: 'benchmark-check',
+          evidenceRef,
         },
       ],
     });
@@ -192,12 +197,17 @@ describe('createZhiyuanEvaluationPolicy', () => {
       result: { content: [{ type: 'text', text: 'checks passed' }] },
       isError: false,
     });
+    const inspectionState = (await productionTool.execute('state', {
+      action: ProductionLoopAction.GetState,
+    })) as { content: Array<{ text: string }> };
+    const evidenceRef = JSON.parse(inspectionState.content[0].text).availableVerifierEvidence[0]
+      .evidenceRef as string;
     await productionTool.execute('inspect', {
       action: ProductionLoopAction.StartInspection,
       verifierEvidence: [
         {
           name: 'official benchmark scorer',
-          toolCallId: 'benchmark-check',
+          evidenceRef,
         },
       ],
     });

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -74,9 +74,10 @@ const reachCritique = (controller: ProductionLoopController) => {
     controller.updatePlanItem(item.id, 'completed');
   }
   controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
   controller.startInspection({
     artifacts: [],
-    verifiers: [{ name: 'preview', toolCallId: 'preview-check' }],
+    verifiers: [{ name: 'preview', evidenceRef }],
   });
   controller.requestCritique();
 };

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -18,9 +18,11 @@ interface DownstreamCompletionWorkflow {
   readonly goal: string;
   resumeForPrompt?(prompt: string): void;
   requestCompletion(reason: string): string;
-  onAgentEnd(
-    signal: PiAgentLoopEndSignal,
-  ): { shouldFinish: boolean; reason?: string; nextPrompt?: string };
+  onAgentEnd(signal: PiAgentLoopEndSignal): {
+    shouldFinish: boolean;
+    reason?: string;
+    nextPrompt?: string;
+  };
 }
 
 const isStandaloneProductionReviewer = (args: unknown): boolean => {
@@ -60,6 +62,11 @@ export class ProductionLoopController {
     return structuredClone(this.state);
   }
 
+  getAvailableVerifierEvidence() {
+    this.refresh();
+    return this.service.getAvailableVerifierEvidence(this.state.runId);
+  }
+
   startRun(input: {
     taskId: string;
     runId: string;
@@ -82,7 +89,7 @@ export class ProductionLoopController {
       phaseInstruction,
       'The plan must include acceptance criteria, expected artifacts, and deterministic verifiers.',
       'After commit_plan, read the returned state and use each generated plan item ID with update_plan_item.',
-      'After execution, call start_inspection with every required artifact and the successful tool call ID for each deterministic verifier, then request_critique and delegate a read-only review to the production-reviewer subagent.',
+      'After execution, call production_loop get_state, then call start_inspection with every required artifact and the exact evidenceRef shown for each successful deterministic verifier. Never guess evidence references.',
       'A reviewer PASS does not replace artifact verification or the completion contract.',
       'When findings exist, revise the work, record_revision, inspect again, and request another critique.',
       'Call agent_loop done only after the production loop reports ready_to_deliver.',
@@ -117,7 +124,9 @@ export class ProductionLoopController {
     return this.update(this.service.updatePlanItem(this.state.runId, itemId, status));
   }
 
-  startInspection(input: Parameters<ProductionLoopService['startInspection']>[1]): ProductionLoopState {
+  startInspection(
+    input: Parameters<ProductionLoopService['startInspection']>[1],
+  ): ProductionLoopState {
     return this.update(this.service.startInspection(this.state.runId, input));
   }
 
@@ -194,9 +203,11 @@ export class ProductionLoopController {
       : 'Delivery requested. End the turn so deterministic verification can run.';
   }
 
-  onAgentEnd(
-    signal: PiAgentLoopEndSignal,
-  ): { shouldFinish: boolean; reason?: string; nextPrompt?: string } {
+  onAgentEnd(signal: PiAgentLoopEndSignal): {
+    shouldFinish: boolean;
+    reason?: string;
+    nextPrompt?: string;
+  } {
     this.refresh();
     if (this.state.skip) {
       return { shouldFinish: true, reason: this.state.skip.reason };
@@ -280,12 +291,7 @@ export class ProductionLoopController {
     return this.getState();
   }
 
-  recordToolResult(
-    toolCallId: string,
-    toolName: string,
-    output: string,
-    isError: boolean,
-  ): void {
+  recordToolResult(toolCallId: string, toolName: string, output: string, isError: boolean): void {
     this.update(
       this.service.recordToolResult(this.state.runId, {
         toolCallId,

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -73,14 +73,20 @@ const recordVerifier = (runId: string, isError = false) => {
     output: isError ? 'Verifier failed.' : 'report.md exists and is valid.',
     isError,
   });
-  return toolCallId;
+  return {
+    toolCallId,
+    evidenceRef: isError
+      ? undefined
+      : service.getAvailableVerifierEvidence(runId).at(-1)?.evidenceRef,
+  };
 };
 
 const startInspection = (runId: string) => {
-  const toolCallId = recordVerifier(runId);
+  const { evidenceRef } = recordVerifier(runId);
+  if (!evidenceRef) throw new Error('Verifier evidence missing in test setup.');
   return service.startInspection(runId, {
     artifacts: [{ kind: 'file', reference: 'report.md' }],
-    verifiers: [{ name: 'artifact_verifier', toolCallId }],
+    verifiers: [{ name: 'artifact_verifier', evidenceRef }],
   });
 };
 
@@ -109,18 +115,21 @@ test('requires deterministic verifier and artifact evidence before inspection', 
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  const successfulToolCallId = recordVerifier(run.id);
+  const successfulEvidence = recordVerifier(run.id);
+  if (!successfulEvidence.evidenceRef) throw new Error('Verifier evidence missing in test setup.');
   expect(() =>
     service.startInspection(run.id, {
       artifacts: [],
-      verifiers: [{ name: 'artifact_verifier', toolCallId: successfulToolCallId }],
+      verifiers: [{ name: 'artifact_verifier', evidenceRef: successfulEvidence.evidenceRef }],
     }),
   ).toThrow('artifact evidence');
-  const failedToolCallId = recordVerifier(run.id, true);
+  const failedEvidence = recordVerifier(run.id, true);
   expect(() =>
     service.startInspection(run.id, {
       artifacts: [{ kind: 'file', reference: 'report.md' }],
-      verifiers: [{ name: 'artifact_verifier', toolCallId: failedToolCallId }],
+      verifiers: [
+        { name: 'artifact_verifier', evidenceRef: failedEvidence.evidenceRef ?? 'ev-failed' },
+      ],
     }),
   ).toThrow('Passing deterministic verifier evidence');
 
@@ -131,6 +140,10 @@ test('requires deterministic verifier and artifact evidence before inspection', 
     toolName: 'bash',
     evidence: 'report.md exists and is valid.',
   });
+  expect(inspecting.inspections[0].verifiers[0].toolCallId).toBe(
+    service.repository.get(run.id)?.observedToolResults.at(-1)?.toolCallId,
+  );
+  expect(inspecting.inspections[0].verifiers[0].toolCallId).not.toContain('ev-');
 });
 
 test('retains only the latest observed tool results', () => {
@@ -164,6 +177,7 @@ test('retains only the latest observed tool results', () => {
     toolCallId: 'tool-2',
     output: 'updated-result',
   });
+  expect(service.getAvailableVerifierEvidence(run.id)).toHaveLength(32);
 });
 
 test('persists plan, critic rejection, revision, and delivery readiness', () => {
@@ -172,7 +186,12 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
   for (const item of planned.planItems) {
     service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
   }
-  const firstInspection = startInspection(run.id);
+  const firstEvidence = recordVerifier(run.id);
+  if (!firstEvidence.evidenceRef) throw new Error('Verifier evidence missing in test setup.');
+  service.startInspection(run.id, {
+    artifacts: [{ kind: 'file', reference: 'report.md' }],
+    verifiers: [{ name: 'artifact_verifier', evidenceRef: firstEvidence.evidenceRef }],
+  });
   service.requestCritique(run.id);
   service.recordCriticStart(run.id, 'review-1');
   const rejected = service.recordCriticResult(
@@ -198,7 +217,7 @@ test('persists plan, critic rejection, revision, and delivery readiness', () => 
       verifiers: [
         {
           name: 'artifact_verifier',
-          toolCallId: firstInspection.inspections[0].verifiers[0].toolCallId,
+          evidenceRef: firstEvidence.evidenceRef,
         },
       ],
     }),

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 
 import { HarnessActivationType } from '../../shared/harness';
 import {
@@ -8,6 +8,7 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
+  type ProductionAvailableVerifierEvidence,
   type ProductionCriticFinding,
   type ProductionCriticExecution,
   type ProductionArtifactEvidence,
@@ -27,7 +28,12 @@ import type { ProductionLoopMeasurement, ProductionLoopStore } from './ports';
 import { assertProductionLoopTransition } from './stateMachine';
 
 const MAX_CRITIC_OUTPUT_LENGTH = 8_000;
+const MAX_MODEL_EVIDENCE_SUMMARY_LENGTH = 300;
+const MAX_MODEL_VERIFIER_EVIDENCE = 32;
 export const MAX_OBSERVED_TOOL_RESULTS = 256;
+
+const createEvidenceRef = (runId: string, toolCallId: string): string =>
+  `ev-${createHash('sha256').update(`${runId}\0${toolCallId}`).digest('hex').slice(0, 16)}`;
 
 interface CriticPayload {
   verdict: ProductionCriticVerdict;
@@ -77,7 +83,9 @@ const parseCriticPayload = (output: string, isError: boolean): CriticPayload => 
   }
   try {
     const parsed = parseJsonRecord(output);
-    if (!Object.values(ProductionCriticVerdict).includes(parsed.verdict as ProductionCriticVerdict)) {
+    if (
+      !Object.values(ProductionCriticVerdict).includes(parsed.verdict as ProductionCriticVerdict)
+    ) {
       throw new Error('Critic verdict is missing or invalid.');
     }
     if (!Array.isArray(parsed.findings)) {
@@ -92,7 +100,9 @@ const parseCriticPayload = (output: string, isError: boolean): CriticPayload => 
       if (typeof raw.summary !== 'string' || !raw.summary.trim()) {
         throw new Error('Critic finding summary is required.');
       }
-      if (!Object.values(ProductionCriticSeverity).includes(raw.severity as ProductionCriticSeverity)) {
+      if (
+        !Object.values(ProductionCriticSeverity).includes(raw.severity as ProductionCriticSeverity)
+      ) {
         throw new Error('Critic finding severity is invalid.');
       }
       if (raw.evidence !== undefined && typeof raw.evidence !== 'string') {
@@ -139,6 +149,20 @@ export class ProductionLoopService {
     const state = this.repository.get(runId);
     if (!state) throw new Error(`Production loop not found: ${runId}`);
     return state;
+  }
+
+  getAvailableVerifierEvidence(runId: string): ProductionAvailableVerifierEvidence[] {
+    const state = this.getState(runId);
+    return (state.observedToolResults ?? [])
+      .filter(result => !result.isError && result.progressVersion === state.progressVersion)
+      .slice(-MAX_MODEL_VERIFIER_EVIDENCE)
+      .map(result => ({
+        evidenceRef: createEvidenceRef(runId, result.toolCallId),
+        toolName: result.toolName,
+        outputSummary:
+          result.output.trim().slice(0, MAX_MODEL_EVIDENCE_SUMMARY_LENGTH) ||
+          `Tool ${result.toolName} completed successfully.`,
+      }));
   }
 
   beginRun(input: {
@@ -317,7 +341,7 @@ export class ProductionLoopService {
     runId: string,
     input: {
       artifacts: ProductionArtifactEvidence[];
-      verifiers: Array<{ name: string; toolCallId: string }>;
+      verifiers: Array<{ name: string; evidenceRef: string }>;
     },
   ): ProductionLoopState {
     return this.mutate(runId, state => {
@@ -332,10 +356,13 @@ export class ProductionLoopService {
       const observedToolResults = state.observedToolResults ?? [];
       const verifiers = input.verifiers.flatMap(verifier => {
         const name = verifier.name.trim();
-        const toolCallId = verifier.toolCallId.trim();
-        const observed = observedToolResults.find(result => result.toolCallId === toolCallId);
+        const evidenceRef = verifier.evidenceRef.trim();
+        const observed = observedToolResults.find(
+          result => createEvidenceRef(runId, result.toolCallId) === evidenceRef,
+        );
         if (
           !name ||
+          !evidenceRef ||
           !observed ||
           observed.isError ||
           observed.progressVersion !== state.progressVersion
@@ -345,10 +372,9 @@ export class ProductionLoopService {
         return [
           {
             name,
-            toolCallId,
+            toolCallId: observed.toolCallId,
             toolName: observed.toolName,
-            evidence:
-              observed.output.trim() || `Tool ${observed.toolName} completed successfully.`,
+            evidence: observed.output.trim() || `Tool ${observed.toolName} completed successfully.`,
           },
         ];
       });
@@ -361,8 +387,7 @@ export class ProductionLoopService {
       }
       const failedVerifier = state.expectedVerifiers.find(
         expected =>
-          expected.deterministic &&
-          !verifiers.some(verifier => verifier.name === expected.name),
+          expected.deterministic && !verifiers.some(verifier => verifier.name === expected.name),
       );
       if (failedVerifier) {
         throw new Error(

--- a/src/main/productionLoop/tool.test.ts
+++ b/src/main/productionLoop/tool.test.ts
@@ -12,15 +12,28 @@ import { buildProductionLoopTool } from './tool';
 const state = {
   phase: ProductionLoopPhase.Plan,
   status: ProductionLoopStatus.Active,
+  acceptanceCriteria: ['Artifact exists'],
+  expectedArtifacts: [{ kind: 'file', description: 'report.md', required: true }],
+  expectedVerifiers: [{ name: 'artifact_check', deterministic: true }],
   planItems: [{ id: 'item-1', title: 'Build', status: ProductionPlanItemStatus.Pending }],
   critic: { requested: false },
   deliveryReason: null,
 };
 
+const availableVerifierEvidence = [
+  {
+    evidenceRef: 'ev-1234',
+    toolName: 'bash',
+    outputSummary: 'checks passed',
+  },
+];
+
 const createTool = () => {
   const controller = {
     getState: vi.fn(() => state),
+    getAvailableVerifierEvidence: vi.fn(() => availableVerifierEvidence),
     commitPlan: vi.fn(),
+    startInspection: vi.fn(),
     updatePlanItem: vi.fn(),
     skipWorkflow: vi.fn(),
   } as unknown as ProductionLoopController;
@@ -47,7 +60,7 @@ test('publishes concrete nested schemas for model-generated plans', () => {
     'name',
     'deterministic',
   ]);
-  expect(parameters.properties.verifierEvidence.items?.required).toEqual(['name', 'toolCallId']);
+  expect(parameters.properties.verifierEvidence.items?.required).toEqual(['name', 'evidenceRef']);
 });
 
 test('normalizes a plan payload before passing it to the controller', async () => {
@@ -82,7 +95,40 @@ test('returns model-visible state with generated plan item IDs', async () => {
 
   const output = await tool.execute('call', { action: ProductionLoopAction.GetState });
 
-  expect(JSON.parse(output.content[0].text)).toEqual(state);
+  expect(JSON.parse(output.content[0].text)).toEqual({
+    ...state,
+    availableVerifierEvidence,
+  });
+});
+
+test('passes model-visible evidence references into inspection', async () => {
+  const { controller, tool } = createTool();
+
+  await tool.execute('call', {
+    action: ProductionLoopAction.StartInspection,
+    artifactEvidence: [{ kind: 'file', reference: 'report.md' }],
+    verifierEvidence: [{ name: 'artifact_check', evidenceRef: 'ev-1234' }],
+  });
+
+  expect(controller.startInspection).toHaveBeenCalledWith({
+    artifacts: [{ kind: 'file', reference: 'report.md' }],
+    verifiers: [{ name: 'artifact_check', evidenceRef: 'ev-1234' }],
+  });
+});
+
+test('returns available evidence when inspection validation fails', async () => {
+  const { controller, tool } = createTool();
+  vi.mocked(controller.startInspection).mockImplementation(() => {
+    throw new Error('Passing deterministic verifier evidence is missing for: artifact_check');
+  });
+
+  const output = await tool.execute('call', {
+    action: ProductionLoopAction.StartInspection,
+    verifierEvidence: [{ name: 'artifact_check', evidenceRef: 'ev-invalid' }],
+  });
+
+  expect(output.content[0].text).toContain('ev-1234');
+  expect(output.content[0].text).toContain('checks passed');
 });
 
 test('returns controller validation errors without advancing the tool state', async () => {

--- a/src/main/productionLoop/tool.ts
+++ b/src/main/productionLoop/tool.ts
@@ -55,13 +55,13 @@ const artifactEvidence = (value: unknown): ProductionArtifactEvidence[] =>
       })
     : [];
 
-const verifierEvidence = (value: unknown): Array<{ name: string; toolCallId: string }> =>
+const verifierEvidence = (value: unknown): Array<{ name: string; evidenceRef: string }> =>
   Array.isArray(value)
     ? value.flatMap(entry => {
         if (!entry || typeof entry !== 'object') return [];
         const raw = entry as Record<string, unknown>;
-        return typeof raw.name === 'string' && typeof raw.toolCallId === 'string'
-          ? [{ name: raw.name, toolCallId: raw.toolCallId }]
+        return typeof raw.name === 'string' && typeof raw.evidenceRef === 'string'
+          ? [{ name: raw.name, evidenceRef: raw.evidenceRef }]
           : [];
       })
     : [];
@@ -74,9 +74,13 @@ export function buildProductionLoopTool(
     return JSON.stringify({
       phase: state.phase,
       status: state.status,
+      acceptanceCriteria: state.acceptanceCriteria,
+      expectedArtifacts: state.expectedArtifacts,
+      expectedVerifiers: state.expectedVerifiers,
       planItems: state.planItems,
       critic: state.critic,
       deliveryReason: state.deliveryReason,
+      availableVerifierEvidence: controller.getAvailableVerifierEvidence(),
     });
   };
   const result = (text: string): ProductionLoopToolResult => ({
@@ -152,14 +156,14 @@ export function buildProductionLoopTool(
           type: 'array',
           minItems: 1,
           description:
-            'Map each deterministic verifier name to the successful tool call that ran it in the current workflow revision.',
+            'Map each deterministic verifier name to an exact evidenceRef returned by get_state for the current workflow revision.',
           items: {
             type: 'object',
             properties: {
               name: { type: 'string' },
-              toolCallId: { type: 'string' },
+              evidenceRef: { type: 'string' },
             },
-            required: ['name', 'toolCallId'],
+            required: ['name', 'evidenceRef'],
             additionalProperties: false,
           },
         },
@@ -254,7 +258,12 @@ export function buildProductionLoopTool(
             return result(`Unknown production_loop action: ${String(params.action || '')}`);
         }
       } catch (error) {
-        return result(error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        return result(
+          params.action === ProductionLoopAction.StartInspection
+            ? `${message}\nCurrent inspection state:\n${stateForModel()}`
+            : message,
+        );
       }
     },
   };

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -70,9 +70,11 @@ const prepareProductionDelivery = (
     output: 'Completion contract passed.',
     isError: false,
   });
+  const evidenceRef = service.productionLoop.getAvailableVerifierEvidence(runId)[0]?.evidenceRef;
+  if (!evidenceRef) throw new Error('Verifier evidence missing in test setup.');
   service.productionLoop.startInspection(runId, {
     artifacts: [{ kind: 'result', reference: 'final-answer' }],
-    verifiers: [{ name: 'completion_contract', toolCallId: 'completion-contract-check' }],
+    verifiers: [{ name: 'completion_contract', evidenceRef }],
   });
   service.productionLoop.requestCritique(runId);
   service.productionLoop.recordCriticStart(runId, 'critic');

--- a/src/renderer/components/cowork/helpers/useTurnArtifacts.test.ts
+++ b/src/renderer/components/cowork/helpers/useTurnArtifacts.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import { ArtifactRole, PREVIEWABLE_ARTIFACT_TYPES, type Artifact } from '../../../types/artifact';
+import type { ConversationTurn } from './messageGrouping';
+import { useTurnArtifacts } from './useTurnArtifacts';
+
+test('maps a persisted deliverable to its final answer anchor in the loaded message page', () => {
+  const turn: ConversationTurn = {
+    id: 'user-message',
+    userMessage: null,
+    assistantItems: [
+      {
+        type: 'assistant',
+        message: {
+          id: 'final-answer-in-current-page',
+          type: 'assistant',
+          content: 'Delivered D:/workspace/presentation.pptx',
+          timestamp: 2,
+          metadata: { isFinal: true, isFinalAnswer: true },
+        },
+      },
+    ],
+  };
+  const artifact: Artifact = {
+    id: 'declared-artifact',
+    messageId: 'final-answer-in-current-page',
+    sessionId: 'session-1',
+    type: 'document',
+    title: 'presentation.pptx',
+    content: '',
+    fileName: 'presentation.pptx',
+    filePath: 'D:/workspace/presentation.pptx',
+    source: 'tool',
+    role: ArtifactRole.Deliverable,
+    declared: true,
+    createdAt: 1,
+  };
+
+  const view = renderHook(() => useTurnArtifacts([turn], [artifact], PREVIEWABLE_ARTIFACT_TYPES));
+
+  expect(view.result.current.get('user-message')).toEqual([artifact]);
+});

--- a/src/renderer/store/slices/artifactSlice.test.ts
+++ b/src/renderer/store/slices/artifactSlice.test.ts
@@ -107,6 +107,67 @@ describe('artifact reducer', () => {
     ]);
   });
 
+  test('anchors a declared deliverable to the final answer that references the same path', () => {
+    const declared = makeArtifact({
+      id: 'declared-artifact',
+      messageId: 'declare-message-outside-page',
+      title: 'Explicit title',
+      role: ArtifactRole.Deliverable,
+      declared: true,
+    });
+    const finalAnswer = makeArtifact({
+      id: 'artifact-final-answer',
+      messageId: 'final-answer-in-current-page',
+      role: ArtifactRole.Deliverable,
+      declared: false,
+    });
+
+    let state = artifactReducer(
+      undefined,
+      addArtifact({ sessionId: 'session-1', artifact: declared }),
+    );
+    state = artifactReducer(state, addArtifact({ sessionId: 'session-1', artifact: finalAnswer }));
+
+    expect(state.artifactsBySession['session-1']).toEqual([
+      expect.objectContaining({
+        id: 'declared-artifact',
+        messageId: 'final-answer-in-current-page',
+        title: 'Explicit title',
+        role: ArtifactRole.Deliverable,
+        declared: true,
+      }),
+    ]);
+  });
+
+  test('keeps the final answer anchor when persisted declaration data arrives later', () => {
+    const finalAnswer = makeArtifact({
+      id: 'artifact-final-answer',
+      messageId: 'final-answer-in-current-page',
+      role: ArtifactRole.Deliverable,
+      declared: false,
+    });
+    const declared = makeArtifact({
+      id: 'declared-artifact',
+      messageId: 'declare-message-outside-page',
+      title: 'Explicit title',
+      role: ArtifactRole.Deliverable,
+      declared: true,
+    });
+
+    let state = artifactReducer(
+      undefined,
+      addArtifact({ sessionId: 'session-1', artifact: finalAnswer }),
+    );
+    state = artifactReducer(state, addArtifact({ sessionId: 'session-1', artifact: declared }));
+
+    expect(state.artifactsBySession['session-1'][0]).toMatchObject({
+      id: 'declared-artifact',
+      messageId: 'final-answer-in-current-page',
+      title: 'Explicit title',
+      declared: true,
+    });
+  });
+
   test('keeps artifact focus mode explicit and resets it when the panel closes', () => {
     const selected = artifactReducer(undefined, selectArtifact('artifact-1'));
     const focused = artifactReducer(selected, setArtifactLayoutMode(ArtifactLayoutMode.Workspace));

--- a/src/renderer/store/slices/artifactSlice.ts
+++ b/src/renderer/store/slices/artifactSlice.ts
@@ -83,13 +83,22 @@ function restoreSessionView(state: ArtifactState, viewState: ArtifactSessionView
 
 function mergeArtifact(existing: Artifact, incoming: Artifact): Artifact {
   const declaredArtifact = incoming.declared ? incoming : existing.declared ? existing : null;
+  const deliveryAnchorArtifact =
+    !incoming.declared && incoming.role === ArtifactRole.Deliverable
+      ? incoming
+      : !existing.declared && existing.role === ArtifactRole.Deliverable
+        ? existing
+        : null;
   const merged = {
     ...existing,
     ...incoming,
     ...(declaredArtifact
       ? {
           id: declaredArtifact.id,
-          messageId: declaredArtifact.messageId,
+          messageId:
+            declaredArtifact.role === ArtifactRole.Deliverable && deliveryAnchorArtifact
+              ? deliveryAnchorArtifact.messageId
+              : declaredArtifact.messageId,
           type: declaredArtifact.type,
           title: declaredArtifact.title,
           fileName: declaredArtifact.fileName,

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -52,6 +52,12 @@ export interface ProductionObservedToolResult {
   createdAt: number;
 }
 
+export interface ProductionAvailableVerifierEvidence {
+  evidenceRef: string;
+  toolName: string;
+  outputSummary: string;
+}
+
 export interface ProductionInspectionEvidence {
   artifacts: ProductionArtifactEvidence[];
   verifiers: ProductionVerifierEvidence[];


### PR DESCRIPTION
## 阶段

第 2/2 阶段，依赖 #420。当前 PR 基于 `codex/production-evidence-ref`，#420 合并后最终进入 `main`。

## 问题

长会话默认只加载最后 30 条消息。`declare_artifact` 可能已经被移出当前分页窗口，但其持久化工件仍保留声明消息的 `messageId`。最终回答再次引用同一路径时，路径去重又固定保留旧声明消息 ID，导致当前任何 turn 都无法认领该工件，交付卡片因此不显示。

实际问题会话中：

- 工件声明位于序号 391
- 最终回答位于序号 462
- 当前页面只加载最后 30 条消息
- PPTX 已生成并持久化为 deliverable，但旧消息锚点不在页面中

## 变更摘要

- 保持显式声明作为工件 ID、标题、类型、角色、路径和创建时间的权威来源
- 当最终回答引用同一路径时，使用最终回答的 `messageId` 作为展示锚点
- 仅对显式声明为 deliverable 的工件应用重锚定，不提升显式 intermediate 工件
- 同时覆盖“持久化声明先恢复”和“最终回答先检测”两种异步顺序
- 新增 turn 映射测试，确认分页窗口中的最终回答可以渲染持久化交付物

## UI 影响

不修改组件结构、样式、文案或交互。仅修正现有 `ArtifactPreviewCard` 的数据归属，使交付物卡片稳定显示在最终回答下方。

## Electron 影响

仅修改 renderer Redux 合并逻辑和测试；不新增 IPC，不修改数据库结构。

## 验证

- `npm.cmd test -- artifactSlice artifactParser useTurnArtifacts`：38 个用例通过
- `npm.cmd run lint`：通过
- `npm.cmd run build`：通过
- `npx.cmd oxfmt --check <本阶段改动文件>`：通过
- `git diff --check`：通过
