### PR TITLE
fix(cowork): 历史消息的输入文件提示行恢复为附件卡片

### DIFF
--- a/src/renderer/components/cowork/components/UserBubble.test.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.test.tsx
@@ -113,4 +113,37 @@ describe('UserBubble', () => {
     expect(preview).toHaveAttribute('src', 'data:image/png;base64,aGVsbG8=');
     expect(screen.queryByText('PNG')).not.toBeInTheDocument();
   });
+
+  test('restores an attachment card from a legacy Windows input-file prompt line', () => {
+    render(
+      <UserBubble
+        message={{
+          ...message,
+          content: '输入文件：C:\\Users\\whz\\Downloads\\brief.docx\n\n请总结这份文件',
+        }}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByText('brief.docx')).toBeInTheDocument();
+    expect(screen.getByText('DOCX')).toBeInTheDocument();
+    expect(screen.getByText('请总结这份文件')).toBeInTheDocument();
+    expect(screen.queryByText(/输入文件：C:/)).not.toBeInTheDocument();
+  });
+
+  test('restores an attachment from an English UNC prompt line after language changes', () => {
+    render(
+      <UserBubble
+        message={{
+          ...message,
+          content: String.raw`Input Files: \\nas\shared\contract.docx`,
+        }}
+        skills={[]}
+      />,
+    );
+
+    expect(screen.getByText('contract.docx')).toBeInTheDocument();
+    expect(screen.getByText('DOCX')).toBeInTheDocument();
+    expect(screen.queryByText(/Input Files:/)).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -29,6 +29,53 @@ const getMessageModelLabel = (metadata?: CoworkMessageMetadata | null): string |
 const hasFocusWithin = (element: HTMLElement): boolean =>
   document.activeElement instanceof Node && element.contains(document.activeElement);
 
+const IMAGE_ATTACHMENT_EXTENSION = /\.(?:png|jpe?g|gif|webp|bmp|svg|tiff?|ico|avif)$/i;
+const LEGACY_INPUT_FILE_LABELS = ['输入文件', 'Input Files'] as const;
+const LEGACY_INPUT_FILE_PREFIX = new RegExp(
+  `^(?:${LEGACY_INPUT_FILE_LABELS.join('|')})\\s*[:：]\\s*`,
+);
+
+const isAbsoluteLocalPath = (value: string): boolean =>
+  value.startsWith('/') || value.startsWith('\\\\') || /^[a-z]:[\\/]/i.test(value);
+
+const getFileAttachmentFromPath = (path: string): CoworkFileAttachment | null => {
+  const normalizedPath = path.trim();
+  if (!isAbsoluteLocalPath(normalizedPath)) return null;
+  const name = normalizedPath.split(/[\\/]/).pop() || normalizedPath;
+  const extensionIndex = name.lastIndexOf('.');
+  return {
+    name,
+    path: normalizedPath,
+    extension: extensionIndex >= 0 ? name.slice(extensionIndex + 1).toUpperCase() : 'FILE',
+    isImage: IMAGE_ATTACHMENT_EXTENSION.test(name),
+  };
+};
+
+const getPromptAttachmentFallbacks = (content: string): CoworkFileAttachment[] => {
+  return content
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .flatMap(line => {
+      const match = LEGACY_INPUT_FILE_PREFIX.exec(line);
+      if (!match) return [];
+      const attachment = getFileAttachmentFromPath(line.slice(match[0].length));
+      return attachment ? [attachment] : [];
+    });
+};
+
+const removePromptAttachmentFallbacks = (content: string): string => {
+  return content
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .filter(line => {
+      const match = LEGACY_INPUT_FILE_PREFIX.exec(line);
+      if (!match) return true;
+      return getFileAttachmentFromPath(line.slice(match[0].length)) === null;
+    })
+    .join('\n')
+    .replace(/^\n+|\n+$/g, '');
+};
+
 const FileAttachmentCard: React.FC<{ file: CoworkFileAttachment }> = ({ file }) => (
   <div
     className="flex h-20 w-64 shrink-0 items-center gap-3 rounded-lg border border-border-subtle bg-surface-raised px-4"
@@ -119,15 +166,23 @@ export const UserBubble: React.FC<{
     [message.metadata],
   );
   const fileAttachments = useMemo(
-    () =>
-      ((message.metadata as CoworkMessageMetadata)?.fileAttachments ??
-        []) as CoworkFileAttachment[],
-    [message.metadata],
+    () => {
+      const persisted =
+        ((message.metadata as CoworkMessageMetadata)?.fileAttachments ??
+          []) as CoworkFileAttachment[];
+      const knownPaths = new Set(persisted.map(file => file.path));
+      const fallbacks = getPromptAttachmentFallbacks(message.content || '').filter(
+        file => !knownPaths.has(file.path),
+      );
+      return [...persisted, ...fallbacks];
+    },
+    [message.content, message.metadata],
   );
   const textContent = useMemo(() => {
-    if (fileAttachments.length === 0) return displayContent;
+    const contentWithoutFallbacks = removePromptAttachmentFallbacks(displayContent);
+    if (fileAttachments.length === 0) return contentWithoutFallbacks;
     const filePaths = new Set(fileAttachments.map(file => file.path));
-    return displayContent
+    return contentWithoutFallbacks
       .split(/\r?\n/)
       .filter(line => !Array.from(filePaths).some(path => line.includes(path)))
       .join('\n')


### PR DESCRIPTION
## Summary

让 `UserBubble` 兼容历史消息的「输入文件」提示行：在元数据附件持久化功能上线之前发送的消息，附件路径是以 `输入文件：C:\...` / `Input Files: \\nas\...` 字面量形式嵌入在消息文本中的。本次改动检测这类提示行，把其中的绝对本地路径解析为附件卡片展示，并从展示文本中移除该行，使旧会话的呈现与新会话保持一致。

## Related Issue

无（#466 待发消息队列携带附件的后续兼容处理）

## Changes Made

- **遗留提示行解析**：新增 `getPromptAttachmentFallbacks`，从消息文本中识别 `输入文件：` / `Input Files:` 前缀 + 绝对本地路径（Windows 盘符路径、UNC 路径、POSIX 路径），转换为 `CoworkFileAttachment`（含 `isImage` 图片标记）
- **文本清理**：`removePromptAttachmentFallbacks` 在展示文本中移除已解析的提示行，避免路径重复出现在正文里
- **去重**：与已持久化的 `metadata.fileAttachments` 按路径去重，二者并存时优先持久化数据
- **测试覆盖**：新增 Windows 路径（`C:\Users\...\brief.docx`）与 UNC 路径（`\\nas\shared\contract.docx`）两个历史消息恢复用例

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Updated existing tests

`UserBubble.test.tsx` 新增 2 个用例，当前 7 个用例全部通过，lint 通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

无 Electron 主进程改动，仅 renderer 侧展示逻辑。

## Additional Notes

无
