### PR TITLE
fix(packaging): rebase POSIX skill Python links

### DIFF
--- a/scripts/setup-skill-python-runtime.js
+++ b/scripts/setup-skill-python-runtime.js
@@ -232,11 +232,7 @@ function rebaseEnvironmentSymlinks(environmentRoot, basePythonPath) {
     ) {
       continue;
     }
-    const targetRelativeToBase = path.relative(baseRuntimeRoot, resolvedTarget);
-    const packageBaseRoot = path.dirname(path.dirname(environmentRoot));
-    const packagedBaseRoot = path.join(packageBaseRoot, path.basename(baseRuntimeRoot));
-    const packagedTarget = path.join(packagedBaseRoot, targetRelativeToBase);
-    const relativeTarget = path.relative(path.dirname(linkPath), packagedTarget);
+    const relativeTarget = path.relative(path.dirname(linkPath), resolvedTarget);
     fs.unlinkSync(linkPath);
     fs.symlinkSync(relativeTarget, linkPath);
   }
@@ -576,6 +572,7 @@ module.exports = {
   normalizePlatform,
   parseImportNames,
   pythonExecutableForEnvironment,
+  rebaseEnvironmentSymlinks,
   validateSkillDependencyDeclarations,
   ensureSkillPythonRuntimes,
 };

--- a/tests/setupSkillPythonRuntime.test.ts
+++ b/tests/setupSkillPythonRuntime.test.ts
@@ -8,6 +8,7 @@ import {
   listRequirementFiles,
   normalizePlatform,
   parseImportNames,
+  rebaseEnvironmentSymlinks,
   validateSkillDependencyDeclarations,
 } from '../scripts/setup-skill-python-runtime.js';
 
@@ -64,6 +65,27 @@ describe('setup-skill-python-runtime', () => {
       expect(validateSkillDependencyDeclarations(root)).toEqual({ ok: true, missing: [] });
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rebases POSIX environment links to the sibling packaged Python runtime', () => {
+    const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-python-links-'));
+    try {
+      const basePython = path.join(resourcesRoot, 'python-mac', 'bin', 'python3');
+      const environmentRoot = path.join(resourcesRoot, 'skill-python', 'layers', 'shared');
+      const environmentPython = path.join(environmentRoot, 'bin', 'python3');
+      fs.mkdirSync(path.dirname(basePython), { recursive: true });
+      fs.mkdirSync(path.dirname(environmentPython), { recursive: true });
+      fs.writeFileSync(basePython, '');
+      fs.symlinkSync(basePython, environmentPython);
+
+      rebaseEnvironmentSymlinks(environmentRoot, basePython);
+
+      const rebasedTarget = fs.readlinkSync(environmentPython);
+      expect(path.isAbsolute(rebasedTarget)).toBe(false);
+      expect(path.resolve(path.dirname(environmentPython), rebasedTarget)).toBe(basePython);
+    } finally {
+      fs.rmSync(resourcesRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Fixes the macOS release failure by rebasing shared Skill Python environment symlinks to the actual sibling packaged Python runtime. Adds a filesystem regression test for the packaged resources layout. Follow-up to failed v2026.8.12-build.3.