### PR TITLE
feat(cowork): 模型图片识别与文件附件支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ SKILLs/**/.venv/
 SKILLs/imap-smtp-email/package-lock.json
 SKILLs/technology-news-search/scripts/vendor/
 .pi/
+.zhiyuan/
 
 # Agent skills (installed via npx skills add)
 .agents/

--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -40,6 +40,14 @@ declare module '@earendil-works/pi-coding-agent' {
   export function createAgentSession(options?: Record<string, unknown>): Promise<{
     session: {
       prompt(text: string): Promise<void>;
+      sendUserMessage(
+        content:
+          | string
+          | Array<
+              { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+            >,
+        options?: { deliverAs?: 'steer' | 'followUp' },
+      ): Promise<void>;
       steer(text: string): Promise<void>;
       abort(): Promise<void>;
       reload(): Promise<void>;

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -957,7 +957,6 @@ describe('PiRuntimeAdapter', () => {
 
       expect(mockSession.prompt).toHaveBeenCalledWith(
         'Describe this image\n\n[image attachments were not sent because the selected model has no confirmed image support]',
-        undefined,
       );
     });
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -29,6 +29,7 @@ import {
 const hoisted = vi.hoisted(() => {
   const mockSession = {
     prompt: vi.fn().mockResolvedValue(undefined),
+    sendUserMessage: vi.fn().mockResolvedValue(undefined),
     steer: vi.fn().mockResolvedValue(undefined),
     abort: vi.fn().mockResolvedValue(undefined),
     abortBash: vi.fn(),
@@ -914,6 +915,50 @@ describe('PiRuntimeAdapter', () => {
 
     it('should throw on empty prompt with no images', async () => {
       await expect(adapter.startSession('test', '')).rejects.toThrow('Prompt is required.');
+    });
+
+    it('forwards image attachments to vision-capable models', async () => {
+      mockResolveRawApiConfig.mockReturnValueOnce({
+        config: {
+          apiKey: 'sk-vision',
+          baseURL: 'https://api.moonshot.cn/v1',
+          model: 'kimi-k2.6',
+          apiType: 'openai',
+        },
+        providerMetadata: {
+          providerName: 'moonshot',
+          codingPlanEnabled: false,
+          supportsImage: true,
+          capabilities: { imageInput: ModelCapabilityStatus.Supported },
+        },
+      });
+
+      await adapter.startSession('vision', 'Describe this image', {
+        imageAttachments: [
+          { name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' },
+        ],
+      });
+
+      expect(mockSession.sendUserMessage).toHaveBeenCalledWith(
+        [
+          { type: 'text', text: 'Describe this image' },
+          { type: 'image', mimeType: 'image/png', data: 'aW1hZ2U=' },
+        ],
+        undefined,
+      );
+    });
+
+    it('keeps an image attachment as a text hint for non-vision models', async () => {
+      await adapter.startSession('text-only', 'Describe this image', {
+        imageAttachments: [
+          { name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' },
+        ],
+      });
+
+      expect(mockSession.prompt).toHaveBeenCalledWith(
+        'Describe this image\n\n[image attachments were not sent because the selected model has no confirmed image support]',
+        undefined,
+      );
     });
 
     it('should replace existing session with same id', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -125,6 +125,10 @@ import type {
 /** Minimal type for the Pi AgentSession — only the methods used by this adapter. */
 interface PiSession {
   prompt(text: string, options?: { streamingBehavior?: 'steer' | 'followUp' }): Promise<void>;
+  sendUserMessage?(
+    content: string | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>,
+    options?: { deliverAs?: 'steer' | 'followUp' },
+  ): Promise<void>;
   steer(text: string): Promise<void>;
   abort(): Promise<void>;
   abortBash(): void;
@@ -198,6 +202,7 @@ interface ActivePiSession {
   piSession: PiSession;
   abortController: AbortController;
   modelRuntime: PiModelRuntime | null;
+  capabilities: ModelCapabilities;
   harnessModelProfile: HarnessModelProfileInput;
   /** System prompt requested by the current Cowork session snapshot. */
   requestedSystemPrompt: string;
@@ -317,6 +322,55 @@ type PiResolvedModel = {
     apiKey?: string;
   };
 };
+
+function preparePiPrompt(
+  text: string,
+  attachments: PiStartOptions['imageAttachments'] | undefined,
+  capabilities: ModelCapabilities,
+): {
+  content: string | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  hasImages: boolean;
+} {
+  if (!attachments?.length) return { content: text, hasImages: false };
+  if (capabilities.imageInput === ModelCapabilityStatus.Supported) {
+    const images = attachments
+      .filter(item => item.base64Data && item.mimeType.startsWith('image/'))
+      .map(item => ({ type: 'image' as const, data: item.base64Data, mimeType: item.mimeType }));
+    if (images.length > 0) {
+      return {
+        content: [{ type: 'text', text }, ...images],
+        hasImages: true,
+      };
+    }
+  }
+  const hint = '[image attachments were not sent because the selected model has no confirmed image support]';
+  return { content: text.trim() ? `${text}\n\n${hint}` : hint, hasImages: false };
+}
+
+async function sendPiPrompt(
+  session: PiSession,
+  text: string,
+  attachments: PiStartOptions['imageAttachments'] | undefined,
+  capabilities: ModelCapabilities,
+  streamingBehavior?: 'steer' | 'followUp',
+): Promise<void> {
+  const prepared = preparePiPrompt(text, attachments, capabilities);
+  if (prepared.hasImages) {
+    if (!session.sendUserMessage) {
+      throw new Error('The installed agent runtime cannot send image attachments.');
+    }
+    await session.sendUserMessage(
+      prepared.content,
+      streamingBehavior ? { deliverAs: streamingBehavior } : undefined,
+    );
+    return;
+  }
+  if (streamingBehavior) {
+    await session.prompt(prepared.content as string, { streamingBehavior });
+  } else {
+    await session.prompt(prepared.content as string);
+  }
+}
 
 let _piModules: PiModules | null = null;
 
@@ -810,6 +864,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         piSession: session,
         abortController,
         modelRuntime: resolvedModel.modelRuntime,
+        capabilities: {
+          toolCalling: ModelCapabilityStatus.Unknown,
+          imageInput: ModelCapabilityStatus.Unknown,
+          videoInput: ModelCapabilityStatus.Unknown,
+          audioInput: ModelCapabilityStatus.Unknown,
+          documentInput: ModelCapabilityStatus.Unknown,
+          reasoning: ModelCapabilityStatus.Unknown,
+          ...resolvedModel.capabilities,
+        },
         harnessModelProfile,
         requestedSystemPrompt: basePrompt,
         requestedSkillIds: resourceState.skillIds,
@@ -881,7 +944,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // open. Do not revive an aborted Pi turn when that question resolves.
       if (abortController.signal.aborted) return;
 
-      await session.prompt(initialPrompt);
+      await sendPiPrompt(
+        session,
+        initialPrompt,
+        options.imageAttachments,
+        active.capabilities,
+        undefined,
+      );
     } catch (error) {
       // A stopped turn can immediately restart from the first queued follow-up.
       // Its eventual abort rejection must not delete that replacement session.
@@ -1079,10 +1148,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         content: prompt,
         timestamp: Date.now(),
         metadata:
-          options.skillIds?.length || options._queueDelivery
+            options.skillIds?.length || options._queueDelivery || options.imageAttachments?.length || options.fileAttachments?.length
             ? {
                 ...(options.skillIds?.length ? { skillIds: options.skillIds } : {}),
                 ...(options._queueDelivery ? { queueDelivery: options._queueDelivery } : {}),
+                ...(options.imageAttachments?.length
+                  ? { imageAttachments: options.imageAttachments }
+                  : {}),
+                ...(options.fileAttachments?.length
+                  ? { fileAttachments: options.fileAttachments }
+                  : {}),
               }
             : undefined,
       };
@@ -1132,14 +1207,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         prompt,
       );
       if (projectMemoryContext) nextPrompt = `${projectMemoryContext}\n\n${nextPrompt}`;
-      const promptOptions = options._streamingBehavior
-        ? { streamingBehavior: options._streamingBehavior }
-        : undefined;
-      if (promptOptions) {
-        await active.piSession.prompt(nextPrompt, promptOptions);
-      } else {
-        await active.piSession.prompt(nextPrompt);
-      }
+      await sendPiPrompt(
+        active.piSession,
+        nextPrompt,
+        options.imageAttachments,
+        active.capabilities,
+        options._streamingBehavior,
+      );
     } catch (error) {
       active.isRunning = false;
       if (active.abortController.signal.aborted) {
@@ -1162,6 +1236,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const model = resolvedModel.model;
       await active.piSession.setModel(model);
       active.modelRuntime = resolvedModel.modelRuntime;
+      active.capabilities = {
+        ...active.capabilities,
+        ...resolvedModel.capabilities,
+      };
       const reasoning = resolvedModel.model.reasoning;
       active.harnessModelProfile = {
         provider: resolvedModel.providerName,

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -75,6 +75,7 @@ export type PiStartOptions = {
   sessionMode?: 'work' | 'chat';
   goalMode?: boolean;
   imageAttachments?: PiImageAttachment[];
+  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
   agentId?: string;
   expertIds?: string[];
   modelOverride?: string;
@@ -93,6 +94,7 @@ export type PiContinueOptions = {
   sessionMode?: 'work' | 'chat';
   goalMode?: boolean;
   imageAttachments?: PiImageAttachment[];
+  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
   /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
   workspaceRoot?: string;
   agentId?: string;

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -67,6 +67,7 @@ export type CoworkStartOptions = {
   /** Work-only: run the prompt as a long-horizon Goal loop. */
   goalMode?: boolean;
   imageAttachments?: CoworkImageAttachment[];
+  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
   agentId?: string;
   expertIds?: string[];
   modelOverride?: string;
@@ -84,6 +85,7 @@ export type CoworkContinueOptions = {
   /** Work-only: enable or keep the long-horizon Goal loop. */
   goalMode?: boolean;
   imageAttachments?: CoworkImageAttachment[];
+  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
   /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
   workspaceRoot?: string;
   agentId?: string;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4194,6 +4194,9 @@ if (!gotTheLock) {
           });
           messageMetadata.imageAttachments = options.imageAttachments;
         }
+        if (options.fileAttachments?.length) {
+          messageMetadata.fileAttachments = options.fileAttachments;
+        }
         coworkStoreInstance.addMessage(session.id, {
           type: 'user',
           content: options.prompt,
@@ -4224,6 +4227,7 @@ if (!gotTheLock) {
             goalMode: options.goalMode,
             autoApprove: options.permissionMode === CoworkPermissionMode.AllowAll,
             imageAttachments: options.imageAttachments,
+            fileAttachments: options.fileAttachments,
             agentId: options.agentId,
             expertIds: expertSnapshots.map(expert => expert.expertId),
             modelOverride: options.modelOverride,
@@ -4280,6 +4284,7 @@ if (!gotTheLock) {
         expertIds?: string[];
         permissionMode?: CoworkPermissionMode;
         imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+        fileAttachments?: Array<{ name: string; path: string; extension: string }>;
       },
     ) => {
       try {
@@ -4363,6 +4368,7 @@ if (!gotTheLock) {
                 : CoworkSessionMode.Work,
             goalMode: options.goalMode,
             imageAttachments: options.imageAttachments,
+            fileAttachments: options.fileAttachments,
             workspaceRoot: existingSession?.cwd,
             agentId: existingSession?.agentId,
             expertIds: existingSession?.experts.map(expert => expert.expertId),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -455,6 +455,7 @@ contextBridge.exposeInMainWorld('electron', {
       modelOverride?: string;
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
     }) => ipcRenderer.invoke(CoworkSessionIpc.Start, options),
 
     continueSession: (options: {
@@ -466,6 +467,7 @@ contextBridge.exposeInMainWorld('electron', {
       expertIds?: string[];
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
     }) => ipcRenderer.invoke(CoworkSessionIpc.Continue, options),
 
     listPendingMessages: (sessionId: string) => ipcRenderer.invoke(CoworkQueueIpc.List, sessionId),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -209,6 +209,7 @@ const resolveModelSupportsImageForProvider = (
 
 const DEFAULT_CUSTOM_MODEL_CAPABILITIES: Partial<ModelCapabilities> = {
   toolCalling: ModelCapabilityStatus.Unknown,
+  imageInput: ModelCapabilityStatus.Unknown,
   videoInput: ModelCapabilityStatus.Unknown,
   audioInput: ModelCapabilityStatus.Unknown,
   documentInput: ModelCapabilityStatus.Unknown,
@@ -217,6 +218,7 @@ const DEFAULT_CUSTOM_MODEL_CAPABILITIES: Partial<ModelCapabilities> = {
 
 const CUSTOM_MODEL_CAPABILITY_KEYS: readonly ModelCapabilityKey[] = [
   'toolCalling',
+  'imageInput',
   'videoInput',
   'audioInput',
   'documentInput',
@@ -849,7 +851,6 @@ const Settings: React.FC<SettingsProps> = ({
   const [editingModelId, setEditingModelId] = useState<string | null>(null);
   const [newModelName, setNewModelName] = useState('');
   const [newModelId, setNewModelId] = useState('');
-  const [newModelSupportsImage, setNewModelSupportsImage] = useState(false);
   const [newModelContextWindow, setNewModelContextWindow] = useState('');
   const [newModelMaxTokens, setNewModelMaxTokens] = useState('');
   const [newModelCapabilities, setNewModelCapabilities] = useState<Partial<ModelCapabilities>>(
@@ -1411,7 +1412,7 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(null);
     setNewModelName('');
     setNewModelId('');
-    setNewModelSupportsImage(false);
+    setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
     setNewModelContextWindow('');
     setNewModelMaxTokens('');
     setModelFormError(null);
@@ -1451,7 +1452,7 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(null);
     setNewModelName('');
     setNewModelId('');
-    setNewModelSupportsImage(false);
+    setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
     setModelFormError(null);
     setActiveProvider(provider);
     // 切换 provider 时清除测试结果
@@ -2220,7 +2221,7 @@ const Settings: React.FC<SettingsProps> = ({
       setEditingModelId(null);
       setNewModelName('');
       setNewModelId('');
-      setNewModelSupportsImage(false);
+      setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
       setModelFormError(null);
     }
     setActiveTab(tab);
@@ -2270,7 +2271,6 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(null);
     setNewModelName('');
     setNewModelId('');
-    setNewModelSupportsImage(false);
     setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
     setNewModelPiRuntime(undefined);
     setModelFormError(null);
@@ -2290,10 +2290,15 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(modelId);
     setNewModelName(modelName);
     setNewModelId(modelId);
-    setNewModelSupportsImage(!!supportsImage);
     setNewModelContextWindow(formatTokenK(contextWindow));
     setNewModelMaxTokens(formatTokenK(maxTokens));
-    setNewModelCapabilities({ ...DEFAULT_CUSTOM_MODEL_CAPABILITIES, ...capabilities });
+    setNewModelCapabilities({
+      ...DEFAULT_CUSTOM_MODEL_CAPABILITIES,
+      ...capabilities,
+      imageInput:
+        capabilities?.imageInput ??
+        (supportsImage ? ModelCapabilityStatus.Supported : ModelCapabilityStatus.Unsupported),
+    });
     setNewModelPiRuntime(piRuntime);
     setModelFormError(null);
   };
@@ -2378,7 +2383,7 @@ const Settings: React.FC<SettingsProps> = ({
       supportsImage: ProviderRegistry.resolveModelSupportsImage(
         activeProvider,
         modelId,
-        newModelSupportsImage,
+        newModelCapabilities.imageInput === ModelCapabilityStatus.Supported,
       ),
       ...(contextWindow ? { contextWindow } : {}),
       ...(maxTokens ? { maxTokens } : {}),
@@ -2405,7 +2410,6 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(null);
     setNewModelName('');
     setNewModelId('');
-    setNewModelSupportsImage(false);
     setNewModelContextWindow('');
     setNewModelMaxTokens('');
     setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
@@ -2419,7 +2423,6 @@ const Settings: React.FC<SettingsProps> = ({
     setEditingModelId(null);
     setNewModelName('');
     setNewModelId('');
-    setNewModelSupportsImage(false);
     setNewModelContextWindow('');
     setNewModelMaxTokens('');
     setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
@@ -5790,19 +5793,29 @@ const Settings: React.FC<SettingsProps> = ({
                         </div>
                       </>
                     )}
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id={`${activeProvider}-supportsImage`}
-                        checked={newModelSupportsImage}
-                        onCheckedChange={checked => setNewModelSupportsImage(checked === true)}
-                      />
-                      <label
-                        htmlFor={`${activeProvider}-supportsImage`}
-                        className="text-xs text-muted-foreground"
-                      >
-                        {i18nService.t('supportsImageInput')}
-                      </label>
-                    </div>
+                    {!isCustomProvider(activeProvider) && (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id={`${activeProvider}-supportsImage`}
+                          checked={newModelCapabilities.imageInput === ModelCapabilityStatus.Supported}
+                          onCheckedChange={checked =>
+                            setNewModelCapabilities(current => ({
+                              ...current,
+                              imageInput:
+                                checked === true
+                                  ? ModelCapabilityStatus.Supported
+                                  : ModelCapabilityStatus.Unsupported,
+                            }))
+                          }
+                        />
+                        <label
+                          htmlFor={`${activeProvider}-supportsImage`}
+                          className="text-xs text-muted-foreground"
+                        >
+                          {i18nService.t('supportsImageInput')}
+                        </label>
+                      </div>
+                    )}
                   </div>
                 </TabsContent>
                 {isCustomProvider(activeProvider) && (

--- a/src/renderer/components/cowork/AttachmentCard.tsx
+++ b/src/renderer/components/cowork/AttachmentCard.tsx
@@ -80,7 +80,7 @@ const ImageCard: React.FC<AttachmentCardProps> = ({ attachment, onRemove }) => {
         <img
           src={thumbUrl!}
           alt={attachment.name}
-          className="h-full w-full object-cover"
+          className="h-full w-full object-contain"
           onError={() => setImgError(true)}
           draggable={false}
         />

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -40,7 +40,7 @@ import {
 } from '../../store/slices/modelSlice';
 import { setSkills, toggleActiveSkill } from '../../store/slices/skillSlice';
 import { WorkMode } from '../../store/workMode/constants';
-import { CoworkImageAttachment } from '../../types/cowork';
+import { CoworkFileAttachment, CoworkImageAttachment } from '../../types/cowork';
 import { Skill } from '../../types/skill';
 import { toOpenClawModelRef } from '../../utils/openclawModelRef';
 import ActiveSkillBadge from '../skills/ActiveSkillBadge';
@@ -157,6 +157,7 @@ interface CoworkPromptInputProps {
     prompt: string,
     skillPrompt?: string,
     imageAttachments?: CoworkImageAttachment[],
+    fileAttachments?: CoworkFileAttachment[],
     expertIds?: string[],
     goalMode?: boolean,
   ) => boolean | void | Promise<boolean | void>;
@@ -565,6 +566,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
         })),
       });
       const imageAtts: CoworkImageAttachment[] = [];
+      const fileAtts: CoworkFileAttachment[] = [];
       for (const attachment of attachments) {
         if (attachment.isImage && attachment.dataUrl) {
           const extracted = extractBase64FromDataUrl(attachment.dataUrl);
@@ -590,6 +592,13 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
             isImage: attachment.isImage,
             hasDataUrl: !!attachment.dataUrl,
           });
+        } else {
+          const dotIndex = attachment.name.lastIndexOf('.');
+          fileAtts.push({
+            name: attachment.name,
+            path: attachment.path,
+            extension: dotIndex >= 0 ? attachment.name.slice(dotIndex + 1).toUpperCase() : 'FILE',
+          });
         }
       }
 
@@ -607,7 +616,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
         .join('\n');
       const finalPrompt = trimmedValue
         ? attachmentLines
-          ? `${trimmedValue}\n\n${attachmentLines}`
+          ? `${attachmentLines}\n\n${trimmedValue}`
           : trimmedValue
         : attachmentLines;
 
@@ -640,6 +649,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
         finalPrompt,
         skillPrompt,
         imageAtts.length > 0 ? imageAtts : undefined,
+        fileAtts.length > 0 ? fileAtts : undefined,
         selectedExpertIds,
         goalMode,
       );

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -46,6 +46,7 @@ import { setActiveSkillIds } from '../../store/slices/skillSlice';
 import { PREVIEWABLE_ARTIFACT_TYPES } from '../../types/artifact';
 import type {
   CoworkImageAttachment,
+  CoworkFileAttachment,
   CoworkMessage,
   CoworkMessageMetadata,
   CoworkPermissionRequest,
@@ -119,6 +120,7 @@ interface CoworkSessionDetailProps {
     prompt: string,
     skillPrompt?: string,
     imageAttachments?: CoworkImageAttachment[],
+    fileAttachments?: CoworkFileAttachment[],
     expertIds?: string[],
   ) => boolean | void | Promise<boolean | void>;
   onStop: () => void;

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -35,7 +35,7 @@ import {
   addMessage,
   addSession,
   clearCurrentSession,
-  setCurrentSession,
+  deleteSession,
   updateMessageContent,
   updateMessageContents,
   updateSessionStatus,
@@ -46,6 +46,7 @@ import { WorkMode } from '../../store/workMode/constants';
 import {
   CoworkSessionStatusValue,
   type CoworkImageAttachment,
+  type CoworkFileAttachment,
   type CoworkPermissionRequest,
   type CoworkPermissionResult,
   type CoworkSession,
@@ -80,6 +81,10 @@ export interface CoworkViewProps {
 const DirectChatDataChunkType = {
   Context: 'data-context',
 } as const;
+
+type DirectChatPart =
+  | { type: 'text'; text: string }
+  | { type: 'file'; mediaType: string; url: string; filename: string };
 
 interface DirectChatContextData {
   cacheReadTokens?: number;
@@ -316,6 +321,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     prompt: string,
     skillPrompt?: string,
     imageAttachments?: CoworkImageAttachment[],
+    fileAttachments?: CoworkFileAttachment[],
     expertIds: string[] = [],
     goalMode = false,
   ): Promise<boolean | void> => {
@@ -405,12 +411,15 @@ const CoworkView: React.FC<CoworkViewProps> = ({
             content: prompt,
             timestamp: now,
             metadata:
-              sessionSkillIds.length > 0 || (imageAttachments && imageAttachments.length > 0)
+              sessionSkillIds.length > 0 ||
+              (imageAttachments && imageAttachments.length > 0) ||
+              (fileAttachments && fileAttachments.length > 0)
                 ? {
                     ...(sessionSkillIds.length > 0 ? { skillIds: sessionSkillIds } : {}),
-                    ...(imageAttachments && imageAttachments.length > 0
+                ...(imageAttachments && imageAttachments.length > 0
                       ? { imageAttachments }
                       : {}),
+                    ...(fileAttachments && fileAttachments.length > 0 ? { fileAttachments } : {}),
                   }
                 : undefined,
           },
@@ -427,8 +436,10 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       if (workMode === WorkMode.Chat && !isChatAgentExecution) {
         dispatch(addSession(tempSession));
       } else {
-        // Work sessions are added after the backend creates their real session.
-        dispatch(setCurrentSession(tempSession));
+        // Keep a new Work session in the list while the backend creates its
+        // persistent record, so attachments and the initial prompt remain
+        // visible if startup takes time or fails.
+        dispatch(addSession(tempSession));
       }
       // Clear quick action selection after starting session
       dispatch(clearSelection());
@@ -502,11 +513,20 @@ const CoworkView: React.FC<CoworkViewProps> = ({
             modelProviderKey: directChatModel.providerKey,
             localThinkingEnabled,
           });
+          const userParts: DirectChatPart[] = [
+            { type: 'text' as const, text: prompt },
+            ...(imageAttachments ?? []).map(image => ({
+              type: 'file' as const,
+              mediaType: image.mimeType,
+              url: `data:${image.mimeType};base64,${image.base64Data}`,
+              filename: image.name,
+            })),
+          ];
           const stream = await transport.sendMessages({
             trigger: 'submit-message',
             chatId: tempSessionId,
             messageId: undefined,
-            messages: [{ id: `msg-${now}`, role: 'user', parts: [{ type: 'text', text: prompt }] }],
+            messages: [{ id: `msg-${now}`, role: 'user', parts: userParts }],
             abortSignal: abortController.signal,
           });
           const reader = stream.getReader();
@@ -807,6 +827,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         modelOverride: sessionModelOverride,
         permissionMode: config.permissionMode,
         imageAttachments,
+        fileAttachments,
       });
 
       if (!startedSession && startError) {
@@ -828,7 +849,12 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         return;
       }
 
-      if (startedSession) clearUnmanagedWorkingDirectory();
+      if (startedSession) {
+        clearUnmanagedWorkingDirectory();
+        // coworkService.startSession already selected the real session.
+        // Remove only the temporary list entry after that replacement.
+        dispatch(deleteSession(tempSessionId));
+      }
 
       // Stop immediately if user cancelled while startup request was in flight.
       if (isPendingStartCancelled() && startedSession) {
@@ -849,6 +875,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     prompt: string,
     skillPrompt?: string,
     imageAttachments?: CoworkImageAttachment[],
+    fileAttachments?: CoworkFileAttachment[],
     expertIds: string[] = [],
     goalMode = false,
   ) => {
@@ -894,6 +921,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         type: 'user' as const,
         content: prompt,
         timestamp: Date.now(),
+        ...(imageAttachments?.length || fileAttachments?.length
+          ? {
+              metadata: {
+                ...(imageAttachments?.length ? { imageAttachments } : {}),
+                ...(fileAttachments?.length ? { fileAttachments } : {}),
+              },
+            }
+          : {}),
       };
       let assistantContent = '';
       let assistantMessageAdded = false;
@@ -986,12 +1021,20 @@ const CoworkView: React.FC<CoworkViewProps> = ({
             .map(m => ({
               id: m.id,
               role: m.type as 'user' | 'assistant',
-              parts: [{ type: 'text' as const, text: m.content }],
+              parts: [{ type: 'text' as const, text: m.content }] as DirectChatPart[],
             }))
             .concat({
               id: userMsgId,
               role: 'user' as const,
-              parts: [{ type: 'text' as const, text: prompt }],
+              parts: [
+                { type: 'text' as const, text: prompt },
+                ...(imageAttachments ?? []).map(image => ({
+                  type: 'file' as const,
+                  mediaType: image.mimeType,
+                  url: `data:${image.mimeType};base64,${image.base64Data}`,
+                  filename: image.name,
+                })),
+              ],
             }),
           abortSignal: abortController.signal,
         });
@@ -1240,6 +1283,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         permissionMode: sessionPermissionMode,
         goalMode,
         imageAttachments,
+        fileAttachments,
       });
     } finally {
       continuingSessionIdsRef.current.delete(currentSession.id);

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 
 import type {
   CoworkImageAttachment,
+  CoworkFileAttachment,
   CoworkMessage,
   CoworkMessageMetadata,
 } from '../../../types/cowork';
@@ -14,6 +15,7 @@ import { formatMessageDateTime } from '../../../utils/tokenFormat';
 import { parseUserMessageForDisplay } from '../../../utils/userMessageDisplay';
 import ImagePreviewModal, { type ImagePreviewSource } from '../ImagePreviewModal';
 import { CopyButton, ReEditButton } from './CopyButton';
+import FileTypeIcon from '../../icons/fileTypes/FileTypeIcon';
 
 const getMessageModelLabel = (metadata?: CoworkMessageMetadata | null): string | null => {
   const model = typeof metadata?.model === 'string' ? metadata.model.trim() : '';
@@ -49,42 +51,45 @@ export const UserBubble: React.FC<{
   const messageSkills = messageSkillIds
     .map(id => skills.find(s => s.id === id))
     .filter((s): s is NonNullable<typeof s> => s !== undefined);
-  const imageAttachments = ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
-    []) as CoworkImageAttachment[];
+  const imageAttachments = useMemo(
+    () =>
+      ((message.metadata as CoworkMessageMetadata)?.imageAttachments ??
+        []) as CoworkImageAttachment[],
+    [message.metadata],
+  );
+  const fileAttachments = useMemo(
+    () =>
+      ((message.metadata as CoworkMessageMetadata)?.fileAttachments ??
+        []) as CoworkFileAttachment[],
+    [message.metadata],
+  );
+  const textContent = useMemo(() => {
+    if (fileAttachments.length === 0) return displayContent;
+    const filePaths = new Set(fileAttachments.map(file => file.path));
+    return displayContent
+      .split(/\r?\n/)
+      .filter(line => !Array.from(filePaths).some(path => line.includes(path)))
+      .join('\n')
+      .replace(/^\n+|\n+$/g, '');
+  }, [displayContent, fileAttachments]);
+  const hasTextContent = Boolean(textContent.trim()) || messageSkills.length > 0;
 
   return (
     <div
-      className="py-2 px-4 focus:outline-none"
+      className="w-full py-2 px-4 focus:outline-none"
       tabIndex={0}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={handleMouseLeave}
       onBlur={handleBlur}
     >
-      <div className="max-w-5xl min-w-[320px] mx-auto">
-        <Message from="user" className="ml-auto items-end">
-          <MessageContent className="px-4 py-3 rounded-2xl rounded-br-md bg-primary/10 dark:bg-primary/15 text-sm text-foreground leading-relaxed whitespace-pre-wrap wrap-break-word">
-            <div className="flex flex-wrap items-center gap-1.5 whitespace-normal">
-              {messageSkills.map(skill => (
-                <span
-                  key={skill.id}
-                  className="inline-flex max-w-40 items-center gap-1 rounded-md bg-background px-1.5 py-1 text-sm text-foreground"
-                >
-                  <PlusMenuSkillsIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                  <span className="truncate">{skill.name}</span>
-                </span>
-              ))}
-              <span className="whitespace-pre-wrap wrap-break-word">{displayContent}</span>
-            </div>
-          </MessageContent>
-        </Message>
-
+      <div className="mx-auto flex w-full max-w-5xl min-w-[320px] flex-col items-end">
         {imageAttachments.length > 0 && (
-          <div className="flex flex-wrap gap-2 justify-end mt-2">
+          <div className="ml-auto mb-2 flex w-fit max-w-full flex-wrap justify-end gap-2">
             {imageAttachments.map((img, idx) => (
               <Button
                 key={idx}
                 variant="ghost"
-                className="block max-w-[200px] rounded-lg overflow-hidden border border-border hover:border-primary/50 p-0"
+                className="block h-auto w-auto min-h-0 shrink-0 cursor-zoom-in rounded-lg p-0 shadow-none hover:bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
                 onClick={() =>
                   setExpandedImage({
                     src: `data:${img.mimeType};base64,${img.base64Data}`,
@@ -96,11 +101,48 @@ export const UserBubble: React.FC<{
                 <img
                   src={`data:${img.mimeType};base64,${img.base64Data}`}
                   alt={img.name || 'image'}
-                  className="max-h-32 object-cover"
+                  className="block h-40 w-auto max-w-80 rounded-lg border border-border object-contain"
                 />
               </Button>
             ))}
           </div>
+        )}
+
+        {fileAttachments.length > 0 && (
+          <div className="ml-auto mb-2 flex w-fit max-w-full flex-wrap justify-end gap-2">
+            {fileAttachments.map(file => (
+              <div
+                key={file.path}
+                className="flex h-20 w-64 shrink-0 items-center gap-3 rounded-lg border border-border-subtle bg-surface-raised px-4"
+                title={file.path}
+              >
+                <FileTypeIcon fileName={file.name} className="h-12 w-12 shrink-0" />
+                <div className="min-w-0">
+                  <div className="truncate text-base text-foreground">{file.name}</div>
+                  <div className="truncate text-sm text-muted-foreground">{file.extension}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {hasTextContent && (
+          <Message from="user" className="ml-auto items-end">
+            <MessageContent className="px-4 py-3 rounded-2xl rounded-br-md bg-primary/10 dark:bg-primary/15 text-sm text-foreground leading-relaxed whitespace-pre-wrap wrap-break-word">
+              <div className="flex flex-wrap items-center gap-1.5 whitespace-normal">
+                {messageSkills.map(skill => (
+                  <span
+                    key={skill.id}
+                    className="inline-flex max-w-40 items-center gap-1 rounded-md bg-background px-1.5 py-1 text-sm text-foreground"
+                  >
+                    <PlusMenuSkillsIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                    <span className="truncate">{skill.name}</span>
+                  </span>
+                ))}
+                <span className="whitespace-pre-wrap wrap-break-word">{textContent}</span>
+              </div>
+            </MessageContent>
+          </Message>
         )}
 
         <div

--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -620,7 +620,7 @@ class ApiService {
 
   /** Native provider tool loop; the gateway credential stays in the main process. */
   async chatWithWebSearch(
-    message: string,
+    message: string | ChatUserMessageInput,
     onProgress?: (content: string, reasoning?: string) => void,
     history: ChatMessagePayload[] = [],
     options: DirectChatRequestOptions = {},
@@ -679,7 +679,11 @@ class ApiService {
     ]
       .filter(Boolean)
       .join('\n');
-    const userMessage: ChatMessagePayload = { role: 'user', content: message };
+    const userMessage: ChatMessagePayload = {
+      role: 'user',
+      content: typeof message === 'string' ? message : message.content,
+      ...(typeof message === 'string' || !message.images?.length ? {} : { images: message.images }),
+    };
 
     if (apiFormat === 'anthropic') {
       const messages = [...history.filter(item => item.role !== 'system'), userMessage]
@@ -700,7 +704,15 @@ class ApiService {
       const contents = [...history.filter(item => item.role !== 'system'), userMessage].map(
         item => ({
           role: item.role === 'assistant' ? 'model' : 'user',
-          parts: [{ text: item.content }],
+          parts: [
+            ...(item.content ? [{ text: item.content }] : []),
+            ...(item.images ?? []).flatMap(image => {
+              const payload = this.extractImageData(image);
+              return payload
+                ? [{ inline_data: { mime_type: payload.mimeType, data: payload.data } }]
+                : [];
+            }),
+          ],
         }),
       );
       return this.runGeminiWebSearchLoop(
@@ -735,7 +747,7 @@ class ApiService {
         .filter(item => item.role !== 'system')
         .map(item => this.formatOpenAIMessage(item, supportsImages))
         .filter(Boolean),
-      { role: 'user', content: message },
+      ...[this.formatOpenAIMessage(userMessage, supportsImages)].filter(Boolean),
     ];
     return this.runOpenAIWebSearchLoop(
       messages,

--- a/src/renderer/services/chatChatTransport.test.ts
+++ b/src/renderer/services/chatChatTransport.test.ts
@@ -199,6 +199,44 @@ test('only uses messages before the latest user turn as history', async () => {
   expect(capturedHistory?.map(m => m.content)).toEqual(['hi', 'thinking...', 'hello']);
 });
 
+test('forwards image file parts to the direct chat API', async () => {
+  vi.mocked(apiService.chatWithWebSearch).mockResolvedValue({ content: 'ok' });
+  const transport = new ChatChatTransport({});
+  await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'chat-1',
+    messageId: undefined,
+    messages: [
+      {
+        id: 'u1',
+        role: 'user',
+        parts: [
+          { type: 'text', text: 'What is this?' },
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            url: 'data:image/png;base64,aW1hZ2U=',
+            filename: 'screen.png',
+          },
+        ],
+      },
+    ],
+    abortSignal: undefined,
+  });
+
+  const [message] = vi.mocked(apiService.chatWithWebSearch).mock.calls.at(-1) ?? [];
+  expect(message).toMatchObject({
+    content: 'What is this?',
+    images: [
+      {
+        name: 'screen.png',
+        type: 'image/png',
+        dataUrl: 'data:image/png;base64,aW1hZ2U=',
+      },
+    ],
+  });
+});
+
 test('passes the request id and abort signal through the native tool loop', async () => {
   vi.mocked(apiService.chatWithWebSearch).mockImplementation(
     () => new Promise<{ content: string }>(() => {}),

--- a/src/renderer/services/chatChatTransport.ts
+++ b/src/renderer/services/chatChatTransport.ts
@@ -8,6 +8,7 @@ import {
 
 import { apiService } from './api';
 import type { DirectChatRequestOptions } from './localThinkingRequest';
+import type { ChatUserMessageInput, ImageAttachment } from '../types/chat';
 import {
   createToolInputAvailableChunk,
   createToolInputStartChunk,
@@ -22,6 +23,23 @@ function extractText(message: UIMessage): string {
     .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
     .map(p => p.text)
     .join('');
+}
+
+function extractImages(message: UIMessage): ImageAttachment[] {
+  return message.parts.flatMap((part, index) => {
+    if (part.type !== 'file' || !part.mediaType?.startsWith('image/')) return [];
+    const url = (part as { url?: string }).url || '';
+    if (!url.startsWith('data:')) return [];
+    return [
+      {
+        id: `${message.id}-image-${index}`,
+        name: (part as { filename?: string }).filename || 'image',
+        type: part.mediaType,
+        size: 0,
+        dataUrl: url,
+      },
+    ];
+  });
 }
 
 function logDirectChat(message: string): void {
@@ -59,6 +77,10 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
     const lastUser = [...messages].reverse().find(m => m.role === 'user');
     const prompt = lastUser ? extractText(lastUser) : '';
     if (!prompt.trim()) throw new Error('No prompt to send.');
+    const images = lastUser ? extractImages(lastUser) : [];
+    const requestMessage: string | ChatUserMessageInput = images.length
+      ? { content: prompt, images }
+      : prompt;
 
     // Build history from previous messages (filtering out the current user message)
     const history: Array<{ role: 'user' | 'assistant'; content: string }> = [];
@@ -178,7 +200,7 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
         logDirectChat(`request ${requestId} started`);
         void apiService
           .chatWithWebSearch(
-            prompt,
+            requestMessage,
             emitProgress,
             history,
             directChatOptions,

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -14,6 +14,12 @@ export interface CoworkImageAttachment {
   base64Data: string;
 }
 
+export interface CoworkFileAttachment {
+  name: string;
+  path: string;
+  extension: string;
+}
+
 // Cowork session status
 export const CoworkSessionStatusValue = {
   Idle: 'idle',
@@ -62,6 +68,7 @@ export interface CoworkMessageMetadata {
   /** Runtime-measured duration for this thinking message. */
   thinkingDurationMs?: number;
   skillIds?: string[];
+  fileAttachments?: CoworkFileAttachment[];
   usage?: {
     inputTokens?: number;
     outputTokens?: number;
@@ -261,6 +268,7 @@ export interface CoworkStartOptions {
   modelOverride?: string;
   permissionMode?: CoworkPermissionMode;
   imageAttachments?: CoworkImageAttachment[];
+  fileAttachments?: CoworkFileAttachment[];
 }
 
 // Continue session options
@@ -273,6 +281,7 @@ export interface CoworkContinueOptions {
   expertIds?: string[];
   permissionMode?: CoworkPermissionMode;
   imageAttachments?: CoworkImageAttachment[];
+  fileAttachments?: CoworkFileAttachment[];
 }
 
 // IPC result types

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -772,6 +772,7 @@ interface IElectronAPI {
       permissionMode?: CoworkPermissionMode;
       permissionModeBySession?: Record<string, CoworkPermissionMode>;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
     }) => Promise<{
       success: boolean;
       session?: CoworkSession;
@@ -787,6 +788,7 @@ interface IElectronAPI {
       expertIds?: string[];
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
     }) => Promise<{
       success: boolean;
       session?: CoworkSession;

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -186,6 +186,11 @@ const ImageAttachmentSchema = z.object({
   mimeType: z.string(),
   base64Data: z.string(),
 });
+const FileAttachmentSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  extension: z.string(),
+});
 
 export const CoworkSessionStartSchema = {
   input: z.object({
@@ -202,6 +207,7 @@ export const CoworkSessionStartSchema = {
     modelOverride: z.string().optional(),
     permissionMode: z.enum([CoworkPermissionMode.Ask, CoworkPermissionMode.AllowAll]).optional(),
     imageAttachments: z.array(ImageAttachmentSchema).optional(),
+    fileAttachments: z.array(FileAttachmentSchema).optional(),
   }),
   output: IpcResult({
     session: z
@@ -227,6 +233,7 @@ export const CoworkSessionContinueSchema = {
     expertIds: z.array(z.string().min(1)).max(16).optional(),
     permissionMode: z.enum([CoworkPermissionMode.Ask, CoworkPermissionMode.AllowAll]).optional(),
     imageAttachments: z.array(ImageAttachmentSchema).optional(),
+    fileAttachments: z.array(FileAttachmentSchema).optional(),
   }),
   output: IpcResult({ engineStatus: z.object({}).passthrough().optional() }),
 };


### PR DESCRIPTION
## Summary

为 Cowork 会话与直接对话增加模型图片识别支持，并新增文件附件能力：当所选模型具备 `imageInput` 图片输入能力时，将用户图片附件通过 Pi 会话的 `sendUserMessage` 发送给模型；不具备该能力的模型自动降级为提示文案，避免图片内容静默丢失。同时为自定义模型新增 `imageInput` 能力配置，并支持 Cowork 会话携带非图片文件附件。

## Related Issue

无关联 issue。

## Changes Made

- **Pi 会话图片识别**：`piRuntimeAdapter` 新增 `sendUserMessage`，按模型 `imageInput` 能力发送图片附件；无图片能力的模型在提示词末尾追加说明文案，`ActivePiSession` 增加 `capabilities` 字段
- **模型能力配置**：`Settings` 自定义模型能力新增 `imageInput` 开关，替换旧的 `supportsImage` 布尔值；非自定义 provider 保留图片能力勾选
- **文件附件支持**：Cowork 会话新增 `fileAttachments`，从输入框 → IPC（schemas/preload/main）→ Pi 运行时全链路透传，气泡（UserBubble）中展示文件卡片并过滤文本中的文件路径
- **直接对话图片**：`chatChatTransport` 提取消息中的图片 parts，`api.ts` 的 `chatWithWebSearch` 支持携带图片（Anthropic images / Gemini inline_data / OpenAI 三种格式）
- **UI 调整**：AttachmentCard 图片预览改为 `object-contain`；Work 会话新会话在列表中立即可见，避免启动慢或失败时附件/首条提示不可见

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Added new tests（`piRuntimeAdapter.test.ts` 图片/降级用例、`chatChatTransport.test.ts` 图片转发用例）
- [x] Updated existing tests
- [x] Manual testing performed

## Screenshots (if applicable)

无。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [x] Changes to preload script (src/main/preload.ts)
- [x] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

降级文案：图片附件因所选模型未确认支持图片输入而未发送（`[image attachments were not sent because the selected model has no confirmed image support]`）。
