### PR TITLE
fix(cowork): MCP 工具发现刷新后重建 Pi 会话

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1156,6 +1156,23 @@ describe('PiRuntimeAdapter', () => {
       expect(mockSession.prompt).toHaveBeenCalledTimes(2);
     });
 
+    it('recreates the session after MCP discovery refreshes its tool topology', async () => {
+      adapter.setMcpServerManager({
+        toolManifest: [{ server: 'Supabase', name: 'list_projects', description: 'List projects' }],
+      } as never);
+      await adapter.startSession('test', 'First');
+
+      adapter.refreshMcpTools();
+      await adapter.continueSession('test', 'Use Supabase');
+
+      expect(mockSession.abort).toHaveBeenCalledOnce();
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      const replacementOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(replacementOptions.customTools?.map(tool => tool.name)).toContain('mcp');
+    });
+
     it('should reload an active session when its system prompt changes', async () => {
       await adapter.startSession('test', 'First', { systemPrompt: 'You are the original expert.' });
       await adapter.continueSession('test', 'Second', {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -273,6 +273,8 @@ interface ActivePiSession {
   turnFailed: boolean;
   /** Prevents duplicate queue drains when Pi emits multiple settled events. */
   queueFlushInFlight: boolean;
+  /** MCP tool manifest generation captured when this Pi session was created. */
+  mcpToolManifestGeneration: number;
 }
 
 // ── Dynamic imports ──
@@ -475,6 +477,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   >();
   private store: CoworkStore | null = null;
   private mcpServerManager: McpServerManager | null = null;
+  /**
+   * Pi custom tools are fixed when a session is created. Bump this whenever
+   * MCP discovery changes so the next user turn recreates an outdated session
+   * with the current MCP proxy topology.
+   */
+  private mcpToolManifestGeneration = 0;
   private workbenchTaskService: WorkbenchTaskService | null = null;
   private projectMemoryService: ProjectMemoryService | null = null;
   private sessionSummaryService: SessionSummaryService | null = null;
@@ -514,6 +522,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   setMcpServerManager(mgr: McpServerManager): void {
     this.mcpServerManager = mgr;
     this.mcpInjected = true;
+    this.mcpToolManifestGeneration += 1;
+  }
+  refreshMcpTools(): void {
+    this.mcpToolManifestGeneration += 1;
   }
   hasMcpServerManager(): boolean {
     return this.mcpInjected;
@@ -965,15 +977,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         isRunning: true,
         turnFailed: false,
         queueFlushInFlight: false,
+        mcpToolManifestGeneration: this.mcpToolManifestGeneration,
       };
       activeSession = active;
 
       // Subscribe to Pi events before sending the prompt
       active.unsubscribe = session.subscribe(event => {
-        if (
-          abortController.signal.aborted ||
-          this.activeSessions.get(sessionId) !== active
-        ) {
+        if (abortController.signal.aborted || this.activeSessions.get(sessionId) !== active) {
           return;
         }
         this.handlePiEvent(sessionId, active, event);
@@ -1034,9 +1044,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       this.emit('error', sessionId, classifyCoworkError(message));
       throw error;
     } finally {
-      if (
-        this.initializingSessions.get(sessionId)?.generation === initialization.generation
-      ) {
+      if (this.initializingSessions.get(sessionId)?.generation === initialization.generation) {
         this.initializingSessions.delete(sessionId);
       }
     }
@@ -1071,12 +1079,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       });
     }
 
-    if (options.autoApprove !== undefined) {
-      active.autoApprove = Boolean(options.autoApprove);
-    }
-    active.isRunning = true;
-    active.turnFailed = false;
-
     const requestedSystemPrompt = options.systemPrompt?.trim();
     const requestedSkillIds =
       options.skillIds === undefined
@@ -1100,11 +1102,17 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     });
     const productionWorkflowTopologyChanged =
       productionWorkflowEnabled !== active.productionWorkflowEnabled;
+    const mcpToolTopologyChanged =
+      active.mcpToolManifestGeneration !== this.mcpToolManifestGeneration;
     if (
       !haveSameStringList(requestedExpertIds, active.requestedExpertIds) ||
-      productionWorkflowTopologyChanged
+      productionWorkflowTopologyChanged ||
+      mcpToolTopologyChanged
     ) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
+      if (mcpToolTopologyChanged) {
+        console.log('[PiRuntime] recreating session after MCP tool manifest refresh');
+      }
       this.disposeSessionForRecreation(sessionId, active);
       return this.startSession(sessionId, prompt, {
         ...options,
@@ -1116,6 +1124,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         _piPromptOverride: buildPiConversationPrompt(history, prompt),
       });
     }
+
+    if (options.autoApprove !== undefined) {
+      active.autoApprove = Boolean(options.autoApprove);
+    }
+    active.isRunning = true;
+    active.turnFailed = false;
 
     const nextSystemPrompt = requestedSystemPrompt ?? active.requestedSystemPrompt;
     const promptChanged = nextSystemPrompt !== active.requestedSystemPrompt;
@@ -2715,16 +2729,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
    */
   private buildMcpProxyTool(): Record<string, unknown> | null {
     if (!this.mcpServerManager) return null;
-    const manifest = this.mcpServerManager.toolManifest;
-    if (manifest.length === 0) return null;
+    if (this.mcpServerManager.toolManifest.length === 0) return null;
 
     const mgr = this.mcpServerManager;
-
-    const toolIndex = manifest.map(e => ({
-      server: e.server,
-      name: e.name,
-      description: e.description,
-    }));
+    const getManifest = () => mgr.toolManifest;
 
     const buildStatusLine = (): string => {
       const servers = this.mcpServerManager?.toolManifest ?? [];
@@ -2781,6 +2789,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         // content = undefined, which breaks the next LLM turn with
         // "content is not iterable". See agent-loop.ts createToolResultMessage.
         try {
+          const manifest = getManifest();
+          const toolIndex = manifest.map(e => ({
+            server: e.server,
+            name: e.name,
+            description: e.description,
+          }));
           const tool = typeof params.tool === 'string' ? params.tool : undefined;
           const argsStr = typeof params.args === 'string' ? params.args : undefined;
           const server = typeof params.server === 'string' ? params.server : undefined;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -644,7 +644,10 @@ const sanitizeCoworkMessageForIpc = (message: unknown): unknown => {
   // and must not be truncated by the generic sanitizer).
   let sanitizedMetadata: unknown;
   if (messageRecord.metadata && typeof messageRecord.metadata === 'object') {
-    const { imageAttachments, fileAttachments, ...rest } = messageRecord.metadata as Record<string, unknown>;
+    const { imageAttachments, fileAttachments, ...rest } = messageRecord.metadata as Record<
+      string,
+      unknown
+    >;
     const sanitizedRest = sanitizeIpcPayload(rest) as Record<string, unknown> | undefined;
     sanitizedMetadata = {
       ...(sanitizedRest && typeof sanitizedRest === 'object' ? sanitizedRest : {}),
@@ -2251,6 +2254,7 @@ const initMcpServers = async (): Promise<McpToolManifestEntry[]> => {
         return [];
       }
       console.log(`[McpInit] MCP servers started: ${tools.length} tools discovered`);
+      syncPiMcpToolManifest();
       return tools;
     } catch (err) {
       console.error('[McpInit] Failed to start MCP servers:', err);
@@ -2261,6 +2265,20 @@ const initMcpServers = async (): Promise<McpToolManifestEntry[]> => {
   });
 
   return mcpInitPromise;
+};
+
+/**
+ * Pi sessions capture their custom-tool topology at creation time. Keep an
+ * already-created Pi runtime synchronized after both startup discovery and
+ * later connector refreshes without instantiating Pi just for MCP bootstrap.
+ */
+const syncPiMcpToolManifest = (): void => {
+  if (!piRuntimeAdapter || !mcpServerManager) return;
+  if (!piRuntimeAdapter.hasMcpServerManager()) {
+    piRuntimeAdapter.setMcpServerManager(mcpServerManager);
+    return;
+  }
+  piRuntimeAdapter.refreshMcpTools();
 };
 
 /**
@@ -2424,6 +2442,12 @@ const refreshMcpBridge = (): Promise<{ tools: number; error?: string }> => {
       }
       const toolCount = bridgeConfig?.tools.length ?? 0;
       console.log(`[McpBridge] refresh: ${toolCount} tools discovered`);
+
+      // Pi's custom tool topology is captured when a session is created.
+      // Mark live sessions stale after discovery so their next user turn is
+      // rebuilt with the freshly discovered MCP proxy instead of relying on
+      // whichever servers happened to be ready during app startup.
+      syncPiMcpToolManifest();
 
       // 3. Sync openclaw.json before reporting completion. The gateway pins
       // its MCP tool snapshot at startup, so returning before this write lets
@@ -4364,7 +4388,12 @@ if (!gotTheLock) {
         expertIds?: string[];
         permissionMode?: CoworkPermissionMode;
         imageAttachments?: Array<{ name: string; mimeType: string; base64Data: string }>;
-        fileAttachments?: Array<{ name: string; path: string; extension: string; isImage?: boolean }>;
+        fileAttachments?: Array<{
+          name: string;
+          path: string;
+          extension: string;
+          isImage?: boolean;
+        }>;
       },
     ) => {
       try {


### PR DESCRIPTION
## Summary

修复 MCP 工具发现后 Pi 会话仍持有旧工具拓扑的问题。Pi 会话的自定义工具（含 MCP 代理工具）在创建时一次性捕获，导致应用启动后才发现/刷新的 MCP 服务器无法被正在运行的会话使用。本次改动引入 MCP 工具清单代数（`mcpToolManifestGeneration`），当 MCP 发现刷新时推进代数，会话在下一次用户轮次自动重建以应用最新的 MCP 代理拓扑；MCP 代理工具也改为执行时惰性读取工具清单。

## Related Issue

无

## Changes Made

- **工具清单代数追踪**：`PiRuntimeAdapter` 新增 `mcpToolManifestGeneration` 计数器；`setMcpServerManager` 与新方法 `refreshMcpTools()` 均推进代数
- **会话按需重建**：`continueSession` 检测到 MCP 工具清单代数变化时，先销毁旧会话再重新创建（`disposeSessionForRecreation` → `startSession`），使新会话携带最新的 MCP 代理工具
- **惰性读取清单**：`buildMcpProxyTool` 不再在构建时快照工具清单，改为每次执行时通过 `getManifest()` 读取，避免执行到已刷新后的陈旧索引
- **主进程同步**：`main.ts` 新增 `syncPiMcpToolManifest()`，在 MCP 服务器启动发现（`initMcpServers`）与 bridge 刷新（`refreshMcpBridge`）后同步 Pi 运行时，无需为 MCP 引导实例化 Pi
- **测试覆盖**：新增「MCP 发现刷新后重建会话」用例，断言会话被中止并重建、重建后的会话包含 MCP 代理工具

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Added new tests
- [x] Manual testing performed

新增 1 个 `piRuntimeAdapter.test.ts` 用例；`piRuntimeAdapter` 相关 93 个用例全部通过，lint 通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

主进程改动：`PiRuntimeAdapter` 会话重建逻辑、`syncPiMcpToolManifest` 在 MCP 发现/刷新后的同步；无 IPC / preload 改动。

## Additional Notes

无
