### PR TITLE
修复：统一停止与审批拒绝的中断传播

### DIFF
--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -410,6 +410,7 @@ export interface CoworkMessageMetadata {
   model?: string;
   modelProviderKey?: string;
   agentName?: string;
+  interruption?: import('../shared/cowork/interruption').CoworkSessionInterruption;
   [key: string]: unknown;
 }
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -20,6 +20,7 @@ import {
   ProviderModelPiMaxTokensField,
 } from '../../../shared/providers';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
+import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import {
   WorkbenchContractKind,
   WorkbenchRunStatus,
@@ -934,9 +935,7 @@ describe('PiRuntimeAdapter', () => {
       });
 
       await adapter.startSession('vision', 'Describe this image', {
-        imageAttachments: [
-          { name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' },
-        ],
+        imageAttachments: [{ name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' }],
       });
 
       expect(mockSession.sendUserMessage).toHaveBeenCalledWith(
@@ -950,9 +949,7 @@ describe('PiRuntimeAdapter', () => {
 
     it('keeps an image attachment as a text hint for non-vision models', async () => {
       await adapter.startSession('text-only', 'Describe this image', {
-        imageAttachments: [
-          { name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' },
-        ],
+        imageAttachments: [{ name: 'example.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' }],
       });
 
       expect(mockSession.prompt).toHaveBeenCalledWith(
@@ -1252,11 +1249,43 @@ describe('PiRuntimeAdapter', () => {
   describe('stopSession', () => {
     it('should keep session entry active (preserves IM routing) but mark it aborted', async () => {
       await adapter.startSession('test', 'Hello');
+      const addMessage = vi.fn(
+        (_sessionId: string, message: Parameters<CoworkStore['addMessage']>[1]) => ({
+          ...message,
+          id: 'persisted-interruption',
+          timestamp: Date.now(),
+        }),
+      );
+      const updateSession = vi.fn();
+      adapter.setCoworkStore({ addMessage, updateSession } as unknown as CoworkStore);
+      const interruptions: Array<{ cause: string; recoverable: boolean }> = [];
+      adapter.on('sessionInterrupted', event => interruptions.push(event));
+      adapter.stopSession('test');
       adapter.stopSession('test');
       // Session entry stays active so isSessionActive still reports true for IM,
       // but the underlying Pi session is marked aborted.
       expect(adapter.isSessionActive('test')).toBe(true);
       expect(mockSession.abort).toHaveBeenCalled();
+      expect(addMessage).toHaveBeenCalledOnce();
+      expect(addMessage).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({
+          type: 'system',
+          metadata: {
+            interruption: expect.objectContaining({
+              cause: CoworkInterruptionCause.UserStop,
+              recoverable: false,
+            }),
+          },
+        }),
+      );
+      expect(updateSession).toHaveBeenCalledWith('test', { status: 'idle' });
+      expect(interruptions).toEqual([
+        expect.objectContaining({
+          cause: CoworkInterruptionCause.UserStop,
+          recoverable: false,
+        }),
+      ]);
     });
 
     it('should cause continueSession to reconstruct after stop', async () => {
@@ -1361,7 +1390,13 @@ describe('PiRuntimeAdapter', () => {
       const service = new RealWorkbenchTaskService(db);
       adapter.setWorkbenchTaskService(service);
       const requests: string[] = [];
+      const interruptions: Array<{
+        cause: string;
+        taskId: string | null;
+        recoverable: boolean;
+      }> = [];
       adapter.on('permissionRequest', (_sessionId, request) => requests.push(request.requestId));
+      adapter.on('sessionInterrupted', event => interruptions.push(event));
 
       try {
         await adapter.startSession('denied-workbench', 'Create and validate a release report', {
@@ -1394,6 +1429,13 @@ describe('PiRuntimeAdapter', () => {
         expect(service.getCurrent('denied-workbench')?.runs[0].status).toBe(
           WorkbenchRunStatus.Paused,
         );
+        expect(interruptions).toEqual([
+          expect.objectContaining({
+            cause: CoworkInterruptionCause.ApprovalDenied,
+            taskId: detail!.task.id,
+            recoverable: true,
+          }),
+        ]);
       } finally {
         db.close();
       }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -28,6 +28,10 @@ import {
   type CoworkPendingMessage,
 } from '../../../shared/cowork/pendingMessageQueue';
 import { CoworkSessionMode } from '../../../shared/cowork/constants';
+import {
+  CoworkInterruptionCause,
+  type CoworkSessionInterruption,
+} from '../../../shared/cowork/interruption';
 import { CoworkToolActivityPhase } from '../../../shared/cowork/toolActivity';
 import {
   HarnessVersion,
@@ -38,6 +42,7 @@ import { MAX_STALE_PRODUCTION_ITERATIONS } from '../../../shared/productionLoop'
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
+  WorkbenchTaskStatus,
   type WorkbenchTaskContract,
 } from '../../../shared/workbenchTask';
 import {
@@ -126,7 +131,9 @@ import type {
 interface PiSession {
   prompt(text: string, options?: { streamingBehavior?: 'steer' | 'followUp' }): Promise<void>;
   sendUserMessage?(
-    content: string | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>,
+    content:
+      | string
+      | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>,
     options?: { deliverAs?: 'steer' | 'followUp' },
   ): Promise<void>;
   steer(text: string): Promise<void>;
@@ -328,7 +335,9 @@ function preparePiPrompt(
   attachments: PiStartOptions['imageAttachments'] | undefined,
   capabilities: ModelCapabilities,
 ): {
-  content: string | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
+  content:
+    | string
+    | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>;
   hasImages: boolean;
 } {
   if (!attachments?.length) return { content: text, hasImages: false };
@@ -343,7 +352,8 @@ function preparePiPrompt(
       };
     }
   }
-  const hint = '[image attachments were not sent because the selected model has no confirmed image support]';
+  const hint =
+    '[image attachments were not sent because the selected model has no confirmed image support]';
   return { content: text.trim() ? `${text}\n\n${hint}` : hint, hasImages: false };
 }
 
@@ -532,7 +542,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     if (this.activeSessions.has(sessionId)) {
-      this.stopSession(sessionId);
+      this.stopActiveSession(sessionId, 'The session was replaced by a new run.', false);
     }
 
     const pi = await getPiModules();
@@ -958,7 +968,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         this.activeSessions.delete(sessionId);
       }
       if (abortController.signal.aborted) {
-        this.emit('sessionStopped', sessionId);
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -1148,7 +1157,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         content: prompt,
         timestamp: Date.now(),
         metadata:
-            options.skillIds?.length || options._queueDelivery || options.imageAttachments?.length || options.fileAttachments?.length
+          options.skillIds?.length ||
+          options._queueDelivery ||
+          options.imageAttachments?.length ||
+          options.fileAttachments?.length
             ? {
                 ...(options.skillIds?.length ? { skillIds: options.skillIds } : {}),
                 ...(options._queueDelivery ? { queueDelivery: options._queueDelivery } : {}),
@@ -1217,7 +1229,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     } catch (error) {
       active.isRunning = false;
       if (active.abortController.signal.aborted) {
-        this.emit('sessionStopped', sessionId);
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -1281,10 +1292,20 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   stopSession(sessionId: string): void {
-    this.stopActiveSession(sessionId, 'The user stopped this run.', true);
+    this.stopActiveSession(
+      sessionId,
+      'The user stopped this run.',
+      true,
+      CoworkInterruptionCause.UserStop,
+    );
   }
 
-  private stopActiveSession(sessionId: string, reason: string, drainQueuedFollowUp: boolean): void {
+  private stopActiveSession(
+    sessionId: string,
+    reason: string,
+    drainQueuedFollowUp: boolean,
+    cause?: CoworkInterruptionCause,
+  ): void {
     this.dismissAskUserQuestionsBySession(sessionId);
     const active = this.activeSessions.get(sessionId);
     if (!active) {
@@ -1293,6 +1314,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       return;
     }
     const wasRunning = active.isRunning;
+    if (!wasRunning && active.aborted) return;
 
     this.finalizeActiveThinking(sessionId, active);
 
@@ -1316,7 +1338,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     void active.piSession.abort();
     this.workbenchTaskService?.pauseRun?.(sessionId, reason);
     this.clearApprovalsBySession(sessionId);
-    this.emit('sessionStopped', sessionId);
+    if (cause) this.recordSessionInterruption(sessionId, cause);
 
     // A user stop ends the current turn without cancelling messages already
     // queued in Work. Start the next follow-up from a fresh Pi session; the
@@ -1336,9 +1358,35 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
   }
 
+  private recordSessionInterruption(
+    sessionId: string,
+    cause: CoworkInterruptionCause,
+  ): CoworkSessionInterruption {
+    const task = this.workbenchTaskService?.getCurrent(sessionId)?.task ?? null;
+    const interruption: CoworkSessionInterruption = {
+      sessionId,
+      interruptionId: randomUUID(),
+      cause,
+      taskId: task?.id ?? null,
+      recoverable: task?.status === WorkbenchTaskStatus.Paused,
+    };
+    const seed: CoworkMessage = {
+      id: randomUUID(),
+      type: 'system',
+      content: '',
+      timestamp: Date.now(),
+      metadata: { interruption },
+    };
+    const message = this.store ? this.store.addMessage(sessionId, seed) : seed;
+    this.store?.updateSession(sessionId, { status: 'idle' });
+    this.emit('message', sessionId, message);
+    this.emit('sessionInterrupted', interruption);
+    return interruption;
+  }
+
   stopAllSessions(): void {
     for (const [sessionId] of this.activeSessions) {
-      this.stopSession(sessionId);
+      this.stopActiveSession(sessionId, 'The application stopped the active session.', false);
     }
   }
 
@@ -1372,7 +1420,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         reason: denied ? result.message : undefined,
       });
       if (denied) {
-        this.stopActiveSession(sessionId, result.message || 'The user denied this action.', false);
+        this.stopActiveSession(
+          sessionId,
+          result.message || 'The user denied this action.',
+          false,
+          CoworkInterruptionCause.ApprovalDenied,
+        );
       }
       return;
     }
@@ -1581,7 +1634,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   onSessionDeleted(sessionId: string): void {
-    this.stopSession(sessionId);
+    this.stopActiveSession(sessionId, 'The session was deleted.', false);
     this.clearApprovalsBySession(sessionId);
     this.activeSessions.delete(sessionId);
     if (this.pendingMessageQueue.clear(sessionId)) this.emitQueueUpdated(sessionId);
@@ -2023,6 +2076,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               sessionId,
               `Production workflow made no progress for ${MAX_STALE_PRODUCTION_ITERATIONS} consecutive iterations.`,
               false,
+              CoworkInterruptionCause.RuntimePaused,
             );
             break;
           }

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -3,6 +3,7 @@ import type { CoworkToolActivityEvent } from '../../../shared/cowork/toolActivit
 import type { CoworkMessage } from '../../coworkStore';
 import type { CoworkPendingMessage } from '../../../shared/cowork/pendingMessageQueue';
 import type { CoworkQueueDelivery } from '../../../shared/cowork/pendingMessageQueue';
+import type { CoworkSessionInterruption } from '../../../shared/cowork/interruption';
 
 /**
  * Pi-native workbench runtime types (issue #225).
@@ -49,7 +50,7 @@ export interface PiRuntimeEvents {
   permissionDismiss: (requestId: string) => void;
   complete: (sessionId: string, claudeSessionId: string | null) => void;
   error: (sessionId: string, error: CoworkError) => void;
-  sessionStopped: (sessionId: string) => void;
+  sessionInterrupted: (event: CoworkSessionInterruption) => void;
   queueUpdated: (sessionId: string, items: CoworkPendingMessage[]) => void;
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1831,6 +1831,18 @@ const forwardPiWorkbenchRuntimeToRenderer = (runtime: PiRuntimeAdapter): void =>
     });
   });
 
+  runtime.on('sessionInterrupted', interruption => {
+    const windows = BrowserWindow.getAllWindows();
+    windows.forEach(win => {
+      if (win.isDestroyed()) return;
+      try {
+        win.webContents.send(CoworkStreamIpc.Interrupted, interruption);
+      } catch (error) {
+        console.error('[PiWorkbenchForwarder] failed to forward a session interruption:', error);
+      }
+    });
+  });
+
   runtime.on('complete', (sessionId: string, claudeSessionId: string | null) => {
     const windows = BrowserWindow.getAllWindows();
     windows.forEach(win => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -590,6 +590,9 @@ contextBridge.exposeInMainWorld('electron', {
       onPush(CoworkStreamIpc.Permission, callback),
     onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) =>
       onPush(CoworkStreamIpc.PermissionDismiss, callback),
+    onStreamInterrupted: (
+      callback: (data: import('../shared/cowork/interruption').CoworkSessionInterruption) => void,
+    ) => onPush(CoworkStreamIpc.Interrupted, callback),
     onStreamComplete: (
       callback: (data: { sessionId: string; claudeSessionId: string | null }) => void,
     ) => onPush(CoworkStreamIpc.Complete, callback),

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { buildSessionTitleFromInput } from '../../../common/sessionTitle';
 import { CoworkPermissionMode, CoworkSessionMode } from '../../../shared/cowork/constants';
+import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { agentService } from '../../services/agent';
 import { ChatChatTransport } from '../../services/chatChatTransport';
@@ -225,9 +226,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     currentSessionWorkingDirectory || unmanagedWorkingDirectory || currentWorkspace?.path || '';
   const currentWorkspacePath =
     activeWorkspacePath ||
-    (workMode === WorkMode.Work
-      ? defaultConversationWorkspace?.path
-      : config.workingDirectory) ||
+    (workMode === WorkMode.Work ? defaultConversationWorkspace?.path : config.workingDirectory) ||
     '';
   const currentWorkspaceDisplayName =
     currentWorkspace && !currentWorkspace.isHidden && isScratchWorkspacePath(currentWorkspace.path)
@@ -416,7 +415,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
               (fileAttachments && fileAttachments.length > 0)
                 ? {
                     ...(sessionSkillIds.length > 0 ? { skillIds: sessionSkillIds } : {}),
-                ...(imageAttachments && imageAttachments.length > 0
+                    ...(imageAttachments && imageAttachments.length > 0
                       ? { imageAttachments }
                       : {}),
                     ...(fileAttachments && fileAttachments.length > 0 ? { fileAttachments } : {}),
@@ -1299,7 +1298,28 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     // to the engine and leave the direct stream running).
     const directChatController = directChatAbortControllersRef.current.get(currentSession.id);
     if (directChatController) {
+      const interruptionId = crypto.randomUUID();
       directChatController.abort();
+      dispatch(
+        addMessage({
+          sessionId: currentSession.id,
+          message: {
+            id: `interruption-${interruptionId}`,
+            type: 'system',
+            content: '',
+            timestamp: Date.now(),
+            metadata: {
+              interruption: {
+                sessionId: currentSession.id,
+                interruptionId,
+                cause: CoworkInterruptionCause.UserStop,
+                taskId: null,
+                recoverable: false,
+              },
+            },
+          },
+        }),
+      );
       dispatch(
         updateSessionStatus({
           sessionId: currentSession.id,

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -11,6 +11,10 @@ import React from 'react';
 import type { CoworkErrorKind } from '../../../../common/coworkError';
 import { getUserErrorI18nKey } from '../../../../common/coworkError';
 import { getScheduledReminderDisplayText } from '../../../../scheduledTask/reminderText';
+import {
+  CoworkInterruptionCause,
+  type CoworkSessionInterruption,
+} from '../../../../shared/cowork/interruption';
 import type { CoworkToolActivity } from '../../../../shared/cowork/toolActivity';
 import { i18nService } from '../../../services/i18n';
 import { ArtifactRole, type Artifact } from '../../../types/artifact';
@@ -34,6 +38,18 @@ import { ExecutionSummary } from './ExecutionSummary';
 import { PersistentChainOfThought, PersistentReasoning } from './PersistentCollapsible';
 import { TypingDots } from './StreamingBar';
 import { ToolCard } from './ToolCard';
+
+const getInterruptionMessage = (interruption: CoworkSessionInterruption): string => {
+  switch (interruption.cause) {
+    case CoworkInterruptionCause.ApprovalDenied:
+      return i18nService.t('coworkInterruptionApprovalDenied');
+    case CoworkInterruptionCause.RuntimePaused:
+      return i18nService.t('coworkInterruptionRuntimePaused');
+    case CoworkInterruptionCause.UserStop:
+    default:
+      return i18nService.t('coworkInterruptionUserStop');
+  }
+};
 
 const TurnBlockComponent: React.FC<{
   turn: ConversationTurn;
@@ -60,17 +76,20 @@ const TurnBlockComponent: React.FC<{
   const visibleAssistantItems = getVisibleAssistantItems(turn.assistantItems);
 
   const renderSystemMessage = (message: CoworkMessage) => {
+    const interruption = message.metadata?.interruption as CoworkSessionInterruption | undefined;
     const isError = !hasText(message.content) && typeof message.metadata?.error === 'string';
     const errorKind = message.metadata?.errorKind as CoworkErrorKind | undefined;
     const i18nKey = isError && errorKind ? getUserErrorI18nKey(errorKind) : null;
     const i18nMessage = i18nKey ? i18nService.t(i18nKey) : null;
-    const rawContent = i18nMessage
-      ? i18nMessage
-      : hasText(message.content)
-        ? message.content
-        : typeof message.metadata?.error === 'string'
-          ? message.metadata.error
-          : '';
+    const rawContent = interruption
+      ? getInterruptionMessage(interruption)
+      : i18nMessage
+        ? i18nMessage
+        : hasText(message.content)
+          ? message.content
+          : typeof message.metadata?.error === 'string'
+            ? message.metadata.error
+            : '';
     const normalizedContent = getScheduledReminderDisplayText(rawContent) ?? rawContent;
     const content = mapDisplayText ? mapDisplayText(normalizedContent) : normalizedContent;
     if (!content.trim()) return null;

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -20,6 +20,7 @@ import {
   appendSessions,
   clearCurrentSession,
   clearPendingPermissions,
+  clearPendingPermissionsForSession,
   deleteSession as deleteSessionAction,
   deleteSessions as deleteSessionsAction,
   dequeuePendingPermission,
@@ -206,6 +207,12 @@ class CoworkService {
       store.dispatch(dequeuePendingPermission({ requestId }));
     });
     this.streamListenerCleanups.push(permissionDismissCleanup);
+
+    const interruptedCleanup = cowork.onStreamInterrupted(({ sessionId }) => {
+      store.dispatch(clearPendingPermissionsForSession(sessionId));
+      store.dispatch(updateSessionStatus({ sessionId, status: 'idle' }));
+    });
+    this.streamListenerCleanups.push(interruptedCleanup);
 
     // Complete listener
     const completeCleanup = cowork.onStreamComplete(({ sessionId }) => {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1278,6 +1278,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkApiConfigSaveFailed: '保存 API 配置失败',
     coworkApiConfigLoadFailed: '加载 API 配置失败',
     coworkStatusIdle: '已停止',
+    coworkInterruptionUserStop: '已停止本次执行。你可以继续发送消息。',
+    coworkInterruptionApprovalDenied: '已拒绝该操作，当前任务已暂停。',
+    coworkInterruptionRuntimePaused: '执行已暂停，请检查任务状态后继续。',
     coworkStatusRunning: '运行中',
     coworkStatusCompleted: '已完成',
     coworkStatusError: '错误',
@@ -4155,6 +4158,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkApiConfigSaveFailed: 'Failed to save API configuration',
     coworkApiConfigLoadFailed: 'Failed to load API configuration',
     coworkStatusIdle: 'Idle',
+    coworkInterruptionUserStop: 'This run was stopped. You can continue sending messages.',
+    coworkInterruptionApprovalDenied: 'The action was denied and the current task was paused.',
+    coworkInterruptionRuntimePaused:
+      'The run was paused. Review the task status before continuing.',
     coworkStatusRunning: 'Running',
     coworkStatusCompleted: 'Completed',
     coworkStatusError: 'Error',
@@ -4884,7 +4891,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpFeishuLoginTitle: 'Sign in to Feishu',
     mcpFeishuSubtitle:
       'Connect Feishu through its official CLI to use calendars, documents, Bitable, chat, and more.',
-    mcpFeishuInstallFailed: 'Could not install the Feishu connector. Check your network and Node.js setup, then try again.',
+    mcpFeishuInstallFailed:
+      'Could not install the Feishu connector. Check your network and Node.js setup, then try again.',
     mcpConfigureTitle: 'Configure {name}',
     mcpGithubConfigureSubtitle:
       'Connect GitHub to access the repositories, issues, and pull requests you authorize.',

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -10,6 +10,7 @@ import coworkReducer, {
   addMessage,
   addSession,
   clearCurrentSessionForWorkspaceChange,
+  clearPendingPermissionsForSession,
   clearLoadingSessionId,
   enqueuePendingPermission,
   setConfig,
@@ -147,6 +148,34 @@ test('changing a session permission mode preserves pending approvals from every 
     'request-a',
     'request-b',
   ]);
+});
+
+test('session interruption clears only approvals owned by that session', () => {
+  const withPermissions = coworkReducer(
+    coworkReducer(
+      undefined,
+      enqueuePendingPermission({
+        origin: CoworkPermissionOrigin.PiWorkbench,
+        sessionId: 'session-a',
+        requestId: 'request-a',
+        toolName: 'write',
+        toolInput: {},
+        toolUseId: null,
+      }),
+    ),
+    enqueuePendingPermission({
+      origin: CoworkPermissionOrigin.PiWorkbench,
+      sessionId: 'session-b',
+      requestId: 'request-b',
+      toolName: 'bash',
+      toolInput: {},
+      toolUseId: null,
+    }),
+  );
+
+  const next = coworkReducer(withPermissions, clearPendingPermissionsForSession('session-a'));
+
+  expect(next.pendingPermissions.map(permission => permission.requestId)).toEqual(['request-b']);
 });
 
 test('addSession preserves the agent id in session summaries', () => {

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -597,6 +597,12 @@ const coworkSlice = createSlice({
       state.pendingPermissions = [];
     },
 
+    clearPendingPermissionsForSession(state, action: PayloadAction<string>) {
+      state.pendingPermissions = state.pendingPermissions.filter(
+        permission => permission.sessionId !== action.payload,
+      );
+    },
+
     setConfig(state, action: PayloadAction<CoworkConfig>) {
       state.config = action.payload;
     },
@@ -677,6 +683,7 @@ export const {
   enqueuePendingPermission,
   dequeuePendingPermission,
   clearPendingPermissions,
+  clearPendingPermissionsForSession,
   setConfig,
   updateConfig,
   clearCurrentSession,

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../shared/cowork/constants';
 import type { CoworkPersistedArtifact } from '../../shared/cowork/artifacts';
 import type { CoworkSessionExpertSnapshot } from '../../shared/cowork/sessionExperts';
+import type { CoworkSessionInterruption } from '../../shared/cowork/interruption';
 import type { OpenClawEnginePhase } from '../../shared/openclaw/constants';
 
 export interface CoworkImageAttachment {
@@ -83,6 +84,7 @@ export interface CoworkMessageMetadata {
   model?: string;
   modelProviderKey?: string;
   agentName?: string;
+  interruption?: CoworkSessionInterruption;
   [key: string]: unknown;
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -934,6 +934,11 @@ interface IElectronAPI {
       }) => void,
     ) => () => void;
     onStreamPermissionDismiss: (callback: (data: { requestId: string }) => void) => () => void;
+    onStreamInterrupted: (
+      callback: (
+        data: import('../../shared/cowork/interruption').CoworkSessionInterruption,
+      ) => void,
+    ) => () => void;
     onStreamComplete: (
       callback: (data: { sessionId: string; claudeSessionId: string | null }) => void,
     ) => () => void;

--- a/src/shared/cowork/interruption.ts
+++ b/src/shared/cowork/interruption.ts
@@ -1,0 +1,16 @@
+export const CoworkInterruptionCause = {
+  UserStop: 'user_stop',
+  ApprovalDenied: 'approval_denied',
+  RuntimePaused: 'runtime_paused',
+} as const;
+
+export type CoworkInterruptionCause =
+  (typeof CoworkInterruptionCause)[keyof typeof CoworkInterruptionCause];
+
+export interface CoworkSessionInterruption {
+  sessionId: string;
+  interruptionId: string;
+  cause: CoworkInterruptionCause;
+  taskId: string | null;
+  recoverable: boolean;
+}

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -32,8 +32,8 @@ export const SkillsIpc = {
   GetConfig: 'skills:getConfig',
   SetConfig: 'skills:setConfig',
   TestEmailConnectivity: 'skills:testEmailConnectivity',
-    FetchMarketplace: 'skills:fetchMarketplace',
-    FetchMarketplaceContent: 'skills:fetchMarketplaceContent',
+  FetchMarketplace: 'skills:fetchMarketplace',
+  FetchMarketplaceContent: 'skills:fetchMarketplaceContent',
   Changed: 'skills:changed',
 } as const;
 export type SkillsIpc = (typeof SkillsIpc)[keyof typeof SkillsIpc];
@@ -201,6 +201,7 @@ export const CoworkStreamIpc = {
   ToolActivity: 'cowork:stream:toolActivity',
   Permission: 'cowork:stream:permission',
   PermissionDismiss: 'cowork:stream:permissionDismiss',
+  Interrupted: 'cowork:stream:interrupted',
   Complete: 'cowork:stream:complete',
   Error: 'cowork:stream:error',
   QueueUpdated: 'cowork:stream:queueUpdated',


### PR DESCRIPTION
## 背景

当前 Work/Agent Chat 在用户点击停止或拒绝审批后，主进程只在运行时内部触发 `sessionStopped`，renderer 无法收到明确的终止事件。结果是会话仍残留在 streaming 状态，下一条消息可能被错误路由到已停止的队列，并出现 `The Work session is not running.`。

同时，停止与审批拒绝都不会在对话记录中留下可持久化的中断提示。

## 本阶段改动

- 新增结构化 `CoworkSessionInterruption`，区分用户停止、审批拒绝和运行时暂停。
- 为 Pi Workbench 补齐 `main → preload → renderer` 的 `cowork:stream:interrupted` IPC 链路。
- 中断时将会话状态收敛到 `idle`，并只清理对应会话的待审批状态和 streaming 标记。
- 在 SQLite 中持久化幂等 system 消息，重新打开会话后仍可看到中断原因。
- Direct Chat 停止写入同构提示，保持两条执行路径的用户语义一致。
- 防止重复点击停止生成重复中断消息。
- 应用退出、会话删除和内部 session 替换继续使用静默停止，不污染对话记录。

## Electron / IPC 变更

- 新增 `CoworkStreamIpc.Interrupted`。
- preload 新增 `onStreamInterrupted` 订阅接口。
- Pi runtime 的停止事件改为携带 `interruptionId`、`cause`、`taskId` 和 `recoverable` 的结构化载荷。

## 验证

- `npm test -- piRuntimeAdapter coworkSlice`：125 项通过。
- `npm run lint`：通过。
- `npx tsc -p electron-tsconfig.json --noEmit`：通过。
- `npm run build`：通过，renderer、main 和 preload 均成功产出。
- `npm run compile:electron` 的预置 native rebuild 曾被 Windows MSBuild `E_ACCESSDENIED` 阻断；随后测试脚本已成功重建 `better-sqlite3`，完整构建通过。

## 后续阶段

下一阶段将在本 PR 之上实现同一 Task 的 amendment/resume，并在可恢复中断消息下增加恢复图标按钮。
