### PR TITLE
fix(installer): avoid synchronous runtime deletion on uninstall

### DIFF
--- a/.github/workflows/windows-installer-pr.yml
+++ b/.github/workflows/windows-installer-pr.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   package-and-install:
     runs-on: windows-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -84,6 +84,15 @@ jobs:
           powershell -NoProfile -ExecutionPolicy Bypass
           -File scripts/ci/windows-installer-smoke.ps1
           -ProjectRoot ${{ github.workspace }}
+      - name: Collect installer diagnostics
+        if: ${{ failure() }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Path installer-diagnostics -Force | Out-Null
+          $timingLog = Join-Path $env:APPDATA 'ZhiYuanAgent\install-timing.log'
+          if (Test-Path -LiteralPath $timingLog) {
+            Copy-Item -LiteralPath $timingLog -Destination installer-diagnostics\install-timing.log -Force
+          }
       - name: Upload installer diagnostics
         if: ${{ failure() }}
         uses: actions/upload-artifact@v6
@@ -91,6 +100,6 @@ jobs:
           name: windows-installer-diagnostics
           path: |
             release/*.exe
-            ~/AppData/Roaming/ZhiYuanAgent/install-timing.log
+            installer-diagnostics/install-timing.log
           if-no-files-found: ignore
           retention-days: 7

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -76,7 +76,13 @@ $componentKeys = @('openclaw', 'skills', 'mcps', 'portable-git', 'python', 'skil
 
 try {
   Invoke-Installer $installer 'cold installation' 2700 $timingLog
-  Assert-Path (Join-Path $installRoot '知远.exe') 'installed application executable'
+  Assert-Path $installRoot 'installation root'
+  $applicationExecutables = @(Get-ChildItem -LiteralPath $installRoot -Filter '*.exe' -File |
+    Where-Object { $_.Name -notlike 'Uninstall*' })
+  if ($applicationExecutables.Count -ne 1) {
+    throw "Expected exactly one installed application executable; found $($applicationExecutables.Count)"
+  }
+  Assert-Path $applicationExecutables[0].FullName 'installed application executable'
   Assert-Path $timingLog 'cold installation timing log'
 
   $coldLog = Get-Content -LiteralPath $timingLog -Raw -Encoding UTF8

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -12,11 +12,53 @@ function Assert-Path {
 }
 
 function Invoke-Installer {
-  param([Parameter(Mandatory = $true)][string]$Path, [string]$Label = 'installer')
-  $process = Start-Process -FilePath $Path -ArgumentList @('/S') -Wait -PassThru
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [string]$Label = 'installer',
+    [int]$TimeoutSeconds = 2700,
+    [string]$DiagnosticLogPath = ''
+  )
+
+  Write-Host "[WindowsInstallerSmoke] Starting $Label (timeout: ${TimeoutSeconds}s)"
+  $startedAt = Get-Date
+  $process = Start-Process -FilePath $Path -ArgumentList @('/S') -PassThru
+  $lastDiagnostic = ''
+  while (-not $process.WaitForExit(10000)) {
+    $elapsedSeconds = [int]((Get-Date) - $startedAt).TotalSeconds
+    if ($DiagnosticLogPath -and $elapsedSeconds % 60 -lt 10 -and (Test-Path -LiteralPath $DiagnosticLogPath)) {
+      $diagnostic = (Get-Content -LiteralPath $DiagnosticLogPath -Tail 6 -Encoding UTF8) -join "`n"
+      if ($diagnostic -and $diagnostic -ne $lastDiagnostic) {
+        Write-Host "[WindowsInstallerSmoke] $Label progress after ${elapsedSeconds}s:`n$diagnostic"
+        $lastDiagnostic = $diagnostic
+      }
+    }
+    if ($elapsedSeconds -ge $TimeoutSeconds) {
+      Write-Host "[WindowsInstallerSmoke] $Label process tree before timeout termination:"
+      $allProcesses = @(Get-CimInstance Win32_Process)
+      $processIds = @([uint32]$process.Id)
+      do {
+        $children = @($allProcesses | Where-Object {
+          $_.ParentProcessId -in $processIds -and $_.ProcessId -notin $processIds
+        })
+        $newIds = @($children | ForEach-Object { [uint32]$_.ProcessId })
+        $processIds += $newIds
+      } while ($newIds.Count -gt 0)
+      $allProcesses | Where-Object { $_.ProcessId -in $processIds } |
+        Select-Object ProcessId, ParentProcessId, Name, CommandLine |
+        Format-Table -Wrap | Out-String | Write-Host
+      if ($DiagnosticLogPath -and (Test-Path -LiteralPath $DiagnosticLogPath)) {
+        Write-Host "[WindowsInstallerSmoke] Complete installer timing log:"
+        Get-Content -LiteralPath $DiagnosticLogPath -Encoding UTF8 | Out-Host
+      }
+      & taskkill.exe /PID $process.Id /T /F 2>&1 | Out-Host
+      throw "$Label timed out after $TimeoutSeconds seconds"
+    }
+  }
   if ($process.ExitCode -ne 0) {
     throw "$Label failed with exit code $($process.ExitCode)"
   }
+  $elapsed = [math]::Round(((Get-Date) - $startedAt).TotalSeconds, 1)
+  Write-Host "[WindowsInstallerSmoke] Completed $Label in ${elapsed}s"
 }
 
 $installers = @(Get-ChildItem -LiteralPath (Join-Path $ProjectRoot 'release') -Filter '*.exe' -File |
@@ -33,7 +75,7 @@ $managedDefenderMarker = Join-Path $env:APPDATA 'ZhiYuanAgent\defender-exclusion
 $componentKeys = @('openclaw', 'skills', 'mcps', 'portable-git', 'python', 'skill-python', 'uv')
 
 try {
-  Invoke-Installer $installer 'cold installation'
+  Invoke-Installer $installer 'cold installation' 2700 $timingLog
   Assert-Path (Join-Path $installRoot '知远.exe') 'installed application executable'
   Assert-Path $timingLog 'cold installation timing log'
 
@@ -60,7 +102,7 @@ try {
     }
   }
 
-  Invoke-Installer $installer 'cache-hit upgrade'
+  Invoke-Installer $installer 'cache-hit upgrade' 600 $timingLog
   Assert-Path $timingLog 'upgrade timing log'
   $upgradeLog = Get-Content -LiteralPath $timingLog -Raw -Encoding UTF8
   if (($upgradeLog | Select-String -AllMatches 'phase=component-cache-hit ').Matches.Count -ne 7) {
@@ -77,7 +119,7 @@ try {
   if ($uninstallers.Count -ne 1) {
     throw "Expected exactly one uninstaller; found $($uninstallers.Count)"
   }
-  Invoke-Installer $uninstallers[0].FullName 'uninstall'
+  Invoke-Installer $uninstallers[0].FullName 'uninstall' 300 $timingLog
   if (Test-Path -LiteralPath $runtimeRoot) {
     throw "Uninstall left the installer-managed runtime cache behind: $runtimeRoot"
   }

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -61,6 +61,37 @@ function Invoke-Installer {
   Write-Host "[WindowsInstallerSmoke] Completed $Label in ${elapsed}s"
 }
 
+function Wait-ForUninstallCompletion {
+  param(
+    [Parameter(Mandatory = $true)][string]$InstallRoot,
+    [Parameter(Mandatory = $true)][string]$RuntimeRoot,
+    [int]$TimeoutSeconds = 300
+  )
+
+  Write-Host "[WindowsInstallerSmoke] Waiting for the spawned background uninstaller (timeout: ${TimeoutSeconds}s)"
+  $startedAt = Get-Date
+  $lastProgressAt = -30
+  while ((Test-Path -LiteralPath $InstallRoot) -or (Test-Path -LiteralPath $RuntimeRoot)) {
+    $elapsedSeconds = [int]((Get-Date) - $startedAt).TotalSeconds
+    if ($elapsedSeconds - $lastProgressAt -ge 30) {
+      Write-Host "[WindowsInstallerSmoke] Background uninstall progress after ${elapsedSeconds}s: installRoot=$([bool](Test-Path -LiteralPath $InstallRoot)) runtimeRoot=$([bool](Test-Path -LiteralPath $RuntimeRoot))"
+      $lastProgressAt = $elapsedSeconds
+    }
+    if ($elapsedSeconds -ge $TimeoutSeconds) {
+      Write-Host '[WindowsInstallerSmoke] Uninstaller processes before timeout:'
+      Get-CimInstance Win32_Process | Where-Object {
+        $_.Name -like 'Uninstall*.exe' -or $_.Name -like 'Un_*.exe' -or
+        $_.CommandLine -like '*ZhiYuanAgent*' -or $_.CommandLine -like '*zhiyuan-agent*'
+      } | Select-Object ProcessId, ParentProcessId, Name, CommandLine |
+        Format-Table -Wrap | Out-String | Write-Host
+      throw "Background uninstall did not remove the managed roots within $TimeoutSeconds seconds"
+    }
+    Start-Sleep -Seconds 2
+  }
+  $elapsed = [math]::Round(((Get-Date) - $startedAt).TotalSeconds, 1)
+  Write-Host "[WindowsInstallerSmoke] Completed background uninstall in ${elapsed}s"
+}
+
 $installers = @(Get-ChildItem -LiteralPath (Join-Path $ProjectRoot 'release') -Filter '*.exe' -File |
   Where-Object { $_.Name -notlike '*Uninstall*' })
 if ($installers.Count -ne 1) {
@@ -126,9 +157,10 @@ try {
     throw "Expected exactly one uninstaller; found $($uninstallers.Count)"
   }
   Invoke-Installer $uninstallers[0].FullName 'uninstall' 300 $timingLog
-  if (Test-Path -LiteralPath $runtimeRoot) {
-    throw "Uninstall left the installer-managed runtime cache behind: $runtimeRoot"
-  }
+  # NSIS copies the uninstaller to a temporary Un_A process. The launcher can
+  # exit before that process reaches customUnInstall, so wait for observable
+  # completion instead of treating the launcher lifetime as the uninstall.
+  Wait-ForUninstallCompletion $installRoot $runtimeRoot 300
 } finally {
   if (Test-Path -LiteralPath $installRoot) {
     $remainingUninstallers = @(Get-ChildItem -LiteralPath $installRoot -Filter 'Uninstall*.exe' -File -ErrorAction SilentlyContinue)

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -241,11 +241,6 @@
     Goto OfflineComponentInstallFailed
 
   ComponentReady_${TOKEN}:
-    FileOpen $2 "$PLUGINSDIR\component-targets.txt" a
-    ; Keep the 64-character content ID in its dedicated version file. Combining
-    ; it with the routing fields can split the skill-python row in NSIS builds.
-    FileWrite $2 "${KEY}|${PREFIX}$\r$\n"
-    FileClose $2
     System::Call 'kernel32::GetTickCount()i .r6'
     IntOp $R5 $6 - $7
     FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
@@ -258,8 +253,9 @@
   CreateDirectory "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
   SetOutPath "$PLUGINSDIR"
   !insertmacro ExtractElevatedActionScript
-  FileOpen $2 "$PLUGINSDIR\component-targets.txt" w
-  FileClose $2
+  ; Embed the routing table as a compile-time asset. Building it incrementally
+  ; with NSIS FileWrite can split the skill-python key on Windows runners.
+  File /oname=component-targets.json "${PROJECT_DIR}\scripts\nsis-offline-components.json"
   Delete "$PLUGINSDIR\component-switch-state.txt"
 
   ; Defender exclusion is optional and requires explicit, informed consent.
@@ -331,13 +327,13 @@
   nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
     $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
     $$statePath = \"$PLUGINSDIR\component-switch-state.txt\";\
-    $$rows = @(Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.txt\" | Where-Object { $$_ } | ForEach-Object {\
-      $$parts = $$_.Split(\"|\");\
-      if ($$parts.Count -ne 2 -or -not $$parts[0] -or -not $$parts[1]) { throw \"Invalid component target row: $$_\" };\
-      $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$parts[0] + \".version\");\
+    $$rows = @((Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.json\" -Raw -ErrorAction Stop | ConvertFrom-Json));\
+    $$rows = @($$rows | ForEach-Object {\
+      if ($$_.key -notmatch \"^[a-z0-9-]+\z\" -or $$_.prefix -notmatch \"^[A-Za-z0-9-]+\z\") { throw \"Invalid component target entry\" };\
+      $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$_.key + \".version\");\
       $$id = (Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop).Trim();\
-      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$parts[0] };\
-      [pscustomobject]@{ Key = $$parts[0]; Prefix = $$parts[1]; Id = $$id }\
+      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$_.key };\
+      [pscustomobject]@{ Key = $$_.key; Prefix = $$_.prefix; Id = $$id }\
     });\
     $$prepared = @();\
     $$switched = @();\
@@ -396,7 +392,7 @@
   nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
     $$resourceRoot = \"$INSTDIR\resources\";\
     $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
-    $$rows = @(Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.txt\" | Where-Object { $$_ } | ForEach-Object { $$parts = $$_.Split(\"|\"); [pscustomobject]@{ Key = $$parts[0]; Prefix = $$parts[1] } });\
+    $$rows = @((Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.json\" -Raw -ErrorAction Stop | ConvertFrom-Json));\
     foreach ($$row in $$rows) {\
       $$link = Join-Path $$resourceRoot $$row.Prefix;\
       $$target = Join-Path (Join-Path (Join-Path $$runtimeRoot $$row.Key) \"current\") $$row.Prefix;\
@@ -456,7 +452,10 @@
     FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
     FileWrite $2 "phase=component-set-rollback reason=$R9$\r$\n"
     FileClose $2
-    MessageBox MB_OK|MB_ICONSTOP "$R9"
+    IfSilent OfflineComponentInstallFailedSilent 0
+      MessageBox MB_OK|MB_ICONSTOP "$R9"
+    OfflineComponentInstallFailedSilent:
+    SetErrorLevel 1
     Abort
 
   OfflineComponentsReady:
@@ -521,13 +520,13 @@
   System::Call 'kernel32::GetTickCount()i .r7'
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
-    $$rows = @(Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.txt\" | Where-Object { $$_ } | ForEach-Object {\
-      $$parts = $$_.Split(\"|\");\
-      if ($$parts.Count -ne 2 -or -not $$parts[0]) { throw \"Invalid component target row: $$_\" };\
-      $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$parts[0] + \".version\");\
+    $$rows = @((Get-Content -LiteralPath \"$PLUGINSDIR\component-targets.json\" -Raw -ErrorAction Stop | ConvertFrom-Json));\
+    $$rows = @($$rows | ForEach-Object {\
+      if ($$_.key -notmatch \"^[a-z0-9-]+\z\") { throw \"Invalid component target entry\" };\
+      $$idPath = Join-Path \"$PLUGINSDIR\" (\"component-\" + $$_.key + \".version\");\
       $$id = (Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop).Trim();\
-      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$parts[0] };\
-      [pscustomobject]@{ Key = $$parts[0]; Id = $$id }\
+      if ($$id -notmatch \"^[0-9a-f]{64}\z\") { throw \"Invalid component content ID for \" + $$_.key };\
+      [pscustomobject]@{ Key = $$_.key; Id = $$id }\
     });\
     foreach ($$row in $$rows) {\
       $$root = Join-Path $$runtimeRoot $$row.Key;\

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -577,8 +577,10 @@
 !macroend
 
 !macro customUnInstall
-  ; Remove component junctions before recursively deleting application-owned
-  ; immutable data. User-created Skills and models remain under userData.
+  ; Remove component junctions before detaching application-owned immutable
+  ; data. User-created Skills and models remain under userData. Deleting the
+  ; expanded runtime tree synchronously can take longer than the uninstaller
+  ; itself, so rename it atomically and reclaim it in the background.
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
     if (Test-Path -LiteralPath $$runtimeRoot) {\
@@ -590,12 +592,43 @@
             if (($$pointerItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { [IO.Directory]::Delete($$pointer) }\
           }\
         }\
-      };\
-      Remove-Item -LiteralPath $$runtimeRoot -Recurse -Force\
-    };\
-    $$legacyRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtime-packs\";\
-    if (Test-Path -LiteralPath $$legacyRoot) { Remove-Item -LiteralPath $$legacyRoot -Recurse -Force }"'
+      }\
+    }"'
   Pop $0
+
+  nsExec::ExecToLog 'cmd /c for /d %D in ("$LOCALAPPDATA\ZhiYuanAgent\runtimes.uninstall.*") do @start "" /b cmd /d /c rd /s /q "%~fD"'
+  Pop $0
+  StrCpy $3 "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
+  IfFileExists "$3\*.*" 0 RuntimeCleanupDone
+    System::Call 'kernel32::GetTickCount()i .r4'
+    StrCpy $4 "$3.uninstall.$4"
+    ClearErrors
+    Rename "$3" "$4"
+    IfErrors RuntimeCleanupDetachFailed
+      nsExec::ExecToLog 'cmd /c start "" /b cmd /d /c rd /s /q "$4"'
+      Pop $0
+      Goto RuntimeCleanupDone
+    RuntimeCleanupDetachFailed:
+      DetailPrint "[Uninstaller] Could not detach the offline runtime cache"
+  RuntimeCleanupDone:
+  RMDir "$3"
+
+  nsExec::ExecToLog 'cmd /c for /d %D in ("$LOCALAPPDATA\ZhiYuanAgent\runtime-packs.uninstall.*") do @start "" /b cmd /d /c rd /s /q "%~fD"'
+  Pop $0
+  StrCpy $3 "$LOCALAPPDATA\ZhiYuanAgent\runtime-packs"
+  IfFileExists "$3\*.*" 0 LegacyRuntimeCleanupDone
+    System::Call 'kernel32::GetTickCount()i .r4'
+    StrCpy $4 "$3.uninstall.$4"
+    ClearErrors
+    Rename "$3" "$4"
+    IfErrors LegacyRuntimeCleanupDetachFailed
+      nsExec::ExecToLog 'cmd /c start "" /b cmd /d /c rd /s /q "$4"'
+      Pop $0
+      Goto LegacyRuntimeCleanupDone
+    LegacyRuntimeCleanupDetachFailed:
+      DetailPrint "[Uninstaller] Could not detach the legacy runtime cache"
+  LegacyRuntimeCleanupDone:
+  RMDir "$3"
 
   ; Remove only exclusions that this installer recorded as user-approved and
   ; installer-managed. Never remove an exclusion created independently.

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -3,6 +3,12 @@
 !define ELEVATED_ACTION_SCRIPT "nsis-elevated-actions.ps1"
 !define ELEVATED_ACTION_RESULT "elevated-action-result.txt"
 
+!macro OpenTimingLogForAppend HANDLE
+  ; NSIS append mode preserves existing data but starts at offset zero.
+  FileOpen ${HANDLE} "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  FileSeek ${HANDLE} 0 END
+!macroend
+
 !macro ExtractElevatedActionScript
   SetOutPath "$PLUGINSDIR"
   File /oname=${ELEVATED_ACTION_SCRIPT} "${PROJECT_DIR}\scripts\nsis-elevated-actions.ps1"
@@ -61,7 +67,7 @@
   Pop $0
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
-  FileOpen $8 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  !insertmacro OpenTimingLogForAppend $8
   FileWrite $8 "phase=process-stop-complete elapsed_ms=$5 exit=$0$\r$\n"
   FileClose $8
 
@@ -94,7 +100,7 @@
   Pop $1
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
-  FileOpen $8 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  !insertmacro OpenTimingLogForAppend $8
   FileWrite $8 "phase=skill-migration-complete elapsed_ms=$5 exit=$0 output=$1$\r$\n"
   FileClose $8
 
@@ -113,7 +119,7 @@
   OldInstallDetachDone:
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
-  FileOpen $8 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  !insertmacro OpenTimingLogForAppend $8
   FileWrite $8 "phase=old-install-detached elapsed_ms=$5 path=$3$\r$\n"
   FileClose $8
 !macroend
@@ -168,14 +174,14 @@
 
   ComponentCacheHit_${TOKEN}:
     DetailPrint "[Installer] Reusing ${LABEL}"
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-cache-hit component=${KEY} content_id=$R1$\r$\n"
     FileClose $2
     Goto ComponentReady_${TOKEN}
 
   ComponentCacheMiss_${TOKEN}:
     DetailPrint "[Installer] Expanding ${LABEL}"
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-cache-miss component=${KEY} content_id=$R1$\r$\n"
     FileClose $2
     StrCpy $R3 "$LOCALAPPDATA\ZhiYuanAgent\runtimes\${KEY}\$R1.installing"
@@ -199,14 +205,14 @@
 
   ComponentHashFailed_${TOKEN}:
     StrCpy $R9 "${LABEL} 归档 SHA-256 校验失败，安装包可能不完整。"
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-hash-failed component=${KEY} expected=$R4 actual=$1 exit=$0$\r$\n"
     FileClose $2
     Goto OfflineComponentInstallFailed
 
   ComponentExtractFailed_${TOKEN}:
     StrCpy $R9 "${LABEL} 展开失败（代码 $0）。请检查磁盘空间或安全软件后重试。"
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-extract-failed component=${KEY} exit=$0 output=$1$\r$\n"
     FileClose $2
     Goto OfflineComponentInstallFailed
@@ -243,7 +249,7 @@
   ComponentReady_${TOKEN}:
     System::Call 'kernel32::GetTickCount()i .r6'
     IntOp $R5 $6 - $7
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-ready component=${KEY} content_id=$R1 elapsed_ms=$R5$\r$\n"
     FileClose $2
 !macroend
@@ -280,7 +286,7 @@
     !insertmacro RunElevatedAction ADD_DEFENDER add-defender-exclusion "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
     StrCmp $0 "0" DefenderExclusionEnabled
       Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
-      FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+      !insertmacro OpenTimingLogForAppend $2
       FileWrite $2 "phase=defender-exclusion-failed exit=$0 output=$1$\r$\n"
       FileClose $2
       MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Defender 排除项未能添加。可能是你取消了管理员授权，或系统安全策略不允许修改。知远仍会继续安装。"
@@ -290,26 +296,26 @@
     FileOpen $2 "$APPDATA\ZhiYuanAgent\defender-exclusion-managed" w
     FileWrite $2 "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
     FileClose $2
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=defender-exclusion-enabled path=$LOCALAPPDATA\ZhiYuanAgent\runtimes$\r$\n"
     FileClose $2
     Goto DefenderExclusionDone
 
   DefenderExclusionAlreadyActive:
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=defender-exclusion-already-active path=$LOCALAPPDATA\ZhiYuanAgent\runtimes$\r$\n"
     FileClose $2
     Goto DefenderExclusionDone
 
   DefenderExclusionDeclined:
     Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=defender-exclusion-declined$\r$\n"
     FileClose $2
     Goto DefenderExclusionDone
 
   DefenderExclusionSkipped:
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=defender-exclusion-skipped-silent$\r$\n"
     FileClose $2
 
@@ -410,7 +416,7 @@
   Pop $0
   Pop $1
   StrCmp $0 "0" RuntimeLinksReady
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=runtime-link-failed exit=$0 output=$1$\r$\n"
     FileClose $2
     StrCpy $R9 "离线运行环境连接失败：$1"
@@ -449,7 +455,7 @@
         }\
       }"'
     Pop $0
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+    !insertmacro OpenTimingLogForAppend $2
     FileWrite $2 "phase=component-set-rollback reason=$R9$\r$\n"
     FileClose $2
     IfSilent OfflineComponentInstallFailedSilent 0
@@ -475,7 +481,7 @@
     StrCmp $0 "0" VcRuntimeReady
     StrCmp $0 "1638" VcRuntimeReady
     StrCmp $0 "3010" VcRuntimeReady
-      FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+      !insertmacro OpenTimingLogForAppend $2
       FileWrite $2 "phase=vc-runtime-install-failed exit=$0 output=$1$\r$\n"
       FileClose $2
       MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Visual C++ Runtime 未能自动安装。知远仍会完成安装，但部分本地组件可能暂时不可用。"
@@ -549,7 +555,7 @@
   Pop $0
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $5 $6 - $7
-  FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  !insertmacro OpenTimingLogForAppend $2
   FileWrite $2 "phase=component-cleanup-complete elapsed_ms=$5 exit=$0$\r$\n"
   FileClose $2
   Delete "$PLUGINSDIR\component-switch-state.txt"
@@ -560,7 +566,7 @@
   FileClose $2
   System::Call 'kernel32::GetTickCount()i .r6'
   IntOp $R6 $6 - $R5
-  FileOpen $2 "$APPDATA\ZhiYuanAgent\install-timing.log" a
+  !insertmacro OpenTimingLogForAppend $2
   FileWrite $2 "phase=install-complete total_ms=$R6 component_set=ready$\r$\n"
   FileClose $2
   Delete "$APPDATA\ZhiYuanAgent\install-start-tick.txt"

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -586,6 +586,9 @@
   ; data. User-created Skills and models remain under userData. Deleting the
   ; expanded runtime tree synchronously can take longer than the uninstaller
   ; itself, so rename it atomically and reclaim it in the background.
+  ; Keep both the uninstaller and spawned cleanup commands outside $INSTDIR so
+  ; electron-builder's final RMDir can remove the now-empty application root.
+  SetOutPath "$TEMP"
   nsExec::ExecToLog 'powershell -NoProfile -NonInteractive -Command "\
     $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
     if (Test-Path -LiteralPath $$runtimeRoot) {\

--- a/scripts/nsis-offline-components.json
+++ b/scripts/nsis-offline-components.json
@@ -1,0 +1,9 @@
+[
+  { "key": "openclaw", "prefix": "cfmind" },
+  { "key": "skills", "prefix": "SKILLs" },
+  { "key": "mcps", "prefix": "MCPs" },
+  { "key": "portable-git", "prefix": "mingit" },
+  { "key": "python", "prefix": "python-win" },
+  { "key": "skill-python", "prefix": "skill-python" },
+  { "key": "uv", "prefix": "uv-win" }
+]

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -85,6 +85,22 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(failureBlock).toContain('SetErrorLevel 1');
   });
 
+  test('seeks to the end before appending installer timing records', () => {
+    const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+
+    expect(installerScript).toContain(
+      '!macro OpenTimingLogForAppend HANDLE\n' +
+        '  ; NSIS append mode preserves existing data but starts at offset zero.\n' +
+        '  FileOpen ${HANDLE} "$APPDATA\\ZhiYuanAgent\\install-timing.log" a\n' +
+        '  FileSeek ${HANDLE} 0 END\n' +
+        '!macroend',
+    );
+    expect(installerScript).not.toMatch(
+      /^\s*FileOpen \$\d+ "\$APPDATA\\ZhiYuanAgent\\install-timing\.log" a$/m,
+    );
+    expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(18);
+  });
+
   test('records optional local inference intent without downloading in NSIS', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
 

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 
 const installerScriptPath = path.resolve('scripts/nsis-installer.nsh');
 const elevatedActionsScriptPath = path.resolve('scripts/nsis-elevated-actions.ps1');
+const offlineComponentsPath = path.resolve('scripts/nsis-offline-components.json');
 const brandAssetScriptPath = path.resolve('scripts/generate-nsis-brand-assets.cjs');
 
 describe('NSIS offline resource and local inference flow', () => {
@@ -44,17 +45,44 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).not.toContain('离线组件原子切换失败');
   });
 
-  test('keeps component content IDs out of the combined NSIS target rows', () => {
+  test('uses an embedded component manifest instead of NSIS-generated routing rows', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+    const offlineComponents = JSON.parse(fs.readFileSync(offlineComponentsPath, 'utf8'));
 
-    expect(installerScript).toContain('FileWrite $2 "${KEY}|${PREFIX}$\\r$\\n"');
-    expect(installerScript).not.toContain('${KEY}|${PREFIX}|$R1');
+    expect(installerScript).toContain(
+      'File /oname=component-targets.json "${PROJECT_DIR}\\scripts\\nsis-offline-components.json"',
+    );
+    expect(installerScript).not.toContain('component-targets.txt');
+    expect(installerScript).not.toContain('FileWrite $2 "${KEY}|${PREFIX}');
     expect(installerScript).toContain('Get-Content -LiteralPath $$idPath -Raw -ErrorAction Stop');
     expect(installerScript).toContain('^[0-9a-f]{64}\\z');
     expect(installerScript).not.toContain('^[0-9a-f]{64}$$');
     expect(installerScript).toContain(
       'New-Item -ItemType Junction -Path $$next -Target $$target -Force -ErrorAction Stop',
     );
+    expect(offlineComponents).toEqual([
+      { key: 'openclaw', prefix: 'cfmind' },
+      { key: 'skills', prefix: 'SKILLs' },
+      { key: 'mcps', prefix: 'MCPs' },
+      { key: 'portable-git', prefix: 'mingit' },
+      { key: 'python', prefix: 'python-win' },
+      { key: 'skill-python', prefix: 'skill-python' },
+      { key: 'uv', prefix: 'uv-win' },
+    ]);
+  });
+
+  test('does not show a blocking failure dialog during silent installs', () => {
+    const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+    const failureBlock = installerScript.slice(
+      installerScript.indexOf('OfflineComponentInstallFailed:'),
+      installerScript.indexOf('OfflineComponentsReady:'),
+    );
+
+    expect(failureBlock).toContain('IfSilent OfflineComponentInstallFailedSilent 0');
+    expect(failureBlock.indexOf('IfSilent OfflineComponentInstallFailedSilent 0')).toBeLessThan(
+      failureBlock.indexOf('MessageBox MB_OK|MB_ICONSTOP'),
+    );
+    expect(failureBlock).toContain('SetErrorLevel 1');
   });
 
   test('records optional local inference intent without downloading in NSIS', () => {

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -98,6 +98,17 @@ describe('NSIS offline resource and local inference flow', () => {
     );
     expect(installerScript).toContain('Get-ChildItem -Path "$INSTDIR.old*"');
   });
+
+  test('detaches expanded runtime caches before deleting them asynchronously', () => {
+    const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
+    const uninstallBlock = installerScript.slice(installerScript.indexOf('!macro customUnInstall'));
+
+    expect(uninstallBlock).toContain('StrCpy $3 "$LOCALAPPDATA\\ZhiYuanAgent\\runtimes"');
+    expect(uninstallBlock).toContain('StrCpy $4 "$3.uninstall.$4"');
+    expect(uninstallBlock).toContain('Rename "$3" "$4"');
+    expect(uninstallBlock).toContain('cmd /d /c rd /s /q "$4"');
+    expect(uninstallBlock).not.toContain('Remove-Item -LiteralPath $$runtimeRoot -Recurse -Force');
+  });
 });
 
 describe('NSIS visual assets', () => {

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -153,6 +153,10 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(uninstallBlock).toContain('Rename "$3" "$4"');
     expect(uninstallBlock).toContain('cmd /d /c rd /s /q "$4"');
     expect(uninstallBlock).not.toContain('Remove-Item -LiteralPath $$runtimeRoot -Recurse -Force');
+    expect(uninstallBlock).toContain('SetOutPath "$TEMP"');
+    expect(uninstallBlock.indexOf('SetOutPath "$TEMP"')).toBeLessThan(
+      uninstallBlock.indexOf("nsExec::ExecToLog 'powershell"),
+    );
   });
 
   test('waits for the spawned NSIS uninstaller to remove managed roots', () => {

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 
 const installerScriptPath = path.resolve('scripts/nsis-installer.nsh');
+const installerSmokeScriptPath = path.resolve('scripts/ci/windows-installer-smoke.ps1');
 const elevatedActionsScriptPath = path.resolve('scripts/nsis-elevated-actions.ps1');
 const offlineComponentsPath = path.resolve('scripts/nsis-offline-components.json');
 const brandAssetScriptPath = path.resolve('scripts/generate-nsis-brand-assets.cjs');
@@ -152,6 +153,19 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(uninstallBlock).toContain('Rename "$3" "$4"');
     expect(uninstallBlock).toContain('cmd /d /c rd /s /q "$4"');
     expect(uninstallBlock).not.toContain('Remove-Item -LiteralPath $$runtimeRoot -Recurse -Force');
+  });
+
+  test('waits for the spawned NSIS uninstaller to remove managed roots', () => {
+    const smokeScript = fs.readFileSync(installerSmokeScriptPath, 'utf8');
+
+    expect(smokeScript).toContain('function Wait-ForUninstallCompletion');
+    expect(smokeScript).toContain("$_.Name -like 'Un_*.exe'");
+    expect(smokeScript).toContain('Wait-ForUninstallCompletion $installRoot $runtimeRoot 300');
+    expect(
+      smokeScript.indexOf('Wait-ForUninstallCompletion $installRoot $runtimeRoot 300'),
+    ).toBeGreaterThan(
+      smokeScript.indexOf("Invoke-Installer $uninstallers[0].FullName 'uninstall'"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- embed the seven offline component routes as a validated JSON asset instead of incrementally constructing a routing file in NSIS
- make silent component failures return a non-zero exit instead of blocking forever on an invisible error dialog
- atomically detach expanded runtime caches during uninstall and reclaim them asynchronously
- add bounded, stage-specific smoke timeouts, progress diagnostics, and reliable failed-run artifact collection

## Confirmed root causes

- Run 31516866623 attempt 2 showed that all component archives expanded in about two minutes, then activation read `skill-python` as only `n` and looked for missing `component-n.version`.
- The installer correctly entered rollback, but `MessageBox MB_OK` blocked the unattended `/S` install for the rest of the timeout.
- The previous diagnostics path crossed workspace and user-profile roots, so upload-artifact rejected it.

## Validation

- `bun run test -- tests/nsis-installer.test.ts` (10 passed)
- `bun run lint`
- `bunx oxfmt --check scripts/nsis-offline-components.json scripts/ci/windows-installer-smoke.ps1 tests/nsis-installer.test.ts`
- NSIS 3.0.4.1 smoke compile with `-WX` covering custom install and uninstall macros
- workflow YAML parse
- `git diff --check`