### PR TITLE
修复：恢复生产任务进度并重建运行证据

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -489,6 +489,44 @@ describe('PiRuntimeAdapter', () => {
         };
         expect(resumedOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
         expect(service.getCurrent('resume-production')?.task.id).toBe(originalTask.id);
+        expect(service.productionLoop.getState(prepared.run.id).goal).toBe(originalTask.goal);
+        expect(mockSession.prompt).toHaveBeenLastCalledWith(
+          expect.stringContaining('Persistent phase: plan'),
+        );
+      } finally {
+        db.close();
+      }
+    });
+
+    it('reinjects the production protocol when a reused runtime starts a new task', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const workspaceRoot = createTemporaryWorkspace();
+
+      try {
+        await adapter.startSession('reused-production', 'Create and validate a release report', {
+          sessionMode: 'work',
+          workspaceRoot,
+        });
+        await adapter.continueSession(
+          'reused-production',
+          'Create and validate a second release report',
+          {
+            sessionMode: 'work',
+            workspaceRoot,
+          },
+        );
+
+        expect(mockCreateAgentSession).toHaveBeenCalledOnce();
+        expect(mockSession.prompt).toHaveBeenLastCalledWith(
+          expect.stringContaining('## Production workflow'),
+        );
+        expect(mockSession.prompt).toHaveBeenLastCalledWith(
+          expect.stringContaining('Persistent phase: plan'),
+        );
       } finally {
         db.close();
       }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -566,6 +566,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     const abortController = new AbortController();
     let workbenchRunId: string | null = null;
     let workbenchTaskId: string | null = null;
+    let workbenchTaskGoal = prompt;
     let activeSession: ActivePiSession | null = null;
 
     try {
@@ -610,6 +611,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         });
         workbenchRunId = workbench.run.id;
         workbenchTaskId = workbench.task?.id ?? null;
+        workbenchTaskGoal = workbench.task?.goal ?? prompt;
       }
 
       // Pi's createAgentSession does not accept a systemPrompt option. Its
@@ -835,7 +837,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 taskId: workbenchTaskId,
                 runId: workbenchRunId,
                 workflowKind: workbenchContract.kind,
-                goal: prompt,
+                goal: workbenchTaskGoal,
                 prototypeRequired: workbenchContract.metadata?.requiresPrototype === true,
               },
               completionWorkflow || undefined,
@@ -1121,7 +1123,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           taskId: workbench.task.id,
           runId: workbench.run.id,
           workflowKind: workbenchContract.kind,
-          goal: prompt,
+          goal: workbench.task.goal,
           prototypeRequired: workbenchContract.metadata?.requiresPrototype === true,
         });
       }
@@ -1204,6 +1206,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       if (!completionWorkflow) {
         nextPrompt = `${loopPrompt}\n\n${nextPrompt}`;
       }
+    }
+    if (active.productionLoop && productionWorkflowEnabled) {
+      nextPrompt = `${active.productionLoop.buildInitialPrompt()}\n\n${nextPrompt}`;
     }
 
     try {

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -59,6 +59,8 @@ const createController = () => {
     ),
     service,
     downstream,
+    task,
+    workbench,
   };
 };
 
