### PR TITLE
feat(release): add manual candidate builds

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,382 @@
+name: Build release candidate (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Final SemVer embedded in the candidate, without a v prefix'
+        required: true
+        type: string
+      source_ref:
+        description: 'Commit, tag, or branch reachable from main'
+        required: true
+        default: 'main'
+        type: string
+
+concurrency:
+  group: zhiyuan-release-candidate-${{ inputs.release_version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  prepare-candidate:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.identity.outputs.version }}
+      commit: ${{ steps.identity.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+      - name: Resolve immutable candidate identity
+        id: identity
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo 'release_version must be a SemVer value without a v prefix' >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          source_commit="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$source_commit" origin/main; then
+            echo 'source_ref must resolve to a commit reachable from origin/main' >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "commit=$source_commit" >> "$GITHUB_OUTPUT"
+          {
+            echo '### Release candidate identity'
+            echo
+            echo "- version: \`$RELEASE_VERSION\`"
+            echo "- source commit: \`$source_commit\`"
+            echo "- candidate run: \`$GITHUB_RUN_ID\`"
+            echo '- external publication: disabled'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  quality:
+    needs: prepare-candidate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-candidate.outputs.commit }}
+      - uses: actions/setup-node@v6
+        with: { node-version: '24.x' }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: '1.3.14' }
+      - name: Restore Bun and Electron caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/electron
+            ~/.cache/electron-builder
+          key: candidate-quality-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            candidate-quality-${{ runner.os }}-1.3.14-
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Verify npm package signatures
+        shell: bash
+        run: |
+          set -euo pipefail
+          for lockfile in \
+            SKILLs/presentation-studio/package-lock.json \
+            SKILLs/web-search/package-lock.json \
+            scripts/release/package-lock.json; do
+            directory="$(dirname "$lockfile")"
+            npm --prefix "$directory" ci --ignore-scripts
+            npm --prefix "$directory" audit signatures --package-lock-only --ignore-scripts
+          done
+      - name: Validate source and dependency policy
+        run: |
+          bun run validate:skills
+          bun run check:openclaw-decoupling
+          bun run check:supply-chain-inputs
+          bun run lint
+      - name: Compile and test
+        run: |
+          bun run compile:electron
+          bun run test
+
+  build-candidate:
+    needs: [prepare-candidate, quality]
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: windows
+            runner: windows-latest
+            target: win32-x64-lite
+            runtime_target: win-x64
+          - platform: macos
+            runner: macos-latest
+            target: darwin-arm64-default
+            runtime_target: mac-arm64
+          - platform: linux
+            runner: ubuntu-latest
+            target: linux-x64-default
+            runtime_target: linux-x64
+    runs-on: ${{ matrix.runner }}
+    environment: release
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-candidate.outputs.commit }}
+      - uses: actions/setup-node@v6
+        with: { node-version: '24.x' }
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: '1.3.14' }
+      - name: Restore bundled runtime cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            resources/python-win
+            resources/uv-win
+            resources/python-mac
+            resources/uv-mac
+            resources/python-linux
+            resources/uv-linux
+            resources/uv-archives
+          key: bundled-runtimes-${{ runner.os }}-${{ matrix.runtime_target }}-${{ hashFiles('scripts/setup-python-runtime.js', 'scripts/setup-uv-runtime.js', 'scripts/setup-mac-python-runtime.js', 'scripts/setup-mac-uv-runtime.js', 'electron-builder.json') }}
+      - name: Restore packaging caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+            vendor/channel-runtime
+          key: candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          restore-keys: |
+            candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
+      - name: Install Electron system dependencies
+        if: ${{ matrix.platform == 'linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
+            libxss1 libxtst6 libuuid1 xdg-utils xvfb
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - name: Set up Windows runtimes
+        if: ${{ matrix.platform == 'windows' }}
+        run: |
+          bun run setup:uv-runtime
+          bun run setup:python-runtime
+      - name: Set up POSIX runtimes
+        if: ${{ matrix.platform != 'windows' }}
+        run: |
+          bun run setup:posix-uv-runtime
+          bun run setup:posix-python-runtime
+      - name: Build Windows candidate
+        if: ${{ matrix.platform == 'windows' }}
+        run: bun run dist:win:lite
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-candidate.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Validate optional macOS signing credentials
+        if: ${{ matrix.platform == 'macos' }}
+        shell: bash
+        run: |
+          values=("$CSC_LINK" "$CSC_KEY_PASSWORD" "$APPLE_ID" "$APPLE_APP_SPECIFIC_PASSWORD" "$APPLE_TEAM_ID")
+          provided=0
+          for value in "${values[@]}"; do [[ -n "$value" ]] && provided=$((provided + 1)); done
+          if [[ $provided -eq 0 ]]; then
+            echo 'ZHIYUAN_MAC_AUTO_UPDATE_ENABLED=false' >> "$GITHUB_ENV"
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=false' >> "$GITHUB_ENV"
+            echo '::warning title=Unsigned macOS candidate::Apple signing credentials are unavailable.'
+          elif [[ $provided -ne ${#values[@]} ]]; then
+            echo 'macOS signing credentials are only partially configured' >&2
+            exit 1
+          else
+            echo 'ZHIYUAN_MAC_AUTO_UPDATE_ENABLED=true' >> "$GITHUB_ENV"
+            echo 'CSC_IDENTITY_AUTO_DISCOVERY=true' >> "$GITHUB_ENV"
+          fi
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Build unsigned macOS candidate
+        if: ${{ matrix.platform == 'macos' && env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED != 'true' }}
+        run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-candidate.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Build signed macOS candidate
+        if: ${{ matrix.platform == 'macos' && env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED == 'true' }}
+        run: node scripts/ensure-build-version.js && bun run prepare:update-release && bun run dist:mac
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-candidate.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify signed and notarized macOS candidate
+        if: ${{ matrix.platform == 'macos' && env.ZHIYUAN_MAC_AUTO_UPDATE_ENABLED == 'true' }}
+        shell: bash
+        run: |
+          app_path="$(find release -maxdepth 3 -type d -name '*.app' -print -quit)"
+          [[ -n "$app_path" ]] || { echo 'Packaged macOS app was not found' >&2; exit 1; }
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          xcrun stapler validate "$app_path"
+          spctl --assess --type execute --verbose=4 "$app_path"
+      - name: Build Linux candidate
+        if: ${{ matrix.platform == 'linux' }}
+        run: bun run dist:linux
+        env:
+          APP_BUILD_VERSION: ${{ needs.prepare-candidate.outputs.version }}
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify Windows candidate size and runtimes
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ci/windows-installer-size-smoke.ps1 -ProjectRoot '${{ github.workspace }}'
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ci/windows-runtime-smoke.ps1 -ProjectRoot '${{ github.workspace }}'
+      - name: Verify Windows cold install, cache-hit upgrade, and uninstall
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/windows-installer-smoke.ps1
+          -ProjectRoot '${{ github.workspace }}'
+      - name: Verify the Linux renderer
+        if: ${{ matrix.platform == 'linux' }}
+        run: xvfb-run -a node scripts/verify-linux-renderer.mjs release/linux-unpacked release/linux-render-smoke.png
+      - name: Assemble Windows candidate payload
+        if: ${{ matrix.platform == 'windows' }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          installers=(release/*.exe)
+          blockmaps=(release/*.exe.blockmap)
+          [[ ${#installers[@]} -eq 1 && ${#blockmaps[@]} -eq 1 ]] || { echo 'Expected one Windows installer and blockmap' >&2; exit 1; }
+          node scripts/release/normalize-electron-updater-metadata.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' win32 x64 lite \
+            release/latest.yml release/electron-updater/latest.yml
+          node scripts/release/create-release-candidate.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' \
+            '${{ needs.prepare-candidate.outputs.commit }}' \
+            '${{ github.run_id }}' candidate candidate-win32-x64-lite.json \
+            "${installers[0]}:win32:x64:lite:installer" \
+            "${installers[0]}:win32:x64:lite:updater" \
+            "${blockmaps[0]}:win32:x64:lite:blockmap" \
+            'release/electron-updater/latest.yml:win32:x64:lite:metadata'
+      - name: Assemble macOS candidate payload
+        if: ${{ matrix.platform == 'macos' }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          dmgs=(release/*.dmg)
+          zips=(release/*.zip)
+          blockmaps=(release/*.zip.blockmap)
+          [[ ${#dmgs[@]} -eq 1 && ${#zips[@]} -eq 1 && ${#blockmaps[@]} -eq 1 ]] || { echo 'Expected one macOS DMG, ZIP, and blockmap' >&2; exit 1; }
+          node scripts/release/normalize-electron-updater-metadata.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' darwin arm64 default \
+            release/latest-mac.yml release/electron-updater/latest-mac.yml
+          node scripts/release/create-release-candidate.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' \
+            '${{ needs.prepare-candidate.outputs.commit }}' \
+            '${{ github.run_id }}' candidate candidate-darwin-arm64-default.json \
+            "${dmgs[0]}:darwin:arm64:default:installer" \
+            "${zips[0]}:darwin:arm64:default:updater" \
+            "${blockmaps[0]}:darwin:arm64:default:blockmap" \
+            'release/electron-updater/latest-mac.yml:darwin:arm64:default:metadata'
+      - name: Assemble Linux candidate payload
+        if: ${{ matrix.platform == 'linux' }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          debs=(release/*.deb)
+          appimages=(release/*.AppImage)
+          [[ ${#debs[@]} -eq 1 && ${#appimages[@]} -eq 1 ]] || { echo 'Expected one Linux deb and AppImage' >&2; exit 1; }
+          node scripts/release/normalize-electron-updater-metadata.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' linux x64 appimage \
+            release/latest-linux.yml release/electron-updater/latest-linux.yml
+          node scripts/release/normalize-electron-updater-metadata.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' linux x64 deb \
+            release/latest-linux.yml release/electron-updater/deb/latest-linux.yml
+          node scripts/release/create-release-candidate.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' \
+            '${{ needs.prepare-candidate.outputs.commit }}' \
+            '${{ github.run_id }}' candidate candidate-linux-x64.json \
+            "${debs[0]}:linux:x64:deb:installer" \
+            "${debs[0]}:linux:x64:deb:updater" \
+            'release/electron-updater/deb/latest-linux.yml:linux:x64:deb:metadata' \
+            "${appimages[0]}:linux:x64:appimage:installer" \
+            "${appimages[0]}:linux:x64:appimage:updater" \
+            'release/electron-updater/latest-linux.yml:linux:x64:appimage:metadata'
+      - name: Upload candidate payload
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-candidate-${{ needs.prepare-candidate.outputs.version }}-${{ matrix.target }}
+          path: candidate
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload candidate manifest for cross-platform verification
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-candidate-manifest-${{ matrix.target }}
+          path: candidate/candidate-*.json
+          if-no-files-found: error
+          retention-days: 7
+
+  verify-candidate:
+    needs: [prepare-candidate, build-candidate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-candidate.outputs.commit }}
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: release-candidate-manifest-*
+          path: candidate-manifests
+          merge-multiple: true
+      - name: Verify candidate completeness and identity
+        shell: bash
+        run: |
+          mapfile -t manifests < <(find candidate-manifests -type f -name 'candidate-*.json' | sort)
+          [[ ${#manifests[@]} -eq 3 ]] || { echo 'Expected exactly three platform candidate manifests' >&2; exit 1; }
+          node scripts/release/verify-release-candidate.mjs \
+            '${{ needs.prepare-candidate.outputs.version }}' \
+            '${{ needs.prepare-candidate.outputs.commit }}' \
+            '${{ github.run_id }}' \
+            "${manifests[@]}"
+      - name: Publish candidate verification summary
+        shell: bash
+        run: |
+          {
+            echo '### Candidate ready for manual verification'
+            echo
+            echo "- version: \`${{ needs.prepare-candidate.outputs.version }}\`"
+            echo "- source commit: \`${{ needs.prepare-candidate.outputs.commit }}\`"
+            echo "- candidate run ID: \`${{ github.run_id }}\`"
+            echo '- retention: 7 days'
+            echo '- R2/Cloudflare upload: not performed'
+            echo
+            echo 'Use the candidate run ID for the promotion workflow after the exact installers have been validated.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/release/create-release-candidate.mjs
+++ b/scripts/release/create-release-candidate.mjs
@@ -1,0 +1,18 @@
+import { createCandidateManifest } from './release-candidate-manifest.mjs';
+
+const [releaseVersion, sourceCommit, candidateRunId, outputDirectory, manifestName, ...specs] =
+  process.argv.slice(2);
+if (!releaseVersion || !sourceCommit || !candidateRunId || !outputDirectory || !manifestName || specs.length === 0) {
+  throw new Error(
+    'usage: create-release-candidate.mjs <version> <commit> <run-id> <output-directory> <manifest-name> <file:platform:arch:variant:kind>...',
+  );
+}
+
+await createCandidateManifest({
+  releaseVersion,
+  sourceCommit,
+  candidateRunId,
+  outputDirectory,
+  manifestName,
+  specs,
+});

--- a/scripts/release/release-candidate-manifest.mjs
+++ b/scripts/release/release-candidate-manifest.mjs
@@ -1,0 +1,253 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+export const CandidateTarget = {
+  WindowsX64Lite: 'win32-x64-lite',
+  MacArm64Default: 'darwin-arm64-default',
+  LinuxX64AppImage: 'linux-x64-appimage',
+  LinuxX64Deb: 'linux-x64-deb',
+};
+
+const REQUIRED_KINDS = new Map([
+  [CandidateTarget.WindowsX64Lite, ['installer', 'updater', 'blockmap', 'metadata']],
+  [CandidateTarget.MacArm64Default, ['installer', 'updater', 'blockmap', 'metadata']],
+  [CandidateTarget.LinuxX64AppImage, ['installer', 'updater', 'metadata']],
+  [CandidateTarget.LinuxX64Deb, ['installer', 'updater', 'metadata']],
+]);
+
+function validateReleaseVersion(value) {
+  if (!/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.test(value)) {
+    throw new Error(`Invalid release version: ${value}`);
+  }
+  return value;
+}
+
+function validateCommit(value) {
+  if (!/^[0-9a-f]{40}$/.test(value)) throw new Error(`Invalid source commit: ${value}`);
+  return value;
+}
+
+function validateRunId(value) {
+  if (!/^[1-9][0-9]*$/.test(String(value))) throw new Error(`Invalid candidate run ID: ${value}`);
+  return String(value);
+}
+
+function validateFilename(value) {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    value.length > 240 ||
+    value === '.' ||
+    value === '..' ||
+    /[\\/\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Unsafe candidate filename: ${value}`);
+  }
+  return value;
+}
+
+function validateRelativePath(value) {
+  if (
+    typeof value !== 'string' ||
+    !value.startsWith('payload/') ||
+    path.posix.isAbsolute(value) ||
+    value.split('/').includes('..') ||
+    value.includes('\\')
+  ) {
+    throw new Error(`Unsafe candidate artifact path: ${value}`);
+  }
+  return value;
+}
+
+function parseSpec(spec) {
+  const parts = spec.split(':');
+  if (parts.length < 5) throw new Error(`Invalid candidate artifact spec: ${spec}`);
+  const kind = parts.pop();
+  const variant = parts.pop();
+  const arch = parts.pop();
+  const platform = parts.pop();
+  const filePath = parts.join(':');
+  const target = `${platform}-${arch}-${variant}`;
+  if (!filePath || !REQUIRED_KINDS.has(target) || !REQUIRED_KINDS.get(target).includes(kind)) {
+    throw new Error(`Invalid candidate artifact spec: ${spec}`);
+  }
+  return { filePath, platform, arch, variant, target, kind };
+}
+
+async function hashFile(filePath, algorithm, encoding) {
+  const hash = crypto.createHash(algorithm);
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  return hash.digest(encoding);
+}
+
+async function describeFile(filePath) {
+  const stat = await fsp.stat(filePath);
+  if (!stat.isFile() || stat.size === 0) throw new Error(`Candidate artifact is missing or empty: ${filePath}`);
+  return {
+    size: stat.size,
+    sha256: await hashFile(filePath, 'sha256', 'hex'),
+    sha512: await hashFile(filePath, 'sha512', 'base64'),
+  };
+}
+
+function validateIdentity(manifest, expectedVersion, expectedCommit, expectedRunId) {
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest) || manifest.schemaVersion !== 1) {
+    throw new Error('Invalid release candidate manifest');
+  }
+  if (manifest.releaseVersion !== expectedVersion) {
+    throw new Error(`Candidate version mismatch: ${manifest.releaseVersion}`);
+  }
+  if (manifest.sourceCommit !== expectedCommit) {
+    throw new Error(`Candidate source commit mismatch: ${manifest.sourceCommit}`);
+  }
+  if (String(manifest.candidateRunId) !== expectedRunId) {
+    throw new Error(`Candidate run ID mismatch: ${manifest.candidateRunId}`);
+  }
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length === 0) {
+    throw new Error('Candidate manifest has no artifacts');
+  }
+}
+
+export async function createCandidateManifest({
+  releaseVersion,
+  sourceCommit,
+  candidateRunId,
+  outputDirectory,
+  manifestName,
+  specs,
+}) {
+  validateReleaseVersion(releaseVersion);
+  validateCommit(sourceCommit);
+  validateRunId(candidateRunId);
+  validateFilename(manifestName);
+  if (!Array.isArray(specs) || specs.length === 0) throw new Error('Candidate artifact specs are required');
+
+  const artifacts = [];
+  const copiedFiles = new Map();
+  for (const spec of specs) {
+    const parsed = parseSpec(spec);
+    const filename = validateFilename(path.basename(parsed.filePath));
+    const relativePath = path.posix.join('payload', parsed.target, filename);
+    const description = await describeFile(parsed.filePath);
+    const existing = copiedFiles.get(relativePath);
+    if (existing) {
+      if (
+        existing.size !== description.size ||
+        existing.sha256 !== description.sha256 ||
+        existing.sha512 !== description.sha512
+      ) {
+        throw new Error(`Candidate artifacts collide at ${relativePath}`);
+      }
+    } else {
+      const destination = path.join(outputDirectory, ...relativePath.split('/'));
+      await fsp.mkdir(path.dirname(destination), { recursive: true });
+      await fsp.copyFile(parsed.filePath, destination);
+      copiedFiles.set(relativePath, description);
+    }
+    artifacts.push({
+      platform: parsed.platform,
+      arch: parsed.arch,
+      variant: parsed.variant,
+      kind: parsed.kind,
+      filename,
+      relativePath,
+      ...description,
+    });
+  }
+
+  artifacts.sort((left, right) =>
+    `${left.platform}:${left.arch}:${left.variant}:${left.kind}`.localeCompare(
+      `${right.platform}:${right.arch}:${right.variant}:${right.kind}`,
+    ),
+  );
+  const manifest = {
+    schemaVersion: 1,
+    releaseVersion,
+    sourceCommit,
+    candidateRunId: String(candidateRunId),
+    artifacts,
+  };
+  await verifyCandidateManifests({
+    releaseVersion,
+    sourceCommit,
+    candidateRunId,
+    manifests: [manifest],
+    payloadRoots: [outputDirectory],
+    requireComplete: false,
+  });
+  await fsp.mkdir(outputDirectory, { recursive: true });
+  await fsp.writeFile(path.join(outputDirectory, manifestName), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+export async function verifyCandidateManifests({
+  releaseVersion,
+  sourceCommit,
+  candidateRunId,
+  manifests,
+  payloadRoots = [],
+  requireComplete = true,
+}) {
+  validateReleaseVersion(releaseVersion);
+  validateCommit(sourceCommit);
+  const expectedRunId = validateRunId(candidateRunId);
+  if (!Array.isArray(manifests) || manifests.length === 0) throw new Error('Candidate manifests are required');
+  if (payloadRoots.length !== 0 && payloadRoots.length !== manifests.length) {
+    throw new Error('Each candidate manifest must have one payload root');
+  }
+
+  const identities = new Set();
+  for (const [manifestIndex, manifest] of manifests.entries()) {
+    validateIdentity(manifest, releaseVersion, sourceCommit, expectedRunId);
+    for (const artifact of manifest.artifacts) {
+      const target = `${artifact.platform}-${artifact.arch}-${artifact.variant}`;
+      const requiredKinds = REQUIRED_KINDS.get(target);
+      const identity = `${target}:${artifact.kind}`;
+      if (!requiredKinds?.includes(artifact.kind) || identities.has(identity)) {
+        throw new Error(`Unexpected or duplicate candidate artifact: ${identity}`);
+      }
+      identities.add(identity);
+      validateFilename(artifact.filename);
+      validateRelativePath(artifact.relativePath);
+      if (
+        path.posix.dirname(artifact.relativePath) !== `payload/${target}` ||
+        path.posix.basename(artifact.relativePath) !== artifact.filename
+      ) {
+        throw new Error(`Candidate filename does not match its path: ${artifact.relativePath}`);
+      }
+      if (
+        !Number.isSafeInteger(artifact.size) ||
+        artifact.size <= 0 ||
+        !/^[0-9a-f]{64}$/.test(artifact.sha256) ||
+        !/^[A-Za-z0-9+/]{86}==$/.test(artifact.sha512)
+      ) {
+        throw new Error(`Candidate artifact integrity is invalid: ${identity}`);
+      }
+      if (payloadRoots.length > 0) {
+        const filePath = path.join(payloadRoots[manifestIndex], ...artifact.relativePath.split('/'));
+        const actual = await describeFile(filePath);
+        if (
+          actual.size !== artifact.size ||
+          actual.sha256 !== artifact.sha256 ||
+          actual.sha512 !== artifact.sha512
+        ) {
+          throw new Error(`Candidate artifact bytes do not match the manifest: ${identity}`);
+        }
+      }
+    }
+  }
+
+  if (requireComplete) {
+    const required = [...REQUIRED_KINDS].flatMap(([target, kinds]) => kinds.map(kind => `${target}:${kind}`));
+    const missing = required.filter(identity => !identities.has(identity));
+    if (missing.length > 0) throw new Error(`Candidate is incomplete: ${missing.join(', ')}`);
+    if (identities.size !== required.length) throw new Error('Candidate contains unexpected artifacts');
+  }
+}

--- a/scripts/release/release-candidate-manifest.test.ts
+++ b/scripts/release/release-candidate-manifest.test.ts
@@ -1,0 +1,239 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import {
+  CandidateTarget,
+  createCandidateManifest,
+  verifyCandidateManifests,
+} from './release-candidate-manifest.mjs';
+
+const VERSION = '2026.8.13-build.2';
+const COMMIT = '0123456789abcdef0123456789abcdef01234567';
+const RUN_ID = '123456789';
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'zhiyuan-release-candidate-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+async function writeArtifact(directory: string, filename: string, content = filename) {
+  const filePath = path.join(directory, filename);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+function spec(filePath: string, target: string, kind: string) {
+  const [platform, arch, ...variantParts] = target.split('-');
+  return `${filePath}:${platform}:${arch}:${variantParts.join('-')}:${kind}`;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('release candidate manifest', () => {
+  test('creates a payload with immutable identity and hashes', async () => {
+    const source = await temporaryDirectory();
+    const output = await temporaryDirectory();
+    const installer = await writeArtifact(source, 'ZhiYuan-Setup.exe', 'candidate bytes');
+    const blockmap = await writeArtifact(source, 'ZhiYuan-Setup.exe.blockmap');
+    const metadata = await writeArtifact(source, 'latest.yml');
+
+    const manifest = await createCandidateManifest({
+      releaseVersion: VERSION,
+      sourceCommit: COMMIT,
+      candidateRunId: RUN_ID,
+      outputDirectory: output,
+      manifestName: 'candidate-win32-x64-lite.json',
+      specs: [
+        spec(installer, CandidateTarget.WindowsX64Lite, 'installer'),
+        spec(installer, CandidateTarget.WindowsX64Lite, 'updater'),
+        spec(blockmap, CandidateTarget.WindowsX64Lite, 'blockmap'),
+        spec(metadata, CandidateTarget.WindowsX64Lite, 'metadata'),
+      ],
+    });
+
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      releaseVersion: VERSION,
+      sourceCommit: COMMIT,
+      candidateRunId: RUN_ID,
+    });
+    expect(manifest.artifacts).toHaveLength(4);
+    expect(new Set(manifest.artifacts.map(artifact => artifact.relativePath)).size).toBe(3);
+    expect(manifest.artifacts.every(artifact => /^[0-9a-f]{64}$/.test(artifact.sha256))).toBe(true);
+    expect(await fs.readFile(path.join(output, 'payload', CandidateTarget.WindowsX64Lite, 'ZhiYuan-Setup.exe'), 'utf8')).toBe(
+      'candidate bytes',
+    );
+  });
+
+  test('accepts only a complete three-platform candidate', async () => {
+    const manifests = [
+      {
+        target: CandidateTarget.WindowsX64Lite,
+        kinds: ['installer', 'updater', 'blockmap', 'metadata'],
+      },
+      {
+        target: CandidateTarget.MacArm64Default,
+        kinds: ['installer', 'updater', 'blockmap', 'metadata'],
+      },
+      {
+        target: CandidateTarget.LinuxX64AppImage,
+        kinds: ['installer', 'updater', 'metadata'],
+      },
+      {
+        target: CandidateTarget.LinuxX64Deb,
+        kinds: ['installer', 'updater', 'metadata'],
+      },
+    ].map(({ target, kinds }) => {
+      const [platform, arch, ...variantParts] = target.split('-');
+      const variant = variantParts.join('-');
+      return {
+        schemaVersion: 1,
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: RUN_ID,
+        artifacts: kinds.map(kind => ({
+          platform,
+          arch,
+          variant,
+          kind,
+          filename: `${target}-${kind}.bin`,
+          relativePath: `payload/${target}/${target}-${kind}.bin`,
+          size: 1,
+          sha256: 'a'.repeat(64),
+          sha512: `${'A'.repeat(86)}==`,
+        })),
+      };
+    });
+
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: RUN_ID,
+        manifests,
+      }),
+    ).resolves.toBeUndefined();
+
+    manifests[0].artifacts.pop();
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: RUN_ID,
+        manifests,
+      }),
+    ).rejects.toThrow('Candidate is incomplete');
+  });
+
+  test('rejects payload bytes changed after candidate assembly', async () => {
+    const source = await temporaryDirectory();
+    const output = await temporaryDirectory();
+    const installer = await writeArtifact(source, 'ZhiYuan-Setup.exe', 'original');
+    const manifest = await createCandidateManifest({
+      releaseVersion: VERSION,
+      sourceCommit: COMMIT,
+      candidateRunId: RUN_ID,
+      outputDirectory: output,
+      manifestName: 'candidate-win32-x64-lite.json',
+      specs: [spec(installer, CandidateTarget.WindowsX64Lite, 'installer')],
+    });
+    await fs.writeFile(
+      path.join(output, 'payload', CandidateTarget.WindowsX64Lite, 'ZhiYuan-Setup.exe'),
+      'changed',
+    );
+
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: RUN_ID,
+        manifests: [manifest],
+        payloadRoots: [output],
+        requireComplete: false,
+      }),
+    ).rejects.toThrow('bytes do not match');
+  });
+
+  test('rejects a candidate from a different run or source commit', async () => {
+    const manifest = {
+      schemaVersion: 1,
+      releaseVersion: VERSION,
+      sourceCommit: COMMIT,
+      candidateRunId: RUN_ID,
+      artifacts: [
+        {
+          platform: 'win32',
+          arch: 'x64',
+          variant: 'lite',
+          kind: 'installer',
+          filename: 'candidate.exe',
+          relativePath: 'payload/win32-x64-lite/candidate.exe',
+          size: 1,
+          sha256: 'a'.repeat(64),
+          sha512: `${'A'.repeat(86)}==`,
+        },
+      ],
+    };
+
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: 'f'.repeat(40),
+        candidateRunId: RUN_ID,
+        manifests: [manifest],
+        requireComplete: false,
+      }),
+    ).rejects.toThrow('source commit mismatch');
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: '987654321',
+        manifests: [manifest],
+        requireComplete: false,
+      }),
+    ).rejects.toThrow('run ID mismatch');
+  });
+
+  test('rejects an artifact path outside its declared target', async () => {
+    const manifest = {
+      schemaVersion: 1,
+      releaseVersion: VERSION,
+      sourceCommit: COMMIT,
+      candidateRunId: RUN_ID,
+      artifacts: [
+        {
+          platform: 'win32',
+          arch: 'x64',
+          variant: 'lite',
+          kind: 'installer',
+          filename: 'candidate.exe',
+          relativePath: 'payload/darwin-arm64-default/candidate.exe',
+          size: 1,
+          sha256: 'a'.repeat(64),
+          sha512: `${'A'.repeat(86)}==`,
+        },
+      ],
+    };
+
+    await expect(
+      verifyCandidateManifests({
+        releaseVersion: VERSION,
+        sourceCommit: COMMIT,
+        candidateRunId: RUN_ID,
+        manifests: [manifest],
+        requireComplete: false,
+      }),
+    ).rejects.toThrow('filename does not match its path');
+  });
+});

--- a/scripts/release/verify-release-candidate.mjs
+++ b/scripts/release/verify-release-candidate.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { verifyCandidateManifests } from './release-candidate-manifest.mjs';
+
+const args = process.argv.slice(2);
+const payloadFlag = args.indexOf('--payload-roots');
+const manifestPaths = payloadFlag === -1 ? args.slice(3) : args.slice(3, payloadFlag);
+const payloadRoots = payloadFlag === -1 ? [] : args.slice(payloadFlag + 1);
+const [releaseVersion, sourceCommit, candidateRunId] = args;
+if (!releaseVersion || !sourceCommit || !candidateRunId || manifestPaths.length === 0) {
+  throw new Error(
+    'usage: verify-release-candidate.mjs <version> <commit> <run-id> <manifest.json>... [--payload-roots <directory>...]',
+  );
+}
+
+const manifests = await Promise.all(
+  manifestPaths.map(async manifestPath => JSON.parse(await fs.readFile(manifestPath, 'utf8'))),
+);
+await verifyCandidateManifests({
+  releaseVersion,
+  sourceCommit,
+  candidateRunId,
+  manifests,
+  payloadRoots: payloadRoots.map(root => path.resolve(root)),
+});
+console.log(
+  `[ReleaseCandidate] verified ${manifests.length} manifests for v${releaseVersion} from ${sourceCommit}`,
+);

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -280,6 +280,28 @@ test("installer-related pull requests build and exercise the Windows installer",
   assert.match(sizeSmoke, /MaximumNonComponentBytes = 220MB/);
 });
 
+test("manual release candidates preserve immutable artifacts without publishing them", () => {
+  const workflow = readFileSync(
+    path.join(root, ".github", "workflows", "release-candidate.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /release_version:/);
+  assert.match(workflow, /source_ref:/);
+  assert.match(workflow, /git merge-base --is-ancestor/);
+  assert.match(workflow, /APP_BUILD_VERSION:/);
+  assert.match(workflow, /create-release-candidate\.mjs/);
+  assert.match(workflow, /verify-release-candidate\.mjs/);
+  assert.match(workflow, /windows-installer-size-smoke\.ps1/);
+  assert.match(workflow, /windows-installer-smoke\.ps1/);
+  assert.match(workflow, /retention-days: 7/);
+  assert.doesNotMatch(workflow, /R2_(?:BUCKET|ACCESS_KEY)/);
+  assert.doesNotMatch(workflow, /CLOUDFLARE_ACCOUNT_ID/);
+  assert.doesNotMatch(workflow, /aws s3/);
+  assert.doesNotMatch(workflow, /upload-update-artifacts\.mjs/);
+});
+
 test("DOCX smoke validator accepts the bundled Markdown converter output", () => {
   const workspace = mkdtempSync(path.join(tmpdir(), "zhiyuan-docx-smoke-"));
   const markdown = path.join(workspace, "smoke.md");


### PR DESCRIPTION
## 目标

新增一个手动发布候选工作流，在不上传 R2/Cloudflare、不切换 stable 指针的前提下，使用最终版本号构建一次可验证的三平台发布产物。

这建立了“构建一次 -> 验证准确字节 -> 后续原字节晋级”的第一阶段，避免用 dev 版本构建后改名，也避免验证后重新构建 release。

## 候选流程

合并后，在 Actions 中运行 **Build release candidate (manual)**：

1. 输入最终 `release_version`，不带 `v` 前缀，例如 `2026.8.13-build.2`。
2. 输入 `source_ref`，默认 `main`；工作流将其解析为固定的 40 位 commit，并要求该 commit 可达 `origin/main`。
3. quality job 执行 frozen lockfile、npm registry 签名、依赖来源、lint、编译和完整测试门禁。
4. Windows、macOS、Linux 从同一个固定 commit 构建，并嵌入同一个最终版本号。
5. Windows 额外执行安装包体积、干净 PATH runtime、冷安装、缓存命中升级和卸载验证；Linux 执行虚拟桌面 renderer 验证；macOS 在凭据可用时执行签名、公证和 Gatekeeper 检查。
6. 三个平台分别上传完整候选 payload，保留 7 天；汇总 job 校验候选完整性和身份一致性。

## 不可变候选身份

每个平台候选包含：

- 安装器
- updater 文件
- blockmap（适用平台）
- 标准化 electron-updater metadata
- 候选 manifest

manifest 绑定：

- 最终 SemVer
- source commit
- GitHub Actions candidate run ID
- target、kind 和安全相对路径
- 每个文件的字节数、SHA-256 和 SHA-512

Windows 安装器可同时承担 installer/updater 角色，但 payload 中只保存一次相同字节。跨平台汇总要求 14 个发布角色完整且无重复。

## 发布隔离

候选工作流中没有：

- R2 bucket 或 Cloudflare account 配置
- AWS/R2 access key 引用
- `aws s3` 命令
- immutable object 上传
- stable manifest 或 pointer 更新

工作流使用现有 `release` environment 获取构建和签名所需 secrets；environment 审批不会授权外部发布，因为工作流根本不具备 R2 上传路径。

## 验证

- 候选 manifest 与配置契约测试：2 个文件、16 项测试通过
- oxlint 通过
- oxfmt 检查通过
- workflow YAML 解析与零发布引用检查通过
- `git diff --check` 通过

本机完整测试受共享 Windows 原生依赖环境影响：`better-sqlite3` 为 Electron ABI 143，而 Node 测试进程需要 ABI 137；此外本机没有 `python3`，已有 release 工具测试也不支持 Windows 盘符。相关候选测试在原生模块恢复后再次通过。PR 的 Linux CI 作为完整测试权威结果。

## 下一步

新增独立的 **Promote release candidate (manual)** 工作流：

- 只接受 candidate run ID、期望版本和 source commit。
- 通过 GitHub API 下载上述 run 的三平台 payload，验证 run 已成功且来自默认分支上的候选工作流。
- 重新计算所有文件哈希并与候选 manifest 比较，拒绝任何缺失、替换或额外文件。
- 经过受保护 `release-promotion` environment 人工审批后，将同一字节上传 R2。
- 复用现有单调版本、并发 ETag、双协议 stable pointer 和发布后 smoke/rollback 逻辑。

晋级工作流落地并验证前，现有 tag 发布工作流保持不变，避免中断当前发布能力。
