### PR TITLE
fix(cowork): refresh todos for resumed runs

### DIFF
--- a/src/renderer/components/cowork/hooks/useProductionPlanTodos.test.ts
+++ b/src/renderer/components/cowork/hooks/useProductionPlanTodos.test.ts
@@ -1,7 +1,19 @@
-import { expect, test } from 'vitest';
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
 
 import { ProductionPlanItemStatus } from '../../../../shared/productionLoop';
-import { productionPlanToTodoSource } from './useProductionPlanTodos';
+import { productionPlanToTodoSource, useProductionPlanTodos } from './useProductionPlanTodos';
+
+const originalElectron = window.electron;
+
+afterEach(() => {
+  Object.defineProperty(window, 'electron', {
+    configurable: true,
+    value: originalElectron,
+  });
+});
 
 test('maps persisted production plan items to todo queue states', () => {
   const result = productionPlanToTodoSource({
@@ -25,4 +37,61 @@ test('maps persisted production plan items to todo queue states', () => {
       { id: 'd', title: 'Blocked', description: undefined, status: 'blocked' },
     ],
   });
+});
+
+test('ignores an older production plan response after the active run changes', async () => {
+  const pending: Array<(value: unknown) => void> = [];
+  const getCurrent = vi.fn(
+    () =>
+      new Promise(resolve => {
+        pending.push(resolve);
+      }),
+  );
+  let onChanged: ((event: { sessionId: string }) => void) | undefined;
+  Object.defineProperty(window, 'electron', {
+    configurable: true,
+    value: {
+      workbenchTask: {
+        getCurrent,
+        onChanged: vi.fn(callback => {
+          onChanged = callback;
+          return vi.fn();
+        }),
+      },
+    },
+  });
+
+  const view = renderHook(() => useProductionPlanTodos('session-1'));
+  await waitFor(() => expect(getCurrent).toHaveBeenCalledTimes(1));
+  act(() => onChanged?.({ sessionId: 'session-1' }));
+  await waitFor(() => expect(getCurrent).toHaveBeenCalledTimes(2));
+
+  await act(async () => {
+    pending[1]?.({
+      success: true,
+      detail: {
+        productionPlan: {
+          runId: 'run-b',
+          progressVersion: 2,
+          items: [{ id: 'b', title: 'New run', status: ProductionPlanItemStatus.InProgress }],
+        },
+      },
+    });
+  });
+  await waitFor(() => expect(view.result.current?.runId).toBe('run-b'));
+
+  await act(async () => {
+    pending[0]?.({
+      success: true,
+      detail: {
+        productionPlan: {
+          runId: 'run-a',
+          progressVersion: 1,
+          items: [{ id: 'a', title: 'Old run', status: ProductionPlanItemStatus.Pending }],
+        },
+      },
+    });
+  });
+
+  expect(view.result.current?.runId).toBe('run-b');
 });

--- a/src/renderer/components/cowork/hooks/useProductionPlanTodos.ts
+++ b/src/renderer/components/cowork/hooks/useProductionPlanTodos.ts
@@ -1,5 +1,5 @@
 import type { QueueTodo } from '@shared/components/ai-elements/queue';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   ProductionPlanItemStatus,
@@ -44,17 +44,25 @@ export function useProductionPlanTodos(
   sessionId?: string,
 ): ProductionPlanTodoSource | null | undefined {
   const [plan, setPlan] = useState<WorkbenchProductionPlan | null | undefined>(undefined);
+  const latestRequestIdRef = useRef(0);
 
   useEffect(() => {
     let active = true;
     setPlan(undefined);
     const loadActive = async () => {
+      const requestId = ++latestRequestIdRef.current;
       if (!sessionId) {
-        if (active) setPlan(null);
+        if (active && requestId === latestRequestIdRef.current) setPlan(null);
         return;
       }
-      const result = await window.electron.workbenchTask.getCurrent(sessionId);
-      if (active && result.success) setPlan(result.detail?.productionPlan ?? null);
+      try {
+        const result = await window.electron.workbenchTask.getCurrent(sessionId);
+        if (active && requestId === latestRequestIdRef.current && result.success) {
+          setPlan(result.detail?.productionPlan ?? null);
+        }
+      } catch {
+        if (active && requestId === latestRequestIdRef.current) setPlan(null);
+      }
     };
     void loadActive();
     const unsubscribe = window.electron.workbenchTask.onChanged(event => {
@@ -62,6 +70,7 @@ export function useProductionPlanTodos(
     });
     return () => {
       active = false;
+      latestRequestIdRef.current += 1;
       unsubscribe();
     };
   }, [sessionId]);


### PR DESCRIPTION
## Summary

- sequence ProductionPlan requests and accept only the newest response
- prevent a delayed previous-run response from replacing the resumed run plan
- preserve the existing message-derived todo fallback for sessions without a ProductionLoop

## Problem

Workbench change events can trigger overlapping `getCurrent()` requests. A slower response for the previous run could arrive last and leave TodoQueue bound to stale plan data after recovery.

## Dependency

Stacked on the Workbench interruption routing PR. Review and merge the two base PRs first.

## Verification

- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run src/renderer/components/cowork/hooks/useProductionPlanTodos.test.ts` (2 tests passed)
- `npm run lint`
- `git diff --check`

## Risk

No visual or component changes. The hook now discards only responses known to be older than the latest request.
