### PR TITLE
fix(installer): repair elevated Windows actions

### DIFF
--- a/scripts/nsis-elevated-actions.ps1
+++ b/scripts/nsis-elevated-actions.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('add-defender-exclusion', 'remove-defender-exclusion', 'install-vc-runtime')]
+  [string]$Action,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Target,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ResultPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-ActionResult {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Status,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  $normalizedMessage = $Message -replace '[\r\n]+', ' '
+  [IO.File]::WriteAllText(
+    $ResultPath,
+    "$Status|$normalizedMessage",
+    [Text.UTF8Encoding]::new($false)
+  )
+}
+
+try {
+  $exitCode = 0
+
+  switch ($Action) {
+    'add-defender-exclusion' {
+      Add-MpPreference -ExclusionPath $Target -ErrorAction Stop
+    }
+    'remove-defender-exclusion' {
+      Remove-MpPreference -ExclusionPath $Target -ErrorAction Stop
+    }
+    'install-vc-runtime' {
+      if (-not (Test-Path -LiteralPath $Target -PathType Leaf)) {
+        throw "VC++ runtime installer is missing: $Target"
+      }
+
+      $process = Start-Process -FilePath $Target -ArgumentList @(
+        '/install',
+        '/quiet',
+        '/norestart'
+      ) -Wait -PassThru -ErrorAction Stop
+      $exitCode = $process.ExitCode
+
+      if ($exitCode -notin @(0, 1638, 3010)) {
+        throw "VC++ runtime installer exited with code $exitCode"
+      }
+    }
+  }
+
+  Write-ActionResult -Status 'success' -Message "$Action completed"
+  exit $exitCode
+} catch {
+  Write-ActionResult -Status 'error' -Message $_.Exception.Message
+  exit 1
+}

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,5 +1,27 @@
 !include "FileFunc.nsh"
 
+!define ELEVATED_ACTION_SCRIPT "nsis-elevated-actions.ps1"
+!define ELEVATED_ACTION_RESULT "elevated-action-result.txt"
+
+!macro ExtractElevatedActionScript
+  SetOutPath "$PLUGINSDIR"
+  File /oname=${ELEVATED_ACTION_SCRIPT} "${PROJECT_DIR}\scripts\nsis-elevated-actions.ps1"
+!macroend
+
+!macro RunElevatedAction TOKEN ACTION TARGET
+  Delete "$PLUGINSDIR\${ELEVATED_ACTION_RESULT}"
+  StrCpy $0 "error"
+  StrCpy $1 ""
+  ClearErrors
+  ExecShellWait "runas" "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File $\"$PLUGINSDIR\${ELEVATED_ACTION_SCRIPT}$\" -Action ${ACTION} -Target $\"${TARGET}$\" -ResultPath $\"$PLUGINSDIR\${ELEVATED_ACTION_RESULT}$\"' SW_HIDE $0
+  IfErrors ElevatedActionResult_${TOKEN}
+  IfFileExists "$PLUGINSDIR\${ELEVATED_ACTION_RESULT}" 0 ElevatedActionResult_${TOKEN}
+    FileOpen $2 "$PLUGINSDIR\${ELEVATED_ACTION_RESULT}" r
+    FileRead $2 $1
+    FileClose $2
+  ElevatedActionResult_${TOKEN}:
+!macroend
+
 !macro customHeader
   ManifestDPIAware true
   ; The application and immutable runtime cache are per-user. Elevated helper
@@ -235,6 +257,7 @@
   CreateDirectory "$APPDATA\ZhiYuanAgent"
   CreateDirectory "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
   SetOutPath "$PLUGINSDIR"
+  !insertmacro ExtractElevatedActionScript
   FileOpen $2 "$PLUGINSDIR\component-targets.txt" w
   FileClose $2
   Delete "$PLUGINSDIR\component-switch-state.txt"
@@ -258,15 +281,13 @@
 
   EnableDefenderExclusion:
     DetailPrint "[Installer] Adding user-approved Defender exclusion"
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "$$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\"; $$command = \"Add-MpPreference -ExclusionPath ''$$runtimeRoot'' -ErrorAction Stop\"; $$process = Start-Process -FilePath powershell.exe -Verb RunAs -ArgumentList @(''-NoProfile'', ''-NonInteractive'', ''-Command'', $$command) -Wait -PassThru; exit $$process.ExitCode"'
-    Pop $0
-    Pop $1
+    !insertmacro RunElevatedAction ADD_DEFENDER add-defender-exclusion "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
     StrCmp $0 "0" DefenderExclusionEnabled
       Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
       FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
       FileWrite $2 "phase=defender-exclusion-failed exit=$0 output=$1$\r$\n"
       FileClose $2
