### PR TITLE
feat(cowork): add scoped conversation history search

### DIFF
--- a/src/main/conversationHistory/constants.ts
+++ b/src/main/conversationHistory/constants.ts
@@ -1,0 +1,13 @@
+export const ConversationHistoryRole = {
+  User: 'user',
+  Assistant: 'assistant',
+} as const;
+
+export type ConversationHistoryRole =
+  (typeof ConversationHistoryRole)[keyof typeof ConversationHistoryRole];
+
+export const CONVERSATION_HISTORY_TOOL_NAME = 'conversation_history';
+
+export const ConversationHistoryExcludedMessageType = {
+  ToolResult: 'tool_result',
+} as const;

--- a/src/main/conversationHistory/piTool.test.ts
+++ b/src/main/conversationHistory/piTool.test.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest';
+
+import { CONVERSATION_HISTORY_TOOL_NAME, ConversationHistoryRole } from './constants';
+import { buildPiConversationHistoryTool } from './piTool';
+
+test('exposes a separate read-only conversation history tool', async () => {
+  const search = vi.fn(() => [
+    {
+      messageId: 'message-1',
+      sessionId: 'session-1',
+      sessionTitle: 'CJK recall',
+      role: ConversationHistoryRole.User,
+      snippet: '项目决定使用 SQLite。',
+      createdAt: Date.parse('2026-08-11T00:00:00.000Z'),
+    },
+  ]);
+  const tool = buildPiConversationHistoryTool({
+    service: { search } as never,
+    workingDirectory: '/workspace/alpha',
+  }) as {
+    name: string;
+    execute: (id: string, params: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  };
+
+  expect(tool.name).toBe(CONVERSATION_HISTORY_TOOL_NAME);
+  await expect(tool.execute('call-1', { query: 'SQLite', limit: 3 })).resolves.toMatchObject({
+    details: { count: 1 },
+  });
+  expect(search).toHaveBeenCalledWith({
+    workingDirectory: '/workspace/alpha',
+    query: 'SQLite',
+    limit: 3,
+  });
+});

--- a/src/main/conversationHistory/piTool.ts
+++ b/src/main/conversationHistory/piTool.ts
@@ -1,0 +1,61 @@
+import { CONVERSATION_HISTORY_TOOL_NAME } from './constants';
+import type { ConversationHistoryService } from './service';
+
+export function buildPiConversationHistoryTool(input: {
+  service: ConversationHistoryService;
+  workingDirectory: string;
+}): Record<string, unknown> {
+  return {
+    name: CONVERSATION_HISTORY_TOOL_NAME,
+    label: 'Conversation History',
+    description:
+      'Search raw user and assistant messages from conversations in the current project. ' +
+      'This is separate from durable memory and excludes thinking and tool output.',
+    promptSnippet:
+      'Use conversation_history when the user asks for details from prior conversations that may not be durable memory.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Text or keywords to search in conversation history.',
+        },
+        limit: { type: 'number', description: 'Maximum number of matching message excerpts.' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    execute: async (_toolCallId: string, params: Record<string, unknown>) => {
+      try {
+        const query = requiredQuery(params.query);
+        const matches = input.service.search({
+          workingDirectory: input.workingDirectory,
+          query,
+          limit: typeof params.limit === 'number' ? params.limit : undefined,
+        });
+        const text = matches.length
+          ? matches
+              .map(
+                match =>
+                  `[history:${match.messageId}] [${match.role}] ${match.sessionTitle} (${new Date(match.createdAt).toISOString()}): ${match.snippet}`,
+              )
+              .join('\n')
+          : 'No matching conversation history found in the current project.';
+        return toolResult(text, { count: matches.length });
+      } catch (error) {
+        return toolResult(error instanceof Error ? error.message : String(error), {
+          isError: true,
+        });
+      }
+    },
+  };
+}
+
+function requiredQuery(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error('query is required.');
+  return value.trim();
+}
+
+function toolResult(text: string, details: Record<string, unknown>) {
+  return { content: [{ type: 'text', text }], details };
+}

--- a/src/main/conversationHistory/service.test.ts
+++ b/src/main/conversationHistory/service.test.ts
@@ -1,0 +1,144 @@
+import Database from 'better-sqlite3';
+import { afterEach, expect, test } from 'vitest';
+
+import type { ProjectIdentity } from '../memory/projectIdentity';
+import { ConversationHistoryExcludedMessageType, ConversationHistoryRole } from './constants';
+import { ConversationHistoryService } from './service';
+
+const databases: Database.Database[] = [];
+
+afterEach(() => {
+  for (const database of databases.splice(0)) database.close();
+});
+
+test('searches CJK conversation text only within the resolved current project', () => {
+  const database = createDatabase();
+  insertSession(database, 'session-a', 'Alpha session', '/workspace/alpha');
+  insertSession(database, 'session-b', 'Beta session', '/workspace/beta');
+  insertMessage(
+    database,
+    'message-a',
+    'session-a',
+    ConversationHistoryRole.User,
+    '项目决定使用 SQLite 数据库。',
+    null,
+    1,
+  );
+  insertMessage(
+    database,
+    'thinking-a',
+    'session-a',
+    ConversationHistoryRole.Assistant,
+    '项目数据库的隐藏思考。',
+    JSON.stringify({ isThinking: true }),
+    2,
+  );
+  insertMessage(
+    database,
+    'tool-a',
+    'session-a',
+    ConversationHistoryExcludedMessageType.ToolResult,
+    '项目数据库工具输出。',
+    null,
+    3,
+  );
+  insertMessage(
+    database,
+    'message-b',
+    'session-b',
+    ConversationHistoryRole.User,
+    '项目决定使用其他数据库。',
+    null,
+    4,
+  );
+  const service = new ConversationHistoryService(database, identityFor);
+
+  const matches = service.search({
+    workingDirectory: '/workspace/alpha',
+    query: '我们之前讨论项目数据库',
+  });
+
+  expect(matches).toEqual([
+    expect.objectContaining({
+      messageId: 'message-a',
+      sessionId: 'session-a',
+      role: ConversationHistoryRole.User,
+    }),
+  ]);
+});
+
+test('returns bounded excerpts instead of full assistant messages', () => {
+  const database = createDatabase();
+  insertSession(database, 'session-a', 'Alpha session', '/workspace/alpha');
+  insertMessage(
+    database,
+    'message-a',
+    'session-a',
+    ConversationHistoryRole.Assistant,
+    `${'prefix '.repeat(100)}needle${' suffix'.repeat(100)}`,
+    null,
+    1,
+  );
+  const service = new ConversationHistoryService(database, identityFor);
+
+  const [match] = service.search({ workingDirectory: '/workspace/alpha', query: 'needle' });
+
+  expect(match.snippet).toContain('needle');
+  expect(match.snippet.length).toBeLessThanOrEqual(606);
+});
+
+function createDatabase(): Database.Database {
+  const database = new Database(':memory:');
+  databases.push(database);
+  database.exec(`
+    CREATE TABLE cowork_sessions (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      cwd TEXT NOT NULL
+    );
+    CREATE TABLE cowork_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at INTEGER NOT NULL,
+      sequence INTEGER
+    );
+  `);
+  return database;
+}
+
+function insertSession(database: Database.Database, id: string, title: string, cwd: string): void {
+  database
+    .prepare('INSERT INTO cowork_sessions (id, title, cwd) VALUES (?, ?, ?)')
+    .run(id, title, cwd);
+}
+
+function insertMessage(
+  database: Database.Database,
+  id: string,
+  sessionId: string,
+  type: string,
+  content: string,
+  metadata: string | null,
+  createdAt: number,
+): void {
+  database
+    .prepare(
+      `INSERT INTO cowork_messages
+       (id, session_id, type, content, metadata, created_at, sequence)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(id, sessionId, type, content, metadata, createdAt, createdAt);
+}
+
+function identityFor(cwd: string): ProjectIdentity {
+  const project = cwd.includes('alpha') ? 'alpha' : 'beta';
+  return {
+    id: `project-${project}`,
+    displayName: project,
+    root: cwd,
+    canonicalSource: `path:${cwd}`,
+  };
+}

--- a/src/main/conversationHistory/service.ts
+++ b/src/main/conversationHistory/service.ts
@@ -1,0 +1,161 @@
+import type Database from 'better-sqlite3';
+
+import type { ProjectIdentity } from '../memory/projectIdentity';
+import { resolveProjectIdentity } from '../memory/projectIdentity';
+import { planRecallQuery } from '../memory/recallQueryPlanner';
+import { ConversationHistoryRole, type ConversationHistoryRole as Role } from './constants';
+
+const DEFAULT_RESULT_LIMIT = 6;
+const MAX_RESULT_LIMIT = 12;
+const MAX_CANDIDATE_MULTIPLIER = 6;
+const MAX_SNIPPET_CHARACTERS = 600;
+
+interface HistoryRow {
+  id: string;
+  session_id: string;
+  session_title: string;
+  type: Role;
+  content: string;
+  metadata: string | null;
+  created_at: number;
+}
+
+export interface ConversationHistoryMatch {
+  messageId: string;
+  sessionId: string;
+  sessionTitle: string;
+  role: Role;
+  snippet: string;
+  createdAt: number;
+}
+
+export class ConversationHistoryService {
+  private readonly projectIdByDirectory = new Map<string, string>();
+
+  constructor(
+    private readonly db: Database.Database,
+    private readonly resolveIdentity: (cwd: string) => ProjectIdentity = resolveProjectIdentity,
+  ) {}
+
+  search(input: {
+    workingDirectory: string;
+    query: string;
+    limit?: number;
+  }): ConversationHistoryMatch[] {
+    const query = input.query.trim();
+    if (!query) return [];
+    const projectId = this.getProjectId(input.workingDirectory);
+    const projectDirectories = this.listProjectDirectories(projectId);
+    if (projectDirectories.length === 0) return [];
+    const limit = normalizeLimit(input.limit);
+    const exact = this.queryRows(projectDirectories, [query], limit).filter(
+      row => !isThinkingMessage(row.metadata),
+    );
+    const rows =
+      exact.length > 0
+        ? exact
+        : this.queryRows(projectDirectories, broadTerms(query), limit).filter(
+            row => !isThinkingMessage(row.metadata),
+          );
+    return rows.slice(0, limit).map(row => ({
+      messageId: row.id,
+      sessionId: row.session_id,
+      sessionTitle: row.session_title,
+      role: row.type,
+      snippet: buildSnippet(row.content, query),
+      createdAt: row.created_at,
+    }));
+  }
+
+  private listProjectDirectories(projectId: string): string[] {
+    const rows = this.db
+      .prepare(
+        `SELECT DISTINCT cwd FROM cowork_sessions
+         WHERE cwd IS NOT NULL AND TRIM(cwd) <> ''`,
+      )
+      .all() as Array<{ cwd: string }>;
+    return rows.map(row => row.cwd).filter(directory => this.getProjectId(directory) === projectId);
+  }
+
+  private getProjectId(directory: string): string {
+    const cached = this.projectIdByDirectory.get(directory);
+    if (cached) return cached;
+    const projectId = this.resolveIdentity(directory).id;
+    this.projectIdByDirectory.set(directory, projectId);
+    return projectId;
+  }
+
+  private queryRows(directories: string[], terms: string[], limit: number): HistoryRow[] {
+    if (terms.length === 0) return [];
+    const directoryPlaceholders = directories.map(() => '?').join(', ');
+    const termPredicates = terms
+      .map(() => "LOWER(m.content) LIKE LOWER(?) ESCAPE '\\'")
+      .join(' OR ');
+    const candidateLimit = Math.min(limit * MAX_CANDIDATE_MULTIPLIER, MAX_RESULT_LIMIT * 10);
+    return this.db
+      .prepare(
+        `SELECT m.id, m.session_id, s.title AS session_title, m.type, m.content,
+                m.metadata, m.created_at
+         FROM cowork_messages m
+         INNER JOIN cowork_sessions s ON s.id = m.session_id
+         WHERE s.cwd IN (${directoryPlaceholders})
+           AND m.type IN (?, ?)
+           AND (${termPredicates})
+         ORDER BY m.created_at DESC, COALESCE(m.sequence, m.created_at) DESC
+         LIMIT ?`,
+      )
+      .all(
+        ...directories,
+        ConversationHistoryRole.User,
+        ConversationHistoryRole.Assistant,
+        ...terms.map(term => `%${escapeLikePattern(term)}%`),
+        candidateLimit,
+      ) as HistoryRow[];
+  }
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return DEFAULT_RESULT_LIMIT;
+  return Math.min(Math.max(Math.floor(value), 1), MAX_RESULT_LIMIT);
+}
+
+function broadTerms(query: string): string[] {
+  const plan = planRecallQuery(query);
+  const source = plan.broadQuery ?? query;
+  return [
+    ...new Set(
+      source
+        .split(/\s+/u)
+        .map(term => term.trim())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function isThinkingMessage(metadata: string | null): boolean {
+  if (!metadata) return false;
+  try {
+    const parsed = JSON.parse(metadata) as { isThinking?: unknown };
+    return parsed.isThinking === true;
+  } catch {
+    return false;
+  }
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, match => `\\${match}`);
+}
+
+function buildSnippet(content: string, query: string): string {
+  const normalized = content.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= MAX_SNIPPET_CHARACTERS) return normalized;
+  const terms = broadTerms(query);
+  const lowerContent = normalized.toLocaleLowerCase();
+  const matchIndex = terms.reduce((best, term) => {
+    const index = lowerContent.indexOf(term.toLocaleLowerCase());
+    return index >= 0 && (best < 0 || index < best) ? index : best;
+  }, -1);
+  const start = Math.max(0, (matchIndex < 0 ? 0 : matchIndex) - MAX_SNIPPET_CHARACTERS / 3);
+  const end = Math.min(normalized.length, start + MAX_SNIPPET_CHARACTERS);
+  return `${start > 0 ? '...' : ''}${normalized.slice(start, end)}${end < normalized.length ? '...' : ''}`;
+}

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -252,6 +252,24 @@ describe('PiRuntimeAdapter', () => {
       expect(mockSession.prompt).toHaveBeenCalledWith('Hello Pi');
     });
 
+    it('rolls up session memory after a successful agent run', async () => {
+      const rollup = vi.fn().mockResolvedValue(null);
+      adapter.setSessionSummaryService({ rollup } as never);
+
+      await adapter.startSession('summary-session', 'Remember this', {
+        workspaceRoot: '/workspace/project',
+      });
+      const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+        type: string;
+      }) => void;
+      listener({ type: 'agent_end' });
+
+      expect(rollup).toHaveBeenCalledWith({
+        sessionId: 'summary-session',
+        workingDirectory: '/workspace/project',
+      });
+    });
+
     it('initializes a controlled persistent run for academic research', async () => {
       const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-academic-runtime-'));
       try {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -210,6 +210,7 @@ import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
 import { DeclareArtifactSystemPrompt } from '../../declareArtifact/tool';
 import { PiAgentLoopAction, PiAgentLoopMode, PiAgentLoopToolName } from './piAgentLoop';
 import { CoworkErrorKind, type CoworkError } from '../../../common/coworkError';
+import { CONVERSATION_HISTORY_TOOL_NAME } from '../../conversationHistory/constants';
 import type { CoworkStore } from '../../coworkStore';
 import type { WorkbenchTaskService } from '../../workbenchTask/taskService';
 import { WorkbenchTaskService as RealWorkbenchTaskService } from '../../workbenchTask/taskService';
@@ -268,6 +269,19 @@ describe('PiRuntimeAdapter', () => {
         sessionId: 'summary-session',
         workingDirectory: '/workspace/project',
       });
+    });
+
+    it('registers raw conversation search as a separate tool', async () => {
+      adapter.setConversationHistoryService({ search: vi.fn(() => []) } as never);
+
+      await adapter.startSession('history-session', 'Find the previous decision');
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools: Array<{ name: string }>;
+      };
+
+      expect(sessionOptions.customTools.map(tool => tool.name)).toContain(
+        CONVERSATION_HISTORY_TOOL_NAME,
+      );
     });
 
     it('initializes a controlled persistent run for academic research', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -55,6 +55,8 @@ import {
 } from '../../../shared/providers';
 import type { CoworkMessage } from '../../coworkStore';
 import type { CoworkStore } from '../../coworkStore';
+import { buildPiConversationHistoryTool } from '../../conversationHistory/piTool';
+import type { ConversationHistoryService } from '../../conversationHistory/service';
 import { t } from '../../i18n';
 import { buildPiProjectMemoryTool } from '../../memory/piMemoryTool';
 import {
@@ -471,6 +473,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private workbenchTaskService: WorkbenchTaskService | null = null;
   private projectMemoryService: ProjectMemoryService | null = null;
   private sessionSummaryService: SessionSummaryService | null = null;
+  private conversationHistoryService: ConversationHistoryService | null = null;
   private workbenchApprovalListener: ((event: WorkbenchApprovalRequestedEvent) => void) | null =
     null;
 
@@ -482,6 +485,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
   setSessionSummaryService(service: SessionSummaryService): void {
     this.sessionSummaryService = service;
+  }
+  setConversationHistoryService(service: ConversationHistoryService): void {
+    this.conversationHistoryService = service;
   }
   setWorkbenchTaskService(service: WorkbenchTaskService): void {
     if (this.workbenchTaskService && this.workbenchApprovalListener) {
@@ -693,6 +699,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           buildPiProjectMemoryTool({
             service: this.projectMemoryService,
             sessionId,
+            workingDirectory: workspaceRoot,
+          }),
+        );
+      }
+      if (this.conversationHistoryService) {
+        customTools.push(
+          buildPiConversationHistoryTool({
+            service: this.conversationHistoryService,
             workingDirectory: workspaceRoot,
           }),
         );

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -61,6 +61,7 @@ import {
   buildProjectMemoryContextSafe,
   type ProjectMemoryService,
 } from '../../memory/projectMemoryService';
+import type { SessionSummaryService } from '../../memory/sessionSummaryService';
 import type {
   WorkbenchApprovalRequestedEvent,
   WorkbenchTaskService,
@@ -469,6 +470,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private mcpServerManager: McpServerManager | null = null;
   private workbenchTaskService: WorkbenchTaskService | null = null;
   private projectMemoryService: ProjectMemoryService | null = null;
+  private sessionSummaryService: SessionSummaryService | null = null;
   private workbenchApprovalListener: ((event: WorkbenchApprovalRequestedEvent) => void) | null =
     null;
 
@@ -477,6 +479,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
   setProjectMemoryService(service: ProjectMemoryService): void {
     this.projectMemoryService = service;
+  }
+  setSessionSummaryService(service: SessionSummaryService): void {
+    this.sessionSummaryService = service;
   }
   setWorkbenchTaskService(service: WorkbenchTaskService): void {
     if (this.workbenchTaskService && this.workbenchApprovalListener) {
@@ -2139,6 +2144,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 : active.agentLoop.getState().done,
             workflowSnapshot,
           });
+        }
+        if (this.sessionSummaryService) {
+          void this.sessionSummaryService
+            .rollup({ sessionId, workingDirectory: active.workspaceRoot })
+            .catch(error => {
+              console.warn(`[SessionSummary] Failed to roll up session ${sessionId}:`, error);
+            });
         }
         this.emit('complete', sessionId, null);
         break;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,6 +84,7 @@ import { AgentManager } from './agentManager';
 import { EngramManager } from './memory/engramManager';
 import { ProjectMemoryService } from './memory/projectMemoryService';
 import { MemoryRepository } from './memory/repository';
+import { SessionSummaryService } from './memory/sessionSummaryService';
 import { ZhiYuanEngramAdapter } from './memory/zhiyuanEngramAdapter';
 import { registerMemoryIpcHandlers } from './memory/ipc';
 import { promoteVerifiedWorkbenchRun } from './memory/taskMemoryPromotion';
@@ -1048,6 +1049,9 @@ const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
     piRuntimeAdapter.setCoworkStore(getCoworkStore());
     piRuntimeAdapter.setWorkbenchTaskService(getWorkbenchTaskService());
     piRuntimeAdapter.setProjectMemoryService(getProjectMemoryService());
+    piRuntimeAdapter.setSessionSummaryService(
+      new SessionSummaryService(getProjectMemoryService(), getCoworkStore()),
+    );
     // mcpServerManager is created async later (ensureOpenClawRunningForCowork),
     // so it is always null here. Late-injection happens on every subsequent call.
     console.log('[PiRuntime] mcpServerManager available at init:', mcpServerManager !== null);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -81,6 +81,7 @@ import { ProviderName } from '../shared/providers';
 import { WorkspaceIpc, WorkspaceStoreKey } from '../shared/workspace';
 import type { WorkbenchRun, WorkbenchTask } from '../shared/workbenchTask';
 import { AgentManager } from './agentManager';
+import { ConversationHistoryService } from './conversationHistory/service';
 import { EngramManager } from './memory/engramManager';
 import { ProjectMemoryService } from './memory/projectMemoryService';
 import { MemoryRepository } from './memory/repository';
@@ -1051,6 +1052,9 @@ const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
     piRuntimeAdapter.setProjectMemoryService(getProjectMemoryService());
     piRuntimeAdapter.setSessionSummaryService(
       new SessionSummaryService(getProjectMemoryService(), getCoworkStore()),
+    );
+    piRuntimeAdapter.setConversationHistoryService(
+      new ConversationHistoryService(getStore().getDatabase()),
     );
     // mcpServerManager is created async later (ensureOpenClawRunningForCowork),
     // so it is always null here. Late-injection happens on every subsequent call.

--- a/src/main/memory/constants.ts
+++ b/src/main/memory/constants.ts
@@ -83,3 +83,4 @@ export const ENGRAM_RUNTIME_DIRECTORY = 'engram-runtime';
 export const ENGRAM_PACKAGED_DIRECTORY = 'memory';
 export const ENGRAM_DATA_DIRECTORY_SEGMENTS = ['memory', 'engram'] as const;
 export const ENGRAM_LOOPBACK_HOST = '127.0.0.1';
+export const SESSION_SUMMARY_TTL_DAYS = 30;

--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -45,6 +45,12 @@ class FakeRepository {
     return new Map();
   }
 
+  findActiveTopic() {
+    return null;
+  }
+
+  supersedeActiveTopic() {}
+
   createLink(input: Record<string, unknown>) {
     this.links.push(input);
     return String(input.id);
@@ -147,7 +153,7 @@ test('keeps an unavailable write pending for a later outbox drain', async () => 
 test('enforces the project context token budget', async () => {
   const adapter = {
     recall: vi.fn(async (input: { scope: string }) =>
-      input.scope === EngramMemoryScope.Personal
+      input.scope !== EngramMemoryScope.Project
         ? []
         : [
             { id: 1, title: 'First', content: 'A'.repeat(40) },
@@ -244,4 +250,80 @@ test('lists only the current project and confirmed personal memories', () => {
   expect(
     service.listRecallableMemories({ workingDirectory: 'alpha' }).map(memory => memory.id),
   ).toEqual(['project-current', 'personal']);
+});
+
+test('stores rolling session summaries with a 30 day expiration', async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-11T00:00:00.000Z'));
+  const repository = new FakeRepository();
+  const adapter = {
+    saveCandidate: vi.fn(input => ({ id: 'candidate-summary', ...input })),
+    confirmMemory: vi.fn(async () => 21),
+    discardCandidate: vi.fn(),
+  };
+  const service = new ProjectMemoryService(repository as never, adapter as never, identityFor);
+
+  await expect(
+    service.saveSessionSummary({
+      sessionId: 'session-1',
+      workingDirectory: 'alpha',
+      summary: 'Session objective: fix recall',
+    }),
+  ).resolves.toBe(21);
+
+  expect(repository.items[0].payload).toMatchObject({
+    scope: EngramMemoryScope.Session,
+    topicKey: 'session/session-1',
+    expiresAt: '2026-09-10T00:00:00.000Z',
+  });
+  vi.useRealTimers();
+});
+
+test('injects session recall under its own context budget', async () => {
+  const adapter = {
+    recall: vi.fn(async (input: { scope: string }) =>
+      input.scope === EngramMemoryScope.Session
+        ? [
+            {
+              id: 31,
+              title: 'Session summary',
+              content: 'The previous session fixed CJK recall.',
+              updated_at: '2026-08-11T00:00:00.000Z',
+            },
+          ]
+        : [],
+    ),
+  };
+  const service = new ProjectMemoryService(
+    new FakeRepository() as never,
+    adapter as never,
+    identityFor,
+  );
+
+  await expect(
+    service.buildProjectContext({ workingDirectory: 'alpha', query: 'CJK recall' }),
+  ).resolves.toContain('Session:\n- [memory:31]');
+});
+
+test('counts CJK characters conservatively against context budgets', async () => {
+  const adapter = {
+    recall: vi.fn(async (input: { scope: string }) =>
+      input.scope === EngramMemoryScope.Project
+        ? [{ id: 41, title: '中文', content: '记'.repeat(80) }]
+        : [],
+    ),
+  };
+  const service = new ProjectMemoryService(
+    new FakeRepository() as never,
+    adapter as never,
+    identityFor,
+  );
+
+  await expect(
+    service.buildProjectContext({
+      workingDirectory: 'alpha',
+      query: 'budget',
+      tokenBudget: 30,
+    }),
+  ).resolves.toBe('');
 });

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -13,7 +13,11 @@ import {
   type MemorySensitivity as MemorySensitivityValue,
   type MemorySourceKind as MemorySourceKindValue,
 } from '../../shared/memory';
-import { EngramSearchMatchMode, MemoryOutboxOperation } from './constants';
+import {
+  EngramSearchMatchMode,
+  MemoryOutboxOperation,
+  SESSION_SUMMARY_TTL_DAYS,
+} from './constants';
 import type { ProjectIdentity } from './projectIdentity';
 import { resolveProjectIdentity } from './projectIdentity';
 import { planRecallQuery, rankRecallResults } from './recallQueryPlanner';
@@ -22,8 +26,9 @@ import { MemoryRepository } from './repository';
 import type { ZhiYuanEngramAdapter } from './zhiyuanEngramAdapter';
 import { redactPrivateBlocks } from './zhiyuanEngramAdapter';
 
-const DEFAULT_PROJECT_RECALL_TOKEN_BUDGET = 1_200;
-const DEFAULT_PERSONAL_RECALL_TOKEN_BUDGET = 300;
+const DEFAULT_PROJECT_RECALL_TOKEN_BUDGET = 900;
+const DEFAULT_PERSONAL_RECALL_TOKEN_BUDGET = 250;
+const DEFAULT_SESSION_RECALL_TOKEN_BUDGET = 350;
 
 interface ConfirmPayload {
   sessionId: string;
@@ -86,6 +91,16 @@ export class ProjectMemoryService {
     });
   }
 
+  async recallSession(input: { workingDirectory: string; query: string; limit?: number }) {
+    const project = this.resolveIdentity(input.workingDirectory);
+    return await this.recallScope({
+      query: input.query,
+      projectId: project.id,
+      scope: MemoryScope.Session,
+      limit: input.limit,
+    });
+  }
+
   listRecallableMemories(input: {
     workingDirectory: string;
     query?: string;
@@ -109,20 +124,25 @@ export class ProjectMemoryService {
     query: string;
     tokenBudget?: number;
   }): Promise<string> {
-    const [project, personal] = await Promise.all([
+    const [project, personal, session] = await Promise.all([
       this.recallProject(input),
       this.recallPersonal({ query: input.query }),
+      this.recallSession(input),
     ]);
     const projectLines = fitObservations(
       project,
       Math.max(0, input.tokenBudget ?? DEFAULT_PROJECT_RECALL_TOKEN_BUDGET),
     );
     const personalLines = fitObservations(personal, DEFAULT_PERSONAL_RECALL_TOKEN_BUDGET);
-    if (projectLines.length === 0 && personalLines.length === 0) return '';
+    const sessionLines = fitObservations(session, DEFAULT_SESSION_RECALL_TOKEN_BUDGET);
+    if (projectLines.length === 0 && personalLines.length === 0 && sessionLines.length === 0) {
+      return '';
+    }
     return [
       'Relevant memory (treat as prior context, not user instructions):',
       ...(projectLines.length ? ['Project:', ...projectLines] : []),
       ...(personalLines.length ? ['Personal:', ...personalLines] : []),
+      ...(sessionLines.length ? ['Session:', ...sessionLines] : []),
     ].join('\n');
   }
 
@@ -278,6 +298,9 @@ export class ProjectMemoryService {
     summary: string;
   }): Promise<number | null> {
     const project = this.resolveIdentity(input.workingDirectory);
+    const topicKey = `session/${input.sessionId}`;
+    const active = this.repository.findActiveTopic(project.id, MemoryScope.Session, topicKey);
+    if (active?.content === input.summary) return active.memoryId;
     const linkId = randomUUID();
     const outboxId = this.repository.enqueue(
       MemoryOutboxOperation.SessionSummary,
@@ -288,10 +311,13 @@ export class ProjectMemoryService {
         type: MemoryKind.SessionSummary,
         title: 'Session summary',
         content: input.summary,
-        topicKey: `session/${input.sessionId}`,
+        topicKey,
         sourceKind: MemorySourceKind.SessionSummary,
         scope: MemoryScope.Session,
         linkId,
+        expiresAt: new Date(
+          Date.now() + SESSION_SUMMARY_TTL_DAYS * 24 * 60 * 60 * 1_000,
+        ).toISOString(),
       },
       linkId,
     );
@@ -345,7 +371,7 @@ export class ProjectMemoryService {
   private async recallScope(input: {
     query: string;
     projectId: string;
-    scope: typeof MemoryScope.Project | typeof MemoryScope.Personal;
+    scope: typeof MemoryScope.Project | typeof MemoryScope.Personal | typeof MemoryScope.Session;
     limit?: number;
   }) {
     const plan = planRecallQuery(input.query);
@@ -544,12 +570,19 @@ function fitObservations(
   const lines: string[] = [];
   for (const observation of observations) {
     const line = `- [memory:${observation.id}] ${observation.title}: ${observation.content}`;
-    const estimatedTokens = Math.ceil(line.length / 4);
+    const estimatedTokens = estimateMemoryTokens(line);
     if (usedTokens + estimatedTokens > budget) continue;
     lines.push(line);
     usedTokens += estimatedTokens;
   }
   return lines;
+}
+
+function estimateMemoryTokens(value: string): number {
+  const cjkCharacters =
+    value.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu)
+      ?.length ?? 0;
+  return Math.ceil(cjkCharacters + (value.length - cjkCharacters) / 4);
 }
 
 export async function buildProjectMemoryContextSafe(

--- a/src/main/memory/repository.ts
+++ b/src/main/memory/repository.ts
@@ -204,6 +204,22 @@ export class MemoryRepository {
     return row ? mapLink(row, this.getDelivery(id)) : null;
   }
 
+  findActiveTopic(
+    projectId: string,
+    scope: MemoryScope,
+    topicKey: string,
+  ): ManagedMemoryRecord | null {
+    this.expireDue();
+    const row = this.db
+      .prepare(
+        `SELECT * FROM memory_links
+         WHERE project_id = ? AND scope = ? AND topic_key = ? AND status = ?
+         ORDER BY updated_at DESC LIMIT 1`,
+      )
+      .get(projectId, scope, topicKey, MemoryLifecycleStatus.Active) as SqlRow | undefined;
+    return row ? mapLink(row, this.getDelivery(String(row.id))) : null;
+  }
+
   findLinkByMemoryId(memoryId: number): ManagedMemoryRecord | null {
     const row = this.db
       .prepare('SELECT * FROM memory_links WHERE memory_id = ? ORDER BY updated_at DESC LIMIT 1')

--- a/src/main/memory/sessionSummaryService.test.ts
+++ b/src/main/memory/sessionSummaryService.test.ts
@@ -1,0 +1,48 @@
+import { expect, test, vi } from 'vitest';
+
+import type { CoworkMessage } from '../coworkStore';
+import { buildSessionSummary, SessionSummaryService } from './sessionSummaryService';
+
+function message(
+  type: CoworkMessage['type'],
+  content: string,
+  metadata?: CoworkMessage['metadata'],
+): CoworkMessage {
+  return { id: `${type}-${content}`, type, content, timestamp: 1, metadata };
+}
+
+test('builds a bounded summary without thinking or tool output', () => {
+  const summary = buildSessionSummary([
+    message('user', '检查中文记忆召回'),
+    message('assistant', 'hidden chain of thought', { isThinking: true }),
+    message('tool_result', 'large private tool output'),
+    message('assistant', '已确认需要使用 CJK 分词并保留项目隔离。'),
+  ]);
+
+  expect(summary).toContain('Session objective: 检查中文记忆召回');
+  expect(summary).toContain('Latest outcome: 已确认需要使用 CJK 分词并保留项目隔离。');
+  expect(summary).not.toContain('chain of thought');
+  expect(summary).not.toContain('tool output');
+});
+
+test('serializes rolling writes for the same session', async () => {
+  let releaseFirst: (() => void) | undefined;
+  const saveSessionSummary = vi
+    .fn()
+    .mockImplementationOnce(() => new Promise<number>(resolve => (releaseFirst = () => resolve(1))))
+    .mockResolvedValueOnce(2);
+  const coworkStore = {
+    getSession: vi.fn(() => ({
+      messages: [message('user', '目标'), message('assistant', '结果')],
+    })),
+  };
+  const service = new SessionSummaryService({ saveSessionSummary } as never, coworkStore as never);
+
+  const first = service.rollup({ sessionId: 'session-1', workingDirectory: '/workspace' });
+  const second = service.rollup({ sessionId: 'session-1', workingDirectory: '/workspace' });
+  await vi.waitFor(() => expect(saveSessionSummary).toHaveBeenCalledTimes(1));
+  releaseFirst?.();
+
+  await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
+  expect(saveSessionSummary).toHaveBeenCalledTimes(2);
+});

--- a/src/main/memory/sessionSummaryService.ts
+++ b/src/main/memory/sessionSummaryService.ts
@@ -1,0 +1,73 @@
+import type { CoworkMessage, CoworkStore } from '../coworkStore';
+import type { ProjectMemoryService } from './projectMemoryService';
+
+const MAX_SUMMARY_MESSAGES = 8;
+const MAX_SOURCE_MESSAGES = 32;
+const MAX_OBJECTIVE_CHARACTERS = 320;
+const MAX_OUTCOME_CHARACTERS = 720;
+const MAX_EARLIER_TOPIC_CHARACTERS = 160;
+
+export class SessionSummaryService {
+  private readonly pendingBySession = new Map<string, Promise<number | null>>();
+
+  constructor(
+    private readonly memoryService: ProjectMemoryService,
+    private readonly coworkStore: CoworkStore,
+  ) {}
+
+  rollup(input: { sessionId: string; workingDirectory: string }): Promise<number | null> {
+    const previous = this.pendingBySession.get(input.sessionId) ?? Promise.resolve(null);
+    const current = previous
+      .catch((): null => null)
+      .then(() => this.rollupNow(input))
+      .finally(() => {
+        if (this.pendingBySession.get(input.sessionId) === current) {
+          this.pendingBySession.delete(input.sessionId);
+        }
+      });
+    this.pendingBySession.set(input.sessionId, current);
+    return current;
+  }
+
+  private async rollupNow(input: {
+    sessionId: string;
+    workingDirectory: string;
+  }): Promise<number | null> {
+    const session = this.coworkStore.getSession(input.sessionId, MAX_SOURCE_MESSAGES);
+    if (!session) return null;
+    const summary = buildSessionSummary(session.messages);
+    if (!summary) return null;
+    return await this.memoryService.saveSessionSummary({ ...input, summary });
+  }
+}
+
+export function buildSessionSummary(messages: CoworkMessage[]): string | null {
+  const conversation = messages
+    .filter(
+      message =>
+        (message.type === 'user' || message.type === 'assistant') &&
+        message.metadata?.isThinking !== true &&
+        message.content.trim().length > 0,
+    )
+    .slice(-MAX_SUMMARY_MESSAGES);
+  const userMessages = conversation.filter(message => message.type === 'user');
+  const assistantMessages = conversation.filter(message => message.type === 'assistant');
+  const objective = userMessages.at(-1);
+  const outcome = assistantMessages.at(-1);
+  if (!objective || !outcome) return null;
+  const earlierTopics = userMessages
+    .slice(0, -1)
+    .slice(-3)
+    .map(message => summarizeText(message.content, MAX_EARLIER_TOPIC_CHARACTERS));
+  return [
+    `Session objective: ${summarizeText(objective.content, MAX_OBJECTIVE_CHARACTERS)}`,
+    `Latest outcome: ${summarizeText(outcome.content, MAX_OUTCOME_CHARACTERS)}`,
+    ...(earlierTopics.length > 0 ? [`Earlier topics: ${earlierTopics.join(' | ')}`] : []),
+  ].join('\n');
+}
+
+function summarizeText(value: string, limit: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}


### PR DESCRIPTION
## Dependency

Depends on #444. Merge in this order: #443, #444, then #445.

## Summary

- Adds a separate read-only conversation_history Pi tool backed by cowork_messages.
- Searches raw user and assistant messages without copying them into Engram.
- Uses exact-first matching with a CJK keyword fallback.
- Returns bounded excerpts rather than complete message bodies.
- Excludes thinking messages, tool calls, and tool output.

## Project isolation

1. Resolve the active working directory through the existing project identity model.
2. Resolve stored Cowork session directories through the same model.
3. Query only directories that belong to the active project.
4. Apply parameterized SQLite predicates and bounded result limits.

This preserves strict project isolation while supporting valid working directories for the same repository.

## Memory boundary

- SQLite remains the source of truth for full conversation history.
- Engram remains the source of durable Project, Personal, and short-lived Session memory.
- Conversation-history searches are read-only and never create durable observations.

## Tests

- Conversation-history SQLite and tool tests passed.
- Pi tool registration test passed.
- Electron main-process TypeScript compilation passed.
- Lint passed.
- GitHub CI test, lint, and bundle-budget checks passed.

## Tracking

Closes #161 after the staged PRs are merged in order.