### PR TITLE
fix(settings): clarify save propagation failures

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -29,7 +29,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import {
   isProviderEnabled,
@@ -59,10 +59,7 @@ import {
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import { getProviderIcon } from '../providers/uiRegistry';
 import { apiService } from '../services/api';
-import {
-  collectAvailableModels,
-  LLAMACPP_RUNNING_MODELS_CHANGED_EVENT,
-} from '../services/availableModels';
+import { LLAMACPP_RUNNING_MODELS_CHANGED_EVENT } from '../services/availableModels';
 import { configService } from '../services/config';
 import { coworkService } from '../services/cowork';
 import {
@@ -74,10 +71,10 @@ import {
 } from '../services/encryption';
 import { i18nService, LanguageType } from '../services/i18n';
 import { imService } from '../services/im';
+import { getSettingsSaveErrorMessage } from '../services/settingsSave';
 import { formatShortcutLabel } from '../services/shortcutLabel';
 import { themeService } from '../services/theme';
 import { selectCoworkConfig } from '../store/selectors/coworkSelectors';
-import { setAvailableModels } from '../store/slices/modelSlice';
 import type {
   CoworkAgentEngine,
   CoworkMemoryStats,
@@ -722,7 +719,6 @@ const Settings: React.FC<SettingsProps> = ({
   enterpriseConfig,
   appUpdateState,
 }) => {
-  const dispatch = useDispatch();
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
@@ -2069,6 +2065,7 @@ const Settings: React.FC<SettingsProps> = ({
     e.preventDefault();
     setIsSaving(true);
     setError(null);
+    let appConfigSaved = false;
 
     try {
       const emailSaved = (await emailSettingsRef.current?.saveIfDirty()) ?? true;
@@ -2138,6 +2135,7 @@ const Settings: React.FC<SettingsProps> = ({
           ...configService.getConfig().app,
         },
       });
+      appConfigSaved = true;
 
       // 应用主题
       themeService.setTheme(theme);
@@ -2153,10 +2151,6 @@ const Settings: React.FC<SettingsProps> = ({
         apiKey: apiKeyToUse,
         baseUrl: baseUrlToUse,
       });
-
-      // 更新 Redux store 中的可用模型列表
-      const allModels = await collectAvailableModels(configService.getConfig());
-      dispatch(setAvailableModels(allModels));
 
       if (hasCoworkConfigChanges) {
         const updated = await coworkService.updateConfig({
@@ -2206,7 +2200,9 @@ const Settings: React.FC<SettingsProps> = ({
       didSaveRef.current = true;
       onClose();
     } catch (error) {
-      setError(error instanceof Error ? error.message : 'Failed to save settings');
+      setError(
+        getSettingsSaveErrorMessage(error, appConfigSaved, key => i18nService.t(key)),
+      );
     } finally {
       setIsSaving(false);
     }

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -885,6 +885,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // 错误信息
     failedToLoadSettings: '加载设置失败',
     failedToSaveSettings: '保存设置失败',
+    settingsPartiallySaved: '基础设置已保存，但后续同步失败：{0}',
 
     // 加载状态
     loading: '加载中...',
@@ -3719,6 +3720,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     // Error Messages
     failedToLoadSettings: 'Failed to load settings',
     failedToSaveSettings: 'Failed to save settings',
+    settingsPartiallySaved: 'Base settings were saved, but a later sync failed: {0}',
 
     // Loading State
     loading: 'Loading...',

--- a/src/renderer/services/settingsSave.test.ts
+++ b/src/renderer/services/settingsSave.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+
+import { getSettingsSaveErrorMessage } from './settingsSave';
+
+const translate = (key: string): string =>
+  ({
+    failedToSaveSettings: 'save failed',
+    settingsPartiallySaved: 'partially saved: {0}',
+  })[key] ?? key;
+
+test('preserves the original error before app config is committed', () => {
+  expect(getSettingsSaveErrorMessage(new Error('storage failed'), false, translate)).toBe(
+    'storage failed',
+  );
+});
+
+test('reports a partial save after app config is committed', () => {
+  expect(getSettingsSaveErrorMessage(new Error('gateway failed'), true, translate)).toBe(
+    'partially saved: gateway failed',
+  );
+});
+
+test('uses the translated fallback for non-error failures', () => {
+  expect(getSettingsSaveErrorMessage('unknown', true, translate)).toBe(
+    'partially saved: save failed',
+  );
+});

--- a/src/renderer/services/settingsSave.ts
+++ b/src/renderer/services/settingsSave.ts
@@ -1,0 +1,11 @@
+export function getSettingsSaveErrorMessage(
+  error: unknown,
+  appConfigSaved: boolean,
+  translate: (key: string) => string,
+): string {
+  const detail = error instanceof Error ? error.message : translate('failedToSaveSettings');
+  if (!appConfigSaved) {
+    return detail;
+  }
+  return translate('settingsPartiallySaved').replace('{0}', detail);
+}


### PR DESCRIPTION
Stacked on PR #425. Summary: use config-updated as the single available-model refresh path from Settings; distinguish pre-commit save failures from post-commit subsystem sync failures; add localized partial-save messages and focused tests. Verification: npm test -- settingsSave config.test.ts; npm run lint; npm run build:tsc.