### PR TITLE
perf(installer): reduce Windows offline package size

### DIFF
--- a/.github/workflows/windows-installer-pr.yml
+++ b/.github/workflows/windows-installer-pr.yml
@@ -78,6 +78,14 @@ jobs:
           powershell -NoProfile -ExecutionPolicy Bypass
           -File scripts/ci/windows-installer-size-smoke.ps1
           -ProjectRoot ${{ github.workspace }}
+      - name: Benchmark shared Skill Python solid compression
+        id: skill-python-compression
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/benchmark-skill-python-compression.ps1
+          -ProjectRoot ${{ github.workspace }}
+          -RequireQualified
       - name: Verify embedded runtimes with a clean PATH
         shell: powershell
         run: >-

--- a/scripts/ci/benchmark-skill-python-compression.ps1
+++ b/scripts/ci/benchmark-skill-python-compression.ps1
@@ -1,0 +1,279 @@
+param(
+  [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [string]$ComponentsDir = '',
+  [string]$SevenZipPath = '',
+  [int]$ExtractionRuns = 2,
+  [int64]$MinimumSavingsBytes = 1MB,
+  [double]$MaximumExtractionRatio = 1.25,
+  [string]$ReportPath = '',
+  [switch]$SkipPythonProbe,
+  [switch]$RequireQualified
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Path {
+  param([Parameter(Mandatory = $true)][string]$Path, [Parameter(Mandatory = $true)][string]$Label)
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Missing ${Label}: $Path"
+  }
+}
+
+function Remove-DirectoryTree {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [switch]$BestEffort
+  )
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return
+  }
+  try {
+    $extendedPath = if ($Path.StartsWith('\\?\')) { $Path } else { "\\?\$Path" }
+    [IO.Directory]::Delete($extendedPath, $true)
+  } catch {
+    if ($BestEffort) {
+      Write-Warning "Could not remove benchmark directory ${Path}: $($_.Exception.Message)"
+      return
+    }
+    throw
+  }
+}
+
+function Invoke-SevenZip {
+  param(
+    [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+  & $SevenZipPath @ArgumentList | Out-Host
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Expand-ArchiveMeasured {
+  param(
+    [Parameter(Mandatory = $true)][string]$ArchivePath,
+    [Parameter(Mandatory = $true)][string]$DestinationPath,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+  New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
+  $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+  Invoke-SevenZip @('x', '-bd', '-y', "-o$DestinationPath", $ArchivePath) $Label
+  $stopwatch.Stop()
+  return [int64]$stopwatch.ElapsedMilliseconds
+}
+
+function Get-ExtractedTreeManifest {
+  param([Parameter(Mandatory = $true)][string]$Root)
+  $manifest = @{}
+  foreach ($item in Get-ChildItem -LiteralPath $Root -Recurse -Force) {
+    $relativePath = $item.FullName.Substring($Root.Length).TrimStart('\').Replace('\', '/')
+    if ($item.PSIsContainer) {
+      $manifest[$relativePath] = 'directory'
+    } else {
+      $hash = (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+      $manifest[$relativePath] = "file:$($item.Length):$hash"
+    }
+  }
+  return $manifest
+}
+
+function Assert-TreesEqual {
+  param(
+    [Parameter(Mandatory = $true)][string]$BaselineRoot,
+    [Parameter(Mandatory = $true)][string]$CandidateRoot
+  )
+  $baseline = Get-ExtractedTreeManifest $BaselineRoot
+  $candidate = Get-ExtractedTreeManifest $CandidateRoot
+  if ($baseline.Count -ne $candidate.Count) {
+    throw "Skill Python archive entry count mismatch: baseline $($baseline.Count), solid $($candidate.Count)"
+  }
+  foreach ($entry in $baseline.GetEnumerator()) {
+    if (-not $candidate.ContainsKey($entry.Key)) {
+      throw "Skill Python solid archive is missing entry: $($entry.Key)"
+    }
+    if ($candidate[$entry.Key] -ne $entry.Value) {
+      throw "Skill Python archive entry mismatch: $($entry.Key)"
+    }
+  }
+}
+
+function Invoke-PythonProbe {
+  param([Parameter(Mandatory = $true)][string]$PythonPath, [Parameter(Mandatory = $true)][string]$Label)
+  $modules = @(
+    'PIL',
+    'cnlunar',
+    'colorama',
+    'line_profiler',
+    'lunardate',
+    'matplotlib',
+    'numpy',
+    'openpyxl',
+    'pandas',
+    'pip_audit',
+    'psycopg2',
+    'pylint',
+    'pypdf',
+    'pypdfium2',
+    'pytest',
+    'reportlab',
+    'scipy',
+    'statsmodels'
+  )
+  $probe = 'import ' + ($modules -join ',') + '; print(1)'
+  & $PythonPath -c $probe
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE"
+  }
+}
+
+if ($ExtractionRuns -lt 1) {
+  throw 'ExtractionRuns must be at least 1'
+}
+if ($MaximumExtractionRatio -le 0) {
+  throw 'MaximumExtractionRatio must be greater than 0'
+}
+if (-not $ComponentsDir) {
+  $ComponentsDir = Join-Path $ProjectRoot 'build-tar\windows-components'
+}
+if (-not $SevenZipPath) {
+  $SevenZipPath = Join-Path $ProjectRoot 'node_modules\7zip-bin\win\x64\7za.exe'
+}
+if (-not $ReportPath) {
+  $ReportPath = Join-Path $ComponentsDir 'skill-python-compression-benchmark.json'
+}
+
+$sourceRoot = Join-Path $ProjectRoot 'resources\skill-python'
+$manifestPath = Join-Path $ComponentsDir 'manifest.json'
+Assert-Path $sourceRoot 'shared Skill Python source layer'
+Assert-Path $manifestPath 'Windows component manifest'
+Assert-Path $SevenZipPath '7za.exe'
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+$components = @($manifest.components | Where-Object { $_.key -eq 'skill-python' })
+if ($components.Count -ne 1) {
+  throw "Expected exactly one skill-python component; found $($components.Count)"
+}
+$component = $components[0]
+if ($component.archiveCompression -ne 'lzma2-mx9-solid-v1') {
+  throw "Skill Python component must use lzma2-mx9-solid-v1; found $($component.archiveCompression)"
+}
+$solidArchive = Join-Path $ComponentsDir $component.archive
+Assert-Path $solidArchive 'solid Skill Python component archive'
+
+$benchmarkRoot = Join-Path ([IO.Path]::GetTempPath()) ("zspb-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N').Substring(0, 8))
+$baselineArchive = Join-Path $benchmarkRoot 'skill-python-nonsolid.7z'
+$baselineTimes = @()
+$solidTimes = @()
+$baselineExtractedRoot = ''
+$solidExtractedRoot = ''
+
+try {
+  New-Item -ItemType Directory -Path $benchmarkRoot -Force | Out-Null
+  Push-Location (Join-Path $ProjectRoot 'resources')
+  try {
+    Invoke-SevenZip @(
+      'a', '-t7z', '-mx=9', '-m0=lzma2', '-ms=off', '-mmt=on', $baselineArchive, 'skill-python'
+    ) 'Skill Python non-solid baseline archive creation'
+  } finally {
+    Pop-Location
+  }
+
+  $solidListing = (& $SevenZipPath 'l' '-slt' $solidArchive 2>&1) -join "`n"
+  if ($LASTEXITCODE -ne 0) {
+    throw "Skill Python solid archive listing failed with exit code $LASTEXITCODE"
+  }
+  if ($solidListing -notmatch '(?m)^Solid = \+$') {
+    throw 'Skill Python candidate archive is not solid'
+  }
+
+  for ($run = 0; $run -lt $ExtractionRuns; $run++) {
+    $order = if (($run % 2) -eq 0) { @('baseline', 'solid') } else { @('solid', 'baseline') }
+    foreach ($profile in $order) {
+      $destination = Join-Path $benchmarkRoot ("extract-{0}-{1}" -f $profile, $run)
+      $archive = if ($profile -eq 'baseline') { $baselineArchive } else { $solidArchive }
+      $elapsed = Expand-ArchiveMeasured $archive $destination "Skill Python $profile extraction run $($run + 1)"
+      if ($profile -eq 'baseline') {
+        $baselineTimes += $elapsed
+        if ($run -eq 0) { $baselineExtractedRoot = $destination }
+      } else {
+        $solidTimes += $elapsed
+        if ($run -eq 0) { $solidExtractedRoot = $destination }
+      }
+      if ($run -ne 0) {
+        Remove-DirectoryTree $destination
+      }
+    }
+  }
+
+  Assert-TreesEqual $baselineExtractedRoot $solidExtractedRoot
+  if (-not $SkipPythonProbe) {
+    $relativePython = 'skill-python\layers\shared\Scripts\python.exe'
+    $baselinePython = Join-Path $baselineExtractedRoot $relativePython
+    $solidPython = Join-Path $solidExtractedRoot $relativePython
+    Assert-Path $baselinePython 'non-solid shared Skill Python executable'
+    Assert-Path $solidPython 'solid shared Skill Python executable'
+    Invoke-PythonProbe $baselinePython 'Non-solid shared Skill Python dependency probe'
+    Invoke-PythonProbe $solidPython 'Solid shared Skill Python dependency probe'
+  }
+
+  $baselineBytes = [int64](Get-Item -LiteralPath $baselineArchive).Length
+  $solidBytes = [int64](Get-Item -LiteralPath $solidArchive).Length
+  $savedBytes = $baselineBytes - $solidBytes
+  $baselineAverageMs = [math]::Round(($baselineTimes | Measure-Object -Average).Average, 1)
+  $solidAverageMs = [math]::Round(($solidTimes | Measure-Object -Average).Average, 1)
+  $extractionRatio = if ($baselineAverageMs -gt 0) {
+    [math]::Round($solidAverageMs / $baselineAverageMs, 3)
+  } else {
+    [double]::PositiveInfinity
+  }
+  $qualified = $savedBytes -ge $MinimumSavingsBytes -and $extractionRatio -le $MaximumExtractionRatio
+
+  $report = [ordered]@{
+    qualified = $qualified
+    baselineBytes = $baselineBytes
+    solidBytes = $solidBytes
+    savedBytes = $savedBytes
+    baselineExtractionMilliseconds = $baselineTimes
+    solidExtractionMilliseconds = $solidTimes
+    baselineAverageMilliseconds = $baselineAverageMs
+    solidAverageMilliseconds = $solidAverageMs
+    extractionRatio = $extractionRatio
+    minimumSavingsBytes = $MinimumSavingsBytes
+    maximumExtractionRatio = $MaximumExtractionRatio
+    contentSha256Equal = $true
+    pythonProbePassed = -not $SkipPythonProbe
+  }
+  $reportDirectory = Split-Path -Parent $ReportPath
+  New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+  $reportJson = $report | ConvertTo-Json -Depth 4
+  [IO.File]::WriteAllText($ReportPath, $reportJson, [Text.UTF8Encoding]::new($false))
+
+  $summary = @(
+    '### Shared Skill Python compression benchmark',
+    '',
+    "- qualified: $($qualified.ToString().ToLowerInvariant())",
+    "- non-solid bytes: $baselineBytes",
+    "- solid bytes: $solidBytes",
+    "- saved bytes: $savedBytes",
+    "- non-solid extraction milliseconds: $($baselineTimes -join ', ')",
+    "- solid extraction milliseconds: $($solidTimes -join ', ')",
+    "- extraction ratio: $extractionRatio (maximum $MaximumExtractionRatio)",
+    '- extracted content SHA-256: identical',
+    "- dependency probe: $(if ($SkipPythonProbe) { 'skipped' } else { 'passed' })"
+  ) -join [Environment]::NewLine
+  Write-Host $summary
+  if ($env:GITHUB_STEP_SUMMARY) {
+    Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $summary -Encoding UTF8
+  }
+  if ($env:GITHUB_OUTPUT) {
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "qualified=$($qualified.ToString().ToLowerInvariant())" -Encoding UTF8
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "saved_bytes=$savedBytes" -Encoding UTF8
+    Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "extraction_ratio=$extractionRatio" -Encoding UTF8
+  }
+  if ($RequireQualified -and -not $qualified) {
+    throw "Shared Skill Python solid compression did not meet the required size and extraction thresholds"
+  }
+} finally {
+  Remove-DirectoryTree $benchmarkRoot -BestEffort
+}

--- a/scripts/ci/benchmark-skill-python-compression.test.ts
+++ b/scripts/ci/benchmark-skill-python-compression.test.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+const scriptPath = path.join(__dirname, 'benchmark-skill-python-compression.ps1');
+const sevenZipPath = require.resolve('7zip-bin/win/x64/7za.exe');
+
+function createFixture(changeSourceAfterBaseline = false) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-skill-python-benchmark-test-'));
+  temporaryDirectories.push(root);
+  const sourceRoot = path.join(root, 'resources', 'skill-python');
+  const componentsRoot = path.join(root, 'build-tar', 'windows-components');
+  fs.mkdirSync(path.join(sourceRoot, 'layers', 'shared', 'Scripts'), { recursive: true });
+  fs.mkdirSync(componentsRoot, { recursive: true });
+  for (let index = 0; index < 40; index += 1) {
+    fs.writeFileSync(path.join(sourceRoot, `module-${index}.txt`), 'shared-content-'.repeat(500));
+  }
+  fs.writeFileSync(path.join(sourceRoot, 'layers', 'shared', 'Scripts', 'python.exe'), 'fixture');
+
+  const archivePath = path.join(componentsRoot, 'skill-python.7z');
+  const archive = spawnSync(
+    sevenZipPath,
+    ['a', '-t7z', '-mx=9', '-m0=lzma2', '-ms=on', archivePath, 'skill-python'],
+    { cwd: path.join(root, 'resources'), encoding: 'utf8' },
+  );
+  expect(archive.status, archive.stderr || archive.stdout).toBe(0);
+  fs.writeFileSync(
+    path.join(componentsRoot, 'manifest.json'),
+    JSON.stringify({
+      components: [
+        {
+          key: 'skill-python',
+          archive: 'skill-python.7z',
+          archiveCompression: 'lzma2-mx9-solid-v1',
+        },
+      ],
+    }),
+  );
+  if (changeSourceAfterBaseline) {
+    fs.writeFileSync(path.join(sourceRoot, 'module-0.txt'), 'changed-after-baseline');
+  }
+  return { root, componentsRoot };
+}
+
+function runBenchmark(
+  root: string,
+  componentsRoot: string,
+  options: { minimumSavingsBytes?: number; requireQualified?: boolean } = {},
+) {
+  return spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-ProjectRoot',
+      root,
+      '-ComponentsDir',
+      componentsRoot,
+      '-SevenZipPath',
+      sevenZipPath,
+      '-ExtractionRuns',
+      '1',
+      '-MinimumSavingsBytes',
+      String(options.minimumSavingsBytes ?? 1),
+      '-MaximumExtractionRatio',
+      '100',
+      '-SkipPythonProbe',
+      ...(options.requireQualified ? ['-RequireQualified'] : []),
+    ],
+    { encoding: 'utf8', timeout: 60_000 },
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform !== 'win32')('shared Skill Python compression benchmark', () => {
+  test('qualifies a smaller solid archive with identical extracted content', () => {
+    const fixture = createFixture();
+    const result = runBenchmark(fixture.root, fixture.componentsRoot);
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    const report = JSON.parse(
+      fs.readFileSync(
+        path.join(fixture.componentsRoot, 'skill-python-compression-benchmark.json'),
+        'utf8',
+      ),
+    );
+    expect(report.qualified).toBe(true);
+    expect(report.savedBytes).toBeGreaterThan(0);
+    expect(report.contentSha256Equal).toBe(true);
+  });
+
+  test('rejects a solid candidate whose source differs from the packaged baseline', () => {
+    const fixture = createFixture(true);
+    const result = runBenchmark(fixture.root, fixture.componentsRoot);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('archive entry mismatch');
+  });
+
+  test('fails the required CI gate when compression does not meet the threshold', () => {
+    const fixture = createFixture();
+    const result = runBenchmark(fixture.root, fixture.componentsRoot, {
+      minimumSavingsBytes: Number.MAX_SAFE_INTEGER,
+      requireQualified: true,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('did not meet the required size and extraction thresholds');
+    const report = JSON.parse(
+      fs.readFileSync(
+        path.join(fixture.componentsRoot, 'skill-python-compression-benchmark.json'),
+        'utf8',
+      ),
+    );
+    expect(report.qualified).toBe(false);
+  });
+});

--- a/scripts/ci/windows-installer-size-smoke.ps1
+++ b/scripts/ci/windows-installer-size-smoke.ps1
@@ -1,5 +1,8 @@
 param(
-  [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+  [string]$ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [int64]$MaximumInstallerBytes = 425MB,
+  [int64]$MaximumComponentBytes = 220MB,
+  [int64]$MaximumNonComponentBytes = 220MB
 )
 
 $ErrorActionPreference = 'Stop'
@@ -24,22 +27,33 @@ if ($null -eq $componentBytes -or $componentBytes -le 0) {
 
 $installer = $installers[0]
 $installerBytes = [int64]$installer.Length
-# The installer embeds the component archives plus the Electron application. A
-# 1GB envelope catches accidental payload duplication without inventing a
-# brittle release-size baseline before the first Windows build is available.
-$maximumBytes = $componentBytes + 1GB
-if ($installerBytes -gt $maximumBytes) {
-  throw "Installer is unexpectedly large: $installerBytes bytes (maximum $maximumBytes bytes; component archive bytes $componentBytes)"
+$nonComponentBytes = $installerBytes - $componentBytes
+if ($componentBytes -gt $MaximumComponentBytes) {
+  throw "Windows component archives are unexpectedly large: $componentBytes bytes (maximum $MaximumComponentBytes bytes)"
+}
+if ($nonComponentBytes -gt $MaximumNonComponentBytes) {
+  throw "Windows installer non-component payload is unexpectedly large: $nonComponentBytes bytes (maximum $MaximumNonComponentBytes bytes)"
+}
+if ($installerBytes -gt $MaximumInstallerBytes) {
+  throw "Windows installer is unexpectedly large: $installerBytes bytes (maximum $MaximumInstallerBytes bytes; component archive bytes $componentBytes)"
 }
 
+$componentSummary = @($manifest.components | ForEach-Object {
+  "- component ``$($_.key)``: $([int64]$_.archiveSizeBytes) bytes ($($_.archiveCompression))"
+})
 $summary = @(
   '### Windows installer size',
   '',
   "- installer: ``$($installer.Name)``",
   "- installer bytes: $installerBytes",
   "- component archive bytes: $componentBytes",
-  "- safety ceiling: $maximumBytes"
-) -join [Environment]::NewLine
+  "- non-component bytes: $nonComponentBytes",
+  "- installer ceiling: $MaximumInstallerBytes",
+  "- component ceiling: $MaximumComponentBytes",
+  "- non-component ceiling: $MaximumNonComponentBytes",
+  ''
+) + $componentSummary
+$summary = $summary -join [Environment]::NewLine
 Write-Host $summary
 if ($env:GITHUB_STEP_SUMMARY) {
   Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $summary -Encoding UTF8

--- a/scripts/ci/windows-installer-size-smoke.test.ts
+++ b/scripts/ci/windows-installer-size-smoke.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+const scriptPath = path.join(__dirname, 'windows-installer-size-smoke.ps1');
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-installer-size-test-'));
+  temporaryDirectories.push(root);
+  fs.mkdirSync(path.join(root, 'release'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'build-tar', 'windows-components'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'release', 'ZhiYuan-Setup.exe'), Buffer.alloc(100));
+  fs.writeFileSync(
+    path.join(root, 'build-tar', 'windows-components', 'manifest.json'),
+    JSON.stringify({
+      components: [
+        {
+          key: 'portable-git',
+          archiveSizeBytes: 40,
+          archiveCompression: 'lzma2-mx9-solid-v1',
+        },
+      ],
+    }),
+  );
+  return root;
+}
+
+function runSizeCheck(
+  projectRoot: string,
+  maximumInstallerBytes: number,
+  maximumComponentBytes: number,
+  maximumNonComponentBytes: number,
+) {
+  return spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-ProjectRoot',
+      projectRoot,
+      '-MaximumInstallerBytes',
+      String(maximumInstallerBytes),
+      '-MaximumComponentBytes',
+      String(maximumComponentBytes),
+      '-MaximumNonComponentBytes',
+      String(maximumNonComponentBytes),
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform !== 'win32')('Windows installer size smoke check', () => {
+  test('reports component compression and accepts a package within every budget', () => {
+    const result = runSizeCheck(createFixture(), 100, 40, 60);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('lzma2-mx9-solid-v1');
+    expect(result.stdout).toContain('non-component bytes: 60');
+  });
+
+  test.each([
+    ['component', 100, 39, 60, 'component archives are unexpectedly large'],
+    ['non-component', 100, 40, 59, 'non-component payload is unexpectedly large'],
+    ['installer', 99, 40, 60, 'installer is unexpectedly large'],
+  ])('rejects an oversized %s payload', (_, installer, component, nonComponent, message) => {
+    const result = runSizeCheck(createFixture(), installer, component, nonComponent);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+  });
+});

--- a/scripts/electron-builder-hooks.cjs
+++ b/scripts/electron-builder-hooks.cjs
@@ -40,6 +40,7 @@ const {
   buildWindowsResourceBundleManifest,
   buildWindowsResourceComponentManifest,
   computeWindowsResourceComponentId,
+  getWindowsResourceArchiveCompression,
   getWindowsResourceComponents,
   isWindowsResourceComponentReusable,
   sha256File,
@@ -102,14 +103,17 @@ function resolveWindows7zaPath() {
 function packWindowsResourceComponent7z(component, archivePath, sevenZipPath) {
   const stagingRoot = mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-component-7z-'));
   const stagedPrefix = path.join(stagingRoot, component.prefix);
+  const temporaryArchivePath = `${archivePath}.${process.pid}.packing`;
   try {
     // A junction keeps the archive layout stable without copying a multi-hundred-MB
     // component into a temporary staging directory.  The archive is created from
     // the relative prefix only, so it never contains an absolute build-machine path.
     symlinkSync(component.dir, stagedPrefix, 'junction');
+    const compression = getWindowsResourceArchiveCompression(component);
+    rmSync(temporaryArchivePath, { force: true });
     const result = spawnSync(
       sevenZipPath,
-      ['a', '-t7z', '-mx=9', '-m0=lzma2', '-ms=off', '-mmt=on', archivePath, component.prefix],
+      ['a', '-t7z', ...compression.sevenZipArgs, temporaryArchivePath, component.prefix],
       {
         cwd: stagingRoot,
         encoding: 'utf8',
@@ -123,7 +127,10 @@ function packWindowsResourceComponent7z(component, archivePath, sevenZipPath) {
           (result.error?.message || result.stderr || result.stdout || `exit ${result.status}`),
       );
     }
+    rmSync(archivePath, { force: true });
+    renameSync(temporaryArchivePath, archivePath);
   } finally {
+    rmSync(temporaryArchivePath, { force: true });
     rmSync(stagingRoot, { recursive: true, force: true });
   }
 }
@@ -529,10 +536,9 @@ async function beforePack(context) {
         const startedAt = Date.now();
         packWindowsResourceComponent7z(component, archivePath, sevenZipPath);
         console.log(
-          `[electron-builder-hooks] Packed ${component.key} ${contentId} in ${(
-            (Date.now() - startedAt) /
-            1000
-          ).toFixed(1)}s`,
+          `[electron-builder-hooks] Packed ${component.key} ${contentId} with ${
+            getWindowsResourceArchiveCompression(component).id
+          } in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
         );
       }
 
@@ -593,4 +599,5 @@ module.exports = {
   afterPack,
   configureMacAutoUpdateMetadata,
   ensureBundledChannelRuntime,
+  packWindowsResourceComponent7z,
 };

--- a/scripts/windows-resource-pack.cjs
+++ b/scripts/windows-resource-pack.cjs
@@ -40,6 +40,23 @@ function shouldExclude(entryPath) {
 const WINDOWS_RESOURCE_COMPONENT_SCHEMA_VERSION = 4;
 const WINDOWS_RESOURCE_ARCHIVE_EXTENSION = '.7z';
 const WINDOWS_RESOURCE_ARCHIVE_FORMAT = '7z';
+const WINDOWS_RESOURCE_ARCHIVE_COMPRESSION = {
+  NonSolid: {
+    id: 'lzma2-mx9-nonsolid-v1',
+    sevenZipArgs: ['-mx=9', '-m0=lzma2', '-ms=off', '-mmt=on'],
+  },
+  Solid: {
+    id: 'lzma2-mx9-solid-v1',
+    sevenZipArgs: ['-mx=9', '-m0=lzma2', '-ms=on', '-mmt=on'],
+  },
+};
+const SOLID_ARCHIVE_COMPONENT_KEYS = new Set(['portable-git', 'python', 'skill-python']);
+
+function getWindowsResourceArchiveCompression(component) {
+  return SOLID_ARCHIVE_COMPONENT_KEYS.has(component.key)
+    ? WINDOWS_RESOURCE_ARCHIVE_COMPRESSION.Solid
+    : WINDOWS_RESOURCE_ARCHIVE_COMPRESSION.NonSolid;
+}
 
 function getWindowsResourceComponents(projectRoot) {
   return [
@@ -173,6 +190,7 @@ function buildWindowsResourceComponentManifest(
   archiveSizeBytes,
   sentinelSha256,
 ) {
+  const compression = getWindowsResourceArchiveCompression(component);
   return {
     version: WINDOWS_RESOURCE_COMPONENT_SCHEMA_VERSION,
     key: component.key,
@@ -182,6 +200,7 @@ function buildWindowsResourceComponentManifest(
     contentId,
     archive: component.key + WINDOWS_RESOURCE_ARCHIVE_EXTENSION,
     archiveFormat: WINDOWS_RESOURCE_ARCHIVE_FORMAT,
+    archiveCompression: compression.id,
     archiveSha256,
     archiveSizeBytes,
     sentinelSha256,
@@ -200,6 +219,7 @@ function isWindowsResourceComponentReusable(manifestPath, archivePath, contentId
       saved.contentId === contentId &&
       saved.archive === component.key + WINDOWS_RESOURCE_ARCHIVE_EXTENSION &&
       saved.archiveFormat === WINDOWS_RESOURCE_ARCHIVE_FORMAT &&
+      saved.archiveCompression === getWindowsResourceArchiveCompression(component).id &&
       typeof saved.archiveSha256 === 'string' &&
       saved.archiveSha256 === sha256File(archivePath) &&
       saved.archiveSizeBytes === fs.statSync(archivePath).size
@@ -222,10 +242,12 @@ module.exports = {
   WINDOWS_RESOURCE_COMPONENT_SCHEMA_VERSION,
   WINDOWS_RESOURCE_ARCHIVE_EXTENSION,
   WINDOWS_RESOURCE_ARCHIVE_FORMAT,
+  WINDOWS_RESOURCE_ARCHIVE_COMPRESSION,
   buildWindowsResourceBundleManifest,
   buildWindowsResourceComponentManifest,
   computeWindowsResourceComponentId,
   getWindowsResourceComponents,
+  getWindowsResourceArchiveCompression,
   isWindowsResourceComponentReusable,
   sha256File,
 };

--- a/tests/electron-builder-hooks.test.ts
+++ b/tests/electron-builder-hooks.test.ts
@@ -1,6 +1,22 @@
-import { describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
-import { configureMacAutoUpdateMetadata } from '../scripts/electron-builder-hooks.cjs';
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  configureMacAutoUpdateMetadata,
+  packWindowsResourceComponent7z,
+} from '../scripts/electron-builder-hooks.cjs';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 describe('electron-builder packaging hooks', () => {
   test('marks macOS automatic installation disabled unless signing explicitly enables it', () => {
@@ -20,5 +36,46 @@ describe('electron-builder packaging hooks', () => {
       retained: true,
       zhiyuanMacAutoUpdateEnabled: true,
     });
+  });
+});
+
+describe.skipIf(process.platform !== 'win32')('Windows component archive creation', () => {
+  test('replaces an existing archive and applies the selected solid profile', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-component-pack-test-'));
+    temporaryDirectories.push(root);
+    const componentRoot = path.join(root, 'component-source');
+    const archivePath = path.join(root, 'portable-git.7z');
+    const sevenZipPath = require.resolve('7zip-bin/win/x64/7za.exe');
+    fs.mkdirSync(componentRoot);
+    fs.writeFileSync(path.join(componentRoot, 'current.txt'), 'current');
+    fs.writeFileSync(path.join(componentRoot, 'second.txt'), 'second');
+
+    const oldSource = path.join(root, 'old-source');
+    fs.mkdirSync(oldSource);
+    fs.writeFileSync(path.join(oldSource, 'stale.txt'), 'stale');
+    const oldArchive = spawnSync(
+      sevenZipPath,
+      ['a', '-t7z', '-mx=1', '-ms=off', archivePath, 'old-source'],
+      { cwd: root, encoding: 'utf8' },
+    );
+    expect(oldArchive.status).toBe(0);
+
+    packWindowsResourceComponent7z(
+      {
+        key: 'portable-git',
+        label: 'PortableGit runtime',
+        dir: componentRoot,
+        prefix: 'mingit',
+        sentinel: 'mingit/current.txt',
+      },
+      archivePath,
+      sevenZipPath,
+    );
+
+    const listing = spawnSync(sevenZipPath, ['l', '-slt', archivePath], { encoding: 'utf8' });
+    expect(listing.status).toBe(0);
+    expect(listing.stdout).toContain('Solid = +');
+    expect(listing.stdout).toContain('Path = mingit\\current.txt');
+    expect(listing.stdout).not.toContain('stale.txt');
   });
 });

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -275,7 +275,9 @@ test("installer-related pull requests build and exercise the Windows installer",
   assert.match(sizeSmoke, /\$_\.archiveSizeBytes/);
   assert.doesNotMatch(sizeSmoke, /\$_\.archiveBytes\b/);
   assert.match(sizeSmoke, /component archive bytes/);
-  assert.match(sizeSmoke, /1GB/);
+  assert.match(sizeSmoke, /MaximumInstallerBytes = 425MB/);
+  assert.match(sizeSmoke, /MaximumComponentBytes = 220MB/);
+  assert.match(sizeSmoke, /MaximumNonComponentBytes = 220MB/);
 });
 
 test("DOCX smoke validator accepts the bundled Markdown converter output", () => {

--- a/tests/windows-resource-pack.test.ts
+++ b/tests/windows-resource-pack.test.ts
@@ -9,6 +9,7 @@ import {
   buildWindowsResourceComponentManifest,
   computeWindowsResourceComponentId,
   getWindowsResourceComponents,
+  getWindowsResourceArchiveCompression,
   isWindowsResourceComponentReusable,
   sha256File,
 } from '../scripts/windows-resource-pack.cjs';
@@ -45,6 +46,26 @@ describe('Windows offline component identity', () => {
       sentinel: 'channel-runtime/cc-connect-sidecar.exe',
     });
     expect(components.map(component => component.key)).not.toContain('openclaw');
+  });
+
+  test('uses solid compression only for benchmarked multi-file runtimes', () => {
+    const components = getWindowsResourceComponents(process.cwd());
+    const compressionByKey = Object.fromEntries(
+      components.map(component => [
+        component.key,
+        getWindowsResourceArchiveCompression(component).id,
+      ]),
+    );
+
+    expect(compressionByKey).toMatchObject({
+      'channel-runtime': 'lzma2-mx9-nonsolid-v1',
+      skills: 'lzma2-mx9-nonsolid-v1',
+      mcps: 'lzma2-mx9-nonsolid-v1',
+      'portable-git': 'lzma2-mx9-solid-v1',
+      python: 'lzma2-mx9-solid-v1',
+      'skill-python': 'lzma2-mx9-solid-v1',
+      uv: 'lzma2-mx9-nonsolid-v1',
+    });
   });
 
   test('is stable when only source mtimes change', () => {
@@ -109,6 +130,30 @@ describe('Windows offline component identity', () => {
     );
     expect(manifest.archive).toBe('runtime.7z');
     expect(manifest.archiveFormat).toBe('7z');
+    expect(manifest.archiveCompression).toBe('lzma2-mx9-nonsolid-v1');
+  });
+
+  test('does not reuse an archive created with a different compression profile', () => {
+    const component = createComponent('portable-git');
+    const contentId = computeWindowsResourceComponentId(component);
+    const archivePath = path.join(component.dir, 'portable-git.7z');
+    const manifestPath = path.join(component.dir, 'manifest.json');
+    fs.writeFileSync(archivePath, 'archive-v1');
+    const manifest = buildWindowsResourceComponentManifest(
+      component,
+      contentId,
+      sha256File(archivePath),
+      fs.statSync(archivePath).size,
+      sha256File(path.join(component.dir, 'nested', 'runtime.exe')),
+    );
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({ ...manifest, archiveCompression: 'lzma2-mx9-nonsolid-v1' }),
+    );
+
+    expect(
+      isWindowsResourceComponentReusable(manifestPath, archivePath, contentId, component),
+    ).toBe(false);
   });
 
   test('marks the aggregate manifest as offline and llama.cpp-free', () => {


### PR DESCRIPTION
## 背景

当前 Windows 离线安装包基线约为 **440.88 MiB**。组件包此前统一使用非 solid 7z，适合局部文件读取，但对只在安装阶段完整解压的 Python、PortableGit 和共享 Skill Python 环境造成了明显的压缩损失。

本 PR 对离线组件采用按用途区分的压缩策略，并补齐缓存一致性、原子写入和 CI 防回退检查。

## 优化进度

| 组件 | 原策略 | 新策略 | 实测减少 | 说明 |
| --- | --- | --- | ---: | --- |
| PortableGit | non-solid | solid | 31.22 MiB | 2,531 个文件及 `bash.exe` 哈希一致；解压 7.20s -> 6.99s |
| Python | non-solid | solid | 1.59 MiB | 901 个文件及 Python 可执行文件哈希一致；解压 0.93s -> 0.78s |
| 共享 Skill Python 层 | non-solid | solid | 23.25 MiB | 11,700 个文件完整哈希一致；解压耗时比 1.155；18 项依赖导入通过 |

三项合计实测减少约 **56.06 MiB**。按当前安装包基线推算，整包预计由 **440.88 MiB** 降至约 **384.82 MiB**；最终值以 Windows 发布构建产物为准。

当前 Skill Python 已经是由 `uv` 管理的单一共享环境，9 个 Skill 不再各自携带 venv。本 PR 压缩的是这一共享层，不改变其去重模型。

## 压缩策略

| 组件 | 7z 策略 | 原因 |
| --- | --- | --- |
| `portable-git` | solid | 文件数量多，仅安装时整体解压，收益显著 |
| `python` | solid | 仅安装时整体解压，实测解压无回退 |
| `skill-python` | solid | 单一共享依赖层，重复内容多，收益显著 |
| `channel-runtime` | non-solid | 保留现状，避免扩大本轮变更面 |
| `skills` | non-solid | 体积较小，保留快速局部访问特性 |
| `mcps` | non-solid | 体积较小，保留现状 |
| `uv` | non-solid | 单文件工具，solid 无实质收益 |

## 安全性与 CI

- 将压缩配置写入组件 manifest，缓存复用同时校验内容 ID 和压缩配置，避免误用旧归档。
- 先写临时归档，再原子替换正式文件，防止中断后留下半成品缓存。
- 保持组件 content ID 不变，已安装运行时仍可命中现有内容缓存。
- Windows 安装包门禁：安装包不超过 425 MiB，组件合计不超过 220 MiB，非组件载荷不超过 220 MiB。
- CI 同时生成共享 Skill Python 的 solid 和临时 non-solid 样本，要求至少节省 1 MiB、解压耗时比不超过 1.25、完整文件树 SHA-256 一致，并执行 18 项依赖导入探针。

## 验证

- 6 个测试文件、32 项测试通过
- `oxlint` 通过
- `oxfmt` 检查通过
- GitHub Actions workflow YAML 解析通过
- `git diff --check` 通过

## 下一步

### 1. 优化剩余应用层

当前非离线组件部分约 **208 MiB**，下一轮应按构建产物逐项审计：

- `app.asar` 与 `app.asar.unpacked`
- production `node_modules` 中的 renderer 依赖重复
- 随包 npm runtime
- 非目标平台 native prebuilds
- Electron locales 和未使用 resources

这一阶段先建立文件级体积分解和启动/运行回归基线，再删除或裁剪，避免影响 Electron 主进程和原生模块加载。

### 2. 增加候选包验证与不可变发布晋级

- 构建一次最终版本号的安装包、blockmap、更新元数据和签名产物。
- 将同一批二进制作为 GitHub Actions candidate artifacts 保存，开发者安装并验证完整功能。
- 通过受保护 environment 审批后，把完全相同的字节上传 R2/Cloudflare，并切换 stable 指针。
- 不通过“dev 版本构建后改名”为 release；内部版本、哈希、blockmap、更新元数据和签名都绑定原始文件，改名无法提供真正的同产物晋级保证。

这样可以实现“先验包、后发布”，且发布阶段不重新构建，不会引入已验证产物与线上产物不一致的问题。
