### PR TITLE
fix(cowork): route interrupted session recovery

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -615,6 +615,8 @@ describe('PiRuntimeAdapter', () => {
       initializeProductionLoopSchema(db);
       const service = new RealWorkbenchTaskService(db);
       adapter.setWorkbenchTaskService(service);
+      const interruptions: Array<{ cause: string; recoverable: boolean }> = [];
+      adapter.on('sessionInterrupted', event => interruptions.push(event));
 
       try {
         await adapter.startSession('paused-production', 'Create and validate a release report', {
@@ -631,6 +633,12 @@ describe('PiRuntimeAdapter', () => {
         expect(mockSession.prompt).toHaveBeenCalledTimes(1);
         expect(mockSession.abort).toHaveBeenCalledOnce();
         expect(adapter.isSessionRunning('paused-production')).toBe(false);
+        expect(interruptions).toEqual([
+          expect.objectContaining({
+            cause: CoworkInterruptionCause.RuntimePaused,
+            recoverable: true,
+          }),
+        ]);
       } finally {
         db.close();
       }
@@ -1417,6 +1425,27 @@ describe('PiRuntimeAdapter', () => {
   });
 
   describe('stopSession', () => {
+    it('keeps agent-backed chat interruptions on the normal continuation path', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const interruptions: Array<{ taskId: string | null; recoverable: boolean }> = [];
+      adapter.on('sessionInterrupted', event => interruptions.push(event));
+
+      try {
+        await adapter.startSession('chat-session', 'Hello', { sessionMode: 'chat' });
+        adapter.stopSession('chat-session');
+
+        expect(interruptions).toEqual([
+          expect.objectContaining({ taskId: null, recoverable: false }),
+        ]);
+      } finally {
+        db.close();
+      }
+    });
+
     it('cancels a session while the runtime is still initializing', async () => {
       let resolveCreateSession: ((value: { session: typeof mockSession }) => void) | undefined;
       mockCreateAgentSession.mockImplementationOnce(

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1441,12 +1441,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     cause: CoworkInterruptionCause,
   ): CoworkSessionInterruption {
     const task = this.workbenchTaskService?.getCurrent(sessionId)?.task ?? null;
+    const resumableTask = task?.contract.kind === WorkbenchContractKind.Chat ? null : task;
     const interruption: CoworkSessionInterruption = {
       sessionId,
       interruptionId: randomUUID(),
       cause,
-      taskId: task?.id ?? null,
-      recoverable: task?.status === WorkbenchTaskStatus.Paused,
+      taskId: resumableTask?.id ?? null,
+      recoverable: resumableTask?.status === WorkbenchTaskStatus.Paused,
     };
     const seed: CoworkMessage = {
       id: randomUUID(),
@@ -2143,7 +2144,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           this.workbenchTaskService &&
           !this.workbenchTaskService.isRunRunning(active.workbenchRunId)
         ) {
-          this.stopActiveSession(sessionId, 'The workbench run is no longer active.', false);
+          this.stopActiveSession(
+            sessionId,
+            'The workbench run is no longer active.',
+            false,
+            CoworkInterruptionCause.RuntimePaused,
+          );
           break;
         }
         // Agent loop: when the finished iteration signaled "next", continue


### PR DESCRIPTION
## Summary

- emit a recoverable runtime interruption when a Workbench run becomes inactive
- expose resume metadata only for non-Chat Workbench contracts
- keep agent-backed Chat interruptions on normal `continueSession` semantics

## Problem

The internal inactive-run stop path emitted no terminal interruption, so the renderer could retain the Stop button. Conversely, treating every internal task as resumable would incorrectly route agent-backed Chat sessions through Workbench resume/retry.

## Dependency

Stacked on the Pi session generation fix. Review and merge the base PR first.

## Verification

- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
- `git diff --check`

SQLite-backed PiRuntime tests are currently blocked by the local Electron/Node native-module ABI mismatch described in the base PR.

## Risk

This changes interruption routing only. Direct Chat and non-recoverable interruptions continue without a Workbench task ID.
