### PR TITLE
feat(cowork): 待发消息队列携带附件与技能，用户气泡渲染图片预览

### DIFF
--- a/src/main/libs/agentEngine/piPendingMessageQueue.test.ts
+++ b/src/main/libs/agentEngine/piPendingMessageQueue.test.ts
@@ -40,6 +40,32 @@ describe('PiPendingMessageQueue', () => {
     expect(queue.takeNext('session-1', CoworkQueueDelivery.FollowUp)?.id).toBe(second.id);
   });
 
+  test('keeps queued attachment metadata through delivery and retry', () => {
+    const queue = new PiPendingMessageQueue();
+    const queued = queue.enqueue(
+      'session-1',
+      'review the attachments',
+      CoworkQueueDelivery.FollowUp,
+      [{ name: 'screen.png', mimeType: 'image/png', base64Data: 'image-data' }],
+      [{ name: 'brief.docx', path: '/tmp/brief.docx', extension: 'DOCX' }],
+      ['skill-docx'],
+      'Use the document skill.',
+    );
+
+    const taken = queue.takeNext('session-1', CoworkQueueDelivery.FollowUp);
+    expect(taken).toMatchObject({
+      id: queued.id,
+      imageAttachments: [{ name: 'screen.png' }],
+      fileAttachments: [{ name: 'brief.docx', extension: 'DOCX' }],
+    });
+
+    const restored = queue.restore('session-1', { ...taken!, error: 'retry' });
+    expect(restored.fileAttachments?.[0]?.path).toBe('/tmp/brief.docx');
+    expect(restored.imageAttachments?.[0]?.base64Data).toBe('image-data');
+    expect(restored.skillIds).toEqual(['skill-docx']);
+    expect(restored.skillPrompt).toBe('Use the document skill.');
+  });
+
   test('does not take an item through the wrong delivery path', () => {
     const queue = new PiPendingMessageQueue();
     const steer = queue.enqueue('session-1', 'steer', CoworkQueueDelivery.Steer);

--- a/src/main/libs/agentEngine/piPendingMessageQueue.ts
+++ b/src/main/libs/agentEngine/piPendingMessageQueue.ts
@@ -40,6 +40,10 @@ export class PiPendingMessageQueue {
     sessionId: string,
     text: string,
     delivery: CoworkQueueDeliveryType = CoworkQueueDelivery.FollowUp,
+    imageAttachments?: CoworkPendingMessage['imageAttachments'],
+    fileAttachments?: CoworkPendingMessage['fileAttachments'],
+    skillIds?: CoworkPendingMessage['skillIds'],
+    skillPrompt?: CoworkPendingMessage['skillPrompt'],
   ): CoworkPendingMessage {
     const item: CoworkPendingMessage = {
       id: randomUUID(),
@@ -47,6 +51,10 @@ export class PiPendingMessageQueue {
       delivery,
       createdAt: Date.now(),
       status: CoworkQueueItemStatus.Pending,
+      ...(imageAttachments?.length ? { imageAttachments } : {}),
+      ...(fileAttachments?.length ? { fileAttachments } : {}),
+      ...(skillIds?.length ? { skillIds } : {}),
+      ...(skillPrompt ? { skillPrompt } : {}),
     };
     const items = this.itemsBySession.get(sessionId) ?? [];
     items.push(item);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -2678,7 +2678,9 @@ describe('PiRuntimeAdapter', () => {
 
       const steered = await adapter.steerPendingMessage('queue-session', queued.item!.id);
       expect(steered.success).toBe(true);
-      expect(mockSession.steer).toHaveBeenCalledWith('Change direction');
+      expect(mockSession.prompt).toHaveBeenCalledWith('Change direction', {
+        streamingBehavior: 'steer',
+      });
       expect(adapter.listPendingMessages('queue-session')).toEqual([]);
     });
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1539,6 +1539,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   enqueuePendingMessage(
     sessionId: string,
     text: string,
+    imageAttachments?: PiContinueOptions['imageAttachments'],
+    fileAttachments?: PiContinueOptions['fileAttachments'],
+    skillIds?: string[],
+    skillPrompt?: string,
   ): { success: boolean; item?: CoworkPendingMessage; error?: string } {
     const active = this.activeSessions.get(sessionId);
     if (!this.isWorkSession(sessionId, active)) {
@@ -1553,6 +1557,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       sessionId,
       normalizedText,
       CoworkQueueDelivery.FollowUp,
+      imageAttachments,
+      fileAttachments,
+      skillIds,
+      skillPrompt,
     );
     this.emitQueueUpdated(sessionId);
     return { success: true, item };
@@ -1602,8 +1610,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     if (!item) return { success: false, error: 'Pending message was not found.' };
     this.emitQueueUpdated(sessionId);
     try {
-      await active.piSession.steer(item.text);
-      this.persistQueuedUserMessage(sessionId, item.text, CoworkQueueDelivery.Steer);
+      await sendPiPrompt(
+        active.piSession,
+        item.skillPrompt ? `${item.skillPrompt}\n\n${item.text}` : item.text,
+        item.imageAttachments,
+        active.capabilities,
+        'steer',
+      );
+      this.persistQueuedUserMessage(sessionId, item, CoworkQueueDelivery.Steer);
       active.isRunning = true;
       this.pendingMessageQueue.finishDelivery(item.id);
       return { success: true, item };
@@ -1635,6 +1649,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionMode: CoworkSessionMode.Work,
         _queueDelivery: CoworkQueueDelivery.FollowUp,
         _streamingBehavior: 'followUp',
+        imageAttachments: item.imageAttachments,
+        fileAttachments: item.fileAttachments,
+        skillIds: item.skillIds,
       });
       this.pendingMessageQueue.finishDelivery(item.id);
       return { success: true, item };
@@ -1653,15 +1670,20 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   private persistQueuedUserMessage(
     sessionId: string,
-    text: string,
+    item: CoworkPendingMessage,
     delivery: CoworkQueueDelivery,
   ): CoworkMessage {
     const message: CoworkMessage = {
       id: randomUUID(),
       type: 'user',
-      content: text,
+      content: item.text,
       timestamp: Date.now(),
-      metadata: { queueDelivery: delivery },
+      metadata: {
+        queueDelivery: delivery,
+        ...(item.skillIds?.length ? { skillIds: item.skillIds } : {}),
+        ...(item.imageAttachments?.length ? { imageAttachments: item.imageAttachments } : {}),
+        ...(item.fileAttachments?.length ? { fileAttachments: item.fileAttachments } : {}),
+      },
     };
     const persisted = this.store ? this.store.addMessage(sessionId, message) : message;
     this.emit('message', sessionId, persisted);
@@ -1689,6 +1711,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           sessionMode: CoworkSessionMode.Work,
           _queueDelivery: CoworkQueueDelivery.FollowUp,
           _streamingBehavior: 'followUp',
+          imageAttachments: next.imageAttachments,
+          fileAttachments: next.fileAttachments,
+          skillIds: next.skillIds,
         });
         this.pendingMessageQueue.finishDelivery(next.id);
       } catch (error) {

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -76,7 +76,7 @@ export type PiStartOptions = {
   sessionMode?: 'work' | 'chat';
   goalMode?: boolean;
   imageAttachments?: PiImageAttachment[];
-  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+  fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
   agentId?: string;
   expertIds?: string[];
   modelOverride?: string;
@@ -97,7 +97,7 @@ export type PiContinueOptions = {
   sessionMode?: 'work' | 'chat';
   goalMode?: boolean;
   imageAttachments?: PiImageAttachment[];
-  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+  fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
   /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
   workspaceRoot?: string;
   agentId?: string;
@@ -137,6 +137,10 @@ export interface PiRuntime {
   enqueuePendingMessage(
     sessionId: string,
     text: string,
+    imageAttachments?: PiImageAttachment[],
+    fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>,
+    skillIds?: string[],
+    skillPrompt?: string,
   ): { success: boolean; item?: CoworkPendingMessage; error?: string };
   updatePendingMessage(
     sessionId: string,

--- a/src/main/libs/agentEngine/types.ts
+++ b/src/main/libs/agentEngine/types.ts
@@ -67,7 +67,7 @@ export type CoworkStartOptions = {
   /** Work-only: run the prompt as a long-horizon Goal loop. */
   goalMode?: boolean;
   imageAttachments?: CoworkImageAttachment[];
-  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+  fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
   agentId?: string;
   expertIds?: string[];
   modelOverride?: string;
@@ -85,7 +85,7 @@ export type CoworkContinueOptions = {
   /** Work-only: enable or keep the long-horizon Goal loop. */
   goalMode?: boolean;
   imageAttachments?: CoworkImageAttachment[];
-  fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+  fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
   /** Session snapshot used when the in-process runtime needs to recreate Pi state. */
   workspaceRoot?: string;
   agentId?: string;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -644,12 +644,28 @@ const sanitizeCoworkMessageForIpc = (message: unknown): unknown => {
   // and must not be truncated by the generic sanitizer).
   let sanitizedMetadata: unknown;
   if (messageRecord.metadata && typeof messageRecord.metadata === 'object') {
-    const { imageAttachments, ...rest } = messageRecord.metadata as Record<string, unknown>;
+    const { imageAttachments, fileAttachments, ...rest } = messageRecord.metadata as Record<string, unknown>;
     const sanitizedRest = sanitizeIpcPayload(rest) as Record<string, unknown> | undefined;
     sanitizedMetadata = {
       ...(sanitizedRest && typeof sanitizedRest === 'object' ? sanitizedRest : {}),
       ...(Array.isArray(imageAttachments) && imageAttachments.length > 0
         ? { imageAttachments }
+        : {}),
+      ...(Array.isArray(fileAttachments) && fileAttachments.length > 0
+        ? {
+            fileAttachments: fileAttachments
+              .filter(
+                (attachment): attachment is Record<string, unknown> =>
+                  Boolean(attachment) && typeof attachment === 'object',
+              )
+              .slice(0, IPC_MAX_ITEMS)
+              .map(attachment => ({
+                name: typeof attachment.name === 'string' ? attachment.name : '',
+                path: typeof attachment.path === 'string' ? attachment.path : '',
+                extension: typeof attachment.extension === 'string' ? attachment.extension : '',
+                ...(typeof attachment.isImage === 'boolean' ? { isImage: attachment.isImage } : {}),
+              })),
+          }
         : {}),
     };
   } else {
@@ -4348,7 +4364,7 @@ if (!gotTheLock) {
         expertIds?: string[];
         permissionMode?: CoworkPermissionMode;
         imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-        fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+        fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
       },
     ) => {
       try {
@@ -4490,7 +4506,14 @@ if (!gotTheLock) {
   ipcMain.handle(CoworkQueueIpc.Enqueue, async (_event, rawInput: unknown) => {
     try {
       const input = CoworkQueueEnqueueSchema.parse(rawInput);
-      return getPiRuntimeAdapter().enqueuePendingMessage(input.sessionId, input.text);
+      return getPiRuntimeAdapter().enqueuePendingMessage(
+        input.sessionId,
+        input.text,
+        input.imageAttachments,
+        input.fileAttachments,
+        input.skillIds,
+        input.skillPrompt,
+      );
     } catch (error) {
       return {
         success: false,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -455,7 +455,7 @@ contextBridge.exposeInMainWorld('electron', {
       modelOverride?: string;
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
     }) => ipcRenderer.invoke(CoworkSessionIpc.Start, options),
 
     continueSession: (options: {
@@ -467,11 +467,18 @@ contextBridge.exposeInMainWorld('electron', {
       expertIds?: string[];
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
     }) => ipcRenderer.invoke(CoworkSessionIpc.Continue, options),
 
     listPendingMessages: (sessionId: string) => ipcRenderer.invoke(CoworkQueueIpc.List, sessionId),
-    enqueuePendingMessage: (options: { sessionId: string; text: string }) =>
+    enqueuePendingMessage: (options: {
+      sessionId: string;
+      text: string;
+      imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
+      skillIds?: string[];
+      skillPrompt?: string;
+    }) =>
       ipcRenderer.invoke(CoworkQueueIpc.Enqueue, options),
     updatePendingMessage: (options: { sessionId: string; itemId: string; text: string }) =>
       ipcRenderer.invoke(CoworkQueueIpc.Update, options),

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -580,6 +580,13 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
             isImage: attachment.isImage,
             hasDataUrl: !!attachment.dataUrl,
           });
+          const dotIndex = attachment.name.lastIndexOf('.');
+          fileAtts.push({
+            name: attachment.name,
+            path: attachment.path,
+            extension: dotIndex >= 0 ? attachment.name.slice(dotIndex + 1).toUpperCase() : 'FILE',
+            isImage: true,
+          });
         } else {
           const dotIndex = attachment.name.lastIndexOf('.');
           fileAtts.push({
@@ -886,7 +893,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                   '[CoworkPromptInput] handleIncomingFiles: native image fallback to path-only (no dataUrl)',
                   { nativePath },
                 );
-                addAttachment(nativePath);
+                addAttachment(nativePath, { isImage: true });
               } else {
                 // No native path (clipboard/drag from browser):
                 // 1. Read as dataUrl for preview + base64 vision
@@ -941,13 +948,13 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
 
           // Non-image file or model doesn't support images: use original flow
           if (nativePath) {
-            addAttachment(nativePath);
+            addAttachment(nativePath, fileIsImage ? { isImage: true } : undefined);
             continue;
           }
 
           const stagedPath = await saveInlineFile(file);
           if (stagedPath) {
-            addAttachment(stagedPath);
+            addAttachment(stagedPath, fileIsImage ? { isImage: true } : undefined);
           }
         }
         if (hasImageWithoutVision) {
@@ -1007,7 +1014,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               hasImageWithoutVision = true;
             }
           }
-          addAttachment(filePath);
+          addAttachment(filePath, isImagePath(filePath) ? { isImage: true } : undefined);
         }
         if (hasImageWithoutVision) {
           setImageVisionHint(true);

--- a/src/renderer/components/cowork/CoworkView.queueAttachments.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkView.queueAttachments.structure.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./CoworkView.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('keeps both attachment kinds when a running Work session queues a prompt', () => {
+  const queueStart = source.indexOf('coworkQueueService.enqueue(');
+  const queueCall = source.slice(queueStart, source.indexOf(');', queueStart) + 2);
+
+  expect(queueCall).toContain('imageAttachments');
+  expect(queueCall).toContain('fileAttachments');
+  expect(queueCall).toContain('[...activeSkillIds]');
+  expect(queueCall).toContain('skillPrompt');
+});

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -901,7 +901,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       isStreaming &&
       (currentSession.mode ?? CoworkSessionMode.Work) === CoworkSessionMode.Work
     ) {
-      const result = await coworkQueueService.enqueue(currentSession.id, prompt);
+      const result = await coworkQueueService.enqueue(
+        currentSession.id,
+        prompt,
+        imageAttachments,
+        fileAttachments,
+        [...activeSkillIds],
+        skillPrompt,
+      );
       if (!result.success) {
         window.dispatchEvent(
           new CustomEvent('app:showToast', {

--- a/src/renderer/components/cowork/components/UserBubble.test.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.test.tsx
@@ -76,4 +76,41 @@ describe('UserBubble', () => {
     expect(screen.getByText('文档')).toBeInTheDocument();
     expect(screen.queryByText('minimax-docx')).not.toBeInTheDocument();
   });
+
+  test('renders a local preview for an image kept as a file attachment', async () => {
+    Object.defineProperty(window, 'electron', {
+      configurable: true,
+      value: {
+        dialog: {
+          readFileAsDataUrl: vi.fn().mockResolvedValue({
+            success: true,
+            dataUrl: 'data:image/png;base64,aGVsbG8=',
+          }),
+        },
+      },
+    });
+
+    render(
+      <UserBubble
+        message={{
+          ...message,
+          metadata: {
+            fileAttachments: [
+              {
+                name: 'reference.png',
+                path: '/tmp/reference.png',
+                extension: 'PNG',
+                isImage: true,
+              },
+            ],
+          },
+        }}
+        skills={[]}
+      />,
+    );
+
+    const preview = await screen.findByAltText('reference.png');
+    expect(preview).toHaveAttribute('src', 'data:image/png;base64,aGVsbG8=');
+    expect(screen.queryByText('PNG')).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -1,6 +1,6 @@
 import { Message, MessageContent } from '@shared/components/ai-elements/message';
 import { Button } from '@shared/components/ui/button';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import type {
@@ -28,6 +28,64 @@ const getMessageModelLabel = (metadata?: CoworkMessageMetadata | null): string |
 
 const hasFocusWithin = (element: HTMLElement): boolean =>
   document.activeElement instanceof Node && element.contains(document.activeElement);
+
+const FileAttachmentCard: React.FC<{ file: CoworkFileAttachment }> = ({ file }) => (
+  <div
+    className="flex h-20 w-64 shrink-0 items-center gap-3 rounded-lg border border-border-subtle bg-surface-raised px-4"
+    title={file.path}
+  >
+    <FileTypeIcon fileName={file.name} className="h-12 w-12 shrink-0" />
+    <div className="min-w-0">
+      <div className="truncate text-base text-foreground">{file.name}</div>
+      <div className="truncate text-sm text-muted-foreground">{file.extension}</div>
+    </div>
+  </div>
+);
+
+const LocalImageAttachmentPreview: React.FC<{
+  file: CoworkFileAttachment;
+  onExpand: (image: ImagePreviewSource) => void;
+}> = ({ file, onExpand }) => {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [readFailed, setReadFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDataUrl(null);
+    setReadFailed(false);
+    void window.electron.dialog.readFileAsDataUrl(file.path).then(result => {
+      if (cancelled) return;
+      if (result.success && result.dataUrl) {
+        setDataUrl(result.dataUrl);
+      } else {
+        setReadFailed(true);
+      }
+    }).catch(() => {
+      if (!cancelled) setReadFailed(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [file.path]);
+
+  if (!dataUrl) {
+    return readFailed ? <FileAttachmentCard file={file} /> : null;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      className="block h-auto w-auto min-h-0 shrink-0 cursor-zoom-in rounded-lg p-0 shadow-none hover:bg-transparent focus-visible:ring-2 focus-visible:ring-primary/50"
+      onClick={() => onExpand({ src: dataUrl, alt: file.name, name: file.name })}
+    >
+      <img
+        src={dataUrl}
+        alt={file.name || 'image'}
+        className="block h-40 w-auto max-w-80 rounded-lg border border-border object-contain"
+      />
+    </Button>
+  );
+};
 
 export const UserBubble: React.FC<{
   message: CoworkMessage;
@@ -75,6 +133,14 @@ export const UserBubble: React.FC<{
       .join('\n')
       .replace(/^\n+|\n+$/g, '');
   }, [displayContent, fileAttachments]);
+  const localImageAttachments = useMemo(
+    () => fileAttachments.filter(file => file.isImage),
+    [fileAttachments],
+  );
+  const documentAttachments = useMemo(
+    () => fileAttachments.filter(file => !file.isImage),
+    [fileAttachments],
+  );
   const hasTextContent = Boolean(textContent.trim()) || messageSkills.length > 0;
 
   return (
@@ -111,21 +177,21 @@ export const UserBubble: React.FC<{
           </div>
         )}
 
-        {fileAttachments.length > 0 && (
+        {localImageAttachments.length > 0 && (
           <div className="ml-auto mb-2 flex w-fit max-w-full flex-wrap justify-end gap-2">
-            {fileAttachments.map(file => (
-              <div
+            {localImageAttachments.map(file => (
+              <LocalImageAttachmentPreview
                 key={file.path}
-                className="flex h-20 w-64 shrink-0 items-center gap-3 rounded-lg border border-border-subtle bg-surface-raised px-4"
-                title={file.path}
-              >
-                <FileTypeIcon fileName={file.name} className="h-12 w-12 shrink-0" />
-                <div className="min-w-0">
-                  <div className="truncate text-base text-foreground">{file.name}</div>
-                  <div className="truncate text-sm text-muted-foreground">{file.extension}</div>
-                </div>
-              </div>
+                file={file}
+                onExpand={setExpandedImage}
+              />
             ))}
+          </div>
+        )}
+
+        {documentAttachments.length > 0 && (
+          <div className="ml-auto mb-2 flex w-fit max-w-full flex-wrap justify-end gap-2">
+            {documentAttachments.map(file => <FileAttachmentCard key={file.path} file={file} />)}
           </div>
         )}
 

--- a/src/renderer/services/cowork.attachments.structure.test.ts
+++ b/src/renderer/services/cowork.attachments.structure.test.ts
@@ -1,0 +1,21 @@
+/**
+ * The renderer service is the final bridge before preload IPC. Keep file
+ * attachments here alongside vision attachments; otherwise a continuing turn
+ * persists only a textual "input file" path and loses its message card.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./cowork.ts', import.meta.url)), 'utf8');
+
+test('forwards file attachments when continuing a cowork session', () => {
+  const continueStart = source.indexOf('async continueSession(options: CoworkContinueOptions)');
+  const continueEnd = source.indexOf('\n  async stopSession', continueStart);
+  const continueSource = source.slice(continueStart, continueEnd);
+
+  expect(continueStart).toBeGreaterThanOrEqual(0);
+  expect(continueSource).toContain('imageAttachments: options.imageAttachments');
+  expect(continueSource).toContain('fileAttachments: options.fileAttachments');
+});

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -510,6 +510,7 @@ class CoworkService {
       expertIds: options.expertIds,
       permissionMode: options.permissionMode,
       imageAttachments: options.imageAttachments,
+      fileAttachments: options.fileAttachments,
     });
     if (!result.success) {
       if (result.code !== ENGINE_NOT_READY_CODE) {

--- a/src/renderer/services/coworkQueue.ts
+++ b/src/renderer/services/coworkQueue.ts
@@ -1,4 +1,5 @@
 import type { CoworkPendingMessage } from '../../shared/cowork/pendingMessageQueue';
+import type { CoworkFileAttachment, CoworkImageAttachment } from '../types/cowork';
 
 type QueueListener = (items: CoworkPendingMessage[]) => void;
 
@@ -32,8 +33,22 @@ class CoworkQueueService {
     return this.itemsBySession.get(sessionId) ?? [];
   }
 
-  enqueue(sessionId: string, text: string) {
-    return window.electron.cowork.enqueuePendingMessage({ sessionId, text });
+  enqueue(
+    sessionId: string,
+    text: string,
+    imageAttachments?: CoworkImageAttachment[],
+    fileAttachments?: CoworkFileAttachment[],
+    skillIds?: string[],
+    skillPrompt?: string,
+  ) {
+    return window.electron.cowork.enqueuePendingMessage({
+      sessionId,
+      text,
+      imageAttachments,
+      fileAttachments,
+      skillIds,
+      skillPrompt,
+    });
   }
 
   update(sessionId: string, itemId: string, text: string) {

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -19,6 +19,8 @@ export interface CoworkFileAttachment {
   name: string;
   path: string;
   extension: string;
+  /** Keeps image rendering independent from whether the selected model accepts vision input. */
+  isImage?: boolean;
 }
 
 // Cowork session status

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -775,7 +775,7 @@ interface IElectronAPI {
       permissionMode?: CoworkPermissionMode;
       permissionModeBySession?: Record<string, CoworkPermissionMode>;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
     }) => Promise<{
       success: boolean;
       session?: CoworkSession;
@@ -791,7 +791,7 @@ interface IElectronAPI {
       expertIds?: string[];
       permissionMode?: CoworkPermissionMode;
       imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-      fileAttachments?: Array<{ name: string; path: string; extension: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
     }) => Promise<{
       success: boolean;
       session?: CoworkSession;
@@ -804,6 +804,10 @@ interface IElectronAPI {
     enqueuePendingMessage: (options: {
       sessionId: string;
       text: string;
+      imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
+      fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
+      skillIds?: string[];
+      skillPrompt?: string;
     }) => Promise<{ success: boolean; item?: CoworkPendingMessage; error?: string }>;
     updatePendingMessage: (options: {
       sessionId: string;

--- a/src/shared/cowork/pendingMessageQueue.ts
+++ b/src/shared/cowork/pendingMessageQueue.ts
@@ -21,12 +21,34 @@ export const CoworkQueueItemStatus = {
 export type CoworkQueueItemStatus =
   (typeof CoworkQueueItemStatus)[keyof typeof CoworkQueueItemStatus];
 
+export const CoworkQueueAttachmentLimit = {
+  MaxImages: 4,
+  MaxImageBase64Chars: 20 * 1024 * 1024,
+} as const;
+
+export interface CoworkQueuedImageAttachment {
+  name: string;
+  mimeType: string;
+  base64Data: string;
+}
+
+export interface CoworkQueuedFileAttachment {
+  name: string;
+  path: string;
+  extension: string;
+  isImage?: boolean;
+}
+
 export interface CoworkPendingMessage {
   id: string;
   text: string;
   delivery: CoworkQueueDelivery;
   createdAt: number;
   status: CoworkQueueItemStatus;
+  imageAttachments?: CoworkQueuedImageAttachment[];
+  fileAttachments?: CoworkQueuedFileAttachment[];
+  skillIds?: string[];
+  /** Immutable prompt snapshot used when a queued item is immediately steered. */
+  skillPrompt?: string;
   error?: string;
 }
-

--- a/src/shared/ipc/queueSchemas.attachments.test.ts
+++ b/src/shared/ipc/queueSchemas.attachments.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+
+import { CoworkQueueAttachmentLimit } from '../cowork/pendingMessageQueue';
+import { CoworkQueueEnqueueSchema } from './queueSchemas';
+
+const baseInput = { sessionId: 'session-1', text: 'review this' };
+
+describe('CoworkQueueEnqueueSchema attachment limits', () => {
+  test('accepts a bounded image attachment and skill snapshot', () => {
+    const parsed = CoworkQueueEnqueueSchema.parse({
+      ...baseInput,
+      imageAttachments: [{ name: 'screen.png', mimeType: 'image/png', base64Data: 'a' }],
+      skillIds: ['skill-docx'],
+      skillPrompt: 'Use the document skill.',
+    });
+
+    expect(parsed.skillIds).toEqual(['skill-docx']);
+  });
+
+  test('rejects image queues beyond the configured limits', () => {
+    expect(() =>
+      CoworkQueueEnqueueSchema.parse({
+        ...baseInput,
+        imageAttachments: Array.from({ length: CoworkQueueAttachmentLimit.MaxImages + 1 }, () => ({
+          name: 'screen.png',
+          mimeType: 'image/png',
+          base64Data: 'a',
+        })),
+      }),
+    ).toThrow();
+    expect(() =>
+      CoworkQueueEnqueueSchema.parse({
+        ...baseInput,
+        imageAttachments: [
+          {
+            name: 'screen.png',
+            mimeType: 'image/png',
+            base64Data: 'a'.repeat(CoworkQueueAttachmentLimit.MaxImageBase64Chars + 1),
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});

--- a/src/shared/ipc/queueSchemas.ts
+++ b/src/shared/ipc/queueSchemas.ts
@@ -1,10 +1,29 @@
 import { z } from 'zod';
 
+import { CoworkQueueAttachmentLimit } from '../cowork/pendingMessageQueue';
+
 export const CoworkQueueSessionSchema = z.string().min(1);
+
+const CoworkQueueImageAttachmentSchema = z.object({
+  name: z.string(),
+  mimeType: z.string(),
+  base64Data: z.string().max(CoworkQueueAttachmentLimit.MaxImageBase64Chars),
+});
+
+const CoworkQueueFileAttachmentSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  extension: z.string(),
+  isImage: z.boolean().optional(),
+});
 
 export const CoworkQueueEnqueueSchema = z.object({
   sessionId: CoworkQueueSessionSchema,
   text: z.string().trim().min(1).max(100_000),
+  imageAttachments: z.array(CoworkQueueImageAttachmentSchema).max(CoworkQueueAttachmentLimit.MaxImages).optional(),
+  fileAttachments: z.array(CoworkQueueFileAttachmentSchema).optional(),
+  skillIds: z.array(z.string().min(1)).max(32).optional(),
+  skillPrompt: z.string().max(100_000).optional(),
 });
 
 export const CoworkQueueUpdateSchema = z.object({

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -190,6 +190,7 @@ const FileAttachmentSchema = z.object({
   name: z.string(),
   path: z.string(),
   extension: z.string(),
+  isImage: z.boolean().optional(),
 });
 
 export const CoworkSessionStartSchema = {


### PR DESCRIPTION
## Summary

让**待发消息队列（pending message queue）**携带完整的图片/文件附件与技能上下文：Work 会话流式执行期间发送的新消息被入队后，会在会话空闲时带着附件、已选技能和 steer 提示快照一起交付，附件与技能会持久化到用户消息元数据中。同时按 `isImage` 标记区分图片与文档附件，用户气泡中对图片附件渲染本地预览（`readFileAsDataUrl`），文档附件保持文件卡片样式。

## Related Issue

无

## Changes Made

- **队列条目承载上下文**：`CoworkPendingMessage` 新增 `imageAttachments` / `fileAttachments` / `skillIds` / `skillPrompt`；`PiPendingMessageQueue` 入队到交付、失败重试全程保留
- **Steer 携带附件**：`steerPendingMessage` 改用共享的 `sendPiPrompt` 路径发送附件，并在 `persistQueuedUserMessage` 中把附件与技能写入用户消息元数据
- **IPC 与 schema**：`CoworkQueueEnqueueSchema` 校验图片附件（最多 4 张、单张 base64 ≤20MB）、技能（≤32）与 skillPrompt；`main.ts` / `preload.ts` 完整转发
- **消息元数据透传**：`main.ts` 的 IPC sanitizer 对 fileAttachments 做安全过滤后透传（与 imageAttachments 一致）
- **附件 isImage 标记**：`CoworkFileAttachment` 新增 `isImage`，`CoworkPromptInput` 对图片文件标注，`cowork.ts` 的 `continueSession` 转发 fileAttachments
- **用户气泡图片预览**：`UserBubble` 将 `isImage` 附件渲染为可点击放大的本地图片预览（点击打开大图），文档附件保留文件卡片；新增 `LocalImageAttachmentPreview` / `FileAttachmentCard`
- **测试**：队列附件保留、schema 上限、视图入队结构、continueSession 转发、UserBubble 图片预览，并同步修正了 steer 路径的既有断言（改用共享 prompt 路径）

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

新增 `CoworkView.queueAttachments.structure.test.ts`、`cowork.attachments.structure.test.ts`、`queueSchemas.attachments.test.ts`，更新 `piPendingMessageQueue.test.ts`、`UserBubble.test.tsx`、`piRuntimeAdapter.test.ts`；完整测试套件 2233 用例通过，lint 通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [x] Changes to preload script (src/main/preload.ts)
- [x] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

主进程改动：`PiPendingMessageQueue` / `PiRuntimeAdapter` 的队列交付与消息持久化、`CoworkQueueIpc.Enqueue` 参数转发、IPC sanitizer 对 fileAttachments 的透传；preload 的 `enqueuePendingMessage` 与 start/continue 附件参数扩展。

## Additional Notes

无
