### PR TITLE
fix(cowork): 审计面板加宽,内容不再被折叠截断

### DIFF
--- a/src/renderer/components/cowork/WorkbenchTaskAcceptanceCard.test.tsx
+++ b/src/renderer/components/cowork/WorkbenchTaskAcceptanceCard.test.tsx
@@ -26,6 +26,7 @@ const task: WorkbenchTask = {
     metadata: {},
   },
   createdAt: 1,
+  completedAt: null,
   updatedAt: 1,
 };
 

--- a/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.tsx
@@ -97,10 +97,10 @@ export function ArtifactAuditTab({ artifacts, runs }: ArtifactAuditTabProps) {
             return (
               <TableRow key={artifact.id}>
                 <TableCell>{getRunAttempt(runs, artifact.runId) ?? '-'}</TableCell>
-                <TableCell className="max-w-[240px] truncate">{artifact.reference}</TableCell>
+                <TableCell className="max-w-[320px] break-all">{artifact.reference}</TableCell>
                 <TableCell>{artifactKindLabel(artifact.kind)}</TableCell>
                 <TableCell>{artifactProvenanceLabel(artifact.provenance)}</TableCell>
-                <TableCell className="max-w-48 truncate font-mono text-xs">
+                <TableCell className="max-w-64 break-all font-mono text-xs">
                   {artifact.contentHash}
                 </TableCell>
                 <TableCell>{artifactVerificationLabel(artifact.verificationStatus)}</TableCell>

--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditSheet.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditSheet.tsx
@@ -100,7 +100,7 @@ export function WorkbenchTaskAuditSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-3xl">
+      <SheetContent className="w-full sm:max-w-5xl">
         <SheetHeader>
           <div className="flex items-center gap-2">
             <SheetTitle className="min-w-0 flex-1">


### PR DESCRIPTION
## 背景

审计面板(WorkbenchTaskAuditSheet)此前固定 `sm:max-w-3xl`(768px),而 Artifacts Tab 是 7 列表格(Attempt / Reference / Type / Source / Hash / Verification / Actions)——768px 下必然被挤压截断:Reference 列 `max-w-[240px] truncate`、Hash 列 `max-w-48 truncate`,文件路径和内容哈希看不全。

## 改动

1. **面板加宽**:`SheetContent` 从 `sm:max-w-3xl` → `sm:max-w-5xl`(1024px),给全部列让出完整空间
2. **Artifacts 列不再省略截断**:Reference / Hash 从 `truncate` 改为 `break-all`(完整换行展示),列宽上限放宽(240→320px / 192→256px)
3. **顺带修复**:`WorkbenchTaskAcceptanceCard.test.tsx` 补 `completedAt` 字段(workbench task 类型演进后导致 tsc 失败)

## 验证

- `tsc` 通过
- acceptance card + audit 测试 9/9 通过
- `oxlint` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)