### PR TITLE
fix(release): align supply-chain lockfile checks

### DIFF
--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           set -euo pipefail
           for lockfile in \
-            package-lock.json \
             SKILLs/presentation-studio/package-lock.json \
             SKILLs/web-search/package-lock.json \
             scripts/release/package-lock.json; do

--- a/scripts/ci/check-supply-chain-inputs.mjs
+++ b/scripts/ci/check-supply-chain-inputs.mjs
@@ -4,7 +4,6 @@ import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 const npmLockfiles = [
-  'package-lock.json',
   'SKILLs/presentation-studio/package-lock.json',
   'SKILLs/web-search/package-lock.json',
   'scripts/release/package-lock.json',

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -126,6 +126,41 @@ test("publish verification uses portable jq flags and preserves updater filename
   );
 });
 
+test("release supply-chain gates track every checked-in npm lockfile", () => {
+  const trackedLockfiles = execFileSync(
+    "git",
+    ["ls-files", "*package-lock.json"],
+    { cwd: root, encoding: "utf8" },
+  )
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .sort();
+  const policy = readFileSync(
+    path.join(root, "scripts", "ci", "check-supply-chain-inputs.mjs"),
+    "utf8",
+  );
+  const workflow = readFileSync(
+    path.join(root, ".github", "workflows", "online-update-release.yml"),
+    "utf8",
+  );
+  const policyLockfiles = Array.from(
+    policy.matchAll(/^\s+'([^']+package-lock\.json)',?$/gm),
+    (match) => match[1],
+  ).sort();
+  const signatureStep = workflow.slice(
+    workflow.indexOf("- name: Verify npm package signatures"),
+    workflow.indexOf("- name: Enforce approved package sources"),
+  );
+  const workflowLockfiles = Array.from(
+    signatureStep.matchAll(/^\s+([^\s]+package-lock\.json)(?: \\|; do)?$/gm),
+    (match) => match[1],
+  ).sort();
+
+  assert.deepEqual(policyLockfiles, trackedLockfiles);
+  assert.deepEqual(workflowLockfiles, trackedLockfiles);
+});
+
 test("unsigned macOS release builds do not receive empty signing credentials", () => {
   const workflow = readFileSync(
     path.join(root, ".github", "workflows", "online-update-release.yml"),


### PR DESCRIPTION
Removes the deleted root package-lock.json from release provenance checks, retains checks for all tracked npm lockfiles, and adds a synchronization regression test. Follow-up to the failed v2026.8.12-build.2 release.