### PR TITLE
fix(artifacts): align resize handle with panel border

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -320,7 +320,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
         className={`non-draggable bg-background flex flex-col h-full overflow-hidden ${
           layoutMode === ArtifactLayoutMode.Workspace || isFullscreen
             ? 'fixed inset-0 z-200 w-screen border-0'
-            : 'relative min-w-0 flex-1 border-l border-border'
+            : 'relative min-w-0 flex-1'
         }`}
       >
         {/* Floating file list overlay */}

--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -320,7 +320,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
         className={`non-draggable bg-background flex flex-col h-full overflow-hidden ${
           layoutMode === ArtifactLayoutMode.Workspace || isFullscreen
             ? 'fixed inset-0 z-200 w-screen border-0'
-            : 'relative min-w-0 flex-1'
+            : 'relative min-w-0 flex-1 border-l border-border'
         }`}
       >
         {/* Floating file list overlay */}

--- a/src/renderer/components/artifacts/ArtifactPanelFallback.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelFallback.tsx
@@ -2,10 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { ArtifactLayoutMode, selectPanelWidth } from '@/store/slices/artifactSlice';
 
-import {
-  ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH,
-  clampArtifactPanelWidth,
-} from './artifactPanelResize';
+import { clampArtifactPanelWidth } from './artifactPanelResize';
 
 interface ArtifactPanelFallbackProps {
   layoutMode: ArtifactLayoutMode;
@@ -28,8 +25,7 @@ export const ArtifactPanelFallback: React.FC<ArtifactPanelFallbackProps> = ({
   const isWorkspace = layoutMode === ArtifactLayoutMode.Workspace;
   const width = isWorkspace
     ? '100%'
-    : clampArtifactPanelWidth(storedWidth, minPanelWidth, maxPanelWidth) +
-      ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH;
+    : clampArtifactPanelWidth(storedWidth, minPanelWidth, maxPanelWidth);
   return (
     <div
       className={`h-full animate-pulse bg-muted/30 ${isWorkspace ? 'flex-1' : 'shrink-0'}`}

--- a/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
@@ -11,11 +11,7 @@ import {
 import type { Artifact } from '@/types/artifact';
 
 import ArtifactPanel from './ArtifactPanel';
-import {
-  ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH,
-  clampArtifactPanelWidth,
-  isArtifactPanelAtMaximum,
-} from './artifactPanelResize';
+import { clampArtifactPanelWidth, isArtifactPanelAtMaximum } from './artifactPanelResize';
 
 interface ArtifactPanelFrameProps {
   sessionId: string | null;
@@ -50,7 +46,7 @@ const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
       const nextWidth = clampArtifactPanelWidth(width, minPanelWidth, maxPanelWidth);
       transientPanelWidthRef.current = nextWidth;
       if (frameRef.current) {
-        frameRef.current.style.width = `${nextWidth + ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH}px`;
+        frameRef.current.style.width = `${nextWidth}px`;
       }
     },
     [maxPanelWidth, minPanelWidth],
@@ -70,11 +66,10 @@ const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
     [dispatch, maxPanelWidth, minPanelWidth],
   );
 
-  const renderedFrameWidth =
-    (transientPanelWidthRef.current ?? panelWidth) + ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH;
+  const renderedFrameWidth = transientPanelWidthRef.current ?? panelWidth;
   const frameStyle: React.CSSProperties = {
     width: isWorkspace ? '100%' : isVisible ? renderedFrameWidth : 0,
-    maxWidth: isWorkspace ? 'none' : maxPanelWidth + ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH,
+    maxWidth: isWorkspace ? 'none' : maxPanelWidth,
   };
 
   return (
@@ -91,7 +86,7 @@ const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
       )}
       style={frameStyle}
     >
-      <div className="flex h-full w-full">
+      <div className="relative flex h-full w-full">
         <ArtifactPanel
           sessionId={sessionId}
           artifacts={artifacts}

--- a/src/renderer/components/artifacts/ArtifactPanelResizeHandle.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelResizeHandle.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@shared/lib/utils';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '@/services/i18n';
@@ -157,13 +156,9 @@ const ArtifactPanelResizeHandle: React.FC<ArtifactPanelResizeHandleProps> = ({
       aria-valuemax={Math.round(maxWidth)}
       aria-valuemin={Math.round(minWidth)}
       aria-valuenow={Math.round(currentWidth)}
-      className={cn(
-        'group relative z-10 w-3 shrink-0 cursor-col-resize touch-none outline-none',
-        'after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-border-subtle after:transition-colors after:duration-150',
-        'hover:after:bg-border focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
-        isResizing && 'after:bg-foreground',
-      )}
+      className="absolute inset-y-0 left-0 z-10 w-3 cursor-col-resize touch-none outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
       data-artifact-resize-handle=""
+      data-resizing={isResizing ? '' : undefined}
       onKeyDown={handleKeyDown}
       onLostPointerCapture={completeResize}
       onPointerDown={handlePointerDown}

--- a/src/renderer/components/artifacts/artifactPanelResize.ts
+++ b/src/renderer/components/artifacts/artifactPanelResize.ts
@@ -1,4 +1,3 @@
-export const ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH = 12;
 export const ARTIFACT_PANEL_KEYBOARD_RESIZE_STEP = 32;
 
 export function clampArtifactPanelWidth(value: number, minWidth: number, maxWidth: number): number {

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -54,7 +54,6 @@ import type {
   CoworkPermissionResult,
 } from '../../types/cowork';
 import { ArtifactPanelFallback } from '../artifacts/ArtifactPanelFallback';
-import { ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH } from '../artifacts/artifactPanelResize';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { ArtifactPanelIcon } from './components/StreamingBar';
 import { TurnBlock } from './components/TurnBlock';
@@ -378,10 +377,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const updateArtifactPanelMaxWidth = useCallback(() => {
     const contentWidth = contentRowRef.current?.clientWidth ?? 0;
     if (contentWidth <= 0) return;
-    const nextMaxWidth = Math.max(
-      MIN_PANEL_WIDTH,
-      contentWidth - ARTIFACT_PANEL_RESIZE_HANDLE_WIDTH,
-    );
+    const nextMaxWidth = Math.max(MIN_PANEL_WIDTH, contentWidth);
     setArtifactPanelMaxWidth(prev => (prev === nextMaxWidth ? prev : nextMaxWidth));
   }, []);
 


### PR DESCRIPTION
## Summary

- use the artifact panel's own left border as the only visible separator
- overlay the transparent resize hit area on the panel edge
- remove the former 12px layout-width compensation for the standalone handle

## Behavior

The split view now renders a single vertical boundary that connects directly with the panel's internal horizontal separators. A transparent 12px separator remains available over the edge for pointer and keyboard resizing without drawing a second line or occupying a separate layout column.

## Validation

- `npm test -- artifactPanelResize`
- `npm run lint`
- `npm run build`
- `git diff --check`

## UI Notes

- preserves the semantic `border-border` token in light and dark themes
- preserves pointer capture, keyboard resizing, focus visibility, and fullscreen behavior
- browser-only visual verification is unavailable because this view requires the Electron preload API
