### PR TITLE
feat(模型市场): 使模型市场中的设配适配支持2F的两种机型

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,20 +59,20 @@
     "version": "v1.20.0-zhiyuan.1",
     "repo": "z189yis/engram-cjk",
     "runtimeAssets": {
-      "mac-x64": "engram_v1.20.0-zhiyuan.1_darwin_amd64.tar.gz",
-      "mac-arm64": "engram_v1.20.0-zhiyuan.1_darwin_arm64.tar.gz",
-      "win-x64": "engram_v1.20.0-zhiyuan.1_windows_amd64.zip",
-      "win-arm64": "engram_v1.20.0-zhiyuan.1_windows_arm64.zip",
-      "linux-x64": "engram_v1.20.0-zhiyuan.1_linux_amd64.tar.gz",
-      "linux-arm64": "engram_v1.20.0-zhiyuan.1_linux_arm64.tar.gz"
+      "mac-x64": "engram_1.20.0-zhiyuan.1_darwin_amd64.tar.gz",
+      "mac-arm64": "engram_1.20.0-zhiyuan.1_darwin_arm64.tar.gz",
+      "win-x64": "engram_1.20.0-zhiyuan.1_windows_amd64.zip",
+      "win-arm64": "engram_1.20.0-zhiyuan.1_windows_arm64.zip",
+      "linux-x64": "engram_1.20.0-zhiyuan.1_linux_amd64.tar.gz",
+      "linux-arm64": "engram_1.20.0-zhiyuan.1_linux_arm64.tar.gz"
     },
     "runtimeChecksums": {
-      "mac-x64": "PENDING",
-      "mac-arm64": "PENDING",
-      "win-x64": "PENDING",
-      "win-arm64": "PENDING",
-      "linux-x64": "PENDING",
-      "linux-arm64": "PENDING"
+      "mac-x64": "11317da3d453ba5d9af4dcae1ec29eafd840e14c0565a5aa8d43d2851e5c2bcb",
+      "mac-arm64": "3f78721060de1b924689e844188985ec780338f8f87b089c386783a76075a8b1",
+      "win-x64": "a40dbd1e09828bac6169227797f0e20306d9e0aae5f752ff520937694bded7d0",
+      "win-arm64": "b927fe5d26c117903b5b3d90bc71e0c02ef9b020e3b8afd9011b5969b1c12093",
+      "linux-x64": "c33dbc137a0c6a9e53eac6e39392990a06e5147cda5f04084cb02d68002ffd0b",
+      "linux-arm64": "83af00cc5bc3cc8a1dacdba70cb7cdad675247166be881f1341d2127933bd8a9"
     }
   },
   "main": "dist-electron/main.js",

--- a/src/main/libs/marketplaceService.test.ts
+++ b/src/main/libs/marketplaceService.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { afterEach, expect, test, vi } from 'vitest';
 
+import { MarketplaceDeviceProfile } from '../../shared/marketplace';
 import { MarketplaceService } from './marketplaceService';
 
 const tempDirs: string[] = [];
@@ -223,6 +224,27 @@ test('MarketplaceService keeps the all-model cache separate from recommendations
     'Qwen/All-8B-GGUF',
   ]);
 });
