### PR TITLE
feat(ui): 侧边栏与本地推理面板图标动画升级

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Button } from '@shared/components/ui/button';
 import { Checkbox } from '@shared/components/ui/checkbox';
 import { cn } from '@shared/lib/utils';
 import { MotionConfig, useReducedMotion } from 'motion/react';
-import { MessageCircle, PanelLeft, Trash2, TriangleAlert, X } from 'lucide-react';
+import { MessageCircle, Trash2, TriangleAlert, X } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -37,6 +37,7 @@ import {
   SidebarAnimatedSearchIcon,
   type SidebarAnimatedSearchIconHandle,
 } from './icons/SidebarAnimatedSearchIcon';
+import { SidebarAnimatedPanelLeftCloseIcon } from './icons/SidebarAnimatedPanelLeftCloseIcon';
 import { toggleBatchSelection, toggleVisibleBatchSelection } from './agentSidebar/batchSelection';
 import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
 import { sortAgentSidebarTasks, toAgentSidebarTaskNode } from './agentSidebar/useAgentSidebarState';
@@ -520,7 +521,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 className="non-draggable h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised transition-colors"
                 aria-label={isCollapsed ? i18nService.t('expand') : i18nService.t('collapse')}
               >
-                <PanelLeft className="h-4 w-4" />
+                <SidebarAnimatedPanelLeftCloseIcon />
               </Button>
             </div>
             <SidebarNavigationControls

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../services/artifactParser';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
+import { ArtifactPanelAnimatedToggleIcon } from '../icons/ArtifactPanelAnimatedToggleIcon';
 import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import { RootState } from '../../store';
 import {
@@ -55,7 +56,6 @@ import type {
 } from '../../types/cowork';
 import { ArtifactPanelFallback } from '../artifacts/ArtifactPanelFallback';
 import WindowTitleBar from '../window/WindowTitleBar';
-import { ArtifactPanelIcon } from './components/StreamingBar';
 import { TurnBlock } from './components/TurnBlock';
 import { UserBubble } from './components/UserBubble';
 import {
@@ -1179,7 +1179,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             aria-label={i18nService.t('artifactPanelToggle')}
             disabled={isSessionSwitching}
           >
-            <ArtifactPanelIcon className="h-4 w-4" open={!isSessionSwitching && isPanelOpen} />
+            <ArtifactPanelAnimatedToggleIcon open={!isSessionSwitching && isPanelOpen} />
           </Button>
 
           <WindowTitleBar inline className="ml-1" />

--- a/src/renderer/components/icons/ArtifactPanelAnimatedToggleIcon.tsx
+++ b/src/renderer/components/icons/ArtifactPanelAnimatedToggleIcon.tsx
@@ -1,0 +1,98 @@
+import { motion, useAnimation, useReducedMotion, type Transition, type Variants } from 'motion/react';
+import type { HTMLAttributes, MouseEvent } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+
+import { cn } from '@shared/lib/utils';
+
+export interface ArtifactPanelAnimatedToggleIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ArtifactPanelAnimatedToggleIconProps extends HTMLAttributes<HTMLDivElement> {
+  open: boolean;
+  size?: number;
+}
+
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
+  duration: 0.5,
+};
+
+const OPEN_PATH_VARIANTS: Variants = {
+  normal: { x: 0 },
+  animate: { x: [0, 1.5, 0] },
+};
+
+const CLOSE_PATH_VARIANTS: Variants = {
+  normal: { x: 0 },
+  animate: { x: [0, -1.5, 0] },
+};
+
+export const ArtifactPanelAnimatedToggleIcon = forwardRef<
+  ArtifactPanelAnimatedToggleIconHandle,
+  ArtifactPanelAnimatedToggleIconProps
+>(({ open, onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+  const prefersReducedMotion = useReducedMotion();
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => {
+        if (!prefersReducedMotion) void controls.start('animate');
+      },
+      stopAnimation: () => void controls.start('normal'),
+    };
+  }, [controls, prefersReducedMotion]);
+
+  const handleMouseEnter = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseEnter?.(event);
+      else if (!prefersReducedMotion) void controls.start('animate');
+    },
+    [controls, onMouseEnter, prefersReducedMotion],
+  );
+
+  const handleMouseLeave = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseLeave?.(event);
+      else void controls.start('normal');
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn('artifact-panel-animated-toggle-icon size-4 shrink-0', className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect height="18" rx="2" width="18" x="3" y="3" />
+        <path d="M9 3v18" />
+        <motion.path
+          animate={controls}
+          d={open ? 'm16 15-3-3 3-3' : 'm14 9 3 3-3 3'}
+          transition={DEFAULT_TRANSITION}
+          variants={open ? CLOSE_PATH_VARIANTS : OPEN_PATH_VARIANTS}
+        />
+      </svg>
+    </div>
+  );
+});
+
+ArtifactPanelAnimatedToggleIcon.displayName = 'ArtifactPanelAnimatedToggleIcon';