-      MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Defender 排除项未能添加，可能被组织策略阻止。知远仍会继续安装。"
+      MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Defender 排除项未能添加。可能是你取消了管理员授权，或系统安全策略不允许修改。知远仍会继续安装。"
       Goto DefenderExclusionDone
 
   DefenderExclusionEnabled:
@@ -315,7 +336,7 @@
       if ($$parts.Count -ne 2 -or -not $$parts[0] -or -not $$parts[1]) { throw \"Invalid component target row: $$_\" };\
       $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$parts[0] + \".version\");\
       $$id = (Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop).Trim();\
-      if ($$id -notmatch \"^[0-9a-f]{64}$$\") { throw \"Invalid component content ID for \" + $$parts[0] };\
+      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$parts[0] };\
       [pscustomobject]@{ Key = $$parts[0]; Prefix = $$parts[1]; Id = $$id }\
     });\
     $$prepared = @();\
@@ -451,12 +472,13 @@
   InstallVcRuntime:
     IfFileExists "$INSTDIR\resources\vc_redist.x64.exe" 0 VcRuntimeReady
     DetailPrint "[Installer] Installing Microsoft Visual C++ Runtime"
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "$$process = Start-Process -FilePath \"$INSTDIR\resources\vc_redist.x64.exe\" -Verb RunAs -ArgumentList @(''/install'', ''/quiet'', ''/norestart'') -Wait -PassThru; exit $$process.ExitCode"'
-    Pop $0
-    Pop $1
+    !insertmacro RunElevatedAction INSTALL_VC install-vc-runtime "$INSTDIR\resources\vc_redist.x64.exe"
     StrCmp $0 "0" VcRuntimeReady
     StrCmp $0 "1638" VcRuntimeReady
     StrCmp $0 "3010" VcRuntimeReady
+      FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+      FileWrite $2 "phase=vc-runtime-install-failed exit=$0 output=$1$\r$\n"
+      FileClose $2
       MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Visual C++ Runtime 未能自动安装。知远仍会完成安装，但部分本地组件可能暂时不可用。"
   VcRuntimeReady:
 
@@ -504,7 +526,7 @@
       if ($$parts.Count -ne 2 -or -not $$parts[0]) { throw \"Invalid component target row: $$_\" };\
       $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$parts[0] + \".version\");\
       $$id = (Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop).Trim();\
-      if ($$id -notmatch \"^[0-9a-f]{64}$$\") { throw \"Invalid component content ID for \" + $$parts[0] };\
+      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$parts[0] };\
       [pscustomobject]@{ Key = $$parts[0]; Id = $$id }\
     });\
     foreach ($$row in $$rows) {\
@@ -578,9 +600,9 @@
   ; Remove only exclusions that this installer recorded as user-approved and
   ; installer-managed. Never remove an exclusion created independently.
   IfFileExists "$APPDATA\ZhiYuanAgent\defender-exclusion-managed" 0 DefenderExclusionUninstallDone
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "$$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\"; $$command = \"Remove-MpPreference -ExclusionPath ''$$runtimeRoot'' -ErrorAction SilentlyContinue\"; $$process = Start-Process -FilePath powershell.exe -Verb RunAs -ArgumentList @(''-NoProfile'', ''-NonInteractive'', ''-Command'', $$command) -Wait -PassThru; exit $$process.ExitCode"'
-    Pop $0
-    Pop $1
-    Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
+    !insertmacro ExtractElevatedActionScript
+    !insertmacro RunElevatedAction REMOVE_DEFENDER remove-defender-exclusion "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
+    StrCmp $0 "0" 0 DefenderExclusionUninstallDone
+      Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
   DefenderExclusionUninstallDone:
 !macroend

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 
 const installerScriptPath = path.resolve('scripts/nsis-installer.nsh');
+const elevatedActionsScriptPath = path.resolve('scripts/nsis-elevated-actions.ps1');
 const brandAssetScriptPath = path.resolve('scripts/generate-nsis-brand-assets.cjs');
 
 describe('NSIS offline resource and local inference flow', () => {
@@ -48,10 +49,9 @@ describe('NSIS offline resource and local inference flow', () => {
 
     expect(installerScript).toContain('FileWrite $2 "${KEY}|${PREFIX}$\\r$\\n"');
     expect(installerScript).not.toContain('${KEY}|${PREFIX}|$R1');
-    expect(installerScript).toContain(
-      'Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop',
-    );
-    expect(installerScript).toContain('^[0-9a-f]{64}$$');
+    expect(installerScript).toContain('Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop');
+    expect(installerScript).toContain('^[0-9a-f]{64}\\z');
+    expect(installerScript).not.toContain('^[0-9a-f]{64}$$');
     expect(installerScript).toContain(
       'New-Item -ItemType Junction -Path $$next -Target $$target -Force -ErrorAction Stop',
     );
@@ -68,14 +68,26 @@ describe('NSIS offline resource and local inference flow', () => {
 
   test('adds only a user-approved scoped Defender exclusion and removes managed exclusions', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+    const elevatedActionsScript = fs.readFileSync(elevatedActionsScriptPath, 'utf8');
 
     expect(installerScript).toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON1');
-    expect(installerScript).toContain('Add-MpPreference -ExclusionPath');
-    expect(installerScript).toContain('Start-Process -FilePath powershell.exe -Verb RunAs');
+    expect(installerScript).toContain('ExecShellWait "runas"');
+    expect(installerScript).toContain('-ExecutionPolicy Bypass -File');
+    expect(installerScript).toContain('!insertmacro RunElevatedAction ADD_DEFENDER');
+    expect(installerScript).toContain('!insertmacro RunElevatedAction INSTALL_VC');
+    expect(installerScript).toContain('!insertmacro RunElevatedAction REMOVE_DEFENDER');
     expect(installerScript).toContain('defender-exclusion-managed');
-    expect(installerScript).toContain('Remove-MpPreference -ExclusionPath');
-    expect(installerScript).not.toMatch(/Add-MpPreference[^\n]*compile-cache/);
-    expect(installerScript).not.toMatch(/Add-MpPreference[^\n]*app\.asar\.unpacked/);
+    expect(installerScript).not.toContain("''");
+    expect(installerScript).not.toContain('Start-Process -FilePath powershell.exe -Verb RunAs');
+    expect(elevatedActionsScript).toContain('Add-MpPreference -ExclusionPath $Target');
+    expect(elevatedActionsScript).toContain('Remove-MpPreference -ExclusionPath $Target');
+    expect(elevatedActionsScript).toContain('-ArgumentList @(');
+    expect(elevatedActionsScript).toContain("'/install'");
+    expect(elevatedActionsScript).toContain("'/quiet'");
+    expect(elevatedActionsScript).toContain("'/norestart'");
+    expect(elevatedActionsScript).toContain('$exitCode -notin @(0, 1638, 3010)');
+    expect(elevatedActionsScript).not.toMatch(/Add-MpPreference[^\n]*compile-cache/);
+    expect(elevatedActionsScript).not.toMatch(/Add-MpPreference[^\n]*app\.asar\.unpacked/);
   });
 
   test('delays old version cleanup until runtime links are ready', () => {


### PR DESCRIPTION
## Summary

- Repair all Windows installer actions that require elevation: Defender exclusion add/remove and VC++ Runtime installation.
- Restore compatibility with the NSIS version bundled by electron-builder so Windows release packaging can complete.

## Root Cause

- NSIS single-quoted strings do not escape embedded single quotes by doubling them. The inline PowerShell commands were therefore split into invalid plugin arguments before PowerShell could run.
- The content ID regex introduced in PR #458 ended with `$$`. electron-builder uses NSIS 3.0.4.1, whose parser interpreted that sequence as an invalid variable and failed the Windows build with `unknown variable/constant "")" detected`.
- Failed workflow: [v2026.8.10-build.2](https://github.com/rongxinzy/RongxinAI/actions/runs/31488277626), [Windows job](https://github.com/rongxinzy/RongxinAI/actions/runs/31488277626/job/93769593217).

## Changes

- Add a packaged PowerShell helper with a strict action whitelist for the three elevated operations.
- Invoke elevation once through NSIS `ExecShellWait "runas"`, avoiding nested PowerShell quoting and nested `Start-Process -Verb RunAs`.
- Capture the elevated child result for installer diagnostics and preserve accepted VC++ Runtime exit codes `0`, `1638`, and `3010`.
- Keep the Defender exclusion consent-based and scoped to `%LOCALAPPDATA%\ZhiYuanAgent\runtimes`; remove the managed marker only after successful cleanup.
- Replace the ambiguous regex end anchor with the .NET `\z` anchor.

## Validation

- `npm test -- nsis-installer runtimePackagingConfig` (17 tests passed)
- `npm run lint`
- `npx oxfmt --check tests/nsis-installer.test.ts`
- PowerShell AST parse for `scripts/nsis-elevated-actions.ps1`
- NSIS 3.12 smoke compile with `/WX`
- Full `npm run format:check` remains unsuitable as a gate because current `main` reports 2,077 pre-existing formatting issues; the changed TypeScript test passes the targeted format check.

## Release Impact

- Unblocks Windows installer compilation and makes elevated actions reliable at runtime.
- The existing `v2026.8.10-build.2` tag is immutable; merge this PR before pushing the next release tag to produce corrected Windows artifacts.
