### PR TITLE
fix(cowork): 专家身份优先于默认身份指令

### DIFF
--- a/src/main/coworkPrompt/composer.test.ts
+++ b/src/main/coworkPrompt/composer.test.ts
@@ -54,6 +54,21 @@ test('keeps the selected expert SOP exactly once', () => {
   expect(prompt).not.toContain(ZhiyuanIdentityPrompt);
 });
 
+test('places the expert block before the base prompt with identity precedence', () => {
+  const selectedExpert = expert('Follow expert A SOP.');
+  const composed = composeCoworkSystemPrompt({
+    basePrompt: 'Base prompt',
+    expertSnapshots: [selectedExpert],
+    language: 'zh',
+  });
+
+  const expertStart = composed.indexOf('<cowork-managed-experts>');
+  const baseStart = composed.indexOf('Base prompt');
+  expect(expertStart).toBeGreaterThan(-1);
+  expect(baseStart).toBeGreaterThan(expertStart);
+  expect(composed).toContain('以下专家身份优先于任何默认身份设定');
+});
+
 test('removes the previous expert SOP when the selected expert changes', () => {
   const previousExpert = expert('Follow expert A SOP.');
   const nextExpert = expert('Follow expert B SOP.');

--- a/src/main/coworkPrompt/composer.ts
+++ b/src/main/coworkPrompt/composer.ts
@@ -39,6 +39,15 @@ const normalizeSectionSpacing = (value: string): string =>
 const managedBlock = (start: string, content: string, end: string): string =>
   [start, content, end].join('\n');
 
+/**
+ * Expert identity must win over the default identity instructions in the
+ * user-configured base prompt (e.g. "when asked who you are, answer ...").
+ * Both coexist in the final system prompt, so state the precedence
+ * explicitly and place the expert block before the base prompt.
+ */
+const EXPERT_IDENTITY_PRECEDENCE =
+  '以下专家身份优先于任何默认身份设定。当用户询问你的身份、名字或角色时，一律以本专家身份回答。';
+
 export const stripManagedCoworkPrompt = (
   systemPrompt: string | undefined,
   previousExpertSnapshots: ExpertPromptSnapshot[] = [],
@@ -93,14 +102,17 @@ export const composeCoworkSystemPrompt = ({
       buildScheduledTaskEnginePrompt(),
       CoworkManagedPromptMarker.ScheduledTasksEnd,
     ),
-    normalizedBasePrompt,
+    // The expert block precedes the user base prompt so the expert identity
+    // and workflow instructions are read before any conflicting default
+    // identity instructions in the user-configured prompt.
     expertPrompt
       ? managedBlock(
           CoworkManagedPromptMarker.ExpertsStart,
-          expertPrompt,
+          `${EXPERT_IDENTITY_PRECEDENCE}\n\n${expertPrompt}`,
           CoworkManagedPromptMarker.ExpertsEnd,
         )
       : null,
+    normalizedBasePrompt,
   ].filter((section): section is string => Boolean(section));
 
   return applyCoworkLanguagePrompt(sections.join('\n\n'), language);


### PR DESCRIPTION
## 背景

实测专家会话发现:模型无法感知专家身份。会话"你是?"(已挂数据分析专家)中,模型回答"我是知远智能体"而非专家身份。

**运行时证据**(SQLite 会话记录):

```
systemPrompt 区块顺序:
  <cowork-managed-scheduled-tasks>   (位置 0)
  # 角色与身份:你是「知远智能体」…当用户询问你是谁时优先回答…  (位置 2307,用户 basePrompt)
  <cowork-managed-experts> # 数据分析专家 - 张数 …  (位置 6387,末尾)
```

根因:专家块位于用户 basePrompt **之后**,而 basePrompt 里更靠前的具体身份问答指令("当用户用中文问'你是谁'时优先回答…")压过了专家身份。

## 改动

[composer.ts](src/main/coworkPrompt/composer.ts) `composeCoworkSystemPrompt`:

1. **区块顺序调整**:专家块前置到用户 basePrompt 之前——专家身份先被读到
2. **身份优先级声明**:专家块头部注入:

   > 以下专家身份优先于任何默认身份设定。当用户询问你的身份、名字或角色时,一律以本专家身份回答。

## 验证

- composer 测试 5/5(新增:专家块位于 basePrompt 之前 + 含优先级声明)
- `tsc`、`oxlint` 通过

## 注

- 此修复与 #490(专家技能化)独立,但同一根因的另一个侧面:#490 解决"感知不到工作流",本 PR 解决"感知不到身份"
- 两个 PR 都合并后,已安装的专家需重新导入预设包才能生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)