--- a/src/renderer/components/icons/LocalInferenceAnimatedFolderDownIcon.tsx
+++ b/src/renderer/components/icons/LocalInferenceAnimatedFolderDownIcon.tsx
@@ -4,34 +4,28 @@ import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 
 import { cn } from '@shared/lib/utils';
 
-export interface SidebarAnimatedCpuIconHandle {
+export interface LocalInferenceAnimatedFolderDownIconHandle {
   startAnimation: () => void;
   stopAnimation: () => void;
 }
 
-interface SidebarAnimatedCpuIconProps extends HTMLAttributes<HTMLDivElement> {
+interface LocalInferenceAnimatedFolderDownIconProps extends HTMLAttributes<HTMLDivElement> {
   size?: number;
 }
 
-const TRANSITION: Transition = {
+const ARROW_VARIANTS: Variants = {
+  normal: { y: 0 },
+  animate: { y: [0, 2, 0] },
+};
+
+const ARROW_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
   duration: 0.5,
-  ease: 'easeInOut',
-  repeat: 1,
 };
 
-const Y_VARIANTS: Variants = {
-  normal: { scale: 1, rotate: 0, opacity: 1 },
-  animate: { scaleY: [1, 1.5, 1], opacity: [1, 0.8, 1] },
-};
-
-const X_VARIANTS: Variants = {
-  normal: { scale: 1, rotate: 0, opacity: 1 },
-  animate: { scaleX: [1, 1.5, 1], opacity: [1, 0.8, 1] },
-};
-
-export const SidebarAnimatedCpuIcon = forwardRef<
-  SidebarAnimatedCpuIconHandle,
-  SidebarAnimatedCpuIconProps
+export const LocalInferenceAnimatedFolderDownIcon = forwardRef<
+  LocalInferenceAnimatedFolderDownIconHandle,
+  LocalInferenceAnimatedFolderDownIconProps
 >(({ onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
   const controls = useAnimation();
   const prefersReducedMotion = useReducedMotion();
@@ -66,7 +60,7 @@ export const SidebarAnimatedCpuIcon = forwardRef<
   return (
     <div
       aria-hidden="true"
-      className={cn('sidebar-local-inference-icon animated-cpu-icon size-4 shrink-0', className)}
+      className={cn('local-inference-animated-folder-down-icon size-4 shrink-0', className)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...props}
@@ -82,29 +76,19 @@ export const SidebarAnimatedCpuIcon = forwardRef<
         width={size}
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect height="16" rx="2" width="16" x="4" y="4" />
-        <rect height="6" rx="1" width="6" x="9" y="9" />
-        <motion.path animate={controls} d="M15 2v2" transition={TRANSITION} variants={Y_VARIANTS} />
-        <motion.path
+        <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+        <motion.g
           animate={controls}
-          d="M15 20v2"
-          transition={TRANSITION}
-          variants={Y_VARIANTS}
-        />
-        <motion.path animate={controls} d="M2 15h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path animate={controls} d="M2 9h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path
-          animate={controls}
-          d="M20 15h2"
-          transition={TRANSITION}
-          variants={X_VARIANTS}
-        />
-        <motion.path animate={controls} d="M20 9h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path animate={controls} d="M9 2v2" transition={TRANSITION} variants={Y_VARIANTS} />
-        <motion.path animate={controls} d="M9 20v2" transition={TRANSITION} variants={Y_VARIANTS} />
+          initial="normal"
+          transition={ARROW_TRANSITION}
+          variants={ARROW_VARIANTS}
+        >
+          <path d="M12 10v6" />
+          <path d="m15 13-3 3-3-3" />
+        </motion.g>
       </svg>
     </div>
   );
 });
 
-SidebarAnimatedCpuIcon.displayName = 'SidebarAnimatedCpuIcon';
+LocalInferenceAnimatedFolderDownIcon.displayName = 'LocalInferenceAnimatedFolderDownIcon';

--- a/src/renderer/components/icons/LocalInferenceAnimatedWifiPenIcon.tsx
+++ b/src/renderer/components/icons/LocalInferenceAnimatedWifiPenIcon.tsx
@@ -1,0 +1,93 @@
+import { motion, useAnimation, useReducedMotion, type Variants } from 'motion/react';
+import type { HTMLAttributes, MouseEvent } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+
+import { cn } from '@shared/lib/utils';
+
+export interface LocalInferenceAnimatedWifiPenIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LocalInferenceAnimatedWifiPenIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PEN_VARIANTS: Variants = {
+  normal: { rotate: 0, x: 0, y: 0 },
+  animate: {
+    rotate: [-0.3, 0.2, -0.4],
+    x: [0, -0.5, 1, 0],
+    y: [0, 1, -0.5, 0],
+    transition: { duration: 0.5, repeat: 1, ease: 'easeInOut' },
+  },
+};
+
+export const LocalInferenceAnimatedWifiPenIcon = forwardRef<
+  LocalInferenceAnimatedWifiPenIconHandle,
+  LocalInferenceAnimatedWifiPenIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
+  const controls = useAnimation();
+  const prefersReducedMotion = useReducedMotion();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => {
+        if (!prefersReducedMotion) void controls.start('animate');
+      },
+      stopAnimation: () => void controls.start('normal'),
+    };
+  }, [controls, prefersReducedMotion]);
+
+  const handleMouseEnter = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseEnter?.(event);
+      else if (!prefersReducedMotion) void controls.start('animate');
+    },
+    [controls, onMouseEnter, prefersReducedMotion],
+  );
+
+  const handleMouseLeave = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseLeave?.(event);
+      else void controls.start('normal');
+    },
+    [controls, onMouseLeave],
+  );
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn('local-inference-animated-wifi-pen-icon size-4 shrink-0', className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <motion.path
+          animate={controls}
+          d="M21.378 16.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z"
+          initial="normal"
+          variants={PEN_VARIANTS}
+        />
+        <path d="M5 12.859a10 10 0 0 1 10.5-2.222" />
+        <path d="M8.5 16.429a5 5 0 0 1 3-1.406" />
+      </motion.svg>
+    </div>
+  );
+});
+
+LocalInferenceAnimatedWifiPenIcon.displayName = 'LocalInferenceAnimatedWifiPenIcon';

