### PR TITLE
fix(cowork): 已发送消息的技能不再重挂到下一次输入

### DIFF
--- a/src/renderer/components/cowork/components/UserBubble.test.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
 import type { CoworkMessage } from '../../../types/cowork';
+import type { Skill } from '../../../types/skill';
 import { i18nService } from '../../../services/i18n';
 import { formatMessageDateTime } from '../../../utils/tokenFormat';
 import { UserBubble } from './UserBubble';
@@ -13,6 +14,20 @@ const message: CoworkMessage = {
   type: 'user',
   content: '请帮我分析这个问题',
   timestamp: 1_754_034_400_000,
+};
+
+const displayNamedSkill: Skill = {
+  id: 'minimax-docx',
+  name: 'minimax-docx',
+  displayName: '文档',
+  description: '',
+  enabled: true,
+  pinned: false,
+  isOfficial: false,
+  isBuiltIn: false,
+  updatedAt: 0,
+  prompt: '',
+  skillPath: '',
 };
 
 describe('UserBubble', () => {
@@ -48,5 +63,17 @@ describe('UserBubble', () => {
 
     expect(screen.getByLabelText(i18nService.t('copyToClipboard'))).toBeInTheDocument();
     expect(screen.queryByLabelText(i18nService.t('coworkReEdit'))).not.toBeInTheDocument();
+  });
+
+  test('uses the localized display name for skills in the message summary', () => {
+    render(
+      <UserBubble
+        message={{ ...message, metadata: { skillIds: [displayNamedSkill.id] } }}
+        skills={[displayNamedSkill]}
+      />,
+    );
+
+    expect(screen.getByText('文档')).toBeInTheDocument();
+    expect(screen.queryByText('minimax-docx')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -9,11 +9,14 @@ import type {
   CoworkMessage,
   CoworkMessageMetadata,
 } from '../../../types/cowork';
+import { i18nService } from '../../../services/i18n';
+import { resolveSkillIconUrl } from '../../../services/skillIcon';
 import { PlusMenuSkillsIcon } from '../plusMenuIcons';
 import type { Skill } from '../../../types/skill';
 import { formatMessageDateTime } from '../../../utils/tokenFormat';
 import { parseUserMessageForDisplay } from '../../../utils/userMessageDisplay';
 import ImagePreviewModal, { type ImagePreviewSource } from '../ImagePreviewModal';
+import { findChatSkillShortcut } from '../../chat/constants';
 import { CopyButton, ReEditButton } from './CopyButton';
 import FileTypeIcon from '../../icons/fileTypes/FileTypeIcon';
 
@@ -131,13 +134,7 @@ export const UserBubble: React.FC<{
             <MessageContent className="px-4 py-3 rounded-2xl rounded-br-md bg-primary/10 dark:bg-primary/15 text-sm text-foreground leading-relaxed whitespace-pre-wrap wrap-break-word">
               <div className="flex flex-wrap items-center gap-1.5 whitespace-normal">
                 {messageSkills.map(skill => (
-                  <span
-                    key={skill.id}
-                    className="inline-flex max-w-40 items-center gap-1 rounded-md bg-background px-1.5 py-1 text-sm text-foreground"
-                  >
-                    <PlusMenuSkillsIcon className="size-3.5 shrink-0 text-muted-foreground" />
-                    <span className="truncate">{skill.name}</span>
-                  </span>
+                  <MessageSkillSummary key={skill.id} skill={skill} />
                 ))}
                 <span className="whitespace-pre-wrap wrap-break-word">{textContent}</span>
               </div>
@@ -165,3 +162,28 @@ export const UserBubble: React.FC<{
     </div>
   );
 });
+
+const MessageSkillSummary: React.FC<{ skill: Skill }> = ({ skill }) => {
+  const shortcut = findChatSkillShortcut(skill.id);
+  const label = shortcut
+    ? i18nService.t(shortcut.labelKey)
+    : skill.displayName || skill.name;
+  const ShortcutIcon = shortcut?.icon;
+
+  return (
+    <span className="inline-flex max-w-40 items-center gap-1 rounded-md bg-background px-1.5 py-1 text-sm text-foreground">
+      {skill.iconUrl ? (
+        <img
+          src={resolveSkillIconUrl(skill.iconUrl)}
+          alt=""
+          className="size-3.5 shrink-0 object-contain"
+        />
+      ) : ShortcutIcon ? (
+        <ShortcutIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      ) : (
+        <PlusMenuSkillsIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      )}
+      <span className="truncate">{label}</span>
+    </span>
+  );
+};

--- a/src/renderer/services/cowork.skillSelection.test.ts
+++ b/src/renderer/services/cowork.skillSelection.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./cowork.ts', import.meta.url)), 'utf8');
+
+test('does not reattach a session\'s completed skills when loading that session', () => {
+  const loadSessionStart = source.indexOf('async loadSession(sessionId: string)');
+  const loadSessionEnd = source.indexOf('\n  async ', loadSessionStart + 1);
+  const loadSession = source.slice(loadSessionStart, loadSessionEnd);
+
+  expect(loadSession).toContain('store.dispatch(clearActiveSkills());');
+  expect(loadSession).not.toContain('setActiveSkillIds(result.session.activeSkillIds)');
+});

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -37,7 +37,7 @@ import {
   updateSessionStatus,
   updateSessionTitle,
 } from '../store/slices/coworkSlice';
-import { clearActiveSkills, setActiveSkillIds } from '../store/slices/skillSlice';
+import { clearActiveSkills } from '../store/slices/skillSlice';
 import type {
   CoworkApiConfig,
   CoworkConfigUpdate,
@@ -749,12 +749,10 @@ class CoworkService {
       // loadSession can be called reactively (onSessionsChanged) while a task
       // is still executing; the backend may report a transitional 'idle' status
       // that would prematurely hide the stop button.
-      // Restore skill selection from session record
-      if (result.session.activeSkillIds?.length) {
-        store.dispatch(setActiveSkillIds(result.session.activeSkillIds));
-      } else {
-        store.dispatch(clearActiveSkills());
-      }
+      // Session skills describe already-sent messages. Never reattach them to
+      // the next prompt when reactive session loading runs during a stream.
+      // Re-edit explicitly restores a message's skills in CoworkSessionDetail.
+      store.dispatch(clearActiveSkills());
 
       const imResult = await cowork.remoteManaged(sessionId);
       if (requestId === this.latestLoadSessionRequestId) {


### PR DESCRIPTION
## Summary

修复会话技能选择的生命周期问题：会话在流式执行期间被响应式加载时，不再把已发送消息中携带的技能重新挂载到下一次输入框（技能只描述「已发送」的消息）。同时优化用户消息气泡中技能摘要的展示：改用语义化快捷标签与真实技能图标，替代原来的通用图标 + 原始技能名。

## Related Issue

无

## Changes Made

- **不再重挂会话技能**：`cowork.ts` 的 `loadSession` 在响应式加载（`onSessionsChanged`）期间始终清空活动技能，避免将已完成消息的技能带到下一条 prompt；re-edit 会显式恢复对应消息的技能
- **消息技能摘要优化**：`UserBubble.tsx` 新增 `MessageSkillSummary`，按语义化快捷标签（`findChatSkillShortcut`）显示本地化名称，并优先展示技能真实图标
- **测试覆盖**：新增 `cowork.skillSelection.test.ts` 结构测试锁定 loadSession 不重挂技能；`UserBubble.test.tsx` 增加本地化 displayName 展示用例

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

新增 `cowork.skillSelection.test.ts`，更新 `UserBubble.test.tsx`；相关用例与 lint 均通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

无 Electron 主进程改动，仅涉及 renderer 侧业务逻辑与组件。

## Additional Notes

无
