### PR TITLE
fix(cowork): 打通门禁反转与验收链路,简单任务不再要求人工验收

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -2264,11 +2264,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         }
         if (active.workbenchRunId && this.workbenchTaskService) {
           const workflowSnapshot = active.productionWorkflowEnabled
-            ? active.researchRun
-              ? active.researchRun.getSnapshot()
-              : active.shortcutWorkflow
-                ? active.shortcutWorkflow.getSnapshot()
-                : active.workExecution?.getSnapshot() || null
+            ? active.productionLoop
+              ? active.productionLoop.getSnapshot()
+              : active.researchRun
+                ? active.researchRun.getSnapshot()
+                : active.shortcutWorkflow
+                  ? active.shortcutWorkflow.getSnapshot()
+                  : active.workExecution?.getSnapshot() || null
             : null;
           this.workbenchTaskService.completeRun({
             sessionId,
@@ -2975,16 +2977,23 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   ): WorkbenchTaskContract {
     const research = managedWorkflow && isAcademicResearchSkillSet(skillIds);
     const shortcut = research ? null : resolveShortcutWorkflowKind(skillIds);
+    const kind =
+      sessionMode === 'chat'
+        ? WorkbenchContractKind.Chat
+        : research
+          ? WorkbenchContractKind.Research
+          : managedWorkflow && shortcut
+            ? WorkbenchContractKind.Shortcut
+            : WorkbenchContractKind.GenericWork;
     return {
-      kind:
-        sessionMode === 'chat'
-          ? WorkbenchContractKind.Chat
-          : research
-            ? WorkbenchContractKind.Research
-            : managedWorkflow && shortcut
-              ? WorkbenchContractKind.Shortcut
-              : WorkbenchContractKind.GenericWork,
-      requiresUserAcceptance: sessionMode !== 'chat' && !research && !(managedWorkflow && shortcut),
+      kind,
+      // Generic work without the production workflow (simple questions, trivial
+      // requests) is gated by the baseline checks alone and never needs manual
+      // acceptance. The production workflow owns the acceptance gate instead.
+      requiresUserAcceptance:
+        sessionMode !== 'chat' &&
+        kind === WorkbenchContractKind.GenericWork &&
+        managedWorkflow,
       metadata: {
         productionWorkflowEnabled: managedWorkflow,
         ...(skillIds?.length ? { skillIds } : {}),

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -340,3 +340,14 @@ test('skip_workflow is rejected after a plan is committed', () => {
   reachCritique(controller);
   expect(() => controller.skipWorkflow('too late')).toThrow('before a plan is committed');
 });
+
+test('getSnapshot exposes the skip flag for the verification chain', () => {
+  const { controller } = createController();
+  expect(controller.getSnapshot().skipped).toBe(false);
+  controller.skipWorkflow('Pure information request with no work to plan');
+  expect(controller.getSnapshot()).toMatchObject({
+    skipped: true,
+    phase: ProductionLoopPhase.Plan,
+    status: ProductionLoopStatus.Completed,
+  });
+});

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -311,6 +311,22 @@ export class ProductionLoopController {
     );
   }
 
+  /** Compact snapshot for the workbench completion verification chain. */
+  getSnapshot(): Record<string, unknown> {
+    this.refresh();
+    return {
+      phase: this.state.phase,
+      status: this.state.status,
+      skipped: Boolean(this.state.skip),
+      planItems: this.state.planItems.map(item => ({
+        status: item.status,
+        title: item.title,
+      })),
+      inspections: this.state.inspections.length,
+      revisions: this.state.revisions.length,
+    };
+  }
+
   private refresh(): void {
     this.state = this.service.getState(this.state.runId);
   }

--- a/src/main/workbenchTask/verification.test.ts
+++ b/src/main/workbenchTask/verification.test.ts
@@ -51,6 +51,44 @@ test('generic work falls back to explicit acceptance', () => {
   expect(result.outcome).toBe(WorkbenchVerificationOutcome.AcceptanceRequired);
 });
 
+test('generic work without user acceptance passes on baseline checks alone', () => {
+  const result = verifyWorkbenchRun({
+    contract: {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: false,
+    },
+    finalAnswer: '2',
+    streamClosedCleanly: true,
+  });
+  expect(result.outcome).toBe(WorkbenchVerificationOutcome.Passed);
+  expect(result.checks.some(check => check.name === 'deterministic_contract')).toBe(true);
+
+  // Baseline failures still block the run.
+  const failed = verifyWorkbenchRun({
+    contract: {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: false,
+    },
+    finalAnswer: '',
+    streamClosedCleanly: true,
+  });
+  expect(failed.outcome).toBe(WorkbenchVerificationOutcome.Failed);
+});
+
+test('a skipped production workflow passes without manual acceptance', () => {
+  const result = verifyWorkbenchRun({
+    contract: {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: true,
+    },
+    finalAnswer: '2',
+    streamClosedCleanly: true,
+    workflowSnapshot: { skipped: true, phase: 'plan' },
+  });
+  expect(result.outcome).toBe(WorkbenchVerificationOutcome.Passed);
+  expect(result.checks.some(check => check.name === 'workflow_skipped')).toBe(true);
+});
+
 test('generic work cannot use acceptance to override baseline failures', () => {
   const contract = {
     kind: WorkbenchContractKind.GenericWork,

--- a/src/main/workbenchTask/verification.ts
+++ b/src/main/workbenchTask/verification.ts
@@ -103,6 +103,41 @@ export function verifyWorkbenchRun(
     };
   }
 
+  // The production workflow was declared unnecessary (skip_workflow): the
+  // baseline checks already passed, so there is nothing left to accept.
+  if (context.workflowSnapshot?.skipped === true) {
+    return {
+      outcome: WorkbenchVerificationOutcome.Passed,
+      checks: [
+        {
+          name: 'workflow_skipped',
+          status: WorkbenchVerificationCheckStatus.Passed,
+        },
+      ],
+      evidence: context.workflowSnapshot ? [context.workflowSnapshot] : [],
+      summary: 'The production workflow was skipped; the baseline checks passed.',
+    };
+  }
+
+  // Generic work without the production workflow (simple questions, trivial
+  // requests) has no verifiable artifacts: the baseline checks are the only
+  // gate and need no explicit user acceptance.
+  if (!context.contract.requiresUserAcceptance) {
+    return {
+      outcome: WorkbenchVerificationOutcome.Passed,
+      checks: [
+        {
+          name: 'deterministic_contract',
+          status: WorkbenchVerificationCheckStatus.Passed,
+          detail: 'The work result passed the baseline completeness checks.',
+        },
+        ...baselineChecks,
+      ],
+      evidence: context.workflowSnapshot ? [context.workflowSnapshot] : [],
+      summary: 'The work result passed the baseline completeness checks.',
+    };
+  }
+
   return {
     outcome: WorkbenchVerificationOutcome.AcceptanceRequired,
     checks: [


### PR DESCRIPTION
## 背景

"1+1=?" 这类简单任务,即使被生产循环门禁判定为无需工作流(#439 反转)或模型显式调用 `skip_workflow`,**仍会以 `AcceptanceRequired` 结束并强制人工验收**。根因是三条链路互不感知:

| 层 | 现状 | 问题 |
|---|---|---|
| `createWorkbenchContract.requiresUserAcceptance` | 只认 sessionMode/kind | 不看生产循环门禁 |
| `verifyWorkbenchRun` | GenericWork 只认 `workflowSnapshot.accepted` | 门禁反转/跳过场景永远 false |
| 生产循环状态 | 不进验证链 | `skip` 标志传不到 verification |

## 改动(3 处打通)

1. **[piRuntimeAdapter.ts](src/main/libs/agentEngine/piRuntimeAdapter.ts) `createWorkbenchContract`**:GenericWork 且生产循环未启用(`managedWorkflow=false`)时 `requiresUserAcceptance = false`——基线检查通过即自动完成
2. **[verification.ts](src/main/workbenchTask/verification.ts) `verifyWorkbenchRun`** 新增两条自动通过路径:
   - `workflowSnapshot.skipped === true`(生产循环已跳过)
   - `requiresUserAcceptance === false`(门禁反转的简单任务)
   - 基线失败仍阻断(`final_response` / `stream_closed_cleanly` 检查不变)
3. **[controller.ts](src/main/productionLoop/controller.ts) 新增 `getSnapshot()`**:把 `skip` 标志、phase/status、planItems 摘要接入 `completeRun` 的 `workflowSnapshot`

## 效果

| 场景 | 之前 | 之后 |
|---|---|---|
| 门禁反转(1+1=?) | 人工验收 | 基线通过即自动完成 |
| skip_workflow | 人工验收 | 基线通过即自动完成 |
| 生产循环正常交付 | 人工验收(未接验证证据) | 不变(仍人工验收) |

## 验证

- verification 测试 6/6(新增 2 条:无验收合约基线通过、skip 后自动通过)
- controller 测试 14/14(新增 getSnapshot skip 标志)
- taskService 测试 21/21
- `tsc`、`oxlint` 通过

> 注:controller/taskService 测试需用 Electron 内置 Node 运行(native 模块版本匹配),CI 不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)