### PR TITLE
fix(settings): reconcile default model on provider save

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -71,6 +71,7 @@ import {
 } from '../services/encryption';
 import { i18nService, LanguageType } from '../services/i18n';
 import { imService } from '../services/im';
+import { reconcileDefaultModelConfig } from '../services/modelConfigReconciliation';
 import { getSettingsSaveErrorMessage } from '../services/settingsSave';
 import { formatShortcutLabel } from '../services/shortcutLabel';
 import { themeService } from '../services/theme';
@@ -2126,6 +2127,7 @@ const Settings: React.FC<SettingsProps> = ({
           baseUrl: primaryProvider.baseUrl,
         },
         providers: normalizedProviders, // Save all providers configuration
+        model: reconcileDefaultModelConfig(configService.getConfig(), normalizedProviders),
         theme,
         language,
         useSystemProxy,

--- a/src/renderer/services/modelConfigReconciliation.test.ts
+++ b/src/renderer/services/modelConfigReconciliation.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'vitest';
+
+import { type AppConfig, defaultConfig } from '../config';
+import { reconcileDefaultModelConfig } from './modelConfigReconciliation';
+
+const createConfig = (): AppConfig => structuredClone(defaultConfig);
+
+test('keeps the current default model when its provider and ID remain available', () => {
+  const config = createConfig();
+  config.providers!.deepseek.enabled = true;
+  config.providers!.deepseek.apiKey = 'key';
+
+  const result = reconcileDefaultModelConfig(config, config.providers!);
+
+  expect(result.defaultModel).toBe(config.model.defaultModel);
+  expect(result.defaultModelProvider).toBe(config.model.defaultModelProvider);
+});
+
+test('falls back when the current default model was deleted', () => {
+  const config = createConfig();
+  config.providers!.deepseek.enabled = true;
+  config.providers!.deepseek.apiKey = 'key';
+  config.providers!.deepseek.models = config.providers!.deepseek.models!.filter(
+    model => model.id !== config.model.defaultModel,
+  );
+
+  const result = reconcileDefaultModelConfig(config, config.providers!);
+
+  expect(result.defaultModel).toBe(config.providers!.deepseek.models![0].id);
+  expect(result.defaultModelProvider).toBe('deepseek');
+});
+
+test('matches duplicate model IDs by provider', () => {
+  const config = createConfig();
+  config.model.defaultModel = 'shared-model';
+  config.model.defaultModelProvider = 'openai';
+  config.providers = {
+    first: {
+      enabled: true,
+      apiKey: 'first-key',
+      baseUrl: 'https://first.example.com',
+      apiFormat: 'openai',
+      models: [{ id: 'shared-model', name: 'First' }],
+    },
+    openai: {
+      enabled: true,
+      apiKey: 'openai-key',
+      baseUrl: 'https://api.openai.com/v1',
+      apiFormat: 'openai',
+      models: [{ id: 'shared-model', name: 'OpenAI' }],
+    },
+  };
+
+  const result = reconcileDefaultModelConfig(config, config.providers);
+
+  expect(result.defaultModelProvider).toBe('openai');
+});
+
+test('keeps the previous default when no model is available', () => {
+  const config = createConfig();
+  const providers = Object.fromEntries(
+    Object.entries(config.providers!).map(([key, provider]) => [
+      key,
+      { ...provider, enabled: false, apiKey: '', models: [] },
+    ]),
+  );
+
+  expect(reconcileDefaultModelConfig(config, providers)).toEqual(config.model);
+});

--- a/src/renderer/services/modelConfigReconciliation.ts
+++ b/src/renderer/services/modelConfigReconciliation.ts
@@ -1,0 +1,29 @@
+import type { AppConfig } from '../config';
+import { buildConfiguredAvailableModels } from './availableModels';
+
+export function reconcileDefaultModelConfig(
+  currentConfig: AppConfig,
+  providers: NonNullable<AppConfig['providers']>,
+): AppConfig['model'] {
+  const availableModels = buildConfiguredAvailableModels({
+    ...currentConfig,
+    providers,
+  });
+  const currentModel = availableModels.find(
+    model =>
+      model.id === currentConfig.model.defaultModel &&
+      (!currentConfig.model.defaultModelProvider ||
+        model.providerKey === currentConfig.model.defaultModelProvider),
+  );
+  const nextModel = currentModel ?? availableModels[0];
+
+  if (!nextModel) {
+    return currentConfig.model;
+  }
+
+  return {
+    ...currentConfig.model,
+    defaultModel: nextModel.id,
+    defaultModelProvider: nextModel.providerKey,
+  };
+}


### PR DESCRIPTION
Stacked on PR #426. Summary: validate the persisted default model against the exact provider and model ID during the same settings save; fall back deterministically when that model was deleted; avoid a second asynchronous config write from Redux reconciliation; add duplicate-ID and empty-list regression tests. Verification: npm test -- modelConfigReconciliation settingsSave config.test.ts; npm run lint; npm run build:tsc.