+
+test('MarketplaceService forwards device profiles and isolates their caches', async () => {
+  const requestedUrls: string[] = [];
+  const fetchMock = vi.fn(async (url: string) => {
+    requestedUrls.push(url);
+    return Response.json({ models: [verifiedModel()], totalCount: 1 });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  const service = new MarketplaceService(() => createTempDir(), {
+    catalogApiUrl: 'https://catalog.example.test',
+    cacheDir: createTempDir(),
+  });
+
+  await service.search({ query: 'qwen', device: MarketplaceDeviceProfile.Base });
+  await service.search({ query: 'qwen', device: MarketplaceDeviceProfile.Pro });
+
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(new URL(requestedUrls[0]).searchParams.get('device')).toBe(MarketplaceDeviceProfile.Base);
+  expect(new URL(requestedUrls[1]).searchParams.get('device')).toBe(MarketplaceDeviceProfile.Pro);
+});
+
 test('MarketplaceService uses the search API for default recommendations', async () => {
   const fetchMock = vi.fn(async (url: string) => {
     expect(url).toBe('https://catalog.example.test/v1/catalog/search?limit=8&sortby=asc');

--- a/src/main/libs/marketplaceService.ts
+++ b/src/main/libs/marketplaceService.ts
@@ -384,6 +384,7 @@ function searchCacheKey(params: MarketplaceSearchParams): string {
     params.limit ?? '',
     params.pageNumber ?? '',
     params.cursor ?? '',
+    params.device ?? '',
     params.sortby ?? '',
     params.featuredOnly ? 'featured' : '',
     params.fit ?? '',

--- a/src/main/libs/modelCatalogClient.test.ts
+++ b/src/main/libs/modelCatalogClient.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
+import { MarketplaceDeviceProfile } from '../../shared/marketplace';
 import { ModelCatalogClient } from './modelCatalogClient';
 
 const VERIFIED_SHA = 'a'.repeat(64);
@@ -31,12 +32,19 @@ test('uses the search endpoint without sending the legacy featured query', async
   });
 
   const client = new ModelCatalogClient('https://catalog.example.test', fetchMock);
-  await client.search({ featuredOnly: true, limit: 8, pageNumber: 2, cursor: 'opaque cursor' });
+  await client.search({
+    device: MarketplaceDeviceProfile.Pro,
+    featuredOnly: true,
+    limit: 8,
+    pageNumber: 2,
+    cursor: 'opaque cursor',
+  });
 
   const url = new URL(requestedUrl);
   expect(url.pathname).toBe('/v1/catalog/search');
   expect(url.searchParams.get('limit')).toBe('8');
   expect(url.searchParams.has('page')).toBe(false);
   expect(url.searchParams.get('cursor')).toBe('opaque cursor');
+  expect(url.searchParams.get('device')).toBe(MarketplaceDeviceProfile.Pro);
   expect(url.searchParams.has('featured')).toBe(false);
 });

--- a/src/main/libs/modelCatalogClient.ts
+++ b/src/main/libs/modelCatalogClient.ts
@@ -93,8 +93,7 @@ export class ModelCatalogClient {
     if (params.task && params.task !== 'all') url.searchParams.set('task', params.task);
     if (params.size && params.size !== 'all') url.searchParams.set('size', params.size);
     if (params.tags?.length) url.searchParams.set('tags', params.tags.join(','));
-    // Device fit is computed from live local hardware and must never be sent to
-    // the cloud catalogue as if it were a server-side model property.
+    if (params.device) url.searchParams.set('device', params.device);
     if (params.limit) url.searchParams.set('limit', String(params.limit));
     if (params.cursor) url.searchParams.set('cursor', params.cursor);
     if (params.sortby) url.searchParams.set('sortby', params.sortby);

--- a/src/renderer/components/localInference/LocalInferenceView.marketplace.test.ts
+++ b/src/renderer/components/localInference/LocalInferenceView.marketplace.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from 'vitest';
+
+import { MarketplaceDeviceProfile } from '../../../shared/marketplace';
 import {
   buildMarketplaceSearchParams,
   filterMarketplaceModelsForDevice,
@@ -119,6 +121,20 @@ test('marketplace browse modes carry their result context into server pagination
     limit: MARKETPLACE_PAGE_SIZE,
     pageNumber: 2,
     task: 'code',
+  });
+});
+
+test('marketplace search params preserve the selected device profile', () => {
+  expect(
+    buildMarketplaceSearchParams({
+      query: 'qwen',
+      device: MarketplaceDeviceProfile.Pro,
+      pageNumber: 2,
+    }),
+  ).toMatchObject({
+    query: 'qwen',
+    device: MarketplaceDeviceProfile.Pro,
+    pageNumber: 2,
   });
 });
 

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -94,6 +94,7 @@ function marketplacePageCacheKey(params: MarketplaceSearchParams): string {
     task: params.task ?? 'all',
     size: params.size ?? 'all',
     limit: params.limit ?? 0,
+    device: params.device ?? '',
     sortby: params.sortby ?? 'asc',
     featuredOnly: params.featuredOnly ?? false,
     fit: params.fit ?? 'all',

--- a/src/renderer/components/localInference/utils/marketplace.ts
+++ b/src/renderer/components/localInference/utils/marketplace.ts
@@ -30,6 +30,7 @@ export function buildMarketplaceSearchParams(input: {
   pageNumber?: number;
   task?: MarketplaceSearchParams['task'];
   size?: MarketplaceSearchParams['size'];
+  device?: MarketplaceSearchParams['device'];
   fit?: MarketplaceSearchParams['fit'];
   sortby?: MarketplaceSearchParams['sortby'];
   minStars?: number;
@@ -44,6 +45,7 @@ export function buildMarketplaceSearchParams(input: {
     return {
       limit,
       pageNumber: input.pageNumber,
+      device: input.device,
       // Empty marketplace browsing uses the full catalogue and local fit scoring.
       // Task categories add their own catalogue filter.
       featuredOnly: input.featuredOnly ?? false,
@@ -59,6 +61,7 @@ export function buildMarketplaceSearchParams(input: {
     query,
     limit,
     pageNumber: input.pageNumber,
+    device: input.device,
     task: input.task,
     size: input.size,
     fit: input.fit,

--- a/src/shared/marketplace/constants.ts
+++ b/src/shared/marketplace/constants.ts
@@ -2,3 +2,12 @@ export const MarketplaceIpcChannel = {
   Search: 'marketplace:search',
   CancelSearch: 'marketplace:cancel-search',
 } as const;
+
+export const MarketplaceDeviceProfile = {
+  Base: 'base',
+  Pro: 'pro',
+  Other: 'other',
+} as const;
+
+export type MarketplaceDeviceProfile =
+  (typeof MarketplaceDeviceProfile)[keyof typeof MarketplaceDeviceProfile];

--- a/src/shared/marketplace/types.ts
+++ b/src/shared/marketplace/types.ts
@@ -1,3 +1,5 @@
+import type { MarketplaceDeviceProfile } from './constants';
+
 export type MarketplaceSource = 'modelscope-gguf';
 
 export type MarketplaceTaskFilter = 'all' | 'chat' | 'reasoning' | 'embedding' | 'code' | 'vision';
@@ -123,6 +125,7 @@ export type MarketplaceSearchParams = {
   limit?: number;
   pageNumber?: number;
   cursor?: string;
+  device?: MarketplaceDeviceProfile;
   sortby?: MarketplaceSortOrder;
   featuredOnly?: boolean;
   fit?: 'all' | 'recommended' | 'excellent' | 'compatible' | 'unsupported';


### PR DESCRIPTION
 PR 描述

  ## 变更背景

  模型市场 API 新增 device 查询参数，用于区分不同设备配置：

  - base：64GB 内存、2×8GB 显存
  - pro：64GB 内存、2×16GB 显存
  - other：其它设备

  ## 实现内容

  - 新增 MarketplaceDeviceProfile 常量及类型定义。
  - 模型市场请求支持传递 device 参数。
  - 前端分页参数保留设备档位。
  - 主进程和渲染进程缓存键加入设备档位，避免不同设备结果串缓存。
  - 补充 API 请求、分页参数和缓存隔离测试。

  ## 验证结果

  - 定向测试：35/35 通过
  - npm run lint：通过
  - npm run build:tsc：通过
  - git diff --check：通过

  ## 兼容性

  device 为可选参数，不传递时保持原有查询逻辑不变。

  ## 注意事项

  当前提交同时包含 package.json 中 Engram 运行时资源文件名和校验值变更，该部分与设备适配无关，建议合并前确认是否需要拆分。