### PR TITLE
fix(agent-engine): pi 会话 bash 工具继承应用托管运行时环境

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -55,6 +55,7 @@ const hoisted = vi.hoisted(() => {
       this.reload = vi.fn().mockResolvedValue(undefined);
     }),
     mockGetAgentDir: vi.fn(() => '/tmp/pi-agent'),
+    mockApplyApplicationRuntimeEnv: vi.fn(),
     mockCompleteSimple: vi.fn().mockResolvedValue({ content: [{ text: 'Hello from Pi' }] }),
     mockGetModel: vi.fn((provider: string, modelId: string) => ({
       provider,
@@ -172,6 +173,7 @@ const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
 const mockResolveRawApiConfig = hoisted.mockResolveRawApiConfig;
 const mockResolveRawApiConfigForModelRef = hoisted.mockResolveRawApiConfigForModelRef;
 const mockRegisterPiOpenAICompatUpstream = hoisted.mockRegisterPiOpenAICompatUpstream;
+const mockApplyApplicationRuntimeEnv = hoisted.mockApplyApplicationRuntimeEnv;
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: hoisted.mockCreateAgentSession,
@@ -201,6 +203,7 @@ vi.mock('../coworkUtil', async importOriginal => {
   const actual = await importOriginal<typeof import('../coworkUtil')>();
   return {
     ...actual,
+    applyApplicationRuntimeEnv: hoisted.mockApplyApplicationRuntimeEnv,
     resolveGitBashPathForPi: vi.fn(() => undefined),
   };
 });
@@ -232,6 +235,7 @@ describe('PiRuntimeAdapter', () => {
   };
 
   beforeEach(() => {
+    mockApplyApplicationRuntimeEnv.mockClear();
     vi.clearAllMocks();
     mockModelRuntimeCreate.mockResolvedValue(mockModelRuntime);
     adapter = new PiRuntimeAdapter();
@@ -249,6 +253,9 @@ describe('PiRuntimeAdapter', () => {
   describe('startSession', () => {
     it('should create a session and subscribe to events', async () => {
       await adapter.startSession('test', 'Hello Pi');
+      await adapter.startSession('test-second', 'Hello again');
+      expect(mockApplyApplicationRuntimeEnv).toHaveBeenCalledOnce();
+      expect(mockApplyApplicationRuntimeEnv).toHaveBeenCalledWith(process.env);
       expect(mockSession.subscribe).toHaveBeenCalled();
       expect(mockSession.prompt).toHaveBeenCalledWith('Hello Pi');
     });

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -76,7 +76,11 @@ import {
   resolveRawApiConfig,
   resolveRawApiConfigForModelRef,
 } from '../claudeSettings';
-import { getSkillsRoot, resolveGitBashPathForPi } from '../coworkUtil';
+import {
+  applyApplicationRuntimeEnv,
+  getSkillsRoot,
+  resolveGitBashPathForPi,
+} from '../coworkUtil';
 import type { McpServerManager } from '../mcpServerManager';
 import { isRasterPreviewDecodable, renderOfficePreview } from '../officePreviewRenderer';
 import {
@@ -460,6 +464,11 @@ const haveSameStringList = (left: string[] | undefined, right: string[] | undefi
 // tools won't emit escape sequences without this env var.
 if (!process.env.FORCE_COLOR) process.env.FORCE_COLOR = '1';
 
+// Pi's bash tool inherits the main-process environment. Initialize the
+// application-managed runtime once so later session creation cannot duplicate
+// PATH entries in process.env.
+let hasAppliedApplicationRuntimeEnv = false;
+
 export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private readonly activeSessions = new Map<string, ActivePiSession>();
   private readonly pendingMessageQueue = new PiPendingMessageQueue();
@@ -598,6 +607,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
     try {
       const workspaceRoot = options.workspaceRoot || process.cwd();
+      // Pi's built-in bash tool snapshots process.env when it executes. Give
+      // that snapshot the same app-managed Node/npm, Python, uv, and Git Bash
+      // PATH configuration used by direct Skill execution.
+      if (!hasAppliedApplicationRuntimeEnv) {
+        applyApplicationRuntimeEnv(process.env as Record<string, string | undefined>);
+        hasAppliedApplicationRuntimeEnv = true;
+      }
       const sessionOptions: Record<string, unknown> = { cwd: workspaceRoot };
 
       // System prompt — user config only. Skills are discovered and appended

--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -1091,7 +1091,14 @@ function applyDomesticPackageMirrorDefaults(env: Record<string, string | undefin
   }
 }
 
-function applyPackagedEnvOverrides(
+/**
+ * Add application-managed command runtimes to a subprocess environment.
+ *
+ * This deliberately does not add provider credentials. Callers that need the
+ * app's Node/npm shim, managed Python, uv, and Windows Git Bash PATH handling
+ * can use it without exposing a session's API configuration globally.
+ */
+export function applyApplicationRuntimeEnv(
   env: Record<string, string | undefined>,
   options: EnhancedEnvOptions = {},
 ): void {
@@ -1554,7 +1561,7 @@ export async function getEnhancedEnv(
   const config = getCurrentApiConfig(target);
   const env = config ? buildEnvForConfig(config) : { ...process.env };
 
-  applyPackagedEnvOverrides(env, options);
+  applyApplicationRuntimeEnv(env, options);
 
   // Inject SKILLs directory path for skill scripts.
   // On Windows, normalise backslashes to forward slashes so the value is usable


### PR DESCRIPTION
## Summary

修复 Pi 会话内建 bash 工具无法使用应用托管运行时（Node/npm、Python、uv、Git Bash）的问题：Pi 的 bash 工具执行时会快照 `process.env`，现在在创建会话前把与 Skill 直接执行一致的应用托管运行时 PATH 配置应用到 `process.env`，且只应用一次避免 PATH 重复追加。

## Related Issue

无关联 issue。

## Changes Made

- **coworkUtil.ts**：`applyPackagedEnvOverrides` 重命名为导出的 `applyApplicationRuntimeEnv`，补充文档注释明确只注入运行时 PATH，不暴露 provider 凭据
- **piRuntimeAdapter.ts**：创建会话前调用 `applyApplicationRuntimeEnv(process.env)`，`hasAppliedApplicationRuntimeEnv` 标志保证仅执行一次
- **piRuntimeAdapter.test.ts**：断言 `applyApplicationRuntimeEnv` 仅调用一次且入参为 `process.env`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Updated existing tests（startSession 用例补充运行时环境断言）

## Screenshots (if applicable)

无。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

`getEnhancedEnv` 内部继续使用 `applyApplicationRuntimeEnv`，行为不变。