--- a/src/renderer/components/icons/SidebarAnimatedPanelLeftCloseIcon.tsx
+++ b/src/renderer/components/icons/SidebarAnimatedPanelLeftCloseIcon.tsx
@@ -4,38 +4,32 @@ import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 
 import { cn } from '@shared/lib/utils';
 
-export interface SidebarAnimatedCpuIconHandle {
+export interface SidebarAnimatedPanelLeftCloseIconHandle {
   startAnimation: () => void;
   stopAnimation: () => void;
 }
 
-interface SidebarAnimatedCpuIconProps extends HTMLAttributes<HTMLDivElement> {
+interface SidebarAnimatedPanelLeftCloseIconProps extends HTMLAttributes<HTMLDivElement> {
   size?: number;
 }
 
-const TRANSITION: Transition = {
+const DEFAULT_TRANSITION: Transition = {
+  times: [0, 0.4, 1],
   duration: 0.5,
-  ease: 'easeInOut',
-  repeat: 1,
 };
 
-const Y_VARIANTS: Variants = {
-  normal: { scale: 1, rotate: 0, opacity: 1 },
-  animate: { scaleY: [1, 1.5, 1], opacity: [1, 0.8, 1] },
+const PATH_VARIANTS: Variants = {
+  normal: { x: 0 },
+  animate: { x: [0, -1.5, 0] },
 };
 
-const X_VARIANTS: Variants = {
-  normal: { scale: 1, rotate: 0, opacity: 1 },
-  animate: { scaleX: [1, 1.5, 1], opacity: [1, 0.8, 1] },
-};
-
-export const SidebarAnimatedCpuIcon = forwardRef<
-  SidebarAnimatedCpuIconHandle,
-  SidebarAnimatedCpuIconProps
+export const SidebarAnimatedPanelLeftCloseIcon = forwardRef<
+  SidebarAnimatedPanelLeftCloseIconHandle,
+  SidebarAnimatedPanelLeftCloseIconProps
 >(({ onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
   const controls = useAnimation();
-  const prefersReducedMotion = useReducedMotion();
   const isControlledRef = useRef(false);
+  const prefersReducedMotion = useReducedMotion();
 
   useImperativeHandle(ref, () => {
     isControlledRef.current = true;
@@ -66,7 +60,7 @@ export const SidebarAnimatedCpuIcon = forwardRef<
   return (
     <div
       aria-hidden="true"
-      className={cn('sidebar-local-inference-icon animated-cpu-icon size-4 shrink-0', className)}
+      className={cn('sidebar-animated-panel-left-close-icon size-4 shrink-0', className)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...props}
@@ -82,29 +76,17 @@ export const SidebarAnimatedCpuIcon = forwardRef<
         width={size}
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect height="16" rx="2" width="16" x="4" y="4" />
-        <rect height="6" rx="1" width="6" x="9" y="9" />
-        <motion.path animate={controls} d="M15 2v2" transition={TRANSITION} variants={Y_VARIANTS} />
+        <rect height="18" rx="2" width="18" x="3" y="3" />
+        <path d="M9 3v18" />
         <motion.path
           animate={controls}
-          d="M15 20v2"
-          transition={TRANSITION}
-          variants={Y_VARIANTS}
+          d="m16 15-3-3 3-3"
+          transition={DEFAULT_TRANSITION}
+          variants={PATH_VARIANTS}
         />
-        <motion.path animate={controls} d="M2 15h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path animate={controls} d="M2 9h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path
-          animate={controls}
-          d="M20 15h2"
-          transition={TRANSITION}
-          variants={X_VARIANTS}
-        />
-        <motion.path animate={controls} d="M20 9h2" transition={TRANSITION} variants={X_VARIANTS} />
-        <motion.path animate={controls} d="M9 2v2" transition={TRANSITION} variants={Y_VARIANTS} />
-        <motion.path animate={controls} d="M9 20v2" transition={TRANSITION} variants={Y_VARIANTS} />
       </svg>
     </div>
   );
 });
 
-SidebarAnimatedCpuIcon.displayName = 'SidebarAnimatedCpuIcon';
+SidebarAnimatedPanelLeftCloseIcon.displayName = 'SidebarAnimatedPanelLeftCloseIcon';

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@shared/components/ui/dropdown-menu';
 import { LayeredTabsContent } from '@shared/components/ui/layered-tabs';
 import { Tabs } from '@shared/components/ui/tabs';
-import { Cpu, FolderOpen, Globe, PanelLeft, Pencil, Settings2 } from 'lucide-react';
+import { PanelLeft, Pencil } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
@@ -32,6 +32,10 @@ import type {
 import { createMarketplaceHardwareProfile, withMarketplaceScore, type MarketplaceHardwareProfile } from '../../../shared/marketplace/scoring';
 import { notifyLlamaCppRunningModelsChanged } from '../../services/availableModels';
 import { i18nService } from '../../services/i18n';
+import { LocalInferenceAnimatedFolderDownIcon } from '../icons/LocalInferenceAnimatedFolderDownIcon';
+import { LocalInferenceAnimatedWifiPenIcon } from '../icons/LocalInferenceAnimatedWifiPenIcon';
+import { SidebarAnimatedCpuIcon } from '../icons/SidebarAnimatedCpuIcon';
+import { SettingsAnimatedSlidersHorizontalIcon } from '../icons/SettingsAnimatedSlidersHorizontalIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
 import { LocalInferenceToastView } from './components/Common';
 import { LocalInferenceAccessSettingsDialog } from './components/LocalInferenceAccessSettingsDialog';
@@ -1018,18 +1022,18 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                           className={`${localInferenceCompactButtonClass} min-w-32 hover:bg-background dark:hover:bg-background`}
                           size="default"
                         >
-                          <Settings2 data-icon="inline-start" />
+                          <SettingsAnimatedSlidersHorizontalIcon className="size-4" size={16} />
                           {i18nService.t('localInferenceSettings')}
                         </Button>
                       }
                     />
                     <DropdownMenuContent align="end" className="min-w-32">
                       <DropdownMenuItem onClick={() => setRuntimeSettingsOpen(true)}>
-                        <Cpu data-icon="inline-start" />
+                        <SidebarAnimatedCpuIcon />
                         {i18nService.t('localInferenceRuntimeSettings')}
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={openAccessSettings}>
-                        <Globe data-icon="inline-start" />
+                        <LocalInferenceAnimatedWifiPenIcon />
                         {i18nService.t('localInferenceAccessMenuItem')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
@@ -1038,7 +1042,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                           setLibrarySettingsOpen(true);
                         }}
                       >
-                        <FolderOpen data-icon="inline-start" />
+                        <LocalInferenceAnimatedFolderDownIcon />
                         {i18nService.t('localInferenceLibraryMenuItem')}
                       </DropdownMenuItem>
                     </DropdownMenuContent>


### PR DESCRIPTION
## Summary

将侧边栏、工件面板、本地推理设置菜单中的静态图标替换为新的动画图标组件，提升交互反馈；同时增强 CPU 图标动画并适配 `prefersReducedMotion`（系统减少动效时禁用动画）。

## Related Issue

无关联 issue。

## Changes Made

- 新增 4 个动画图标组件：
  - `SidebarAnimatedPanelLeftCloseIcon`（侧边栏折叠/展开按钮）
  - `ArtifactPanelAnimatedToggleIcon`（工件面板开关）
  - `LocalInferenceAnimatedFolderDownIcon`（本地推理-模型库菜单项）
  - `LocalInferenceAnimatedWifiPenIcon`（本地推理-访问设置菜单项）
- `Sidebar.tsx`：折叠按钮改用 `SidebarAnimatedPanelLeftCloseIcon`
- `CoworkSessionDetail.tsx`：工件面板开关改用 `ArtifactPanelAnimatedToggleIcon`，移除旧 `ArtifactPanelIcon`
- `LocalInferenceView.tsx`：设置菜单改用动画图标（`SettingsAnimatedSlidersHorizontalIcon`、`SidebarAnimatedCpuIcon` 等）
- `SidebarAnimatedCpuIcon.tsx`：动画增强为 `easeInOut` + 重复一次 + scale/rotate，并用 `useReducedMotion` 尊重系统减少动效设置

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Manual testing performed（悬停/点击图标动画、系统减少动效开关下验证）

## Screenshots (if applicable)

无。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

无。