@@ -98,6 +100,33 @@ test('a normal agent_loop next continues without recording a recovery', () => {
   expect(decision.nextPrompt).toContain('drafted the outline');
   // No recovery is recorded for an explicit, orderly iteration end.
   expect(controller.getState().recoveries.length).toBe(before);
+});
+
+test('describes resumed execution without asking the agent to recommit the plan', () => {
+  const { controller, task, workbench } = createController();
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  controller.updatePlanItem(planned.planItems[0].id, 'completed');
+  const retry = workbench.createRun(task.id, WorkbenchRunTrigger.Resume);
+  controller.startRun({
+    taskId: task.id,
+    runId: retry.id,
+    workflowKind: WorkbenchContractKind.Shortcut,
+    goal: 'Use the persisted state',
+    prototypeRequired: false,
+  });
+
+  const prompt = controller.buildInitialPrompt();
+
+  expect(controller.getState().phase).toBe(ProductionLoopPhase.Execute);
+  expect(prompt).toContain('Resume the persisted execution plan');
+  expect(prompt).toContain('evidence belongs to this run');
+  expect(prompt).not.toContain('Begin by committing an executable plan');
 });
 
 test('an omitted agent_loop signal records a missing-signal recovery', () => {

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -80,9 +80,18 @@ export class ProductionLoopController {
 
   buildInitialPrompt(): string {
     this.refresh();
-    const phaseInstruction = this.state.prototypeRequired
-      ? 'Begin by creating a concrete prototype or materially distinct direction, then record it with production_loop record_prototype.'
-      : 'Begin by committing an executable plan with production_loop commit_plan before making changes.';
+    const phaseInstruction = (() => {
+      if (this.state.phase === ProductionLoopPhase.Explore) {
+        return 'Begin by creating a concrete prototype or materially distinct direction, then record it with production_loop record_prototype.';
+      }
+      if (this.state.phase === ProductionLoopPhase.Plan) {
+        return 'Begin by committing an executable plan with production_loop commit_plan before making changes.';
+      }
+      if (this.state.phase === ProductionLoopPhase.Execute) {
+        return 'Resume the persisted execution plan. Completed items remain completed; continue pending or blocked items, and rerun deterministic verifiers before inspection so their evidence belongs to this run.';
+      }
+      return 'Resume from the persisted production phase and rebuild any execution or verification evidence required by this run.';
+    })();
     return [
       '## Production workflow',
       `Persistent phase: ${this.state.phase}`,

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -390,11 +390,103 @@ test('keeps acceptance-required work ready until the user accepts it', () => {
   });
 });
 
-test('inherits the durable plan into a new run without replaying prior progress', () => {
+test('inherits durable task progress while rebuilding run evidence', () => {
   const { task, run } = begin();
   const first = commitPlan(run.id);
   service.updatePlanItem(run.id, first.planItems[0].id, ProductionPlanItemStatus.Completed);
+  service.updatePlanItem(run.id, first.planItems[1].id, ProductionPlanItemStatus.InProgress);
+  const priorEvidence = recordVerifier(run.id);
   const retry = workbench.createRun(task.id, WorkbenchRunTrigger.Retry);
+  const resumed = service.beginRun({
+    taskId: task.id,
+    runId: retry.id,
+    workflowKind: WorkbenchContractKind.GenericWork,
+    goal: 'Also use a shorter title',
+    prototypeRequired: false,
+  });
+
+  expect(resumed.phase).toBe(ProductionLoopPhase.Execute);
+  expect(resumed.goal).toBe(task.goal);
+  expect(resumed.acceptanceCriteria).toEqual(first.acceptanceCriteria);
+  expect(resumed.planItems.map(item => item.id)).toEqual(first.planItems.map(item => item.id));
+  expect(resumed.planItems.map(item => item.status)).toEqual([
+    ProductionPlanItemStatus.Completed,
+    ProductionPlanItemStatus.Pending,
+  ]);
+  expect(resumed.observedToolResults).toEqual([]);
+  expect(resumed.inspections).toEqual([]);
+  expect(resumed.critic.requested).toBe(false);
+  expect(resumed.critic.toolCallId).toBeNull();
+  expect(resumed.deliveryReason).toBeNull();
+  expect(resumed.revisions).toEqual([]);
+  expect(resumed.recoveries).toEqual([]);
+  expect(resumed.progressVersion).toBe(first.progressVersion + 2);
+  expect(resumed.lastObservedProgressVersion).toBe(resumed.progressVersion);
+
+  service.updatePlanItem(retry.id, resumed.planItems[1].id, ProductionPlanItemStatus.Completed);
+  expect(() =>
+    service.startInspection(retry.id, {
+      artifacts: [{ kind: 'file', reference: 'report.md' }],
+      verifiers: [
+        {
+          name: 'artifact_verifier',
+          evidenceRef: priorEvidence.evidenceRef ?? 'missing',
+        },
+      ],
+    }),
+  ).toThrow('Passing deterministic verifier evidence');
+
+  expect(startInspection(retry.id).phase).toBe(ProductionLoopPhase.Inspect);
+});
+
+test('keeps blocked plan items when resuming prototype-based work', () => {
+  const { task, run } = begin(true);
+  service.recordPrototype(run.id, 'prototype-a.html', 'First concrete direction');
+  const planned = commitPlan(run.id);
+  service.updatePlanItem(run.id, planned.planItems[0].id, ProductionPlanItemStatus.Blocked);
+  const retry = workbench.createRun(task.id, WorkbenchRunTrigger.Resume);
+
+  const resumed = service.beginRun({
+    taskId: task.id,
+    runId: retry.id,
+    workflowKind: WorkbenchContractKind.GenericWork,
+    goal: 'Continue',
+    prototypeRequired: true,
+  });
+
+  expect(resumed.phase).toBe(ProductionLoopPhase.Execute);
+  expect(resumed.prototypes).toEqual(service.getState(run.id).prototypes);
+  expect(resumed.planItems[0].status).toBe(ProductionPlanItemStatus.Blocked);
+});
+
+test('resumes prototype-only work at planning without requiring another prototype', () => {
+  const { task, run } = begin(true);
+  service.recordPrototype(run.id, 'prototype-a.html', 'First concrete direction');
+  const retry = workbench.createRun(task.id, WorkbenchRunTrigger.Resume);
+
+  const resumed = service.beginRun({
+    taskId: task.id,
+    runId: retry.id,
+    workflowKind: WorkbenchContractKind.GenericWork,
+    goal: task.goal,
+    prototypeRequired: true,
+  });
+
+  expect(resumed.phase).toBe(ProductionLoopPhase.Plan);
+  expect(resumed.prototypes).toHaveLength(1);
+});
+
+test('clears prior inspection and critic bindings before resumed verification', () => {
+  const { task, run } = begin();
+  const planned = commitPlan(run.id);
+  for (const item of planned.planItems) {
+    service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
+  }
+  startInspection(run.id);
+  service.requestCritique(run.id);
+  service.recordCriticStart(run.id, 'prior-review');
+  const retry = workbench.createRun(task.id, WorkbenchRunTrigger.Resume);
+
   const resumed = service.beginRun({
     taskId: task.id,
     runId: retry.id,
@@ -403,16 +495,18 @@ test('inherits the durable plan into a new run without replaying prior progress'
     prototypeRequired: false,
   });
 
-  expect(resumed.phase).toBe(ProductionLoopPhase.Plan);
-  expect(resumed.acceptanceCriteria).toEqual(first.acceptanceCriteria);
-  expect(resumed.planItems.every(item => item.status === ProductionPlanItemStatus.Pending)).toBe(
+  expect(resumed.phase).toBe(ProductionLoopPhase.Execute);
+  expect(resumed.planItems.every(item => item.status === ProductionPlanItemStatus.Completed)).toBe(
     true,
   );
-  expect(resumed.critic.requested).toBe(false);
-  expect(resumed.deliveryReason).toBeNull();
-  expect(resumed.revisions).toEqual([]);
-  expect(resumed.recoveries).toEqual([]);
-  expect(resumed.progressVersion).toBe(0);
+  expect(resumed.observedToolResults).toEqual([]);
+  expect(resumed.inspections).toEqual([]);
+  expect(resumed.critic).toMatchObject({
+    requested: false,
+    toolCallId: null,
+    passed: false,
+    execution: null,
+  });
 });
 
 test('records explicit stale recovery without marking the loop complete', () => {

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -135,6 +135,23 @@ const parseCriticPayload = (output: string, isError: boolean): CriticPayload => 
   }
 };
 
+const resumePlanItemStatus = (status: ProductionPlanItemStatus): ProductionPlanItemStatus =>
+  status === ProductionPlanItemStatus.InProgress ? ProductionPlanItemStatus.Pending : status;
+
+const resolveInitialPhase = (
+  previous: ProductionLoopState | null,
+  prototypeRequired: boolean,
+): ProductionLoopPhase => {
+  if (!previous) {
+    return prototypeRequired ? ProductionLoopPhase.Explore : ProductionLoopPhase.Plan;
+  }
+  if (previous.planItems.length > 0) return ProductionLoopPhase.Execute;
+  if (prototypeRequired && previous.prototypes.length === 0) {
+    return ProductionLoopPhase.Explore;
+  }
+  return ProductionLoopPhase.Plan;
+};
+
 export class ProductionLoopService {
   readonly repository: ProductionLoopStore;
 
@@ -176,13 +193,14 @@ export class ProductionLoopService {
     if (existing) return existing;
     const previous = this.repository.getLatestForTask(input.taskId, input.runId);
     const now = Date.now();
+    const progressBaseline = previous?.progressVersion ?? 0;
     return this.repository.create({
       version: 1,
       taskId: input.taskId,
       runId: input.runId,
       workflowKind: input.workflowKind,
-      goal: input.goal,
-      phase: input.prototypeRequired ? ProductionLoopPhase.Explore : ProductionLoopPhase.Plan,
+      goal: previous?.goal ?? input.goal,
+      phase: resolveInitialPhase(previous, input.prototypeRequired),
       status: ProductionLoopStatus.Active,
       prototypeRequired: input.prototypeRequired,
       prototypes: previous?.prototypes ?? [],
@@ -194,8 +212,10 @@ export class ProductionLoopService {
       observedToolResults: [],
       inspections: [],
       planItems:
-        previous?.planItems.map(item => ({ ...item, status: ProductionPlanItemStatus.Pending })) ??
-        [],
+        previous?.planItems.map(item => ({
+          ...item,
+          status: resumePlanItemStatus(item.status),
+        })) ?? [],
       critic: {
         requested: false,
         toolCallId: null,
@@ -208,8 +228,8 @@ export class ProductionLoopService {
       recoveries: [],
       skip: null,
       deliveryReason: null,
-      progressVersion: 0,
-      lastObservedProgressVersion: 0,
+      progressVersion: progressBaseline,
+      lastObservedProgressVersion: progressBaseline,
       staleCount: 0,
       createdAt: now,
       updatedAt: now,


### PR DESCRIPTION
## 背景

生产任务在 Stop 或审批拒绝后显式恢复时，旧实现会把全部计划项重置为 `pending`，并把 phase 与进度版本一律归零。这会导致已完成工作被重复执行；同时，恢复提示仍要求重新 `commit_plan`，与持久化状态冲突。

本 PR 将 Task 级可继承状态与 Run 级验证证据分离：恢复沿用原任务目标和仍有效的执行进度，但检查、reviewer 绑定和工具证据必须在新 Run 中重新建立。

## 主要改动

- 继承原 Task 的目标、原型、选定方向、约束、验收标准、预期工件、verifier 和计划项 ID。
- `completed` 保持完成，`in_progress` 回退为 `pending`，`pending` 与 `blocked` 保持原状态。
- 已有计划从 `execute` 恢复；只有原型时从 `plan` 恢复；仍缺必需原型时从 `explore` 恢复。
- 清空旧 Run 的 `observedToolResults`、`inspections`、critic 请求、`toolCallId`、结论、delivery 和 recovery 状态。
- 继承进度版本作为新 Run 的稳定基线，并同步 `lastObservedProgressVersion`，避免恢复后立即误判 stale。
- production 提示按持久化 phase 生成；`execute` 恢复不再要求重复提交计划，并明确要求重新运行 deterministic verifier。
- 同一 runtime 开始新的 production task 时重新注入 production 协议，避免门禁已开启但模型未收到协议。
- controller 始终使用 Workbench Task 的原始目标，amendment 只作为本轮补充要求，不覆盖任务主目标。

## 恢复规则

| 中断前状态 | 新 Run 状态 |
| --- | --- |
| `completed` | 保持 `completed` |
| `in_progress` | 回退为 `pending` |
| `pending` | 保持 `pending` |
| `blocked` | 保持 `blocked` |
| inspection / critic / tool evidence | 清空并在新 Run 重建 |

旧 Run 的 `evidenceRef` 包含旧 `runId`，无法通过新 Run 的 inspection 校验；新 verifier 必须实际执行并生成属于新 Run 的 `toolCallId`。

## 验证

- `npm test -- src/main/productionLoop/service.test.ts src/main/productionLoop/controller.test.ts src/main/libs/agentEngine/piRuntimeAdapter.test.ts`：116 项通过
- `npm run lint`：通过
- `tsc --project electron-tsconfig.json --noEmit`：通过
- `npm run build`：通过

构建仅有仓库既有的 Vite chunk、弃用项和 CommonJS `import.meta` 提示。

## 堆叠关系

本 PR 以 `codex/production-loop-gate-inversion` 为 base，依赖以下 PR：

1. #437 统一停止与审批拒绝的中断传播
2. #438 增加任务显式恢复与补充要求
3. #439 反转 production-loop 门禁并继承任务策略
4. 本 PR 继承生产任务有效进度并重建 Run 级证据

请按以上顺序合并。
