### PR TITLE
Feat/fixbug

### DIFF
--- a/src/main/ipcHandlers/llamacpp.test.ts
+++ b/src/main/ipcHandlers/llamacpp.test.ts
@@ -1,6 +1,10 @@
 import { expect, test, vi } from 'vitest';
 
-import { LlamaCppRuntimeBackend, LlamaCppRuntimeCudaMajor } from '../../shared/llamacpp';
+import {
+  LlamaCppIpcChannel,
+  LlamaCppRuntimeBackend,
+  LlamaCppRuntimeCudaMajor,
+} from '../../shared/llamacpp';
 import { ProviderName } from '../../shared/providers/constants';
 import type { LlamaCppManager } from '../libs/llamacppManager';
 import {
@@ -413,6 +417,58 @@ test('does not refresh model capabilities for manager status events', async () =
 
   expect(listRunningModels).not.toHaveBeenCalled();
   expect(client).not.toHaveBeenCalled();
+});
+
+test('waits for runtime install cleanup before confirming cancellation', async () => {
+  electronMocks.handlers.clear();
+  let resolveInstall: ((value: { success: false; cancelled: true }) => void) | undefined;
+  let aborted = false;
+  const manager = {} as LlamaCppManager;
+  Object.assign(manager, {
+    on: vi.fn(() => manager),
+    installRuntime: vi.fn(({ signal }: { signal: AbortSignal }) =>
+      new Promise<{ success: false; cancelled: true }>(resolve => {
+        resolveInstall = resolve;
+        signal.addEventListener(
+          'abort',
+          () => {
+            aborted = true;
+          },
+          { once: true },
+        );
+      }),
+    ),
+  });
+  const store = {
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  };
+
+  registerLlamaCppIpcHandlers(manager, {
+    getStore: () => store as never,
+    syncOpenClawConfig: vi.fn(async () => ({ success: true })),
+  });
+
+  const installHandler = electronMocks.handlers.get(LlamaCppIpcChannel.Install);
+  const cancelHandler = electronMocks.handlers.get(LlamaCppIpcChannel.CancelRuntimeInstall);
+  if (!installHandler || !cancelHandler) throw new Error('Runtime install IPC handlers were not registered.');
+
+  const install = Promise.resolve(installHandler());
+  await Promise.resolve();
+  let cancelSettled = false;
+  const cancel = Promise.resolve(cancelHandler()).then(result => {
+    cancelSettled = true;
+    return result;
+  });
+  await Promise.resolve();
+
+  expect(aborted).toBe(true);
+  expect(cancelSettled).toBe(false);
+
+  resolveInstall?.({ success: false, cancelled: true });
+
+  await expect(cancel).resolves.toEqual({ success: true, cancelled: true });
+  await expect(install).resolves.toEqual({ success: false, cancelled: true });
 });
 
 test('computes total free VRAM from nvidia-smi snapshots', () => {

--- a/src/main/ipcHandlers/llamacpp.ts
+++ b/src/main/ipcHandlers/llamacpp.ts
@@ -382,9 +382,15 @@ export function registerLlamaCppIpcHandlers(
     runRuntimeInstall(signal => manager.installRuntime({ signal })),
   );
   ipcMain.handle(LlamaCppIpcChannel.CancelRuntimeInstall, async () => {
-    const cancelled = Boolean(runtimeInstallController && !runtimeInstallController.signal.aborted);
-    runtimeInstallController?.abort();
-    return { success: true as const, cancelled };
+    const controller = runtimeInstallController;
+    const install = activeRuntimeInstall;
+    if (!controller || controller.signal.aborted || !install) {
+      return { success: true as const, cancelled: false };
+    }
+
+    controller.abort();
+    const result = await install.catch((): RuntimeInstallResult | undefined => undefined);
+    return { success: true as const, cancelled: Boolean(result?.cancelled) };
   });
   ipcMain.handle(LlamaCppIpcChannel.UninstallRuntime, async () => manager.uninstallRuntime());
   ipcMain.handle(LlamaCppIpcChannel.ListRuntimeDevices, async (_event, input: unknown) => {

--- a/src/main/libs/llamacppBackendManager.ts
+++ b/src/main/libs/llamacppBackendManager.ts
@@ -571,6 +571,9 @@ export async function installLlamaCppBackend(input: {
   onProgress?: BackendInstallProgressReporter;
 }): Promise<LlamaCppRuntimeInstallResult> {
   const manifest = input.manifest ?? (await fetchLlamaCppBackendManifest());
+  if (input.signal?.aborted) {
+    return { ...failedInstall('Download cancelled.'), cancelled: true };
+  }
   const entry = findManifestEntry(manifest, input.ref);
   if (!entry) {
     return failedInstall(`llama.cpp backend is not available: ${input.ref.versionBackend}`);
@@ -639,9 +642,11 @@ export async function installLlamaCppBackend(input: {
       throw new Error(`Backend archive does not contain ${executableName}.`);
     }
 
+    throwIfDownloadCancelled(input.signal);
     fs.rmSync(backendDir, { recursive: true, force: true });
     fs.mkdirSync(getManagedBackendBinDir(backendDir), { recursive: true });
     copyDirectoryContents(path.dirname(extractedExecutable), getManagedBackendBinDir(backendDir));
+    throwIfDownloadCancelled(input.signal);
 
     for (const companion of entry.companions ?? []) {
       reportProgress({ phase: 'downloading' });
@@ -667,8 +672,10 @@ export async function installLlamaCppBackend(input: {
         findRuntimePayloadDirectory(companionExtractDir),
         getManagedBackendBinDir(backendDir),
       );
+      throwIfDownloadCancelled(input.signal);
     }
 
+    throwIfDownloadCancelled(input.signal);
     reportProgress({ phase: 'detecting', message: 'verifying' });
     const installedExecutablePath = getLlamaCppBackendExecutablePath(
       input.runtimeRoot,
@@ -680,6 +687,7 @@ export async function installLlamaCppBackend(input: {
     }
     if (input.platform !== 'win32') fs.chmodSync(installedExecutablePath, 0o755);
 
+    throwIfDownloadCancelled(input.signal);
     writeBackendBuildInfo(backendDir, {
       ...input.ref,
       target: input.ref.backend,
@@ -690,6 +698,7 @@ export async function installLlamaCppBackend(input: {
       cudaMajor: entry.cudaMajor,
       installedAt: new Date().toISOString(),
     });
+    throwIfDownloadCancelled(input.signal);
     if (input.switchCurrent !== false) syncCurrentBackend(input.runtimeRoot, input.ref);
     // Retain partial archives for a failed or cancelled resumable download, but
     // do not keep completed archives after the backend is installed.

--- a/src/main/libs/resumableDownload.test.ts
+++ b/src/main/libs/resumableDownload.test.ts
@@ -16,6 +16,52 @@ afterEach(() => {
 });
 
 describe('resumable runtime download', () => {
+  test('cancels an in-flight resume preflight before it starts a download', async () => {
+    let notifyHeadRequest: (() => void) | undefined;
+    let closeHeadRequest: (() => void) | undefined;
+    let getRequests = 0;
+    const server = http.createServer((request, response) => {
+      if (request.method === 'HEAD') {
+        notifyHeadRequest?.();
+        response.once('close', () => closeHeadRequest?.());
+        return;
+      }
+      getRequests += 1;
+      response.statusCode = 500;
+      response.end();
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Test server failed to start.');
+
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-resume-preflight-test-'));
+    temporaryDirectories.push(directory);
+    const outputPath = path.join(directory, 'runtime.zip');
+    fs.writeFileSync(outputPath, Buffer.alloc(1));
+    const controller = new AbortController();
+    const headRequestReceived = new Promise<void>(resolve => {
+      notifyHeadRequest = resolve;
+    });
+    const headRequestClosed = new Promise<void>(resolve => {
+      closeHeadRequest = resolve;
+    });
+    const download = downloadFileWithResume({
+      url: `http://127.0.0.1:${address.port}/runtime.zip`,
+      outputPath,
+      signal: controller.signal,
+    });
+
+    try {
+      await headRequestReceived;
+      controller.abort();
+      await expect(download).rejects.toBeInstanceOf(DownloadCancelledError);
+      await headRequestClosed;
+      expect(getRequests).toBe(0);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
   test('keeps a cancelled partial file and resumes it with Range', async () => {
     const bytes = Buffer.alloc(512 * 1024, 7);
     const ranges: Array<string | undefined> = [];

--- a/src/main/libs/resumableDownload.ts
+++ b/src/main/libs/resumableDownload.ts
@@ -23,14 +23,14 @@ export async function downloadFileWithResume(input: {
   throwIfDownloadCancelled(input.signal);
   const outputDir = path.dirname(input.outputPath);
   fs.mkdirSync(outputDir, { recursive: true });
-  if (
-    typeof input.expectedSize === 'number' &&
-    fs.existsSync(input.outputPath) &&
-    fs.statSync(input.outputPath).size === input.expectedSize
-  ) {
-    input.onProgress?.(input.expectedSize, input.expectedSize, undefined);
-    return;
+  let resumeState: Awaited<ReturnType<typeof getResumeState>>;
+  try {
+    resumeState = await getResumeState(input);
+  } catch (error) {
+    if (input.signal?.aborted) throw new DownloadCancelledError();
+    throw error;
   }
+  if (resumeState === 'complete') return;
 
   const downloader = new DownloaderHelper(input.url, outputDir, {
     fileName: path.basename(input.outputPath),
@@ -38,7 +38,9 @@ export async function downloadFileWithResume(input: {
     override: true,
     removeOnStop: false,
     removeOnFail: false,
-    resumeIfFileExists: true,
+    // Resume explicitly below. The helper's automatic resume path starts with
+    // an internal HEAD request that cannot be aborted through AbortSignal.
+    resumeIfFileExists: false,
     resumeOnIncomplete: true,
     resumeOnIncompleteMaxRetry: 3,
     retry: { maxRetries: 3, delay: 1000 },
@@ -60,12 +62,30 @@ export async function downloadFileWithResume(input: {
   });
   downloader.on('error', (): void => undefined);
 
+  let stopPromise: Promise<void> | undefined;
+  const stopDownloader = (): Promise<void> => {
+    stopPromise ??= downloader.stop().then(
+      (): void => undefined,
+      (): void => undefined,
+    );
+    return stopPromise;
+  };
+
+  let rejectAbort: ((error: DownloadCancelledError) => void) | undefined;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
   const cancel = () => {
-    void downloader.stop().catch((): void => undefined);
+    void stopDownloader().finally(() => {
+      rejectAbort?.(new DownloadCancelledError());
+    });
   };
   input.signal?.addEventListener('abort', cancel, { once: true });
   try {
-    await downloader.start();
+    const download = resumeState
+      ? downloader.resumeFromFile(input.outputPath, resumeState)
+      : downloader.start();
+    await Promise.race([download, abortPromise]);
     throwIfDownloadCancelled(input.signal);
   } catch (error) {
     if (input.signal?.aborted) throw new DownloadCancelledError();
@@ -73,4 +93,49 @@ export async function downloadFileWithResume(input: {
   } finally {
     input.signal?.removeEventListener('abort', cancel);
   }
+}
+
+async function getResumeState(input: {
+  url: string;
+  outputPath: string;
+  expectedSize?: number;
+  signal?: AbortSignal;
+  onProgress?: (completed: number, total?: number, speed?: number) => void;
+}): Promise<
+  | 'complete'
+  | {
+      downloaded: number;
+      fileName: string;
+      total: number;
+    }
+  | undefined
+> {
+  if (!fs.existsSync(input.outputPath)) return undefined;
+
+  const downloaded = fs.statSync(input.outputPath).size;
+  let total = input.expectedSize;
+  if (total === undefined) {
+    const response = await fetch(input.url, {
+      method: 'HEAD',
+      headers: { 'User-Agent': 'ZhiYuanAgent/llamacpp-backend-manager' },
+      signal: input.signal,
+    });
+    if (!response.ok) throw new Error(`Failed to determine download size: ${response.status}.`);
+    const contentLength = Number(response.headers.get('content-length'));
+    total = Number.isFinite(contentLength) && contentLength > 0 ? contentLength : undefined;
+  }
+  throwIfDownloadCancelled(input.signal);
+
+  if (total === undefined) return undefined;
+  if (downloaded === total) {
+    input.onProgress?.(total, total, undefined);
+    return 'complete';
+  }
+  if (downloaded <= 0 || downloaded > total) return undefined;
+
+  return {
+    downloaded,
+    fileName: path.basename(input.outputPath),
+    total,
+  };
 }

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -1,7 +1,19 @@
 import { Button } from '@shared/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@shared/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@shared/components/ui/dropdown-menu';
 import { LayeredTabsContent } from '@shared/components/ui/layered-tabs';
 import { Tabs } from '@shared/components/ui/tabs';
-import { Globe, PanelLeft, Pencil, Settings2 } from 'lucide-react';
+import { Cpu, FolderOpen, Globe, PanelLeft, Pencil, Settings2 } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
@@ -126,8 +138,12 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
   const [activeTab, setActiveTab] = useState<LocalInferenceTab>(
     restoredSession?.activeTab ?? 'models',
   );
+  const [runtimeSettingsOpen, setRuntimeSettingsOpen] = useState(Boolean(installRequestId));
   useEffect(() => {
-    if (installRequestId) setActiveTab('models');
+    if (installRequestId) {
+      setActiveTab('models');
+      setRuntimeSettingsOpen(true);
+    }
   }, [installRequestId]);
   const [tabDirection, setTabDirection] = useState(1);
   const [status, setStatus] = useState<OllamaStatusSnapshot | null>(cachedStatus);
@@ -992,33 +1008,41 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
               }
             >
               {activeTab === 'models' ? (
-                <RuntimeInstallCard installRequestId={installRequestId} />
-              ) : null}
-              {activeTab === 'models' ? (
                 <div className="flex flex-wrap items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className={localInferenceCompactButtonClass}
-                    size="sm"
-                    onClick={openAccessSettings}
-                  >
-                    <Globe data-icon="inline-start" />
-                    {i18nService.t('localInferenceAccessSettings')}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className={localInferenceCompactButtonClass}
-                    size="sm"
-                    onClick={() => {
-                      setDraftModelsDir(modelsDir);
-                      setLibrarySettingsOpen(true);
-                    }}
-                  >
-                    <Settings2 data-icon="inline-start" />
-                    {i18nService.t('localInferenceLibrarySettings')}
-                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className={`${localInferenceCompactButtonClass} min-w-32 hover:bg-background dark:hover:bg-background`}
+                          size="default"
+                        >
+                          <Settings2 data-icon="inline-start" />
+                          {i18nService.t('localInferenceSettings')}
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent align="end" className="min-w-32">
+                      <DropdownMenuItem onClick={() => setRuntimeSettingsOpen(true)}>
+                        <Cpu data-icon="inline-start" />
+                        {i18nService.t('localInferenceRuntimeSettings')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={openAccessSettings}>
+                        <Globe data-icon="inline-start" />
+                        {i18nService.t('localInferenceAccessMenuItem')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setDraftModelsDir(modelsDir);
+                          setLibrarySettingsOpen(true);
+                        }}
+                      >
+                        <FolderOpen data-icon="inline-start" />
+                        {i18nService.t('localInferenceLibraryMenuItem')}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               ) : null}
 
@@ -1088,6 +1112,15 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
           />
         </div>
       </Tabs>
+
+      <Dialog open={runtimeSettingsOpen} onOpenChange={setRuntimeSettingsOpen}>
+        <DialogContent className="w-[min(48rem,calc(100%-2rem))] max-h-[85vh] gap-4 overflow-y-auto sm:max-w-2xl">
+          <DialogHeader className="gap-1 pr-8">
+            <DialogTitle>{i18nService.t('localInferenceRuntimeSettings')}</DialogTitle>
+          </DialogHeader>
+          <RuntimeInstallCard installRequestId={installRequestId} />
+        </DialogContent>
+      </Dialog>
 
       <ModelLibrarySettingsModal
         isOpen={librarySettingsOpen}

--- a/src/renderer/components/localInference/components/BreathingDot.module.css
+++ b/src/renderer/components/localInference/components/BreathingDot.module.css
@@ -1,0 +1,50 @@
+.dot {
+  position: relative;
+  display: inline-block;
+  flex: 0 0 auto;
+  width: var(--dot-size);
+  height: var(--dot-size);
+  border-radius: 50%;
+  background: var(--dot-color);
+  box-shadow: 0 0 4px var(--dot-color);
+}
+
+.dot::before {
+  position: absolute;
+  inset: 0;
+  content: '';
+  border-radius: inherit;
+  background: var(--dot-color);
+  animation: breathe var(--dot-duration) ease-in-out infinite;
+  pointer-events: none;
+}
+
+.dot[data-active='false'] {
+  opacity: 0.45;
+  filter: saturate(0.4);
+}
+
+.dot[data-active='false']::before {
+  display: none;
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 0.55;
+    transform: scale(2);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot::before {
+    animation: none;
+    opacity: 0.25;
+    transform: scale(1.4);
+  }
+}

--- a/src/renderer/components/localInference/components/BreathingDot.tsx
+++ b/src/renderer/components/localInference/components/BreathingDot.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties, HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+
+import styles from './BreathingDot.module.css';
+
+interface BreathingDotProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+  color?: string;
+  size?: number;
+  duration?: number;
+  active?: boolean;
+  label?: string;
+}
+
+type DotStyle = CSSProperties & {
+  '--dot-color': string;
+  '--dot-size': string;
+  '--dot-duration': string;
+};
+
+export const BreathingDot = forwardRef<HTMLSpanElement, BreathingDotProps>(
+  function BreathingDot(
+    {
+      color = 'var(--zy-success)',
+      size = 10,
+      duration = 2,
+      active = true,
+      label,
+      className,
+      style,
+      ...props
+    },
+    ref,
+  ) {
+    const dotStyle: DotStyle = {
+      ...style,
+      '--dot-color': color,
+      '--dot-size': `${size}px`,
+      '--dot-duration': `${duration}s`,
+    };
+
+    return (
+      <span
+        ref={ref}
+        {...props}
+        className={`${styles.dot}${className ? ` ${className}` : ''}`}
+        data-active={active}
+        style={dotStyle}
+        role={label ? 'status' : undefined}
+        aria-label={label}
+        aria-hidden={label ? undefined : true}
+      />
+    );
+  },
+);
+
+BreathingDot.displayName = 'BreathingDot';

--- a/src/renderer/components/localInference/components/RuntimeInstallCard.tsx
+++ b/src/renderer/components/localInference/components/RuntimeInstallCard.tsx
@@ -1,7 +1,9 @@
 import { Button } from '@shared/components/ui/button';
+import { Button21st } from '@shared/components/ui/button-21st';
 import {
   Card,
   CardContent,
+  CardFooter,
   CardDescription,
   CardHeader,
   CardTitle,
@@ -14,7 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@shared/components/ui/select';
-import { CheckCircle2, Download, RotateCcw, X } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/components/ui/tooltip';
+import { Download, RotateCcw, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import type {
@@ -24,10 +27,15 @@ import type {
 } from '../../../../shared/llamacpp';
 import { i18nService } from '../../../services/i18n';
 import { InstallProgressBar } from './Common';
+import { BreathingDot } from './BreathingDot';
 import { formatBytes, formatInstallProgressSummary } from '../utils/progress';
 
 const RUNTIME_PROGRESS_KEY = '__llamacpp_runtime__';
 const handledInstallerRequests = new Set<string>();
+
+function formatCompactBytes(value: number): string {
+  return formatBytes(value).replace(' ', '');
+}
 
 type RuntimeInstallCardProps = {
   installRequestId?: string;
@@ -53,10 +61,7 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
   const [status, setStatus] = useState<LlamaCppStatusSnapshot | null>(null);
   const [progress, setProgress] = useState<LlamaCppInstallProgress | null>(null);
   const [error, setError] = useState<string>();
-  const [resolvedDownloadSize, setResolvedDownloadSize] = useState<{
-    backendKey: string;
-    sizeBytes?: number;
-  }>();
+  const [resolvedDownloadSizes, setResolvedDownloadSizes] = useState<Record<string, number>>({});
   const active = isActive(progress);
   const cancellable = canCancel(progress);
 
@@ -91,18 +96,14 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
   }, []);
 
   const loadDownloadSize = useCallback(async (backend: LlamaCppBackendInfo): Promise<void> => {
-    if (backend.downloadSizeBytes !== undefined) {
-      setResolvedDownloadSize({
-        backendKey: backend.versionBackend,
-        sizeBytes: backend.downloadSizeBytes,
-      });
-      return;
-    }
-    const result = await window.electron.llamacpp.getBackendDownloadSize(backend);
-    setResolvedDownloadSize({
-      backendKey: backend.versionBackend,
-      sizeBytes: result.success ? result.sizeBytes : undefined,
-    });
+    const sizeBytes =
+      backend.downloadSizeBytes ??
+      (await window.electron.llamacpp.getBackendDownloadSize(backend)).sizeBytes;
+    if (sizeBytes === undefined) return;
+    setResolvedDownloadSizes(current => ({
+      ...current,
+      [backend.versionBackend]: sizeBytes,
+    }));
   }, []);
 
   const startInstall = useCallback(
@@ -169,24 +170,28 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
   }, [installRequestId, loadMetadata, startInstall]);
 
   useEffect(() => {
-    if (!selectedBackend) return;
-    void loadDownloadSize(selectedBackend);
-  }, [loadDownloadSize, selectedBackend]);
+    if (backends.length === 0) return;
+    void Promise.all(backends.map(backend => loadDownloadSize(backend)));
+  }, [backends, loadDownloadSize]);
 
   const summary = progress ? formatInstallProgressSummary(progress) : null;
   const ready = isInstalled(status);
-  const backendLabel =
-    selectedBackend?.versionBackend ?? i18nService.t('localInferenceBackendNone');
-  const selectedDownloadSize =
-    selectedBackend?.downloadSizeBytes ??
-    (resolvedDownloadSize?.backendKey === selectedBackend?.versionBackend
-      ? resolvedDownloadSize?.sizeBytes
-      : undefined);
-  const sizeLabel = selectedDownloadSize
-    ? i18nService
-        .t('localInferenceRuntimeDownloadSize')
-        .replace('{size}', formatBytes(selectedDownloadSize))
-    : i18nService.t('localInferenceRuntimeDownloadSizeUnknown');
+  const serviceRunning = status?.status === 'running';
+  const serviceProgramAvailable = ready || Boolean(status?.executablePath);
+  const serviceStatusLabel = serviceRunning
+    ? i18nService.t('localInferenceRuntimeServiceRunning')
+    : serviceProgramAvailable
+      ? i18nService.t('localInferenceRuntimeServiceNotRunning')
+      : i18nService.t('localInferenceRuntimeServiceUnavailable');
+  const serviceStatusColor = serviceRunning
+    ? 'var(--zy-success)'
+    : serviceProgramAvailable
+      ? 'var(--zy-warning)'
+      : 'var(--zy-text-muted)';
+  const runtimeBackendLabel =
+    status?.versionBackend?.trim() ||
+    selectedBackend?.versionBackend ||
+    i18nService.t('localInferenceBackendNone');
 
   const cancelInstall = async () => {
     setProgress(current => ({
@@ -197,82 +202,117 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
   };
 
   return (
-    <Card className="gap-3 border-primary/20 bg-primary/[0.03]">
-      <CardHeader className="grid-cols-[1fr_auto] px-0">
+    <Card className="relative gap-2 border-primary/20 bg-primary/[0.03]">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <span className="absolute right-4 top-4 inline-flex">
+              <BreathingDot color={serviceStatusColor} duration={2} label={serviceStatusLabel} />
+            </span>
+          }
+        />
+        <TooltipContent side="bottom" align="end">
+          {serviceStatusLabel}
+        </TooltipContent>
+      </Tooltip>
+      <CardHeader className="gap-3 px-0">
         <div className="min-w-0">
           <CardTitle className="flex items-center gap-2">
-            {ready ? (
-              <CheckCircle2 className="size-4 text-emerald-500" />
-            ) : (
+            {!ready ? (
               <Download className="size-4" />
-            )}
+            ) : null}
             {i18nService.t('localInferenceRuntimeCardTitle')}
           </CardTitle>
-          <CardDescription className="mt-1">
-            {ready
-              ? i18nService.t('localInferenceRuntimeReady')
-              : i18nService.t('localInferenceRuntimeCardDescription')}
-          </CardDescription>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="-mx-4 w-auto px-1.5">
           <Select
             value={selectedKey}
             onValueChange={value => setSelectedKey(value ?? '')}
             disabled={active || backends.length === 0}
           >
-            <SelectTrigger className="max-w-64">
+            <SelectTrigger className="w-full">
               <SelectValue placeholder={i18nService.t('localInferenceBackendNone')} />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent
+              alignItemWithTrigger={false}
+              side="bottom"
+              sideOffset={4}
+              collisionAvoidance={{
+                side: 'none',
+                align: 'shift',
+                fallbackAxisSide: 'none',
+              }}
+            >
               <SelectGroup>
-                {backends.map(backend => (
-                  <SelectItem key={backend.versionBackend} value={backend.versionBackend}>
-                    {backend.versionBackend}
-                    {backend.recommended
-                      ? ` · ${i18nService.t('localInferenceBackendRecommendedLabel')}`
-                      : ''}
-                  </SelectItem>
-                ))}
+                {backends.map(backend => {
+                  const downloadSize =
+                    backend.downloadSizeBytes ?? resolvedDownloadSizes[backend.versionBackend];
+                  return (
+                    <SelectItem key={backend.versionBackend} value={backend.versionBackend}>
+                      {backend.versionBackend}
+                      {downloadSize !== undefined
+                        ? ` · ${formatCompactBytes(downloadSize)}`
+                        : ''}
+                      {backend.recommended ? (
+                        <>
+                          <span> · </span>
+                          <span className="font-semibold text-foreground">
+                            {i18nService.t('localInferenceBackendRecommendedLabel')}
+                          </span>
+                        </>
+                      ) : null}
+                    </SelectItem>
+                  );
+                })}
               </SelectGroup>
             </SelectContent>
           </Select>
-          {active && cancellable ? (
-            <Button type="button" variant="outline" size="sm" onClick={() => void cancelInstall()}>
-              <X data-icon="inline-start" />
-              {i18nService.t('cancel')}
-            </Button>
-          ) : active ? (
-            <Button type="button" variant="outline" size="sm" disabled>
-              {i18nService.t('localInferenceRuntimeInstalling')}
-            </Button>
-          ) : (
-            <Button type="button" variant="outline" size="sm" onClick={() => void startInstall()}>
-              {error ? (
-                <RotateCcw data-icon="inline-start" />
-              ) : (
-                <Download data-icon="inline-start" />
-              )}
-              {error
-                ? i18nService.t('localInferenceRuntimeRetry')
-                : i18nService.t('localInferenceBackendUpdate')}
-            </Button>
-          )}
         </div>
       </CardHeader>
-      <CardContent className="space-y-2 px-0">
-        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span>{backendLabel}</span>
-          <span>{sizeLabel}</span>
-        </div>
-        {progress ? <InstallProgressBar progress={progress} /> : null}
-        {summary ? (
-          <div className="text-xs text-muted-foreground">
-            {summary.phase ? `${summary.phase} · ` : ''}
-            {summary.primary}
-          </div>
-        ) : null}
-        {error ? <div className="text-xs text-destructive">{error}</div> : null}
-      </CardContent>
+      {progress || summary || error ? (
+        <CardContent className="space-y-2 px-0">
+          {progress ? <InstallProgressBar progress={progress} /> : null}
+          {summary ? (
+            <div className="text-xs text-muted-foreground">
+              {summary.phase ? `${summary.phase} · ` : ''}
+              {summary.primary}
+            </div>
+          ) : null}
+          {error ? <div className="text-xs text-destructive">{error}</div> : null}
+        </CardContent>
+      ) : null}
+      <CardFooter className="justify-between border-0 bg-transparent p-0 pb-2">
+        <CardDescription>
+          {ready
+            ? i18nService
+                .t('localInferenceRuntimeReadyWithBackend')
+                .replace('{backend}', runtimeBackendLabel)
+            : i18nService.t('localInferenceRuntimeNotInstalledMessage')}
+        </CardDescription>
+        {active && cancellable ? (
+          <Button type="button" variant="outline" size="sm" onClick={() => void cancelInstall()}>
+            <X data-icon="inline-start" />
+            {i18nService.t('cancel')}
+          </Button>
+        ) : active ? (
+          <Button type="button" variant="outline" size="sm" disabled>
+            {i18nService.t('localInferenceRuntimeInstalling')}
+          </Button>
+        ) : (
+          <Button21st
+            type="button"
+            variant="primary"
+            size="sm"
+            className="-mr-2.5 h-8 min-w-16 px-3"
+            onClick={() => void startInstall()}
+          >
+            {error ? <RotateCcw data-icon="inline-start" /> : <Download data-icon="inline-start" />}
+            {error
+              ? i18nService.t('localInferenceRuntimeRetry')
+              : i18nService.t('localInferenceBackendUpdate')}
+          </Button21st>
+        )}
+      </CardFooter>
     </Card>
   );
 }

--- a/src/renderer/components/localInference/components/RuntimeInstallCard.tsx
+++ b/src/renderer/components/localInference/components/RuntimeInstallCard.tsx
@@ -152,6 +152,8 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
         setProgress(nextProgress);
         if (nextProgress.phase === 'failed') {
           setError(nextProgress.error || i18nService.t('localInferenceRuntimeMissing'));
+        } else if (nextProgress.phase === 'cancelled') {
+          setError(undefined);
         } else if (nextProgress.phase === 'done') {
           setError(undefined);
         }
@@ -198,7 +200,14 @@ export function RuntimeInstallCard({ installRequestId }: RuntimeInstallCardProps
       ...(current ?? { modelId: RUNTIME_PROGRESS_KEY }),
       phase: 'cancelling',
     }));
-    await window.electron.llamacpp.cancelRuntimeInstall();
+    const result = await window.electron.llamacpp.cancelRuntimeInstall();
+    if (!result.cancelled) {
+      setProgress(current =>
+        current?.phase === 'cancelling'
+          ? { ...current, phase: 'cancelled' }
+          : current,
+      );
+    }
   };
 
   return (

--- a/src/renderer/components/localInference/panels/ModelsPanel.tsx
+++ b/src/renderer/components/localInference/panels/ModelsPanel.tsx
@@ -20,7 +20,6 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from '@shared/component
 import { Spinner } from '@shared/components/ui/spinner';
 import { cn } from '@shared/lib/utils';
 import { ArrowRight, Box, Clock3, Ellipsis, Settings2, Trash2 } from 'lucide-react';
-import { motion, useReducedMotion } from 'motion/react';
 import {
   type ComponentType,
   type CSSProperties,
@@ -90,9 +89,7 @@ const MODEL_PAGE_GRID_COLUMNS_WITH_SINGLE_COLUMN_LOG = 1;
 const MODEL_CARD_MIN_WIDTH = 280;
 const MODEL_GRID_COLUMN_GAP = 12;
 const MODEL_GRID_TWO_COLUMN_MIN_WIDTH = MODEL_CARD_MIN_WIDTH * 2 + MODEL_GRID_COLUMN_GAP;
-const modelCardActionClassName =
-  'relative z-20 transition-[opacity,transform] duration-200 ease-out group-hover/card:translate-x-0 group-hover/card:opacity-100 group-hover/card:pointer-events-auto';
-const modelCardHiddenActionClassName = 'pointer-events-none translate-x-1 opacity-0';
+const modelCardActionClassName = 'relative z-20';
 type ModelCardTag = {
   label: string;
 };
@@ -458,10 +455,6 @@ function ModelCard({
   onOpenLaunchLog,
 }: ModelCardProps) {
   const isRunning = Boolean(runningModel);
-  const reduceMotion = useReducedMotion();
-  const hoverTransition = reduceMotion
-    ? { duration: 0 }
-    : { duration: 0.2, ease: [0.16, 1, 0.3, 1] as const };
   const buttonsDisabled = loading || unloading;
   const displayName = getModelDisplayName(model.name);
   const provider = resolveLocalModelProvider(model);
@@ -480,15 +473,9 @@ function ModelCard({
   };
 
   return (
-    <motion.div
+    <div
       data-local-inference-model-card-frame="true"
-      className="relative h-full w-full transform-gpu"
-      whileHover={
-        reduceMotion || loadingModel || unloading || dragging
-          ? undefined
-          : { scale: 1.02, zIndex: 1 }
-      }
-      transition={{ scale: hoverTransition }}
+      className="relative z-0 h-full w-full rounded-xl transition-[box-shadow,z-index] duration-200 hover:z-20 hover:shadow-xl hover:shadow-foreground/20 focus-within:z-20"
     >
       <Card
         size="sm"
@@ -641,7 +628,6 @@ function ModelCard({
           <div
             className={cn(
               modelCardActionClassName,
-              !isRunning && modelCardHiddenActionClassName,
               'absolute bottom-4 right-4',
             )}
           >
@@ -675,7 +661,7 @@ function ModelCard({
           </div>
         </CardHeader>
       </Card>
-    </motion.div>
+    </div>
   );
 }
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -6,6 +6,15 @@ export type LanguageType = 'zh' | 'en';
 // 语言文本映射
 const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
+    localInferenceSettings: '本地模型设置',
+    localInferenceRuntimeSettings: '运行环境',
+    localInferenceAccessMenuItem: '访问',
+    localInferenceLibraryMenuItem: '模型库',
+    localInferenceRuntimeReadyWithBackend: '当前版本：{backend}',
+    localInferenceRuntimeNotInstalledMessage: '未安装本地推理引擎',
+    localInferenceRuntimeServiceRunning: '服务运行中',
+    localInferenceRuntimeServiceNotRunning: '服务程序已安装但未运行',
+    localInferenceRuntimeServiceUnavailable: '未安装本地推理服务程序',
     coworkQueueTitle: '\u5f85\u5904\u7406\u6d88\u606f',
     coworkQueueCount: '{count} \u6761\u5f85\u5904\u7406\u6d88\u606f',
     coworkQueueEmpty: '\u961f\u5217\u4e3a\u7a7a',
@@ -2853,6 +2862,15 @@ const translations: Record<LanguageType, Record<string, string>> = {
     emailDeleting: '删除中...',
   },
   en: {
+    localInferenceSettings: 'Local Settings',
+    localInferenceRuntimeSettings: 'Runtime',
+    localInferenceAccessMenuItem: 'Access',
+    localInferenceLibraryMenuItem: 'Model Library',
+    localInferenceRuntimeReadyWithBackend: 'Current version: {backend}',
+    localInferenceRuntimeNotInstalledMessage: 'The local inference engine is not installed.',
+    localInferenceRuntimeServiceRunning: 'Service is running',
+    localInferenceRuntimeServiceNotRunning: 'Service is installed but not running',
+    localInferenceRuntimeServiceUnavailable: 'The local inference service is not installed',
     coworkQueueTitle: 'Pending messages',
     coworkQueueCount: '{count} pending',
     coworkQueueEmpty: 'Queue is empty',


### PR DESCRIPTION
## 概要

  修复本地推理服务驱动下载过程中，点击取消后下载任务仍可能继续执行的问题。

  ## 关联问题

  修复 #（待填写）

  ## 修改内容

  - 调整可恢复下载逻辑，使取消信号可中断预请求、下载流和断点续传流程。
  - 取消操作等待下载器和安装任务完成清理后，再向前端确认取消结果。
  - 在驱动解压、复制、校验和切换当前驱动前增加取消检查。
  - 前端正确处理“已取消”状态，取消后恢复可安装状态。
  - 新增下载预请求取消与进程间通信等待清理的回归测试。
  - 修复取消链路中的两处 TypeScript 严格类型错误。

  ## 变更类型

  - [x] 缺陷修复
  - [ ] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## 测试

  - [x] 已本地测试
  - [x] 已新增测试
  - [ ] 已更新已有测试
  - [ ] 已手动测试界面

  已执行：

  - npm run build:tsc
  - npx vitest run src/main/libs/resumableDownload.test.ts src/main/ipcHandlers/llamacpp.test.ts
  - npm run lint
  - npm run build

  ## 截图

  不适用，本次为下载取消与进程间通信状态修复。

  ## 检查清单

  - [x] 代码遵循项目代码规范
  - [x] 已完成代码自检
  - [x] 已为复杂逻辑添加必要注释
  - [ ] 无需修改文档
  - [x] 未引入新的警告
  - [x] 已添加验证修复有效性的测试
  - [x] 新增和已有单元测试均已通过

  ## Electron 专项变更

  - [x] 修改主进程代码（src/main/）
  - [ ] 修改预加载脚本
  - [x] 修改进程间通信
  - [ ] 修改窗口管理
  - [ ] 无

  ## 补充说明

  取消后会保留已下载的部分文件，后续重新安装可继续断点续传；取消不会写入不完整驱动、完成标记或切换当前驱动。