### PR TITLE
feat(模型市场): 优化了模型市场的前端呈现效果

### DIFF
--- a/src/renderer/components/localInference/components/MarketplaceModelCard.test.tsx
+++ b/src/renderer/components/localInference/components/MarketplaceModelCard.test.tsx
@@ -85,6 +85,14 @@ describe('MarketplaceModelCard', () => {
     };
   });
 
+  test('uses a contained hover shadow inside the scroll viewport', () => {
+    const { container } = renderCard();
+    const card = container.querySelector('[data-marketplace-model-card="true"]');
+
+    expect(card).toHaveClass('hover:shadow-xl');
+    expect(card).not.toHaveClass('hover:shadow-md');
+  });
+
   test.each([
     ['excellent', '推荐运行', 'text-success'],
     ['good', '适合运行', 'text-blue-600'],

--- a/src/renderer/components/localInference/panels/MarketplacePanel.test.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.test.tsx
@@ -131,7 +131,7 @@ describe('MarketplacePanel result grid', () => {
     const viewport = container.querySelector('.overflow-y-auto');
     const pagination = screen.getByText(/1\s*\/\s*1/);
 
-    expect(viewport).toHaveClass('overflow-x-hidden', 'scrollbar-gutter-stable');
+    expect(viewport).toHaveClass('overflow-x-hidden', 'scrollbar-gutter-stable', 'px-4');
     expect(viewport).not.toContainElement(pagination);
   });
 
@@ -139,7 +139,7 @@ describe('MarketplacePanel result grid', () => {
     const { container } = renderPanel({ hasSearched: true, marketplaceLoading: true });
     const viewport = container.querySelector('.overflow-y-auto');
 
-    expect(viewport).toHaveClass('overflow-x-hidden', 'scrollbar-gutter-stable');
+    expect(viewport).toHaveClass('overflow-x-hidden', 'scrollbar-gutter-stable', 'px-4');
   });
 
   test('does not render the server result count in the header', () => {
@@ -284,6 +284,28 @@ describe('MarketplacePanel search and filters', () => {
 
     expect(screen.getByRole('combobox', { name: '\u8bbe\u5907\u9002\u914d' })).toBeInTheDocument();
   });
+
+  test('unselected task tabs provide a hover indicator and stronger text', () => {
+    renderPanel({ hasSearched: true, models: [makeModel('alpha')] });
+
+    const chatTab = screen.getByRole('tab', { name: '\u5bf9\u8bdd' });
+    expect(screen.getByRole('tablist', { name: '\u4efb\u52a1\u7c7b\u578b' })).toHaveClass(
+      'border',
+      'border-border-subtle',
+    );
+    expect(chatTab).toHaveClass(
+      'h-8',
+      'font-medium',
+      'hover:opacity-100',
+    );
+    expect(chatTab.querySelector('[data-fluid-tabs-hover-indicator="true"]')).toHaveClass(
+      'bg-surface',
+      'shadow-md',
+      'opacity-0',
+      'group-hover:opacity-100',
+    );
+  });
+
   test('switching the fit filter to "不限" re-searches the whole catalogue', async () => {
     // The reported regression: choosing the unrestricted fit ("不限") stayed on
     // the curated featured list (7 models, one page) instead of browsing the

--- a/src/renderer/components/localInference/panels/MarketplacePanel.tsx
+++ b/src/renderer/components/localInference/panels/MarketplacePanel.tsx
@@ -18,7 +18,7 @@ import {
 import { i18nService } from '../../../services/i18n';
 import { EmptyState } from '../components/Common';
 import { MarketplaceModelCard } from '../components/MarketplaceModelCard';
-import { FluidTabs } from '@shared/components/ui/fluid-tabs';
+import { FluidTabs, FluidTabsSize } from '@shared/components/ui/fluid-tabs';
 import { Separator } from '@shared/components/ui/separator';
 import {
   Select,
@@ -236,9 +236,9 @@ export function MarketplacePanel({
   ) : null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4">
+    <div className="flex h-full min-h-0 flex-col gap-2">
       <div className="flex flex-col gap-3">
-        <div className="mx-auto flex w-full max-w-6xl items-center gap-3">
+        <div className="mx-auto flex w-full max-w-6xl items-center gap-3 px-6">
           <form
             className="min-w-0 flex-1"
             onSubmit={event => {
@@ -275,13 +275,17 @@ export function MarketplacePanel({
         </div>
       </div>
 
-      <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col gap-3 rounded-lg bg-background p-1">
-      <div className="flex w-full shrink-0 flex-col gap-3 px-4 py-3">
+      <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col gap-2 rounded-lg bg-background p-1">
+      <div className="flex w-full shrink-0 flex-col gap-3 px-5 pt-1 pb-1">
         <div className="flex w-full flex-wrap items-stretch justify-between gap-x-4 gap-y-2">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-4 gap-y-2">
             <div className="shrink-0">
               <FluidTabs
                 className="w-fit max-w-full"
+                inactiveTabClassName="hover:opacity-100"
+                listClassName="border border-border-subtle"
+                showInactiveHoverIndicator
+                size={FluidTabsSize.Default}
                 aria-label={i18nService.t('marketplaceFilterTask')}
                 value={taskFilter}
                 onValueChange={value => setTaskFilter(value as MarketplaceTaskFilter)}
@@ -294,13 +298,13 @@ export function MarketplacePanel({
                 ]}
               />
             </div>
-            <div className="inline-flex items-center gap-1 rounded-lg border border-border-subtle bg-muted/80 p-1">
+            <div className="inline-flex h-10 items-center gap-1 rounded-lg border border-border-subtle bg-muted/80 px-1 py-0.5">
                 <span className="px-2 text-sm leading-5 font-normal text-muted-foreground">
                   {i18nService.t('marketplaceFilterFit')}
                 </span>
                 <Select value={fitFilter} onValueChange={value => setFitFilter(value as NonNullable<MarketplaceSearchParams['fit']>)}>
-                  <SelectTrigger size="sm" aria-label={i18nService.t('marketplaceFilterFit')} className="min-w-32 border-border-subtle bg-surface">
-                    <SelectValue className="font-semibold text-foreground">{fitFilterLabel}</SelectValue>
+                  <SelectTrigger size="default" aria-label={i18nService.t('marketplaceFilterFit')} className="min-w-32 border-border-subtle bg-surface">
+                    <SelectValue className="font-medium text-foreground">{fitFilterLabel}</SelectValue>
                   </SelectTrigger>
                   <SelectContent
                     side="bottom"
@@ -348,7 +352,7 @@ export function MarketplacePanel({
       ) : null}
 
       {marketplaceLoading && models.length === 0 ? (
-        <div ref={marketplaceGridViewportRef} className="relative mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-y-auto overflow-x-hidden scrollbar-gutter-stable rounded-lg bg-surface p-1">
+        <div ref={marketplaceGridViewportRef} className="relative mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-y-auto overflow-x-hidden scrollbar-gutter-stable rounded-lg bg-surface px-4 py-1">
           <MarketplaceGridSkeleton columnCount={gridColumnCount} pageSize={MARKETPLACE_PAGE_SIZE} />
         </div>
       ) : !hasSearched ? null : visibleModels.length === 0 ? (
@@ -374,7 +378,7 @@ export function MarketplacePanel({
       ) : (
         <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col rounded-lg bg-surface p-1">
           {installedModelActions}
-          <div ref={marketplaceGridViewportRef} className="relative mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-y-auto overflow-x-hidden scrollbar-gutter-stable rounded-lg bg-surface p-1">
+          <div ref={marketplaceGridViewportRef} className="relative mx-auto min-h-0 w-full max-w-6xl flex-1 overflow-y-auto overflow-x-hidden scrollbar-gutter-stable rounded-lg bg-surface px-4 py-1">
             <div
               className="mx-auto grid w-full max-w-6xl auto-rows-min content-start gap-4"
               style={{ gridTemplateColumns: `repeat(${gridColumnCount}, minmax(0, 1fr))` }}

--- a/src/shared/components/ui/fluid-tabs.tsx
+++ b/src/shared/components/ui/fluid-tabs.tsx
@@ -14,9 +14,20 @@ export interface FluidTabItem<Value extends string> {
   value: Value;
 }
 
+export const FluidTabsSize = {
+  Small: 'sm',
+  Default: 'default',
+} as const;
+
+export type FluidTabsSize = (typeof FluidTabsSize)[keyof typeof FluidTabsSize];
+
 export interface FluidTabsProps<Value extends string> {
   'aria-label': string;
   className?: string;
+  inactiveTabClassName?: string;
+  listClassName?: string;
+  showInactiveHoverIndicator?: boolean;
+  size?: FluidTabsSize;
   items: readonly FluidTabItem<Value>[];
   onValueChange: (value: Value) => void;
   value: Value;
@@ -25,10 +36,18 @@ export interface FluidTabsProps<Value extends string> {
 export function FluidTabs<Value extends string>({
   'aria-label': ariaLabel,
   className,
+  inactiveTabClassName,
+  listClassName,
+  showInactiveHoverIndicator = false,
+  size = FluidTabsSize.Small,
   items,
   onValueChange,
   value,
 }: FluidTabsProps<Value>) {
+  const sizeClasses = size === FluidTabsSize.Default
+    ? { list: 'h-10', tab: 'h-8' }
+    : { list: 'h-9', tab: 'h-7' };
+
   return (
     <TabsPrimitive.Root
       value={value}
@@ -38,7 +57,7 @@ export function FluidTabs<Value extends string>({
       <TabsPrimitive.List
         activateOnFocus
         aria-label={ariaLabel}
-        className="relative inline-flex h-9 items-center gap-0.5 rounded-lg bg-muted/80 p-1 select-none"
+        className={cn('relative inline-flex items-center gap-0.5 rounded-lg bg-muted/80 p-1 select-none', sizeClasses.list, listClassName)}
       >
         {items.map(item => {
           const isActive = item.value === value;
@@ -47,14 +66,21 @@ export function FluidTabs<Value extends string>({
               key={item.value}
               value={item.value}
               className={cn(
-                'relative z-10 flex h-7 min-w-16 cursor-pointer items-center justify-center rounded-md px-3 text-sm leading-5 font-normal whitespace-nowrap outline-none transition-colors duration-100',
+                'group relative z-10 flex min-w-16 cursor-pointer items-center justify-center rounded-md px-3 text-sm leading-5 font-medium whitespace-nowrap outline-none transition-colors duration-100',
+                sizeClasses.tab,
                 'focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 focus-visible:ring-offset-muted',
                 isActive
-                  ? 'font-semibold text-foreground'
-                  : 'font-normal text-muted-foreground opacity-50 hover:text-foreground',
+                  ? 'font-medium text-foreground'
+                  : cn('font-medium text-muted-foreground opacity-50 hover:text-foreground', inactiveTabClassName),
               )}
             >
-              {isActive ? (
+              {!isActive && showInactiveHoverIndicator ? (
+                <span
+                  aria-hidden="true"
+                  data-fluid-tabs-hover-indicator="true"
+                  className="pointer-events-none absolute inset-0 rounded-md border border-border-subtle bg-surface shadow-md opacity-0 transition-opacity duration-100 group-hover:opacity-100 group-focus-visible:opacity-100"
+                />
+              ) : isActive ? (
                 <motion.span
                   aria-hidden="true"
                   layoutId="fluid-tabs-active-indicator"


### PR DESCRIPTION
## Summary

  本 PR 为模型市场增加设备档位查询支持，并优化模型市场页面的布局、滚动和交互样式。

  ## Related Issue

  暂无关联 Issue。

  ## Changes Made

  - 新增 base、pro、other 三种设备档位参数。
  - 模型市场 API 请求和缓存键支持设备档位隔离。
  - 优化分类栏、设备适配栏和硬件信息区域的尺寸与对齐。
  - 增加未选中分类项的悬停背景指示效果。
  - 优化模型卡片悬停阴影，减少滚动区域裁剪。
  - 为模型结果和加载骨架区域增加纵向滚动及横向裁剪。
  - 保持页码区域位于模型结果区域外部。
  - 增加相关单元测试和布局行为测试。

  ## Type of Change

  - [x] Bug 修复
  - [x] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## Testing

  - [x] 已进行本地测试
  - [x] 已新增测试
  - [x] 已更新现有测试
  - [ ] 已完成 Electron 窄窗口手动测试

  已执行：

  - npx vitest run src/renderer/components/localInference/panels/MarketplacePanel.test.tsx
  - npm run lint
  - npm run build:tsc
  - git diff --check

  ## Screenshots

  暂无，建议补充模型市场调整前后的对比截图。

  ## Checklist

  - [x] 代码遵循项目样式规范
  - [x] 已完成代码自检
  - [x] 已为相关复杂逻辑补充必要说明
  - [ ] 已同步更新文档
  - [x] 未引入新的 lint 或 TypeScript 警告
  - [x] 已添加能够验证修改效果的测试
  - [x] 新增及现有单元测试通过

  ## Electron-Specific Changes

  - [x] 修改主进程代码（src/main/）
  - [ ] 修改 Preload 脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [ ] 无 Electron 相关修改

  ## Additional Notes

  当前 device 参数已贯通共享类型、API 客户端和缓存逻辑，但模型市场页面暂未提供 base/pro/other 的直接选择控件。 narrow window 下的 Electron 实际视觉效果仍建议补充手动验证。