### PR TITLE
fix(cowork): 对齐 declare_artifact 声明与对话末尾渲染

### DIFF
--- a/src/main/coworkArtifactCollector.test.ts
+++ b/src/main/coworkArtifactCollector.test.ts
@@ -103,6 +103,45 @@ describe('collectSessionArtifactCandidates', () => {
     });
   });
 
+  test('declared kind code/document/image wins over extension inference', () => {
+    const candidates = collectSessionArtifactCandidates([
+      message('declare-code', 1, 'tool_use', '', {
+        toolName: 'declare_artifact',
+        toolInput: { filePath: 'D:/output/notes.md', kind: 'code' },
+      }),
+      message('declare-document', 2, 'tool_use', '', {
+        toolName: 'declare_artifact',
+        toolInput: { filePath: 'D:/output/report.txt', kind: 'document' },
+      }),
+      message('declare-image', 3, 'tool_use', '', {
+        toolName: 'declare_artifact',
+        toolInput: { filePath: 'D:/output/icon.svg', kind: 'image' },
+      }),
+    ]);
+
+    expect(candidates.map(candidate => candidate.artifact.type)).toEqual([
+      'code',
+      'document',
+      'image',
+    ]);
+  });
+
+  test('marks assistant code blocks as intermediate, not deliverable', () => {
+    const [candidate] = collectSessionArtifactCandidates([
+      message(
+        'assistant-1',
+        1,
+        'assistant',
+        '```artifact:html title="Preview"\n<h1>Hello</h1>\n```',
+      ),
+    ]);
+
+    expect(candidate.artifact).toMatchObject({
+      role: CoworkArtifactRole.Intermediate,
+      declared: false,
+    });
+  });
+
   test('collects supported assistant code blocks with stable keys and content', () => {
     const [candidate] = collectSessionArtifactCandidates([
       message(

--- a/src/main/coworkArtifactCollector.ts
+++ b/src/main/coworkArtifactCollector.ts
@@ -12,6 +12,11 @@ const LANGUAGE_TYPES: Record<string, CoworkArtifactType> = {
   mermaid: 'mermaid',
   jsx: 'code',
   tsx: 'code',
+  // The declare_artifact tool advertises these kinds directly. Keep them
+  // mapped so an explicit declaration wins over extension inference.
+  code: 'code',
+  document: 'document',
+  image: 'image',
   markdown: 'markdown',
   md: 'markdown',
   text: 'text',
@@ -169,7 +174,10 @@ function collectCodeBlocks(messages: CoworkArtifactMessage[]): CoworkArtifactCan
           content: block.content,
           language: artifactType === 'code' ? block.language : undefined,
           source: CoworkArtifactSource.CodeBlock,
-          role: CoworkArtifactRole.Deliverable,
+          // Code blocks are inline evidence, not final outputs. Deliverable
+          // identity must come from an explicit declare_artifact call so the
+          // end-of-turn deliverables strip stays meaningful.
+          role: CoworkArtifactRole.Intermediate,
           declared: false,
           createdAt: message.timestamp,
         },

--- a/src/main/declareArtifact/tool.ts
+++ b/src/main/declareArtifact/tool.ts
@@ -66,6 +66,8 @@ export function buildDeclareArtifactTool(): Record<string, unknown> {
         };
       }
       const role = params.role === 'intermediate' ? 'intermediate' : 'deliverable';
+      const title = text(params.title);
+      const kind = text(params.kind);
       const fileName = filePath.split(/[/\\]/).pop() || filePath;
       return {
         content: [
@@ -74,7 +76,12 @@ export function buildDeclareArtifactTool(): Record<string, unknown> {
             text: `Artifact declared: ${fileName} (${role})`,
           },
         ],
-        details: { filePath, role },
+        details: {
+          filePath,
+          role,
+          ...(title ? { title } : {}),
+          ...(kind ? { kind } : {}),
+        },
       };
     },
   };

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -468,10 +468,14 @@ const TurnBlockComponent: React.FC<{
               </ChainOfThought>
             )}
             {showTypingIndicator && <TypingDots />}
-            {artifacts?.some(artifact => artifact.role === ArtifactRole.Deliverable) && (
+            {artifacts?.some(
+              artifact => artifact.role === ArtifactRole.Deliverable && artifact.declared,
+            ) && (
               <div className="flex flex-wrap gap-2 pt-1">
                 {artifacts
-                  .filter(artifact => artifact.role === ArtifactRole.Deliverable)
+                  .filter(
+                    artifact => artifact.role === ArtifactRole.Deliverable && artifact.declared,
+                  )
                   .map(artifact => (
                     <ArtifactPreviewCard key={artifact.id} artifact={artifact} />
                   ))}


### PR DESCRIPTION
## 背景

审查 `declare_artifact` 工具与对话末尾共建渲染逻辑,发现三处声明与渲染未对齐:

| # | 问题 | 影响 |
|---|---|---|
| 1 | 工具 kind 枚举含 `code/document/image`,但采集器 `LANGUAGE_TYPES` 缺失这三个直映射 | 声明被静默丢弃、退回扩展名推断:`kind:"code"` + `.md` 文件得到 `markdown`;无扩展名文件得到 `unsupported` |
| 2 | 工具 `execute` 的 `details` 只回传 `filePath/role`,`title/kind` 被丢弃 | 任何下游消费 tool_result details(workbench 交付物、审计导出)都会丢字段 |
| 3 | 助手回复的代码围栏一律标 `Deliverable` | 与 declare_artifact 系统提示定义的"deliverable = 最终产物"语义冲突,对话末尾交付物卡区混入演示片段 |

## 改动

1. **[coworkArtifactCollector.ts](src/main/coworkArtifactCollector.ts)**:`LANGUAGE_TYPES` 补 `code/document/image` 直映射(它们是 `CoworkArtifactType` 一等类型),显式 kind 声明优先于扩展名推断
2. **[declareArtifact/tool.ts](src/main/declareArtifact/tool.ts)**:`execute` 的 details 原样回传 `title/kind`
3. **[coworkArtifactCollector.ts](src/main/coworkArtifactCollector.ts) + [TurnBlock.tsx](src/renderer/components/cowork/components/TurnBlock.tsx)**:
   - code block 默认 `Intermediate`——交付物身份必须来自显式 `declare_artifact`
   - TurnBlock 对话末尾只渲染 `declared === true` 的交付物

## 验证

- coworkArtifactCollector 测试 6/6(新增:kind 直映射覆盖扩展名、code block 角色断言)
- coworkArtifactIndex 5/5
- 渲染层相关(artifacts/cowork components/artifactSlice)57/57
- `tsc`、`oxlint` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)