### PR TITLE
fix(ci): make release plugin installs independent of ClawHub

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -118,10 +118,6 @@ jobs:
             runtime_target: linux-x64
     runs-on: ${{ matrix.runner }}
     environment: release
-    env:
-      # OpenClaw reads CLAWHUB_TOKEN; map the repository secret without
-      # exposing its name or value in the build command line.
-      CLAWHUB_TOKEN: ${{ secrets.CLAW_HUB }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/package.json
+++ b/package.json
@@ -15,27 +15,32 @@
       {
         "id": "dingtalk-connector",
         "npm": "@dingtalk-real-ai/dingtalk-connector",
-        "version": "0.8.16"
+        "version": "0.8.16",
+        "integrity": "sha512-xqz8/Fr1+u2J1nsWohWtigVZdnUd17tQwzitpzYbuUH2l5sWxKYPA/F+VmVGqXB9IB+iU7ewoArf+55K3w91fw=="
       },
       {
         "id": "openclaw-lark",
         "npm": "@larksuite/openclaw-lark",
-        "version": "2026.4.8"
+        "version": "2026.4.8",
+        "integrity": "sha512-HHIwDBQPtEZSLHHCnV52ip5WL8mag/qBUucIyH+pbyMHAAXyKtPHTfXFGTm1/HVMC0ZH2km5f11QvNyy85SDGw=="
       },
       {
         "id": "wecom-openclaw-plugin",
         "npm": "@wecom/wecom-openclaw-plugin",
-        "version": "2026.4.22"
+        "version": "2026.4.22",
+        "integrity": "sha512-scrJJ6LEm+b68MO9E5TKvIF7jDB5CDpf0RWT5C5V0WcqX7ZNfGsc6om6D3DZknOs0iPylzCbHCGu8vwbeVXzjA=="
       },
       {
         "id": "openclaw-weixin",
         "npm": "@tencent-weixin/openclaw-weixin",
-        "version": "2.4.3"
+        "version": "2.4.3",
+        "integrity": "sha512-dPQbidUNWigC6V10vGW4i+GLH09x+6zUhafZRjuxkJ9GDu8o62WBsnUTojp4KqUH756hz+t2v9khiCRSi0dBDw=="
       },
       {
         "id": "clawemail-email",
         "npm": "@clawemail/email",
-        "version": "0.9.12"
+        "version": "0.9.12",
+        "integrity": "sha512-J4mah1UWyVXX9hbTPfZb+5u2awj1k0XZigpjvGuSH2nGokAaI54a+3G+GRxeX+BoODNSBWyU7Nay2Whi4cbajg=="
       }
     ]
   },

--- a/scripts/ensure-openclaw-plugins.cjs
+++ b/scripts/ensure-openclaw-plugins.cjs
@@ -4,9 +4,11 @@
  * Ensure preinstalled OpenClaw plugins are downloaded and placed into the
  * runtime extensions directory.
  *
- * Uses the OpenClaw CLI (`openclaw plugins install`) to handle downloading,
- * dependency resolution, and proper module setup for each plugin declared in
- * package.json ("openclaw.plugins").
+ * Downloads exact npm packages directly from their registry, verifies their
+ * repository-pinned SRI digest, then uses the OpenClaw CLI
+ * (`openclaw plugins install`) for its security scan, dependency resolution,
+ * and proper module setup. This keeps release builds independent from the
+ * availability of the ClawHub catalog.
  *
  * Flow per plugin:
  *   1. Checks a local cache in vendor/openclaw-plugins/{id}/
@@ -19,6 +21,7 @@
  */
 
 const { spawnSync } = require('child_process');
+const { createHash, timingSafeEqual } = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -281,6 +284,19 @@ function npmPack(packSpec, registry, outputDir) {
   return path.join(outputDir, tgzName);
 }
 
