### PR TITLE
fix(memory): improve CJK recall reliability

### DIFF
--- a/src/main/memory/authenticatedProxy.test.ts
+++ b/src/main/memory/authenticatedProxy.test.ts
@@ -52,5 +52,6 @@ test('blocks routes outside the product memory capability boundary', async () =>
 
   expect(response.status).toBe(404);
   expect(isAllowedEngramRequest('GET', '/search')).toBe(true);
+  expect(isAllowedEngramRequest('GET', '/observations/recent')).toBe(true);
   expect(isAllowedEngramRequest('POST', '/conflicts/judge')).toBe(false);
 });

--- a/src/main/memory/authenticatedProxy.ts
+++ b/src/main/memory/authenticatedProxy.ts
@@ -24,6 +24,7 @@ function tokensMatch(expected: string, actual: string): boolean {
 export function isAllowedEngramRequest(method = '', pathname = ''): boolean {
   if (method === 'GET' && pathname === '/health') return true;
   if (method === 'GET' && pathname === '/search') return true;
+  if (method === 'GET' && pathname === '/observations/recent') return true;
   if (method === 'POST' && pathname === '/sessions') return true;
   if (method === 'POST' && /^\/sessions\/[^/]+\/end$/.test(pathname)) return true;
   if (method === 'POST' && pathname === '/observations') return true;

--- a/src/main/memory/constants.ts
+++ b/src/main/memory/constants.ts
@@ -55,12 +55,21 @@ export type MemorySourceKind = MemorySourceKindValue;
 
 export const PiMemoryAction = {
   Recall: 'recall',
+  List: 'list',
   Save: 'save',
   ProposePersonal: 'propose_personal',
   SessionSummary: 'session_summary',
 } as const;
 
 export type PiMemoryAction = (typeof PiMemoryAction)[keyof typeof PiMemoryAction];
+
+export const EngramSearchMatchMode = {
+  All: 'all',
+  Any: 'any',
+} as const;
+
+export type EngramSearchMatchMode =
+  (typeof EngramSearchMatchMode)[keyof typeof EngramSearchMatchMode];
 
 export const EngramEnvironment = {
   BinaryPath: 'ZHIYUAN_ENGRAM_BIN',

--- a/src/main/memory/piMemoryTool.test.ts
+++ b/src/main/memory/piMemoryTool.test.ts
@@ -10,6 +10,15 @@ test('exposes only controlled project memory actions', async () => {
     saveProjectMemory: vi.fn(),
     proposePersonalMemory: vi.fn(),
     saveSessionSummary: vi.fn(),
+    listRecallableMemories: vi.fn(() => [
+      {
+        id: 'link-1',
+        memoryId: 7,
+        scope: 'project',
+        title: 'Database',
+        content: 'Use SQLite.',
+      },
+    ]),
   };
   const tool = buildPiProjectMemoryTool({
     service: service as never,
@@ -29,5 +38,13 @@ test('exposes only controlled project memory actions', async () => {
   expect(service.recallProject).toHaveBeenCalledWith({
     workingDirectory: '/workspace/project',
     query: 'database',
+  });
+
+  const listResult = await tool.execute('call-2', { action: PiMemoryAction.List, limit: 5 });
+  expect(listResult).toMatchObject({ details: { count: 1 } });
+  expect(service.listRecallableMemories).toHaveBeenCalledWith({
+    workingDirectory: '/workspace/project',
+    query: undefined,
+    limit: 5,
   });
 });

--- a/src/main/memory/piMemoryTool.ts
+++ b/src/main/memory/piMemoryTool.ts
@@ -15,7 +15,7 @@ export function buildPiProjectMemoryTool(input: {
     label: 'Memory',
     description:
       'Recall project and confirmed personal memory, explicitly save durable project memory, ' +
-      'propose personal memory for user review, or save a short-lived session summary.',
+      'list controlled active memory, propose personal memory for user review, or save a short-lived session summary.',
     promptSnippet:
       'Use memory to recall prior project decisions or save durable facts only when they are useful later.',
     parameters: {
@@ -24,9 +24,10 @@ export function buildPiProjectMemoryTool(input: {
         action: {
           type: 'string',
           enum: Object.values(PiMemoryAction),
-          description: 'recall, save, propose_personal, or session_summary',
+          description: 'recall, list, save, propose_personal, or session_summary',
         },
         query: { type: 'string', description: 'Search query for recall.' },
+        limit: { type: 'number', description: 'Maximum number of memories to list.' },
         title: { type: 'string', description: 'Short title for a saved project memory.' },
         content: { type: 'string', description: 'Atomic memory content or session summary.' },
         topicKey: { type: 'string', description: 'Stable topic key for project memory upsert.' },
@@ -59,6 +60,22 @@ export function buildPiProjectMemoryTool(input: {
                 .join('\n')
             : 'No relevant project memory found.';
           return toolResult(text, { count: observations.length });
+        }
+        if (action === PiMemoryAction.List) {
+          const memories = input.service.listRecallableMemories({
+            workingDirectory: input.workingDirectory,
+            query: typeof params.query === 'string' ? params.query.trim() || undefined : undefined,
+            limit: typeof params.limit === 'number' ? params.limit : undefined,
+          });
+          const text = memories.length
+            ? memories
+                .map(
+                  memory =>
+                    `[memory:${memory.memoryId ?? memory.id}] [${memory.scope}] ${memory.title}: ${memory.content}`,
+                )
+                .join('\n')
+            : 'No active project or confirmed personal memory found.';
+          return toolResult(text, { count: memories.length });
         }
         if (action === PiMemoryAction.ProposePersonal) {
           const candidateId = input.service.proposePersonalMemory({

--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -3,6 +3,7 @@ import { expect, test, vi } from 'vitest';
 import {
   EngramMemoryScope,
   EngramObservationType,
+  EngramSearchMatchMode,
   MemoryOutboxOperation,
   MemoryOutboxStatus,
 } from './constants';
@@ -34,6 +35,14 @@ class FakeRepository {
 
   filterRecallableMemoryIds(_projectId: string, memoryIds: number[]) {
     return new Set(memoryIds);
+  }
+
+  listManaged() {
+    return [];
+  }
+
+  getRecallMetadata() {
+    return new Map();
   }
 
   createLink(input: Record<string, unknown>) {
@@ -160,4 +169,79 @@ test('enforces the project context token budget', async () => {
 
   expect(context).toContain('[memory:1]');
   expect(context).not.toContain('[memory:2]');
+});
+
+test('broadens an empty CJK search with any-match terms', async () => {
+  const recall = vi.fn(async (input: { matchMode: string }) =>
+    input.matchMode === EngramSearchMatchMode.Any
+      ? [
+          {
+            id: 9,
+            title: 'Project database',
+            content: 'Use SQLite.',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        ]
+      : [],
+  );
+  const service = new ProjectMemoryService(
+    new FakeRepository() as never,
+    { recall, recent: vi.fn(async () => []) } as never,
+    identityFor,
+  );
+
+  await expect(
+    service.recallProject({ workingDirectory: 'alpha', query: '我们项目使用什么数据库' }),
+  ).resolves.toMatchObject([{ id: 9 }]);
+  expect(recall).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({ matchMode: EngramSearchMatchMode.Any }),
+  );
+});
+
+test('falls back to bounded recent active memory only for explicit memory intent', async () => {
+  const recent = vi.fn(async () => [
+    {
+      id: 10,
+      title: 'Current project',
+      content: 'The project is ZhiYuan.',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+  ]);
+  const service = new ProjectMemoryService(
+    new FakeRepository() as never,
+    { recall: vi.fn(async () => []), recent } as never,
+    identityFor,
+  );
+
+  await expect(
+    service.recallProject({ workingDirectory: 'alpha', query: '当前项目是什么' }),
+  ).resolves.toMatchObject([{ id: 10 }]);
+  expect(recent).toHaveBeenCalledWith({
+    project: 'project-alpha',
+    scope: EngramMemoryScope.Project,
+    limit: 8,
+  });
+});
+
+test('lists only the current project and confirmed personal memories', () => {
+  const memories = [
+    { id: 'project-current', projectId: 'project-alpha', scope: EngramMemoryScope.Project },
+    { id: 'project-other', projectId: 'project-beta', scope: EngramMemoryScope.Project },
+    {
+      id: 'personal',
+      projectId: 'personal://zhiyuan-agent/user',
+      scope: EngramMemoryScope.Personal,
+    },
+    { id: 'session', projectId: 'project-alpha', scope: EngramMemoryScope.Session },
+  ];
+  const service = new ProjectMemoryService(
+    { listManaged: vi.fn(() => memories) } as never,
+    {} as never,
+    identityFor,
+  );
+
+  expect(
+    service.listRecallableMemories({ workingDirectory: 'alpha' }).map(memory => memory.id),
+  ).toEqual(['project-current', 'personal']);
 });

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -13,9 +13,10 @@ import {
   type MemorySensitivity as MemorySensitivityValue,
   type MemorySourceKind as MemorySourceKindValue,
 } from '../../shared/memory';
-import { MemoryOutboxOperation } from './constants';
+import { EngramSearchMatchMode, MemoryOutboxOperation } from './constants';
 import type { ProjectIdentity } from './projectIdentity';
 import { resolveProjectIdentity } from './projectIdentity';
+import { planRecallQuery, rankRecallResults } from './recallQueryPlanner';
 import type { MemoryOutboxItem } from './repository';
 import { MemoryRepository } from './repository';
 import type { ZhiYuanEngramAdapter } from './zhiyuanEngramAdapter';
@@ -68,23 +69,39 @@ export class ProjectMemoryService {
 
   async recallProject(input: { workingDirectory: string; query: string; limit?: number }) {
     const project = this.resolveIdentity(input.workingDirectory);
-    const observations = await this.adapter.recall({
+    return await this.recallScope({
       query: input.query,
-      project: project.id,
+      projectId: project.id,
       scope: MemoryScope.Project,
       limit: input.limit,
     });
-    return this.filterRecallable(project.id, observations);
   }
 
   async recallPersonal(input: { query: string; limit?: number }) {
-    const observations = await this.adapter.recall({
+    return await this.recallScope({
       query: input.query,
-      project: PERSONAL_MEMORY_PROJECT_ID,
+      projectId: PERSONAL_MEMORY_PROJECT_ID,
       scope: MemoryScope.Personal,
       limit: input.limit,
     });
-    return this.filterRecallable(PERSONAL_MEMORY_PROJECT_ID, observations);
+  }
+
+  listRecallableMemories(input: {
+    workingDirectory: string;
+    query?: string;
+    limit?: number;
+  }): ManagedMemoryRecord[] {
+    const project = this.resolveIdentity(input.workingDirectory);
+    const limit = Math.min(Math.max(input.limit ?? 12, 1), 20);
+    return this.repository
+      .listManaged({ status: MemoryLifecycleStatus.Active, query: input.query })
+      .filter(
+        memory =>
+          (memory.scope === MemoryScope.Project && memory.projectId === project.id) ||
+          (memory.scope === MemoryScope.Personal &&
+            memory.projectId === PERSONAL_MEMORY_PROJECT_ID),
+      )
+      .slice(0, limit);
   }
 
   async buildProjectContext(input: {
@@ -323,6 +340,54 @@ export class ProjectMemoryService {
   async retryPendingOutbox(limit = 20): Promise<number> {
     this.repository.makePendingAvailable();
     return await this.drainOutbox(limit);
+  }
+
+  private async recallScope(input: {
+    query: string;
+    projectId: string;
+    scope: typeof MemoryScope.Project | typeof MemoryScope.Personal;
+    limit?: number;
+  }) {
+    const plan = planRecallQuery(input.query);
+    if (!plan.exactQuery) return [];
+    const limit = Math.min(Math.max(input.limit ?? 8, 1), 20);
+    let observations = this.filterRecallable(
+      input.projectId,
+      await this.adapter.recall({
+        query: plan.exactQuery,
+        project: input.projectId,
+        scope: input.scope,
+        limit,
+        matchMode: EngramSearchMatchMode.All,
+      }),
+    );
+    if (observations.length === 0 && plan.broadQuery) {
+      observations = this.filterRecallable(
+        input.projectId,
+        await this.adapter.recall({
+          query: plan.broadQuery,
+          project: input.projectId,
+          scope: input.scope,
+          limit,
+          matchMode: EngramSearchMatchMode.Any,
+        }),
+      );
+    }
+    if (observations.length === 0 && plan.explicitMemoryIntent) {
+      observations = this.filterRecallable(
+        input.projectId,
+        await this.adapter.recent({ project: input.projectId, scope: input.scope, limit }),
+      );
+    }
+    const unique = [
+      ...new Map(observations.map(observation => [observation.id, observation])).values(),
+    ];
+    if (unique.length === 0) return [];
+    const metadata = this.repository.getRecallMetadata(
+      input.projectId,
+      unique.map(observation => observation.id),
+    );
+    return rankRecallResults(plan.exactQuery, unique, metadata).slice(0, limit);
   }
 
   private filterRecallable<T extends { id: number }>(projectId: string, observations: T[]): T[] {

--- a/src/main/memory/recallQueryPlanner.test.ts
+++ b/src/main/memory/recallQueryPlanner.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest';
+
+import { planRecallQuery, rankRecallResults } from './recallQueryPlanner';
+import type { EngramObservation } from './types';
+
+function observation(input: Partial<EngramObservation> & Pick<EngramObservation, 'id'>) {
+  return {
+    sync_id: `sync-${input.id}`,
+    session_id: 'session-1',
+    type: 'decision',
+    title: '',
+    content: '',
+    scope: 'project',
+    revision_count: 1,
+    duplicate_count: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...input,
+  } satisfies EngramObservation;
+}
+
+test('segments an unspaced CJK memory question into a broad fallback query', () => {
+  const plan = planRecallQuery('我们之前决定当前项目使用什么数据库');
+
+  expect(plan.exactQuery).toBe('我们之前决定当前项目使用什么数据库');
+  expect(plan.broadQuery).toContain('项目');
+  expect(plan.broadQuery).toContain('数据');
+  expect(plan.explicitMemoryIntent).toBe(true);
+});
+
+test('does not broaden ordinary non-CJK queries', () => {
+  expect(planRecallQuery('database decision')).toEqual({
+    exactQuery: 'database decision',
+    broadQuery: null,
+    explicitMemoryIntent: false,
+  });
+});
+
+test('ranks exact title matches ahead of weaker content matches', () => {
+  const results = rankRecallResults('知远', [
+    observation({ id: 1, title: 'Other', content: '知远 is mentioned here.' }),
+    observation({ id: 2, title: '知远', content: 'Project identity.' }),
+  ]);
+
+  expect(results.map(result => result.id)).toEqual([2, 1]);
+});

--- a/src/main/memory/recallQueryPlanner.ts
+++ b/src/main/memory/recallQueryPlanner.ts
@@ -1,0 +1,139 @@
+import type { EngramObservation } from './types';
+
+const CJK_PATTERN = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+const TOKEN_PATTERN = /[\p{L}\p{N}_]+/gu;
+const MEMORY_INTENT_PATTERN =
+  /(?:记得|记忆|之前|以前|上次|历史|曾经|当前.{0,6}(?:项目|偏好|决定)|(?:项目|偏好|决定).{0,4}(?:是什么|有哪些)|还记得|what did we|do you remember|previous(?:ly)?|last time|memory|memories)/iu;
+const STOP_WORDS = new Set([
+  '的',
+  '了',
+  '是',
+  '在',
+  '和',
+  '与',
+  '或',
+  '吗',
+  '呢',
+  '吧',
+  '我',
+  '你',
+  '我们',
+  '这个',
+  '那个',
+  '什么',
+  '一下',
+  '当前',
+  '请',
+  '帮我',
+  'about',
+  'did',
+  'do',
+  'the',
+  'what',
+]);
+
+interface SegmentData {
+  segment: string;
+  isWordLike?: boolean;
+}
+
+interface SegmenterLike {
+  segment(input: string): Iterable<SegmentData>;
+}
+
+interface SegmenterConstructor {
+  new (locales?: string | string[], options?: { granularity?: string }): SegmenterLike;
+}
+
+export interface RecallQueryPlan {
+  exactQuery: string;
+  broadQuery: string | null;
+  explicitMemoryIntent: boolean;
+}
+
+export interface RecallRankingMetadata {
+  importance: number;
+  updatedAt: string;
+}
+
+export function planRecallQuery(query: string): RecallQueryPlan {
+  const exactQuery = query.trim();
+  const broadQuery = CJK_PATTERN.test(exactQuery) ? buildBroadQuery(exactQuery) : null;
+  return {
+    exactQuery,
+    broadQuery:
+      broadQuery && normalizeForComparison(broadQuery) !== normalizeForComparison(exactQuery)
+        ? broadQuery
+        : null,
+    explicitMemoryIntent: MEMORY_INTENT_PATTERN.test(exactQuery),
+  };
+}
+
+export function rankRecallResults(
+  query: string,
+  observations: EngramObservation[],
+  metadata: ReadonlyMap<number, RecallRankingMetadata> = new Map(),
+): EngramObservation[] {
+  const normalizedQuery = query.toLocaleLowerCase();
+  const terms = tokenizeForRanking(query);
+  const now = Date.now();
+  return [...observations].sort((left, right) => {
+    const scoreDifference =
+      scoreObservation(right, normalizedQuery, terms, metadata.get(right.id), now) -
+      scoreObservation(left, normalizedQuery, terms, metadata.get(left.id), now);
+    if (scoreDifference !== 0) return scoreDifference;
+    return (right.updated_at ?? '').localeCompare(left.updated_at ?? '');
+  });
+}
+
+function buildBroadQuery(query: string): string | null {
+  const segmenterConstructor = (Intl as typeof Intl & { Segmenter?: SegmenterConstructor })
+    .Segmenter;
+  const rawSegments = segmenterConstructor
+    ? [...new segmenterConstructor(['zh', 'ja', 'ko'], { granularity: 'word' }).segment(query)]
+        .filter(item => item.isWordLike !== false)
+        .map(item => item.segment)
+    : (query.match(TOKEN_PATTERN) ?? []);
+  const terms = rawSegments
+    .flatMap((segment): string[] => [...(segment.match(TOKEN_PATTERN) ?? [])])
+    .map(segment => segment.toLocaleLowerCase())
+    .filter(segment => segment.length > 0 && !STOP_WORDS.has(segment));
+  const uniqueTerms = [...new Set(terms)];
+  return uniqueTerms.length > 0 ? uniqueTerms.join(' ') : null;
+}
+
+function tokenizeForRanking(query: string): string[] {
+  const plan = CJK_PATTERN.test(query) ? buildBroadQuery(query) : query;
+  return [...new Set((plan?.match(TOKEN_PATTERN) ?? []).map(term => term.toLocaleLowerCase()))];
+}
+
+function scoreObservation(
+  observation: EngramObservation,
+  normalizedQuery: string,
+  terms: string[],
+  metadata: RecallRankingMetadata | undefined,
+  now: number,
+): number {
+  const title = observation.title.toLocaleLowerCase();
+  const content = observation.content.toLocaleLowerCase();
+  let score = 0;
+  if (title === normalizedQuery) score += 24;
+  else if (title.includes(normalizedQuery)) score += 12;
+  if (content.includes(normalizedQuery)) score += 6;
+  for (const term of terms) {
+    if (title.includes(term)) score += 3;
+    if (content.includes(term)) score += 1;
+  }
+  score += (metadata?.importance ?? 0.5) * 4;
+  const updatedAt = Date.parse(metadata?.updatedAt ?? observation.updated_at);
+  if (Number.isFinite(updatedAt)) {
+    const ageDays = Math.max(0, (now - updatedAt) / 86_400_000);
+    score += 2 / (1 + ageDays / 30);
+  }
+  if (typeof observation.rank === 'number') score += 1 / (1 + Math.abs(observation.rank));
+  return score;
+}
+
+function normalizeForComparison(value: string): string {
+  return value.toLocaleLowerCase().replace(/[^\p{L}\p{N}_]+/gu, '');
+}

--- a/src/main/memory/repository.ts
+++ b/src/main/memory/repository.ts
@@ -62,6 +62,11 @@ export interface MemoryOutboxItem {
   lastError: string | null;
 }
 
+export interface MemoryRecallMetadata {
+  importance: number;
+  updatedAt: string;
+}
+
 interface MemoryOutboxRow {
   id: string;
   link_id: string | null;
@@ -308,6 +313,25 @@ export class MemoryRepository {
       )
       .all(projectId, MemoryLifecycleStatus.Active, ...memoryIds) as Array<{ memory_id: number }>;
     return new Set(rows.map(row => row.memory_id));
+  }
+
+  getRecallMetadata(projectId: string, memoryIds: number[]): Map<number, MemoryRecallMetadata> {
+    if (memoryIds.length === 0) return new Map();
+    this.expireDue();
+    const placeholders = memoryIds.map(() => '?').join(', ');
+    const rows = this.db
+      .prepare(
+        `SELECT memory_id, importance, updated_at FROM memory_links
+         WHERE project_id = ? AND status = ? AND memory_id IN (${placeholders})`,
+      )
+      .all(projectId, MemoryLifecycleStatus.Active, ...memoryIds) as Array<{
+      memory_id: number;
+      importance: number;
+      updated_at: string;
+    }>;
+    return new Map(
+      rows.map(row => [row.memory_id, { importance: row.importance, updatedAt: row.updated_at }]),
+    );
   }
 
   setLinkStatus(id: string, status: MemoryLifecycleStatus, supersededBy?: string): void {

--- a/src/main/memory/zhiyuanEngramAdapter.test.ts
+++ b/src/main/memory/zhiyuanEngramAdapter.test.ts
@@ -66,6 +66,35 @@ test('normalizes the runtime null search response after the last memory is forgo
   await expect(adapter.recall({ query: 'decision', project: 'project-a' })).resolves.toEqual([]);
 });
 
+test('forwards the requested match mode and supports bounded recent observations', async () => {
+  const urls: URL[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL) => {
+      urls.push(new URL(url));
+      return new Response('[]', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }),
+  );
+  const adapter = new ZhiYuanEngramAdapter({
+    getConnection: () => ({ url: 'http://127.0.0.1:4000', token: 'token' }),
+    start: vi.fn(),
+  } as never);
+
+  await adapter.recall({
+    query: '项目 数据库',
+    project: 'project-a',
+    matchMode: 'any',
+  });
+  await adapter.recent({ project: 'project-a', scope: EngramMemoryScope.Project, limit: 99 });
+
+  expect(urls[0].searchParams.get('match_mode')).toBe('any');
+  expect(urls[1].pathname).toBe('/observations/recent');
+  expect(urls[1].searchParams.get('limit')).toBe('20');
+});
+
 test('redacts explicit private blocks before a candidate can be persisted', () => {
   expect(redactPrivateBlocks('keep <private>secret-token</private> this')).toBe(
     'keep [REDACTED] this',

--- a/src/main/memory/zhiyuanEngramAdapter.ts
+++ b/src/main/memory/zhiyuanEngramAdapter.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import {
   EngramMemoryScope,
   EngramObservationType,
+  type EngramSearchMatchMode as EngramSearchMatchModeValue,
   type EngramMemoryScope as EngramMemoryScopeValue,
   type EngramObservationType as EngramObservationTypeValue,
 } from './constants';
@@ -30,6 +31,7 @@ export class ZhiYuanEngramAdapter {
     project: string;
     scope?: EngramMemoryScopeValue;
     limit?: number;
+    matchMode?: EngramSearchMatchModeValue;
   }): Promise<EngramObservation[]> {
     const connection = await this.getConnection();
     if (!connection) return [];
@@ -39,9 +41,29 @@ export class ZhiYuanEngramAdapter {
       scope: input.scope ?? EngramMemoryScope.Project,
       limit: String(Math.min(Math.max(input.limit ?? 8, 1), 20)),
     });
+    if (input.matchMode) params.set('match_mode', input.matchMode);
     const observations = await this.request<EngramObservation[] | null>(
       connection,
       `/search?${params.toString()}`,
+    );
+    return Array.isArray(observations) ? observations : [];
+  }
+
+  async recent(input: {
+    project: string;
+    scope?: EngramMemoryScopeValue;
+    limit?: number;
+  }): Promise<EngramObservation[]> {
+    const connection = await this.getConnection();
+    if (!connection) return [];
+    const params = new URLSearchParams({
+      project: input.project,
+      scope: input.scope ?? EngramMemoryScope.Project,
+      limit: String(Math.min(Math.max(input.limit ?? 8, 1), 20)),
+    });
+    const observations = await this.request<EngramObservation[] | null>(
+      connection,
+      `/observations/recent?${params.toString()}`,
     );
     return Array.isArray(observations) ? observations : [];
   }


### PR DESCRIPTION
## Summary

- Adds exact-first Engram recall with an Intl.Segmenter-based CJK keyword fallback.
- Adds bounded recent-memory fallback for explicit memory intents.
- Deduplicates and reranks results using title/content matches, importance, and recency.
- Adds a controlled memory list action limited to the current project and confirmed personal memories.

## Recall flow

1. Search the original query with match_mode=all.
2. If no recallable result remains, segment CJK text and retry with match_mode=any.
3. For explicit memory requests only, fall back to bounded recent active observations.
4. Apply local lifecycle filtering, deduplication, reranking, and result limits.

## Security and isolation

- Keeps project and personal scopes separate.
- Preserves active, expired, superseded, archived, and deleted lifecycle filtering.
- Expands the authenticated Engram proxy only for the recent-observation read endpoint.
- Does not expose arbitrary Engram routes.

## Tests

- Memory test suite: 34 tests passed.
- Electron main-process TypeScript compilation passed.
- Lint passed.
- GitHub CI test, lint, and bundle-budget checks passed.

## Tracking

Part 1 of #161. This PR does not close the issue.