### PR TITLE
fix(theme): align dark variants with app theme

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -8,6 +8,8 @@
 
 @plugin '@tailwindcss/typography';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* ── Tailwind v4 theme configuration ── */
 @theme {
   /* Typography scale extension (arithmetic series, 2px step — see DESIGN.md) */


### PR DESCRIPTION
Summary: Configure Tailwind v4 dark variants to follow the application-managed dark class, restoring Shiki dark token colors when the app theme differs from the operating system preference. Verification: npm.cmd run build; npm.cmd test -- code-block; npm.cmd run lint; generated CSS uses the dark class selector for Shiki rules.