+function verifyPackageIntegrity(packagePath, expectedIntegrity) {
+  const match = /^sha512-([A-Za-z0-9+/]+={0,2})$/.exec(expectedIntegrity || '');
+  if (!match) {
+    throw new Error('Plugin package integrity must be a sha512 SRI value');
+  }
+
+  const expected = Buffer.from(match[1], 'base64');
+  const actual = createHash('sha512').update(fs.readFileSync(packagePath)).digest();
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new Error(`Plugin package integrity mismatch for ${path.basename(packagePath)}`);
+  }
+}
+
 function gitCloneAndPack(spec, version, outputDir) {
   const parsed = parseGitSpec(spec, version);
   if (!parsed) {
@@ -399,7 +415,7 @@ function gitCloneAndPack(spec, version, outputDir) {
 }
 
 function resolvePluginInstallSource(plugin) {
-  const { npm: npmSpec, version, registry } = plugin;
+  const { npm: npmSpec, version, registry, integrity } = plugin;
 
   if (registry) {
     return {
@@ -407,6 +423,7 @@ function resolvePluginInstallSource(plugin) {
       packSpec: `${npmSpec}@${version}`,
       pinnedDisplaySpec: `${npmSpec}@${version}`,
       registry,
+      ...(integrity ? { integrity } : {}),
     };
   }
 
@@ -427,9 +444,10 @@ function resolvePluginInstallSource(plugin) {
   }
 
   return {
-    kind: 'direct',
-    installSpec: `${npmSpec}@${version}`,
+    kind: 'packed',
+    packSpec: `${npmSpec}@${version}`,
     pinnedDisplaySpec: `${npmSpec}@${version}`,
+    integrity,
   };
 }
 
@@ -460,6 +478,9 @@ function main() {
           'Each plugin must have "id", "npm", and "version" fields.',
       );
     }
+    if (!isGitSpec(plugin.npm) && !isLocalPathSpec(plugin.npm) && !plugin.integrity) {
+      die(`Registry plugin ${plugin.id} must declare a pinned sha512 integrity value.`);
+    }
   }
 
   const forceInstall = process.env.OPENCLAW_FORCE_PLUGIN_INSTALL === '1';
@@ -481,7 +502,7 @@ function main() {
   log(`Processing ${plugins.length} plugin(s)...`);
 
   for (const plugin of plugins) {
-    const { id, npm: npmSpec, version, optional } = plugin;
+    const { id, npm: npmSpec, version, integrity, optional } = plugin;
     const cacheDir = path.join(pluginCacheBase, id);
     const installInfoPath = path.join(cacheDir, 'plugin-install-info.json');
     const targetDir = path.join(runtimeExtensionsDir, id);
@@ -492,7 +513,12 @@ function main() {
     let needsDownload = true;
     if (!forceInstall && fs.existsSync(installInfoPath)) {
       const info = readJsonFile(installInfoPath);
-      if (info && info.version === version && info.npmSpec === npmSpec) {
+      if (
+        info &&
+        info.version === version &&
+        info.npmSpec === npmSpec &&
+        info.integrity === integrity
+      ) {
         log(`Cache hit (version=${version}), skipping download.`);
         needsDownload = false;
       } else {
@@ -518,7 +544,11 @@ function main() {
           if (source.registry) {
             log(`  Packing from custom registry: ${source.registry}`);
           }
-          installSpec = npmPack(source.packSpec, source.registry, stagingDir);
+          installSpec = retryPluginInstall(
+            () => npmPack(source.packSpec, source.registry, stagingDir),
+            { label: `Plugin ${id} package download` },
+          );
+          verifyPackageIntegrity(installSpec, source.integrity);
         } else {
           installSpec = source.installSpec;
         }
@@ -586,6 +616,7 @@ function main() {
               pluginId: id,
               npmSpec,
               version,
+              integrity,
               installedAt: new Date().toISOString(),
             },
             null,
@@ -894,4 +925,5 @@ module.exports = {
   retryPluginInstall,
   resolveGitPackSpec,
   resolvePluginInstallSource,
+  verifyPackageIntegrity,
 };

--- a/tests/ensure-openclaw-plugins.test.ts
+++ b/tests/ensure-openclaw-plugins.test.ts
@@ -1,3 +1,7 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, test } from 'vitest';
 
 const {
@@ -9,6 +13,7 @@ const {
   retryPluginInstall,
   resolveGitPackSpec,
   resolvePluginInstallSource,
+  verifyPackageIntegrity,
 } = require('../scripts/ensure-openclaw-plugins.cjs');
 
 describe('ensure-openclaw-plugins', () => {
@@ -152,5 +157,41 @@ describe('ensure-openclaw-plugins', () => {
       installSpec: '/tmp/local-plugin',
       pinnedDisplaySpec: '/tmp/local-plugin',
     });
+  });
+
+  test('packs pinned npm packages instead of resolving them through ClawHub', () => {
+    expect(
+      resolvePluginInstallSource({
+        id: 'openclaw-lark',
+        npm: '@larksuite/openclaw-lark',
+        version: '2026.4.8',
+        integrity: 'sha512-test',
+      }),
+    ).toEqual({
+      kind: 'packed',
+      packSpec: '@larksuite/openclaw-lark@2026.4.8',
+      pinnedDisplaySpec: '@larksuite/openclaw-lark@2026.4.8',
+      integrity: 'sha512-test',
+    });
+  });
+
+  test('accepts the pinned sha512 digest and rejects changed package bytes', () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'openclaw-plugin-integrity-'));
+    const packagePath = join(testDir, 'plugin.tgz');
+
+    try {
+      writeFileSync(packagePath, 'trusted plugin bytes');
+      const integrity = `sha512-${createHash('sha512')
+        .update('trusted plugin bytes')
+        .digest('base64')}`;
+
+      expect(() => verifyPackageIntegrity(packagePath, integrity)).not.toThrow();
+      writeFileSync(packagePath, 'changed plugin bytes');
+      expect(() => verifyPackageIntegrity(packagePath, integrity)).toThrow(
+        'Plugin package integrity mismatch',
+      );
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- download exact OpenClaw plugin packages from npm instead of resolving them through the ClawHub catalog
- pin and verify SHA-512 SRI values before invoking the OpenClaw installer
- retain OpenClaw's security scan, dependency installation, bounded retries, and existing post-install patches
- remove the now-unused release `CLAWHUB_TOKEN` mapping

## Root cause

Release run https://github.com/rongxinzy/RongxinAI/actions/runs/31494483011 passed quality and supply-chain gates, then the macOS build failed after three connection timeouts to `clawhub.ai` while installing `@larksuite/openclaw-lark@2026.4.8`. Matrix fail-fast cancelled Windows and Linux and skipped publish.

## Verification

- `CI=true bun run test` — 289 files, 2216 passed, 1 skipped
- `bun run lint`
- `bun run build:tsc`
- `bun run compile:electron`
- `VITE_SKIP_ELECTRON=1 bun run build:vite && bun run test:bundle-budget`
- Presentation Studio validator and Skill frontmatter validation
- `bun run check:supply-chain-inputs`
- all five npm tarballs matched their pinned SHA-512 values
- forced five-plugin install without any ClawHub token completed successfully; archives were installed locally and OpenClaw security scans still ran
