### PR TITLE
fix(cowork): isolate Pi session generations

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1119,10 +1119,18 @@ describe('PiRuntimeAdapter', () => {
 
     it('should replace existing session with same id', async () => {
       await adapter.startSession('test', 'First');
+      const staleListener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+        type: string;
+      }) => void;
       await adapter.startSession('test', 'Second');
       // Old session aborted, new one created
       expect(mockSession.abort).toHaveBeenCalled();
       expect(mockSession.prompt).toHaveBeenCalledTimes(2);
+
+      staleListener({ type: 'agent_end' });
+
+      expect(adapter.isSessionRunning('test')).toBe(true);
+      expect(mockSession.abort).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1409,6 +1417,31 @@ describe('PiRuntimeAdapter', () => {
   });
 
   describe('stopSession', () => {
+    it('cancels a session while the runtime is still initializing', async () => {
+      let resolveCreateSession: ((value: { session: typeof mockSession }) => void) | undefined;
+      mockCreateAgentSession.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveCreateSession = resolve;
+          }),
+      );
+      const interruptions: Array<{ cause: string }> = [];
+      adapter.on('sessionInterrupted', event => interruptions.push(event));
+
+      const startPromise = adapter.startSession('initializing', 'Hello');
+      await vi.waitFor(() => expect(mockCreateAgentSession).toHaveBeenCalledOnce());
+      adapter.stopSession('initializing');
+      resolveCreateSession?.({ session: mockSession });
+      await startPromise;
+
+      expect(mockSession.prompt).not.toHaveBeenCalled();
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      expect(adapter.isSessionActive('initializing')).toBe(false);
+      expect(interruptions).toEqual([
+        expect.objectContaining({ cause: CoworkInterruptionCause.UserStop }),
+      ]);
+    });
+
     it('should keep session entry active (preserves IM routing) but mark it aborted', async () => {
       await adapter.startSession('test', 'Hello');
       const addMessage = vi.fn(
@@ -1467,6 +1500,25 @@ describe('PiRuntimeAdapter', () => {
   });
 
   describe('stopAllSessions', () => {
+    it('cancels sessions that are still initializing', async () => {
+      let resolveCreateSession: ((value: { session: typeof mockSession }) => void) | undefined;
+      mockCreateAgentSession.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveCreateSession = resolve;
+          }),
+      );
+
+      const startPromise = adapter.startSession('initializing', 'Hello');
+      await vi.waitFor(() => expect(mockCreateAgentSession).toHaveBeenCalledOnce());
+      adapter.stopAllSessions();
+      resolveCreateSession?.({ session: mockSession });
+      await startPromise;
+
+      expect(mockSession.prompt).not.toHaveBeenCalled();
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+    });
+
     it('should keep all sessions active (preserves history)', async () => {
       await adapter.startSession('s1', 'A');
       await adapter.startSession('s2', 'B');

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -312,6 +312,11 @@ interface PiResourceState {
   fileToolsEnabled: boolean;
 }
 
+interface InitializingPiSession {
+  abortController: AbortController;
+  generation: symbol;
+}
+
 interface PiModelRuntime {
   registerProvider(provider: string, config: Record<string, unknown>): void;
   setRuntimeApiKey(provider: string, apiKey: string): Promise<void>;
@@ -474,6 +479,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private projectMemoryService: ProjectMemoryService | null = null;
   private sessionSummaryService: SessionSummaryService | null = null;
   private conversationHistoryService: ConversationHistoryService | null = null;
+  private readonly initializingSessions = new Map<string, InitializingPiSession>();
   private workbenchApprovalListener: ((event: WorkbenchApprovalRequestedEvent) => void) | null =
     null;
 
@@ -552,11 +558,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       throw new Error('Prompt is required.');
     }
 
-    if (this.activeSessions.has(sessionId)) {
+    if (this.activeSessions.has(sessionId) || this.initializingSessions.has(sessionId)) {
       this.stopActiveSession(sessionId, 'The session was replaced by a new run.', false);
     }
 
+    const abortController = new AbortController();
+    const initialization: InitializingPiSession = {
+      abortController,
+      generation: Symbol(sessionId),
+    };
+    this.initializingSessions.set(sessionId, initialization);
+    const isCurrentInitialization = (): boolean =>
+      this.initializingSessions.get(sessionId)?.generation === initialization.generation &&
+      !abortController.signal.aborted;
+
     const pi = await getPiModules();
+    if (!isCurrentInitialization()) return;
 
     // Emit user message to UI (unless the caller already did).
     // Must persist via store.addMessage() — the CoworkStore is the source of
@@ -574,7 +591,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       this.emit('message', sessionId, persisted);
     }
 
-    const abortController = new AbortController();
     let workbenchRunId: string | null = null;
     let workbenchTaskId: string | null = null;
     let workbenchTaskGoal = prompt;
@@ -630,6 +646,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // so override that loader per session to keep expert contexts isolated.
       // Resolve model early — needed by both MCP proxy and subagent tool
       const resolvedModel = await resolvePiModel(pi, options.modelOverride);
+      if (!isCurrentInitialization()) return;
       const modelId =
         typeof resolvedModel.model.id === 'string'
           ? resolvedModel.model.id
@@ -686,6 +703,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         getAutoApprove: () =>
           this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
       });
+      if (!isCurrentInitialization()) return;
       sessionOptions.resourceLoader = resourceLoader;
       if (settingsManager) {
         sessionOptions.settingsManager = settingsManager;
@@ -893,6 +911,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
       const result = await pi.createAgentSession(sessionOptions);
       const session = result.session;
+      if (!isCurrentInitialization()) {
+        void session.abort();
+        return;
+      }
 
       const active: ActivePiSession = {
         sessionId,
@@ -948,11 +970,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
       // Subscribe to Pi events before sending the prompt
       active.unsubscribe = session.subscribe(event => {
-        if (abortController.signal.aborted) return;
+        if (
+          abortController.signal.aborted ||
+          this.activeSessions.get(sessionId) !== active
+        ) {
+          return;
+        }
         this.handlePiEvent(sessionId, active, event);
       });
 
+      if (!isCurrentInitialization()) {
+        active.unsubscribe();
+        void session.abort();
+        return;
+      }
       this.activeSessions.set(sessionId, active);
+      this.initializingSessions.delete(sessionId);
 
       // Send the prompt (may include conversation history for restart restores)
       let initialPrompt = researchRun
@@ -973,6 +1006,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workspaceRoot,
         prompt,
       );
+      if (this.activeSessions.get(sessionId) !== active || abortController.signal.aborted) return;
       if (projectMemoryContext) initialPrompt = `${projectMemoryContext}\n\n${initialPrompt}`;
 
       // The user may stop the session while the execution-mode question is
@@ -999,6 +1033,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       this.workbenchTaskService?.failRun?.(sessionId, { message });
       this.emit('error', sessionId, classifyCoworkError(message));
       throw error;
+    } finally {
+      if (
+        this.initializingSessions.get(sessionId)?.generation === initialization.generation
+      ) {
+        this.initializingSessions.delete(sessionId);
+      }
     }
   }
 
@@ -1339,10 +1379,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     cause?: CoworkInterruptionCause,
   ): void {
     this.dismissAskUserQuestionsBySession(sessionId);
+    const initializing = this.initializingSessions.get(sessionId);
+    if (initializing) {
+      initializing.abortController.abort();
+      this.initializingSessions.delete(sessionId);
+    }
     const active = this.activeSessions.get(sessionId);
     if (!active) {
       this.workbenchTaskService?.pauseRun?.(sessionId, reason);
       this.clearApprovalsBySession(sessionId);
+      if (cause) this.recordSessionInterruption(sessionId, cause);
       return;
     }
     const wasRunning = active.isRunning;
@@ -1417,7 +1463,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   }
 
   stopAllSessions(): void {
-    for (const [sessionId] of this.activeSessions) {
+    const sessionIds = new Set([
+      ...this.activeSessions.keys(),
+      ...this.initializingSessions.keys(),
+    ]);
+    for (const sessionId of sessionIds) {
       this.stopActiveSession(sessionId, 'The application stopped the active session.', false);
     }
   }


### PR DESCRIPTION
## Summary

- register Pi sessions before asynchronous initialization begins
- cancel initializing sessions from Stop and application-wide shutdown paths
- ignore events emitted by superseded session generations
- emit an interruption terminal event when Stop occurs before an active session exists

## Problem

An older Pi execution could finish initialization after it had been stopped, register itself again, and emit `agent_end` into a newer Workbench run for the same session. Stop also could not reach a session while it was still loading resources, leaving the renderer in a streaming state.

## Verification

- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
- `npx vitest run src/main/libs/agentEngine/piRuntimeAdapter.test.ts`: 82 tests passed; 8 existing SQLite-backed tests could not start because the running Electron process keeps `better_sqlite3.node` on the Electron ABI while Node requires a different ABI
- `git diff --check`

## Risk

The change is limited to Pi session lifecycle ownership and cancellation. Persisted session data and Workbench schemas are unchanged.
