### PR TITLE
修复：反转生产循环门禁并继承任务策略

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -23,6 +23,7 @@ import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import {
   WorkbenchContractKind,
+  WorkbenchRunTrigger,
   WorkbenchRunStatus,
   WorkbenchTaskStatus,
 } from '../../../shared/workbenchTask';
@@ -314,7 +315,7 @@ describe('PiRuntimeAdapter', () => {
       }
     });
 
-    it('runs an arbitrary selected Work skill through a durable acceptance loop by default', async () => {
+    it('runs an explicit production request through a durable acceptance loop', async () => {
       const onPermissionRequest = vi.fn();
       const onComplete = vi.fn();
       adapter.on('permissionRequest', onPermissionRequest);
@@ -395,7 +396,8 @@ describe('PiRuntimeAdapter', () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
-      adapter.setWorkbenchTaskService(new RealWorkbenchTaskService(db));
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
 
       try {
         await adapter.startSession('production-work', 'Create and validate a release report', {
@@ -444,6 +446,49 @@ describe('PiRuntimeAdapter', () => {
         expect(
           db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
         ).toEqual({ count: 1 });
+        expect(
+          service.getCurrent('production-work')?.task.contract.metadata?.productionWorkflowEnabled,
+        ).toBe(true);
+        expect(
+          service.getCurrent('production-simple')?.task.contract.metadata
+            ?.productionWorkflowEnabled,
+        ).toBe(false);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('restores the production gate from the owning task on an explicit resume', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const workspaceRoot = createTemporaryWorkspace();
+
+      try {
+        await adapter.startSession('resume-production', 'Create and validate a release report', {
+          sessionMode: 'work',
+          workspaceRoot,
+        });
+        const originalTask = service.getCurrent('resume-production')!.task;
+        await adapter.stopSession('resume-production');
+        const prepared = service.prepareRun(originalTask.id, WorkbenchRunTrigger.Resume);
+
+        await adapter.continueSession('resume-production', 'Continue', {
+          sessionMode: 'work',
+          workspaceRoot,
+          _workbenchRunId: prepared.run.id,
+          _productionWorkflowEnabled:
+            originalTask.contract.metadata?.productionWorkflowEnabled === true,
+          _skipUserMessage: true,
+        });
+
+        const resumedOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        expect(resumedOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
+        expect(service.getCurrent('resume-production')?.task.id).toBe(originalTask.id);
       } finally {
         db.close();
       }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -591,10 +591,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionMode: options.sessionMode,
         prompt,
         goalMode: options.goalMode,
-        skillIds: resourceState.skillIds,
-        expertIds: normalizeExpertIds(options.expertIds),
-        imageAttachmentCount: options.imageAttachments?.length,
-        resumeRun: Boolean(options._workbenchRunId),
+        inheritedProductionWorkflow: options._productionWorkflowEnabled,
       });
       const workbenchContract = this.createWorkbenchContract(
         options.sessionMode,
@@ -1031,10 +1028,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       sessionMode: requestedSessionMode,
       prompt,
       goalMode: nextGoalMode,
-      skillIds: requestedSkillIds,
-      expertIds: requestedExpertIds,
-      imageAttachmentCount: options.imageAttachments?.length,
-      resumeRun: Boolean(options._workbenchRunId),
+      inheritedProductionWorkflow: options._productionWorkflowEnabled,
     });
     const productionWorkflowTopologyChanged =
       productionWorkflowEnabled !== active.productionWorkflowEnabled;
@@ -2835,7 +2829,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               ? WorkbenchContractKind.Shortcut
               : WorkbenchContractKind.GenericWork,
       requiresUserAcceptance: sessionMode !== 'chat' && !research && !(managedWorkflow && shortcut),
-      metadata: skillIds?.length ? { skillIds } : undefined,
+      metadata: {
+        productionWorkflowEnabled: managedWorkflow,
+        ...(skillIds?.length ? { skillIds } : {}),
+      },
     };
   }
 }

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -86,6 +86,8 @@ export type PiStartOptions = {
   _piPromptOverride?: string;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
+  /** Internal: production workflow policy inherited from the owning task. */
+  _productionWorkflowEnabled?: boolean;
 };
 
 export type PiContinueOptions = {
@@ -105,6 +107,8 @@ export type PiContinueOptions = {
   autoApprove?: boolean;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
+  /** Internal: production workflow policy inherited from the owning task. */
+  _productionWorkflowEnabled?: boolean;
   /** Internal: do not persist a synthetic Resume/Retry prompt as a user message. */
   _skipUserMessage?: boolean;
   /** Internal: marks a queued follow-up in the persisted transcript. */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7714,6 +7714,7 @@ if (!gotTheLock) {
           imageAttachments: resumeInput?.imageAttachments,
           fileAttachments: resumeInput?.fileAttachments,
           _workbenchRunId: run.id,
+          _productionWorkflowEnabled: task.contract.metadata?.productionWorkflowEnabled === true,
           _skipUserMessage: !amendment,
         });
       },

--- a/src/main/productionLoop/entryPolicy.test.ts
+++ b/src/main/productionLoop/entryPolicy.test.ts
@@ -29,54 +29,52 @@ test('bypasses production workflow for explicit lightweight one-step tasks', () 
   );
   expect(shouldEnableProductionWorkflow(workRequest('你好，帮我翻译这句话'))).toBe(false);
   expect(shouldEnableProductionWorkflow(workRequest('当前时间'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('Create an empty file.'))).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('把标题改成蓝色'))).toBe(false);
 });
 
-test('retains production workflow for changes and scoped reviews', () => {
+test('enables production workflow only for changes with production evidence', () => {
   expect(shouldEnableProductionWorkflow(workRequest('修复登录流程中的刷新问题'))).toBe(true);
   expect(
     shouldEnableProductionWorkflow(workRequest('Review this repository for regressions.')),
   ).toBe(true);
   expect(shouldEnableProductionWorkflow(workRequest('先修改配置，然后运行测试'))).toBe(true);
   expect(shouldEnableProductionWorkflow(workRequest('Can you fix the stale closure?'))).toBe(true);
+  expect(
+    shouldEnableProductionWorkflow(workRequest('Research reliable agent architectures.')),
+  ).toBe(true);
 });
 
-test('retains production workflow for explicit signals and ambiguous Work requests', () => {
+test('uses explicit goal mode and inherited task policy as authoritative signals', () => {
   expect(shouldEnableProductionWorkflow({ ...workRequest('你好'), goalMode: true })).toBe(true);
   expect(
     shouldEnableProductionWorkflow({
-      ...workRequest('Review this repository'),
-      skillIds: ['code-review'],
+      ...workRequest('Continue'),
+      inheritedProductionWorkflow: true,
     }),
   ).toBe(true);
-  expect(shouldEnableProductionWorkflow({ ...workRequest('Continue'), resumeRun: true })).toBe(
-    true,
-  );
-  expect(shouldEnableProductionWorkflow(workRequest('Handle the request'))).toBe(true);
-});
-
-test('does not let a selected skill override an explicitly lightweight turn', () => {
-  expect(
-    shouldEnableProductionWorkflow({ ...workRequest('你好'), skillIds: ['presentation-studio'] }),
-  ).toBe(false);
   expect(
     shouldEnableProductionWorkflow({
-      ...workRequest('Read package.json'),
-      skillIds: ['code-review'],
+      ...workRequest('Build an application'),
+      inheritedProductionWorkflow: false,
     }),
   ).toBe(false);
+  expect(shouldEnableProductionWorkflow(workRequest('Handle the request'))).toBe(false);
 });
 
-test('keeps continuations and revisions inside an existing skilled workflow', () => {
+test('does not let skills, experts, attachments, or old-task hints raise the gate', () => {
+  const incidentalContext = {
+    ...workRequest('继续'),
+    skillIds: ['presentation-studio'],
+    expertIds: ['reviewer'],
+    imageAttachmentCount: 1,
+    resumeRun: true,
+  };
+  expect(shouldEnableProductionWorkflow(incidentalContext)).toBe(false);
   expect(
     shouldEnableProductionWorkflow({
-      ...workRequest('继续'),
-      skillIds: ['presentation-studio'],
+      ...incidentalContext,
+      prompt: 'Read package.json',
     }),
-  ).toBe(true);
-  expect(
-    shouldEnableProductionWorkflow({
-      ...workRequest('把标题改成蓝色'),
-      skillIds: ['presentation-studio'],
-    }),
-  ).toBe(true);
+  ).toBe(false);
 });

--- a/src/main/productionLoop/entryPolicy.ts
+++ b/src/main/productionLoop/entryPolicy.ts
@@ -12,39 +12,49 @@ const INFORMATION_REQUEST_PATTERN =
 const LIGHTWEIGHT_TASK_PATTERN =
   /^(?:please\s+)?(?:show|list|read|find|search|count|calculate|translate|rewrite|summarize|proofread)\b|^(?:请)?(?:帮我)?(?:查看|列出|读取|查找|搜索|统计|计算|翻译|改写|总结|校对)|^(?:current time|today's date|现在几点|当前时间|今天几号|今天日期)/i;
 const EXECUTION_REQUEST_PATTERN =
-  /^(?:(?:please|can you|could you|would you)\s+)?(?:build|create|write|edit|modify|fix|implement|refactor|develop|test|deploy|install|configure|migrate|optimize|publish|generate|review|audit|inspect)\b|^(?:(?:请|能否|可以|你能)(?:帮我)?)?(?:构建|创建|写|编写|编辑|修改|修复|实现|重构|开发|测试|部署|安装|配置|迁移|优化|发布|生成|审查|审核|检查)|^(?:把|将).+(?:编辑|修改|修复|重构|迁移|优化|发布)/i;
+  /^(?:(?:please|can you|could you|would you)\s+)?(?:build|create|write|edit|modify|fix|implement|refactor|develop|test|deploy|install|configure|migrate|optimize|publish|generate|review|audit|inspect|analyze)\b|^(?:(?:请|能否|可以|你能)(?:帮我)?)?(?:构建|创建|写|编写|编辑|修改|修复|实现|重构|开发|测试|部署|安装|配置|迁移|优化|发布|生成|审查|审核|检查|分析)|^(?:把|将).+(?:编辑|修改|修复|重构|迁移|优化|发布)/i;
 const MULTI_STEP_PATTERN =
   /\b(?:multi[- ]step|end[- ]to[- ]end|first.+then|and then)\b|(?:多步骤|完整流程|端到端|先.+再|然后)/i;
+const RESEARCH_WORKFLOW_PATTERN =
+  /^(?:(?:please|can you|could you|would you)\s+)?(?:research|investigate)\b|^(?:(?:请|能否|可以|你能)(?:帮我)?)?(?:研究|调研|调查)\b/i;
+const PRODUCTION_OBJECT_PATTERN =
+  /\b(?:app|application|website|service|feature|module|component|api|database|schema|repository|codebase|project|package|workflow|pipeline|presentation|deck|slide deck|spreadsheet|workbook|document|dashboard|report|test suite|deployment|release|stale closure)\b|(?:应用|网站|服务|功能|模块|组件|接口|数据库|数据表|仓库|代码库|项目|软件包|工作流|流程|流水线|演示文稿|幻灯片|PPT|电子表格|工作簿|文档|仪表盘|报告|测试套件|部署|发布|登录流程)/i;
+const VALIDATION_OR_DELIVERY_PATTERN =
+  /\b(?:validate|verify|acceptance|deliver|release|publish|deploy|package|benchmark|end[- ]to[- ]end test)\b|(?:验证|验收|交付|发布|部署|打包|基准测试|端到端测试)/i;
 
 export interface ProductionWorkflowEntryInput {
   sessionMode?: CoworkSessionModeValue;
   prompt: string;
   goalMode?: boolean;
-  skillIds?: string[];
-  expertIds?: string[];
-  imageAttachmentCount?: number;
-  resumeRun?: boolean;
+  inheritedProductionWorkflow?: boolean;
 }
 
 export const shouldEnableProductionWorkflow = (input: ProductionWorkflowEntryInput): boolean => {
   if (input.sessionMode === CoworkSessionMode.Chat) return false;
-  if (input.goalMode || input.resumeRun) return true;
+  if (input.inheritedProductionWorkflow !== undefined) {
+    return input.inheritedProductionWorkflow;
+  }
+  if (input.goalMode) return true;
 
   const prompt = input.prompt.replace(/\s+/g, ' ').trim();
   if (!prompt) return false;
   const intentPrompt = prompt.replace(/^(?:hi|hello|hey|你好|您好|嗨)[,，!！\s]+/i, '');
   if (SIMPLE_CONVERSATION_PATTERN.test(prompt)) return false;
-  if (EXECUTION_REQUEST_PATTERN.test(intentPrompt) || MULTI_STEP_PATTERN.test(intentPrompt)) {
-    return true;
-  }
+  const executionRequested = EXECUTION_REQUEST_PATTERN.test(intentPrompt);
   if (
     prompt.length <= MAX_LIGHTWEIGHT_PROMPT_LENGTH &&
+    !executionRequested &&
     (INFORMATION_REQUEST_PATTERN.test(intentPrompt) || LIGHTWEIGHT_TASK_PATTERN.test(intentPrompt))
   ) {
     return false;
   }
-  if (input.skillIds?.length || input.expertIds?.length || input.imageAttachmentCount) return true;
+  if (MULTI_STEP_PATTERN.test(intentPrompt) || RESEARCH_WORKFLOW_PATTERN.test(intentPrompt)) {
+    return true;
+  }
+  if (!executionRequested) return false;
 
-  // Ambiguous Work requests retain the workflow gate.
-  return true;
+  return (
+    PRODUCTION_OBJECT_PATTERN.test(intentPrompt) ||
+    VALIDATION_OR_DELIVERY_PATTERN.test(intentPrompt)
+  );
 };


### PR DESCRIPTION
## 背景

现有入口策略虽然已排除部分问候和轻量请求，但仍采用“模糊 Work 默认开启”的正向门禁，并允许技能、专家、附件或 Resume Run 单独触发 production-loop。这会让简单对话和单步任务意外进入生产循环。

本阶段将门禁反转为“默认关闭，充分证据才开启”。

## 门禁规则

| 输入信号 | 是否开启 production-loop |
| --- | --- |
| Chat 模式 | 否 |
| 问候、解释、问答、翻译、总结、读取、计算 | 否 |
| 单步修改或单工具任务 | 否 |
| 模糊 Work 请求 | 否 |
| 仅选择技能、专家或附件 | 否 |
| 仅存在旧 Task / Resume Run | 否 |
| 显式目标模式 | 是 |
| 明确多步骤或端到端请求 | 是 |
| 执行动作 + 生产对象/验收交付证据 | 是 |
| 显式恢复原 Task | 继承原 Task 策略 |

## 改动内容

- 删除 `skillIds`、`expertIds`、`imageAttachmentCount`、`resumeRun` 作为入口充分条件
- 将未命中的模糊 Work 请求从默认开启改为默认关闭
- 引入“执行动作 + 生产对象/验收交付证据”的合取判断
- 保留研究、调研和明确多步骤任务的生产工作流入口
- 将 `productionWorkflowEnabled` 持久化到 Task contract 元数据
- Resume Run 通过内部选项读取原 Task 的门禁策略，不再根据恢复提示或当前技能重新猜测
- 新 Task 仍按当前提示重新评估，简单新消息不会继承旧生产循环
- 更新运行时测试名称，移除“选择任意技能默认进入生产循环”的错误语义

## 关键行为

- `你好`、`解释事件循环`、`翻译这句话`、`读取 package.json`、`创建空文件`：跳过
- `把标题改成蓝色`：跳过
- `修复登录流程中的刷新问题`：开启
- `分析代码库、输出审查报告并验证结论`：开启
- 生产 Task 中断后显式恢复：保持开启
- 非生产 Task 即使恢复时补充“构建应用”：仍保持原 Task 的关闭策略

## 验证

- production-loop / Pi runtime 定向 Vitest：2 个测试文件、91 项测试通过
- `npm run lint` 通过
- `npx tsc -p electron-tsconfig.json --noEmit` 通过
- `npm run build` 通过
- `git diff --check` 通过

## PR 关系

- 依赖：#438
- Base：`codex/recoverable-task-resume`
- 后续阶段将在本 PR 之上补齐生产计划、验收条件与有效进度状态的恢复继承
