### PR TITLE
feat(cowork): persist production todo plans

### DIFF
--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -158,6 +158,7 @@ export class ProductionLoopService {
   constructor(
     repository: ProductionLoopStore,
     private readonly measurement: ProductionLoopMeasurement,
+    private readonly onPlanChanged?: (state: ProductionLoopState) => void,
   ) {
     this.repository = repository;
   }
@@ -194,7 +195,7 @@ export class ProductionLoopService {
     const previous = this.repository.getLatestForTask(input.taskId, input.runId);
     const now = Date.now();
     const progressBaseline = previous?.progressVersion ?? 0;
-    return this.repository.create({
+    const state = this.repository.create({
       version: 1,
       taskId: input.taskId,
       runId: input.runId,
@@ -234,6 +235,8 @@ export class ProductionLoopService {
       createdAt: now,
       updatedAt: now,
     });
+    this.onPlanChanged?.(state);
+    return state;
   }
 
   recordPrototype(runId: string, reference: string, summary: string): ProductionLoopState {
@@ -271,7 +274,7 @@ export class ProductionLoopService {
       selectedDirection?: string;
     },
   ): ProductionLoopState {
-    return this.mutate(runId, state => {
+    const state = this.mutate(runId, state => {
       if (state.phase === ProductionLoopPhase.Explore) {
         if (state.prototypeRequired && state.prototypes.length === 0) {
           throw new Error('At least one prototype is required before committing the plan.');
@@ -331,6 +334,8 @@ export class ProductionLoopService {
         },
       });
     });
+    this.onPlanChanged?.(state);
+    return state;
   }
 
   updatePlanItem(
@@ -338,7 +343,7 @@ export class ProductionLoopService {
     itemId: string,
     status: ProductionPlanItemStatus,
   ): ProductionLoopState {
-    return this.mutate(runId, state => {
+    const state = this.mutate(runId, state => {
       if (
         state.phase !== ProductionLoopPhase.Execute &&
         state.phase !== ProductionLoopPhase.Revise
@@ -355,6 +360,8 @@ export class ProductionLoopService {
         state.progressVersion += 1;
       }
     });
+    this.onPlanChanged?.(state);
+    return state;
   }
 
   startInspection(

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -20,6 +20,7 @@ import {
   type WorkbenchTaskChangedEvent,
   type WorkbenchTaskContract,
   type WorkbenchTaskDetail,
+  type WorkbenchProductionPlan,
   type WorkbenchVerificationResult,
 } from '../../shared/workbenchTask';
 import { HarnessActivationType } from '../../shared/harness';
@@ -82,16 +83,35 @@ export class WorkbenchTaskService extends EventEmitter {
     this.productionLoop = new ProductionLoopService(
       new ProductionLoopRepository(db),
       this.measurement,
+      state => {
+        const task = this.repository.getTask(state.taskId);
+        if (task) this.emitChanged(task);
+      },
     );
   }
 
   getCurrent(sessionId: string): WorkbenchTaskDetail | null {
     const task = this.repository.getLatestTaskForSession(sessionId);
-    return task ? this.repository.getDetail(task.id) : null;
+    return task ? this.withProductionPlan(this.repository.getDetail(task.id)) : null;
   }
 
   getDetail(taskId: string): WorkbenchTaskDetail | null {
-    return this.repository.getDetail(taskId);
+    return this.withProductionPlan(this.repository.getDetail(taskId));
+  }
+
+  private withProductionPlan(detail: WorkbenchTaskDetail | null): WorkbenchTaskDetail | null {
+    if (!detail) return null;
+    const state = detail.task.activeRunId
+      ? this.productionLoop.repository.get(detail.task.activeRunId)
+      : this.productionLoop.repository.getLatestForTask(detail.task.id);
+    const productionPlan: WorkbenchProductionPlan | null = state
+      ? {
+          runId: state.runId,
+          progressVersion: state.progressVersion,
+          items: state.planItems,
+        }
+      : null;
+    return { ...detail, productionPlan };
   }
 
   beginRun(input: {

--- a/src/renderer/components/cowork/TodoQueue.tsx
+++ b/src/renderer/components/cowork/TodoQueue.tsx
@@ -1,9 +1,4 @@
-import {
-  QueueItem,
-  QueueItemContent,
-  QueueItemIndicator,
-  type QueueTodo,
-} from '@shared/components/ai-elements/queue';
+import { QueueItem, QueueItemContent, type QueueTodo } from '@shared/components/ai-elements/queue';
 import { Button } from '@shared/components/ui/button';
 import {
   Collapsible,
@@ -13,7 +8,7 @@ import {
 import { ScrollArea } from '@shared/components/ui/scroll-area';
 import { Spinner } from '@shared/components/ui/spinner';
 import { cn } from '@shared/lib/utils';
-import { CircleCheck } from 'lucide-react';
+import { Circle, CircleAlert, CircleCheck } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -65,6 +60,24 @@ export function TodoQueue({ isDismissing = false, todos }: TodoQueueProps) {
   const title = i18nService.t('coworkTodosTitle');
   const motionDuration = prefersReducedMotion ? 0 : 0.22;
 
+  const renderIndicator = (todo: QueueTodo) => {
+    if (todo.status === 'in_progress') {
+      return <Spinner className="size-4 shrink-0 text-muted-foreground" />;
+    }
+    if (todo.status === 'blocked') {
+      return (
+        <CircleAlert
+          aria-label={i18nService.t('coworkTodoBlocked')}
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      );
+    }
+    if (todo.status === 'completed') {
+      return <CircleCheck aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />;
+    }
+    return <Circle aria-hidden="true" className="size-4 shrink-0 text-muted-foreground" />;
+  };
+
   return (
     <div
       ref={containerRef}
@@ -103,28 +116,30 @@ export function TodoQueue({ isDismissing = false, todos }: TodoQueueProps) {
               </Button>
             }
           />
-          <CollapsibleContent className="h-[var(--collapsible-panel-height)] overflow-hidden transition-[height] duration-200 ease-out motion-reduce:transition-none data-ending-style:h-0 data-starting-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+          <CollapsibleContent className="max-h-64 overflow-hidden [&[hidden]:not([hidden='until-found'])]:hidden">
             <motion.div
               initial={{ opacity: 0, y: 4 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: motionDuration, ease: 'easeOut' }}
               className="px-2 pb-2"
             >
-              <ScrollArea className="max-h-64">
+              <ScrollArea className="max-h-64 [&_[data-slot=scroll-area-viewport]]:max-h-64">
                 <ul>
                   {todos.map(todo => (
                     <QueueItem key={todo.id} className="px-2 py-1.5">
                       <div className="flex items-center gap-2">
-                        <QueueItemIndicator
-                          completed={todo.status === 'completed'}
-                          className="mt-0"
-                        />
-                        <QueueItemContent
-                          completed={todo.status === 'completed'}
-                          className="line-clamp-none"
-                        >
-                          {todo.title}
-                        </QueueItemContent>
+                        {renderIndicator(todo)}
+                        <div className="min-w-0 flex-1">
+                          <QueueItemContent
+                            completed={todo.status === 'completed'}
+                            className="line-clamp-none"
+                          >
+                            {todo.title}
+                          </QueueItemContent>
+                          {todo.description && (
+                            <p className="text-xs text-muted-foreground">{todo.description}</p>
+                          )}
+                        </div>
                       </div>
                     </QueueItem>
                   ))}

--- a/src/renderer/components/cowork/hooks/useProductionPlanTodos.test.ts
+++ b/src/renderer/components/cowork/hooks/useProductionPlanTodos.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest';
+
+import { ProductionPlanItemStatus } from '../../../../shared/productionLoop';
+import { productionPlanToTodoSource } from './useProductionPlanTodos';
+
+test('maps persisted production plan items to todo queue states', () => {
+  const result = productionPlanToTodoSource({
+    runId: 'run-1',
+    progressVersion: 4,
+    items: [
+      { id: 'a', title: 'Pending', status: ProductionPlanItemStatus.Pending },
+      { id: 'b', title: 'Active', status: ProductionPlanItemStatus.InProgress },
+      { id: 'c', title: 'Done', status: ProductionPlanItemStatus.Completed },
+      { id: 'd', title: 'Blocked', status: ProductionPlanItemStatus.Blocked },
+    ],
+  });
+
+  expect(result).toEqual({
+    runId: 'run-1',
+    progressVersion: 4,
+    todos: [
+      { id: 'a', title: 'Pending', description: undefined, status: 'pending' },
+      { id: 'b', title: 'Active', description: undefined, status: 'in_progress' },
+      { id: 'c', title: 'Done', description: undefined, status: 'completed' },
+      { id: 'd', title: 'Blocked', description: undefined, status: 'blocked' },
+    ],
+  });
+});

--- a/src/renderer/components/cowork/hooks/useProductionPlanTodos.ts
+++ b/src/renderer/components/cowork/hooks/useProductionPlanTodos.ts
@@ -1,0 +1,70 @@
+import type { QueueTodo } from '@shared/components/ai-elements/queue';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  ProductionPlanItemStatus,
+  type ProductionPlanItem,
+} from '../../../../shared/productionLoop';
+import type { WorkbenchProductionPlan } from '../../../../shared/workbenchTask';
+
+export interface ProductionPlanTodoSource {
+  progressVersion: number;
+  runId: string;
+  todos: QueueTodo[];
+}
+
+const mapPlanItemStatus = (status: ProductionPlanItem['status']): QueueTodo['status'] => {
+  switch (status) {
+    case ProductionPlanItemStatus.InProgress:
+      return 'in_progress';
+    case ProductionPlanItemStatus.Completed:
+      return 'completed';
+    case ProductionPlanItemStatus.Blocked:
+      return 'blocked';
+    case ProductionPlanItemStatus.Pending:
+    default:
+      return 'pending';
+  }
+};
+
+export const productionPlanToTodoSource = (
+  plan: WorkbenchProductionPlan,
+): ProductionPlanTodoSource => ({
+  progressVersion: plan.progressVersion,
+  runId: plan.runId,
+  todos: plan.items.map(item => ({
+    id: item.id,
+    title: item.title,
+    description: item.detail,
+    status: mapPlanItemStatus(item.status),
+  })),
+});
+
+export function useProductionPlanTodos(
+  sessionId?: string,
+): ProductionPlanTodoSource | null | undefined {
+  const [plan, setPlan] = useState<WorkbenchProductionPlan | null | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+    setPlan(undefined);
+    const loadActive = async () => {
+      if (!sessionId) {
+        if (active) setPlan(null);
+        return;
+      }
+      const result = await window.electron.workbenchTask.getCurrent(sessionId);
+      if (active && result.success) setPlan(result.detail?.productionPlan ?? null);
+    };
+    void loadActive();
+    const unsubscribe = window.electron.workbenchTask.onChanged(event => {
+      if (event.sessionId === sessionId) void loadActive();
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [sessionId]);
+
+  return useMemo(() => (plan ? productionPlanToTodoSource(plan) : plan), [plan]);
+}

--- a/src/renderer/components/cowork/hooks/useTodoQueueLifecycle.ts
+++ b/src/renderer/components/cowork/hooks/useTodoQueueLifecycle.ts
@@ -7,6 +7,7 @@ import {
   extractLatestTodoListFromMessages,
   extractTodoListFromLatestAssistantMessage,
 } from '../../../utils/todoParser';
+import { useProductionPlanTodos } from './useProductionPlanTodos';
 
 export const TODO_COMPLETION_VISIBLE_MS = 3000;
 export const TODO_DISMISS_ANIMATION_MS = 200;
@@ -56,11 +57,21 @@ export function useTodoQueueLifecycle({
   messages,
   sessionId,
 }: UseTodoQueueLifecycleOptions): TodoQueueLifecycleState {
-  const [initialTodoList] = useState(() => extractLatestTodoListFromMessages(messages));
-  const latestTodoList = useMemo(
-    () => extractTodoListFromLatestAssistantMessage(messages),
-    [messages],
-  );
+  const productionPlan = useProductionPlanTodos(sessionId);
+  const [initialTodoList] = useState<ExtractedTodoList | null>(null);
+  const latestTodoList = useMemo(() => {
+    if (productionPlan === undefined) return null;
+    if (productionPlan) {
+      return productionPlan.todos.length > 0
+        ? {
+            sourceMessageId: `production-plan:${productionPlan.runId}`,
+            sourceTimestamp: productionPlan.progressVersion,
+            todos: productionPlan.todos,
+          }
+        : null;
+    }
+    return extractTodoListFromLatestAssistantMessage(messages);
+  }, [messages, productionPlan]);
   const [displayedTodoList, setDisplayedTodoList] = useState<DisplayedTodoList | null>(() =>
     toDisplayedTodoList(sessionId, initialTodoList),
   );
@@ -68,7 +79,7 @@ export function useTodoQueueLifecycle({
   displayedTodoListRef.current = displayedTodoList;
   const [isDismissing, setIsDismissing] = useState(false);
   const activeSessionIdRef = useRef(sessionId);
-  const restoredSessionIdRef = useRef(messages.length > 0 ? sessionId : undefined);
+  const restoredSessionIdRef = useRef<string | undefined>(undefined);
   const acceptedSourceRef = useRef<AcceptedTodoSource | null>(
     sessionId && initialTodoList
       ? {
@@ -85,13 +96,14 @@ export function useTodoQueueLifecycle({
   );
 
   useEffect(() => {
-    const acceptedSource = acceptedSourceRef.current;
+    let acceptedSource = acceptedSourceRef.current;
     const sessionChanged = activeSessionIdRef.current !== sessionId;
 
     if (!sessionId) {
       activeSessionIdRef.current = sessionId;
       restoredSessionIdRef.current = undefined;
       acceptedSourceRef.current = null;
+      acceptedSource = null;
       dismissedSourceIdRef.current = null;
       setDisplayedTodoList(null);
       setIsDismissing(false);
@@ -102,15 +114,18 @@ export function useTodoQueueLifecycle({
       activeSessionIdRef.current = sessionId;
       restoredSessionIdRef.current = undefined;
       acceptedSourceRef.current = null;
+      acceptedSource = null;
       dismissedSourceIdRef.current = null;
       setDisplayedTodoList(null);
       setIsDismissing(false);
     }
 
     if (restoredSessionIdRef.current !== sessionId) {
-      if (messages.length === 0) return;
+      if (productionPlan === undefined) return;
 
-      const restoredTodoList = extractLatestTodoListFromMessages(messages);
+      const restoredTodoList = productionPlan
+        ? latestTodoList
+        : extractLatestTodoListFromMessages(messages);
       restoredSessionIdRef.current = sessionId;
       acceptedSourceRef.current = restoredTodoList
         ? {
@@ -128,7 +143,13 @@ export function useTodoQueueLifecycle({
       return;
     }
 
-    if (!latestTodoList) return;
+    if (!latestTodoList) {
+      if (productionPlan) {
+        setDisplayedTodoList(null);
+        setIsDismissing(false);
+      }
+      return;
+    }
     if (acceptedSource && latestTodoList.sourceTimestamp < acceptedSource.sourceTimestamp) {
       return;
     }
@@ -146,7 +167,7 @@ export function useTodoQueueLifecycle({
     if (!complete) dismissedSourceIdRef.current = null;
     setDisplayedTodoList({ sessionId, ...latestTodoList });
     setIsDismissing(false);
-  }, [latestTodoList, messages, sessionId]);
+  }, [latestTodoList, messages, productionPlan, sessionId]);
 
   const todoStatusKey = getTodoStatusKey(displayedTodoList);
   const displayedSourceMessageId = displayedTodoList?.sourceMessageId;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1301,6 +1301,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkTodoCompleted: '已完成',
     coworkTodoInProgress: '进行中',
     coworkTodoPending: '待处理',
+    coworkTodoBlocked: '受阻',
     coworkTodoUntitled: '未命名待办',
     coworkTodoUnknownStatus: '未知状态',
     coworkDangerousOperation: '警告：此操作可能会修改文件或执行系统命令，请仔细检查。',
@@ -4191,6 +4192,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkTodoCompleted: 'completed',
     coworkTodoInProgress: 'in progress',
     coworkTodoPending: 'pending',
+    coworkTodoBlocked: 'blocked',
     coworkTodoUntitled: 'Untitled todo',
     coworkTodoUnknownStatus: 'Unknown status',
     coworkDangerousOperation:

--- a/src/shared/components/ai-elements/queue.tsx
+++ b/src/shared/components/ai-elements/queue.tsx
@@ -28,7 +28,7 @@ export interface QueueTodo {
   id: string;
   title: string;
   description?: string;
-  status?: 'pending' | 'completed';
+  status?: 'pending' | 'in_progress' | 'completed' | 'blocked';
 }
 
 export type QueueItemProps = ComponentProps<'li'>;

--- a/src/shared/workbenchTask/types.ts
+++ b/src/shared/workbenchTask/types.ts
@@ -14,6 +14,7 @@ import type {
   WorkbenchVerificationCheckStatus,
   WorkbenchVerificationOutcome,
 } from './constants';
+import type { ProductionPlanItem } from '../productionLoop';
 
 export type WorkbenchJsonObject = Record<string, unknown>;
 
@@ -110,6 +111,13 @@ export interface WorkbenchTaskDetail {
   events: WorkbenchRunEvent[];
   artifacts: WorkbenchArtifact[];
   approvals: WorkbenchApproval[];
+  productionPlan?: WorkbenchProductionPlan | null;
+}
+
+export interface WorkbenchProductionPlan {
+  runId: string;
+  progressVersion: number;
+  items: ProductionPlanItem[];
 }
 
 export interface WorkbenchTaskChangedEvent {


### PR DESCRIPTION
## 变更内容

- 将持久化的 `production_loop.planItems` 接入 Workbench 任务详情，作为 TodoQueue 的结构化数据源
- 复用现有 `workbenchTask:changed` 事件，在计划创建、提交和状态更新时刷新界面
- 支持 `pending`、`in_progress`、`completed`、`blocked` 四种任务状态
- 仅在当前任务不存在结构化生产计划时回退解析 Markdown checklist
- 修复 TodoQueue 展开时高度先抬升再回缩的问题，并为长列表提供垂直滚动

## 行为边界

- 同一 Workbench 任务中的计划可跨模型轮次、暂停恢复、重试和应用重启存活
- 已完成、取消或被替代任务的计划不会泄漏到独立的新任务
- 保留 TodoQueue 原有的完成后收起、点击外部关闭和 Escape 关闭行为

## 测试

- `npx tsc -p electron-tsconfig.json --noEmit`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npx vitest run useProductionPlanTodos.test.ts todoParser.test.ts`
- `npx vite build`
- `git diff --check`

## 已知限制

- 未完成 Electron 界面视觉回归和 SQLite-backed production tests。本地 `better-sqlite3` 原生重建因 MSBuild FileTracker `E_ACCESSDENIED` 失败；TypeScript、lint、单元测试和完整 Vite 构建均已通过。
