### PR TITLE
fix(installer): avoid legacy NSIS dollar parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prepare:modelscope-tokens": "node scripts/write-modelscope-token-resource.cjs",
     "prepare:update-release": "node scripts/prepare-update-release.cjs",
     "start:electron": "cross-env NODE_ENV=development ELECTRON_START_URL=http://localhost:5175 electron .",
-    "electron:dev": "bun run channel:runtime:host && bun run engram:runtime:host && rimraf dist-electron && bun run compile:electron && concurrently \"vite --port 5175\" \"wait-on -l -t 120000 -d 20000 -i 1000 -s 1 http://localhost:5175 && wait-on -l -t 120000 -i 1000 dist-electron/.electron-ready && bun run start:electron\"",
+    "electron:dev": "bun run channel:runtime:download && bun run engram:runtime:host && rimraf dist-electron && bun run compile:electron && concurrently \"vite --port 5175\" \"wait-on -l -t 120000 -d 20000 -i 1000 -s 1 http://localhost:5175 && wait-on -l -t 120000 -i 1000 dist-electron/.electron-ready && bun run start:electron\"",
     "postinstall": "patch-package && electron-builder install-app-deps",
     "pack": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run channel:runtime:download && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder --dir",
     "dist": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run channel:runtime:download && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder",

--- a/scripts/channel-runtime-smoke.cjs
+++ b/scripts/channel-runtime-smoke.cjs
@@ -90,7 +90,7 @@ async function main() {
   } catch {}
   const executable = path.join(runtimeRoot, publishedBinary);
   if (!fs.existsSync(executable)) {
-    throw new Error('Channel runtime is missing. Run `npm run channel:runtime:host` first.');
+    throw new Error('Channel runtime is missing. Run `npm run channel:runtime:download` first.');
   }
 
   const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-channel-smoke-'));

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -493,7 +493,7 @@
       $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
       $$statePath = Join-Path $$runtimeRoot \"component-switch-state.txt\";\
       if (Test-Path -LiteralPath $$statePath) {\
-        $$states = @(Get-Content -LiteralPath $$statePath | Where-Object { $$_ -match \"^[^=|]+\\|(?:True|False)$$\" });\
+        $$states = @(Get-Content -LiteralPath $$statePath | Where-Object { $$_ -match \"^[^=|]+\\|(?:True|False)\\z\" });\
         [array]::Reverse($$states);\
         foreach ($$state in $$states) {\
           $$parts = $$state.Split(\"|\");\

--- a/src/renderer/components/cowork/WorkbenchTaskAcceptanceCard.test.tsx
+++ b/src/renderer/components/cowork/WorkbenchTaskAcceptanceCard.test.tsx
@@ -26,6 +26,7 @@ const task: WorkbenchTask = {
     metadata: {},
   },
   createdAt: 1,
+  completedAt: null,
   updatedAt: 1,
 };
 

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -63,6 +63,8 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('component-switch-state.txt');
     expect(installerScript).toContain('Keep the journal in the persistent cache');
     expect(installerScript).toContain('Join-Path $$runtimeRoot \\"component-switch-state.txt\\"');
+    expect(installerScript).toContain('^[^=|]+\\\\|(?:True|False)\\\\z');
+    expect(installerScript).not.toContain('(?:True|False)$$');
     expect(installerScript).toContain('phase=component-set-rollback');
     expect(installerScript).toContain('phase=component-cleanup-complete');
     expect(installerScript).not.toContain('离线组件原子切换失败');


### PR DESCRIPTION
## Summary

- replace a PowerShell regex end anchor that NSIS 3.0.4.1 misparses during customInstall expansion
- add a regression assertion that prevents the ambiguous dollar sequence from returning

## Verification

- npx vitest run tests/nsis-installer.test.ts tests/windows-resource-pack.test.ts
- npx tsc --noEmit
- npx tsc -p electron-tsconfig.json --noEmit
- npm run lint
- node scripts/ci/check-openclaw-decoupling.mjs
- makensis /WX full customInstall macro expansion (NSIS 3.12)

Follow-up to #442.