### PR TITLE
feat(release): promote immutable candidates

### DIFF
--- a/.github/workflows/release-candidate-promotion.yml
+++ b/.github/workflows/release-candidate-promotion.yml
@@ -1,0 +1,373 @@
+name: Promote release candidate (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_run_id:
+        description: 'Successful Build release candidate run ID'
+        required: true
+        type: string
+      release_version:
+        description: 'Exact candidate SemVer, without a v prefix'
+        required: true
+        type: string
+      source_commit:
+        description: 'Exact 40-character candidate source commit'
+        required: true
+        type: string
+
+concurrency:
+  group: zhiyuan-online-update-production
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  R2_BUCKET: zhiyuan-releases
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Validate requested candidate identity
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]] || { echo 'Candidate promotion must be dispatched from main' >&2; exit 1; }
+          [[ "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]] || { echo 'Invalid release_version' >&2; exit 1; }
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || { echo 'Invalid source_commit' >&2; exit 1; }
+          [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo 'Invalid candidate_run_id' >&2; exit 1; }
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$SOURCE_COMMIT" origin/main || { echo 'Candidate source commit is not reachable from origin/main' >&2; exit 1; }
+      - name: Verify candidate workflow run provenance
+        uses: actions/github-script@v8
+        env:
+          EXPECTED_RUN_ID: ${{ inputs.candidate_run_id }}
+        with:
+          script: |
+            const runId = Number(process.env.EXPECTED_RUN_ID);
+            if (!Number.isSafeInteger(runId) || runId <= 0) core.setFailed('Invalid candidate run ID');
+            const { data: run } = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            if (run.path !== '.github/workflows/release-candidate.yml') core.setFailed(`Unexpected candidate workflow: ${run.path}`);
+            if (run.event !== 'workflow_dispatch') core.setFailed(`Unexpected candidate event: ${run.event}`);
+            if (run.status !== 'completed' || run.conclusion !== 'success') core.setFailed('Candidate workflow did not complete successfully');
+            if (run.head_repository?.full_name !== context.repo.owner + '/' + context.repo.repo) core.setFailed('Candidate run came from a different repository');
+            if (run.head_branch !== 'main') core.setFailed(`Candidate workflow was not dispatched from main: ${run.head_branch}`);
+      - name: Download exact candidate payloads
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/windows
+          name: release-candidate-${{ inputs.release_version }}-win32-x64-lite
+      - uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/macos
+          name: release-candidate-${{ inputs.release_version }}-darwin-arm64-default
+      - uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/linux
+          name: release-candidate-${{ inputs.release_version }}-linux-x64-default
+      - name: Recompute and verify every candidate byte
+        shell: bash
+        run: |
+          node scripts/release/verify-release-candidate.mjs \
+            '${{ inputs.release_version }}' \
+            '${{ inputs.source_commit }}' \
+            '${{ inputs.candidate_run_id }}' \
+            candidate/windows/candidate-win32-x64-lite.json \
+            candidate/macos/candidate-darwin-arm64-default.json \
+            candidate/linux/candidate-linux-x64.json \
+            --payload-roots candidate/windows candidate/macos candidate/linux
+      - name: Summarize promotion request
+        shell: bash
+        run: |
+          {
+            echo '### Release candidate passed preflight'
+            echo
+            echo "- candidate run ID: \`${{ inputs.candidate_run_id }}\`"
+            echo "- version: \`${{ inputs.release_version }}\`"
+            echo "- source commit: \`${{ inputs.source_commit }}\`"
+            echo '- all payload hashes: verified'
+            echo '- R2 changes: none (approval is next)'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  promote:
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - uses: actions/setup-node@v6
+        with: { node-version: '24.x' }
+      - name: Install release tools
+        run: |
+          pipx install 'awscli>=1.45.10,<2'
+          npm ci --prefix scripts/release --ignore-scripts --no-audit --no-fund
+      - name: Download exact candidate payloads after approval
+        uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/windows
+          name: release-candidate-${{ inputs.release_version }}-win32-x64-lite
+      - uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/macos
+          name: release-candidate-${{ inputs.release_version }}-darwin-arm64-default
+      - uses: actions/download-artifact@v8
+        with:
+          run-id: ${{ inputs.candidate_run_id }}
+          github-token: ${{ github.token }}
+          path: candidate/linux
+          name: release-candidate-${{ inputs.release_version }}-linux-x64-default
+      - name: Configure protected R2 access
+        shell: bash
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          {
+            echo "AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID"
+            echo "AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY"
+            echo 'AWS_DEFAULT_REGION=auto'
+            echo "AWS_ENDPOINT_URL_S3=https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          } >> "$GITHUB_ENV"
+      - name: Verify and upload immutable candidate bytes
+        shell: bash
+        run: |
+          node scripts/release/upload-release-candidate.mjs \
+            '${{ inputs.release_version }}' \
+            '${{ inputs.source_commit }}' \
+            '${{ inputs.candidate_run_id }}' \
+            uploaded-metadata \
+            candidate/windows/candidate-win32-x64-lite.json \
+            candidate/macos/candidate-darwin-arm64-default.json \
+            candidate/linux/candidate-linux-x64.json \
+            --payload-roots candidate/windows candidate/macos candidate/linux
+      - name: Create signed stable manifest from uploaded candidate metadata
+        run: |
+          node scripts/release/publish-update-manifest.mjs \
+            manifest/stable.json \
+            '${{ inputs.release_version }}' \
+            '${{ inputs.source_commit }}' \
+            --metadata uploaded-metadata/update-artifacts-1.json uploaded-metadata/update-artifacts-2.json uploaded-metadata/update-artifacts-3.json
+        env:
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PRIVATE_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PRIVATE_KEY_BASE64 }}
+          UPDATE_SOURCE_PIPELINE_ID: ${{ inputs.candidate_run_id }}
+      - name: Read current stable release
+        id: current
+        shell: bash
+        run: |
+          mkdir -p manifest
+          set +e
+          aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json > manifest/current-pointer-head.json 2> manifest/current-pointer-head.err
+          status=$?
+          set -e
+          if [[ $status -eq 0 ]]; then
+            aws s3api get-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json manifest/current-pointer.json > /dev/null
+            generation="$(jq -er 'select(.schemaVersion == 1) | .generation | select(type == "string" and test("^[A-Za-z0-9._-]+$"))' manifest/current-pointer.json)"
+            aws s3api get-object --bucket "$R2_BUCKET" --key "generations/${generation}/legacy/stable.json" manifest/current.json > /dev/null
+            echo 'exists=true' >> "$GITHUB_OUTPUT"
+            echo 'pointer_exists=true' >> "$GITHUB_OUTPUT"
+            echo "pointer_etag=$(jq -r '.ETag' manifest/current-pointer-head.json)" >> "$GITHUB_OUTPUT"
+          elif grep -Eq '404|Not Found|NoSuchKey' manifest/current-pointer-head.err; then
+            set +e
+            aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable.json > manifest/current-head.json 2> manifest/current-head.err
+            stable_status=$?
+            set -e
+            if [[ $stable_status -eq 0 ]]; then
+              aws s3api get-object --bucket "$R2_BUCKET" --key channels/stable.json manifest/current.json > /dev/null
+              echo 'exists=true' >> "$GITHUB_OUTPUT"
+              echo 'pointer_exists=false' >> "$GITHUB_OUTPUT"
+            elif grep -Eq '404|Not Found|NoSuchKey' manifest/current-head.err; then
+              echo 'exists=false' >> "$GITHUB_OUTPUT"
+              echo 'pointer_exists=false' >> "$GITHUB_OUTPUT"
+            else
+              cat manifest/current-head.err >&2
+              exit "$stable_status"
+            fi
+          else
+            cat manifest/current-pointer-head.err >&2
+            exit "$status"
+          fi
+      - name: Enforce monotonic release version
+        id: version_check
+        shell: bash
+        run: |
+          current_path='-'
+          [[ '${{ steps.current.outputs.exists }}' == 'true' ]] && current_path='manifest/current.json'
+          node scripts/release/verify-update-transition.mjs "$current_path" manifest/stable.json '${{ inputs.release_version }}'
+        env:
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+      - name: Verify electron-updater metadata and publish immutable generation
+        if: steps.version_check.outputs.idempotent != 'true'
+        shell: bash
+        run: |
+          metadata=(uploaded-metadata/update-artifacts-1.json uploaded-metadata/update-artifacts-2.json uploaded-metadata/update-artifacts-3.json)
+          mkdir -p manifest/electron
+          while IFS=$'\t' read -r key target filename; do
+            target_file="${target//:/-}"
+            mkdir -p "manifest/electron/${target_file}"
+            aws s3api get-object --bucket "$R2_BUCKET" --key "$key" "manifest/electron/${target_file}/${filename}" > /dev/null
+          done < <(jq -s -r '[.[].artifacts[] | select(.kind == "metadata")] | sort_by(.platform,.arch,.variant) | .[] | [.key,(.platform+":"+.arch+":"+.variant),.filename] | @tsv' "${metadata[@]}")
+          node scripts/release/verify-electron-updater-generation.mjs \
+            '${{ inputs.release_version }}' \
+            manifest/electron/win32-x64-lite/latest.yml:win32:x64:lite \
+            manifest/electron/darwin-arm64-default/latest-mac.yml:darwin:arm64:default \
+            manifest/electron/linux-x64-appimage/latest-linux.yml:linux:x64:appimage \
+            manifest/electron/linux-x64-deb/latest-linux.yml:linux:x64:deb \
+            --artifact-metadata "${metadata[@]}"
+          generation_key='generations/${{ inputs.release_version }}/legacy/stable.json'
+          set +e
+          aws s3api head-object --bucket "$R2_BUCKET" --key "$generation_key" > manifest/generation-head.json 2> manifest/generation-head.err
+          generation_status=$?
+          set -e
+          if [[ $generation_status -eq 0 ]]; then
+            aws s3api get-object --bucket "$R2_BUCKET" --key "$generation_key" manifest/existing-generation.json > /dev/null
+            node scripts/release/verify-update-transition.mjs manifest/existing-generation.json manifest/stable.json '${{ inputs.release_version }}'
+            cp manifest/existing-generation.json manifest/stable.json
+          elif grep -Eq '404|Not Found|NoSuchKey' manifest/generation-head.err; then
+            aws s3api put-object --bucket "$R2_BUCKET" --key "$generation_key" --body manifest/stable.json --content-type application/json --cache-control 'public, max-age=31536000, immutable' --if-none-match '*' > /dev/null
+          else
+            cat manifest/generation-head.err >&2
+            exit "$generation_status"
+          fi
+          node scripts/release/create-update-generation-pointer.mjs manifest/stable-pointer.json '${{ inputs.release_version }}'
+        env:
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
+      - name: Preserve previous stable state
+        if: steps.version_check.outputs.idempotent != 'true' && steps.current.outputs.exists == 'true'
+        shell: bash
+        run: |
+          aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable.previous.json --body manifest/current.json --content-type application/json --cache-control no-store
+          if [[ '${{ steps.current.outputs.pointer_exists }}' == 'true' ]]; then
+            aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable.previous-pointer.json --body manifest/current-pointer.json --content-type application/json --cache-control no-store
+          fi
+      - name: Read legacy stable manifest ETag
+        id: legacy
+        if: steps.version_check.outputs.idempotent != 'true'
+        shell: bash
+        run: |
+          set +e
+          aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable.json > manifest/legacy-head.json 2> manifest/legacy-head.err
+          status=$?
+          set -e
+          if [[ $status -eq 0 ]]; then
+            echo 'exists=true' >> "$GITHUB_OUTPUT"
+            echo "etag=$(jq -r '.ETag' manifest/legacy-head.json)" >> "$GITHUB_OUTPUT"
+          elif grep -Eq '404|Not Found|NoSuchKey' manifest/legacy-head.err; then
+            echo 'exists=false' >> "$GITHUB_OUTPUT"
+          else
+            cat manifest/legacy-head.err >&2
+            exit "$status"
+          fi
+      - name: Atomically publish stable manifests
+        id: publish
+        if: steps.version_check.outputs.idempotent != 'true'
+        shell: bash
+        run: |
+          legacy_args=(--if-none-match '*')
+          [[ '${{ steps.legacy.outputs.exists }}' == 'true' ]] && legacy_args=(--if-match '${{ steps.legacy.outputs.etag }}')
+          pointer_args=(--if-none-match '*')
+          [[ '${{ steps.current.outputs.pointer_exists }}' == 'true' ]] && pointer_args=(--if-match '${{ steps.current.outputs.pointer_etag }}')
+
+          publish_legacy() {
+            aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable.json --body manifest/stable.json --content-type application/json --cache-control no-store "${legacy_args[@]}" > manifest/publish-legacy.json || return $?
+            legacy_etag="$(jq -er '.ETag' manifest/publish-legacy.json)"
+          }
+          publish_pointer() {
+            aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json --body manifest/stable-pointer.json --content-type application/json --cache-control no-store "${pointer_args[@]}" > manifest/publish-pointer.json || return $?
+            pointer_etag="$(jq -er '.ETag' manifest/publish-pointer.json)"
+          }
+          rollback_legacy() {
+            if [[ '${{ steps.legacy.outputs.exists }}' == 'true' ]]; then
+              aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable.json --body manifest/current.json --content-type application/json --cache-control no-store --if-match "$legacy_etag"
+            else
+              published_etag="$(aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable.json --query ETag --output text)"
+              [[ "$published_etag" == "$legacy_etag" ]] || { echo 'Legacy stable manifest changed concurrently; refusing unsafe rollback' >&2; return 1; }
+              aws s3api delete-object --bucket "$R2_BUCKET" --key channels/stable.json
+            fi
+          }
+          rollback_pointer() {
+            if [[ '${{ steps.current.outputs.pointer_exists }}' == 'true' ]]; then
+              aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json --body manifest/current-pointer.json --content-type application/json --cache-control no-store --if-match "$pointer_etag"
+            else
+              published_etag="$(aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json --query ETag --output text)"
+              [[ "$published_etag" == "$pointer_etag" ]] || { echo 'Stable pointer changed concurrently; refusing unsafe rollback' >&2; return 1; }
+              aws s3api delete-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json
+            fi
+          }
+
+          if [[ '${{ steps.current.outputs.pointer_exists }}' == 'true' ]]; then
+            publish_legacy
+            set +e
+            publish_pointer
+            publish_status=$?
+            set -e
+            [[ $publish_status -eq 0 ]] || { rollback_legacy; exit "$publish_status"; }
+          else
+            publish_pointer
+            set +e
+            publish_legacy
+            publish_status=$?
+            set -e
+            [[ $publish_status -eq 0 ]] || { rollback_pointer; exit "$publish_status"; }
+          fi
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+          echo "legacy_etag=$legacy_etag" >> "$GITHUB_OUTPUT"
+          echo "pointer_etag=$pointer_etag" >> "$GITHUB_OUTPUT"
+      - name: Smoke test published release and roll back on failure
+        shell: bash
+        run: |
+          set +e
+          node scripts/release/verify-published-update.mjs '${{ inputs.release_version }}' win32:x64:lite darwin:arm64:default linux:x64:deb linux:x64:appimage
+          smoke_status=$?
+          set -e
+          if [[ $smoke_status -ne 0 && '${{ steps.publish.outputs.changed }}' == 'true' ]]; then
+            if [[ '${{ steps.legacy.outputs.exists }}' == 'true' ]]; then
+              aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable.json --body manifest/current.json --content-type application/json --cache-control no-store --if-match '${{ steps.publish.outputs.legacy_etag }}'
+            else
+              published_legacy_etag="$(aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable.json --query ETag --output text)"
+              [[ "$published_legacy_etag" == '${{ steps.publish.outputs.legacy_etag }}' ]] || { echo 'Legacy stable manifest changed concurrently; refusing unsafe rollback' >&2; exit 1; }
+              aws s3api delete-object --bucket "$R2_BUCKET" --key channels/stable.json
+            fi
+            if [[ '${{ steps.current.outputs.pointer_exists }}' == 'true' ]]; then
+              aws s3api put-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json --body manifest/current-pointer.json --content-type application/json --cache-control no-store --if-match '${{ steps.publish.outputs.pointer_etag }}'
+            else
+              published_pointer_etag="$(aws s3api head-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json --query ETag --output text)"
+              [[ "$published_pointer_etag" == '${{ steps.publish.outputs.pointer_etag }}' ]] || { echo 'Stable pointer changed concurrently; refusing unsafe rollback' >&2; exit 1; }
+              aws s3api delete-object --bucket "$R2_BUCKET" --key channels/stable-pointer.json
+            fi
+          fi
+          exit "$smoke_status"
+        env:
+          UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
+          UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -41,6 +41,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.release_version }}
         run: |
           set -euo pipefail
+          [[ "$GITHUB_REF" == 'refs/heads/main' ]] || { echo 'Release candidates must be dispatched from main' >&2; exit 1; }
           if [[ ! "$RELEASE_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo 'release_version must be a SemVer value without a v prefix' >&2
             exit 1

--- a/scripts/release/publish-update-manifest.mjs
+++ b/scripts/release/publish-update-manifest.mjs
@@ -12,6 +12,10 @@ if (!outputPath || !releaseVersion || !commitSha || specs.length === 0) {
 const keyId = process.env.UPDATE_MANIFEST_KEY_ID;
 const privateKeyBase64 = process.env.UPDATE_MANIFEST_PRIVATE_KEY_BASE64;
 if (!keyId || !privateKeyBase64) throw new Error('Update signing secrets are required');
+const pipelineId = process.env.UPDATE_SOURCE_PIPELINE_ID ?? process.env.GITHUB_RUN_ID ?? 'local';
+if (!/^(?:local|[1-9][0-9]*)$/.test(pipelineId)) {
+  throw new Error(`Invalid update source pipeline ID: ${pipelineId}`);
+}
 
 const REQUIRED_RELEASE_TARGETS = new Set([
   'win32:x64:lite',
@@ -184,7 +188,7 @@ const manifests = installerArtifacts.map(({ platform, arch, variant, filename, s
     },
     source: {
       commitSha,
-      pipelineId: process.env.GITHUB_RUN_ID ?? 'local',
+      pipelineId,
     },
   };
   const payloadBytes = Buffer.from(JSON.stringify(payload));

--- a/scripts/release/update-manifest-lib.test.ts
+++ b/scripts/release/update-manifest-lib.test.ts
@@ -131,7 +131,7 @@ describe('online update release tools', () => {
     const result = runScript(
       'publish-update-manifest.mjs',
       [manifestPath, version, 'b'.repeat(40), '--metadata', metadataPath],
-      releaseEnvironment,
+      { ...releaseEnvironment, UPDATE_SOURCE_PIPELINE_ID: '123456789' },
     );
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
@@ -145,6 +145,7 @@ describe('online update release tools', () => {
     expect(payloads.map(payload => payload.artifact.sha256)).toEqual(
       artifacts.filter(artifact => !artifact.kind || artifact.kind === 'installer').map(artifact => artifact.sha256),
     );
+    expect(payloads.every(payload => payload.source.pipelineId === '123456789')).toBe(true);
     expect(payloads.find(payload => payload.artifact.platform === 'darwin').artifact.updater.filename).toBe(
       'installer.zip',
     );

--- a/scripts/release/upload-release-candidate.mjs
+++ b/scripts/release/upload-release-candidate.mjs
@@ -1,0 +1,263 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { verifyCandidateManifests } from './release-candidate-manifest.mjs';
+
+export function artifactFormat(platform, variant, kind) {
+  if (kind === 'metadata') return { extension: '.yml', contentType: 'application/x-yaml' };
+  if (kind === 'blockmap') return { extension: '.blockmap', contentType: 'application/octet-stream' };
+  if (kind === 'updater' && platform === 'darwin' && variant === 'default') {
+    return { extension: '.zip', contentType: 'application/zip' };
+  }
+  if (platform === 'win32' && variant === 'lite') {
+    return { extension: '.exe', contentType: 'application/vnd.microsoft.portable-executable' };
+  }
+  if (platform === 'darwin' && variant === 'default') {
+    return { extension: '.dmg', contentType: 'application/x-apple-diskimage' };
+  }
+  if (platform === 'linux' && variant === 'deb') {
+    return { extension: '.deb', contentType: 'application/vnd.debian.binary-package' };
+  }
+  if (platform === 'linux' && variant === 'appimage') {
+    return { extension: '.appimage', contentType: 'application/vnd.appimage' };
+  }
+  throw new Error(`Unsupported release candidate artifact: ${platform}:${variant}:${kind}`);
+}
+
+function runAwsCommand(commandArgs, stdio = 'inherit') {
+  const result = spawnSync('aws', commandArgs, { encoding: 'utf8', stdio });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+export function immutableKey(releaseVersion, artifact) {
+  const target = `${artifact.platform}-${artifact.arch}-${artifact.variant}`;
+  return artifact.kind === 'metadata'
+    ? `generations/${releaseVersion}/electron/${target}/${artifact.filename}`
+    : `releases/${releaseVersion}/${target}/${artifact.filename}`;
+}
+
+async function hashFile(filePath, algorithm, encoding) {
+  const hash = crypto.createHash(algorithm);
+  await new Promise((resolve, reject) => {
+    const stream = fs.createReadStream(filePath);
+    stream.on('data', chunk => hash.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', resolve);
+  });
+  return hash.digest(encoding);
+}
+
+export async function verifyLocalArtifact(filePath, artifact) {
+  const format = artifactFormat(artifact.platform, artifact.variant, artifact.kind);
+  const stat = await fsp.stat(filePath);
+  if (
+    !stat.isFile() ||
+    stat.size !== artifact.size ||
+    path.extname(artifact.filename).toLowerCase() !== format.extension ||
+    (await hashFile(filePath, 'sha256', 'hex')) !== artifact.sha256 ||
+    (await hashFile(filePath, 'sha512', 'base64')) !== artifact.sha512
+  ) {
+    throw new Error(`Candidate bytes changed before upload: ${artifact.relativePath}`);
+  }
+  return format;
+}
+
+export function createImmutableUploader({
+  bucket,
+  releaseVersion,
+  runAws = runAwsCommand,
+  wait = sleep,
+}) {
+  if (!bucket) throw new Error('R2_BUCKET is required');
+
+  return async function uploadImmutable(filePath, artifact, uploadedObjects) {
+    const key = immutableKey(releaseVersion, artifact);
+    const format = await verifyLocalArtifact(filePath, artifact);
+    const existingLocal = uploadedObjects.get(key);
+    if (existingLocal) {
+      if (
+        existingLocal.size !== artifact.size ||
+        existingLocal.sha256 !== artifact.sha256 ||
+        existingLocal.sha512 !== artifact.sha512
+      ) {
+        throw new Error(`Candidate artifacts collide at immutable key ${key}`);
+      }
+      return key;
+    }
+
+    let available = false;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const existing = runAws(
+        [
+          's3api',
+          'head-object',
+          '--bucket',
+          bucket,
+          '--key',
+          key,
+          '--query',
+          '{size:ContentLength,sha256:Metadata.sha256,sha512:Metadata.sha512}',
+          '--output',
+          'json',
+        ],
+        'pipe',
+      );
+      if (existing.status === 0) {
+        const remote = JSON.parse(existing.stdout);
+        if (
+          remote.size !== artifact.size ||
+          remote.sha256 !== artifact.sha256 ||
+          remote.sha512 !== artifact.sha512
+        ) {
+          throw new Error(`Immutable object already exists with different content: ${key}`);
+        }
+        available = true;
+        break;
+      }
+      if (!/404|Not Found|NoSuchKey/i.test(existing.stderr)) {
+        throw new Error(`Could not inspect immutable object ${key}: ${existing.stderr.trim()}`);
+      }
+      const uploaded = runAws([
+        's3api',
+        'put-object',
+        '--bucket',
+        bucket,
+        '--key',
+        key,
+        '--body',
+        filePath,
+        '--cache-control',
+        'public, max-age=31536000, immutable',
+        '--content-type',
+        format.contentType,
+        '--metadata',
+        `sha256=${artifact.sha256},sha512=${artifact.sha512}`,
+        '--if-none-match',
+        '*',
+      ]);
+      if (uploaded.status === 0) {
+        available = true;
+        break;
+      }
+      if (attempt < 3) await wait(attempt * 1_000);
+    }
+    if (!available) throw new Error(`Failed to upload immutable object: ${key}`);
+
+    const remoteSize = runAws(
+      [
+        's3api',
+        'head-object',
+        '--bucket',
+        bucket,
+        '--key',
+        key,
+        '--query',
+        'ContentLength',
+        '--output',
+        'text',
+      ],
+      'pipe',
+    );
+    if (remoteSize.status !== 0 || Number.parseInt(remoteSize.stdout.trim(), 10) !== artifact.size) {
+      throw new Error(`Remote size verification failed: ${key}`);
+    }
+    uploadedObjects.set(key, artifact);
+    return key;
+  };
+}
+
+export async function uploadReleaseCandidate({
+  releaseVersion,
+  sourceCommit,
+  candidateRunId,
+  outputDirectory,
+  manifestPaths,
+  payloadRoots,
+  bucket = process.env.R2_BUCKET,
+  runAws = runAwsCommand,
+  wait = sleep,
+}) {
+  const manifests = await Promise.all(
+    manifestPaths.map(async manifestPath => JSON.parse(await fsp.readFile(manifestPath, 'utf8'))),
+  );
+  await verifyCandidateManifests({
+    releaseVersion,
+    sourceCommit,
+    candidateRunId,
+    manifests,
+    payloadRoots,
+  });
+
+  const uploadImmutable = createImmutableUploader({ bucket, releaseVersion, runAws, wait });
+  await fsp.mkdir(outputDirectory, { recursive: true });
+  const uploadedObjects = new Map();
+  for (const [manifestIndex, manifest] of manifests.entries()) {
+    const artifacts = [];
+    for (const artifact of manifest.artifacts) {
+      const filePath = path.join(payloadRoots[manifestIndex], ...artifact.relativePath.split('/'));
+      const key = await uploadImmutable(filePath, artifact, uploadedObjects);
+      artifacts.push({
+        platform: artifact.platform,
+        arch: artifact.arch,
+        variant: artifact.variant,
+        kind: artifact.kind,
+        filename: artifact.filename,
+        key,
+        size: artifact.size,
+        sha256: artifact.sha256,
+        sha512: artifact.sha512,
+      });
+    }
+    await fsp.writeFile(
+      path.join(outputDirectory, `update-artifacts-${manifestIndex + 1}.json`),
+      `${JSON.stringify(
+        { schemaVersion: 1, releaseVersion, sourceCommit, candidateRunId: String(candidateRunId), artifacts },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+  console.log(
+    `[ReleasePromotion] uploaded ${uploadedObjects.size} immutable objects from candidate run ${candidateRunId}`,
+  );
+}
+
+async function main(args) {
+  const payloadFlag = args.indexOf('--payload-roots');
+  const manifestPaths = payloadFlag === -1 ? [] : args.slice(4, payloadFlag);
+  const payloadRoots = payloadFlag === -1 ? [] : args.slice(payloadFlag + 1);
+  const [releaseVersion, sourceCommit, candidateRunId, outputDirectory] = args;
+  if (
+    !releaseVersion ||
+    !sourceCommit ||
+    !candidateRunId ||
+    !outputDirectory ||
+    manifestPaths.length === 0 ||
+    manifestPaths.length !== payloadRoots.length
+  ) {
+    throw new Error(
+      'usage: upload-release-candidate.mjs <version> <commit> <run-id> <output-directory> <manifest.json>... --payload-roots <directory>...',
+    );
+  }
+  await uploadReleaseCandidate({
+    releaseVersion,
+    sourceCommit,
+    candidateRunId,
+    outputDirectory,
+    manifestPaths,
+    payloadRoots,
+  });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main(process.argv.slice(2));
+}

--- a/scripts/release/upload-release-candidate.test.ts
+++ b/scripts/release/upload-release-candidate.test.ts
@@ -1,0 +1,140 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { createImmutableUploader } from './upload-release-candidate.mjs';
+
+const VERSION = '2026.8.13-build.2';
+const temporaryDirectories: string[] = [];
+
+async function candidateArtifact(kind = 'installer') {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'zhiyuan-candidate-upload-'));
+  temporaryDirectories.push(directory);
+  const filePath = path.join(directory, 'ZhiYuan-Setup.exe');
+  const content = Buffer.from('validated candidate bytes');
+  await fs.writeFile(filePath, content);
+  return {
+    filePath,
+    artifact: {
+      platform: 'win32',
+      arch: 'x64',
+      variant: 'lite',
+      kind,
+      filename: path.basename(filePath),
+      relativePath: `payload/win32-x64-lite/${path.basename(filePath)}`,
+      size: content.length,
+      sha256: crypto.createHash('sha256').update(content).digest('hex'),
+      sha512: crypto.createHash('sha512').update(content).digest('base64'),
+    },
+  };
+}
+
+function result(status: number, stdout = '', stderr = '') {
+  return { status, stdout, stderr };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporaryDirectories.splice(0).map(directory => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('release candidate immutable upload', () => {
+  test('accepts an identical existing immutable object without uploading it', async () => {
+    const { filePath, artifact } = await candidateArtifact();
+    const runAws = vi.fn((args: string[]) =>
+      args.includes('{size:ContentLength,sha256:Metadata.sha256,sha512:Metadata.sha512}')
+        ? result(
+            0,
+            JSON.stringify({ size: artifact.size, sha256: artifact.sha256, sha512: artifact.sha512 }),
+          )
+        : result(0, String(artifact.size)),
+    );
+    const upload = createImmutableUploader({ bucket: 'test', releaseVersion: VERSION, runAws });
+
+    await expect(upload(filePath, artifact, new Map())).resolves.toContain(`releases/${VERSION}/`);
+    expect(runAws.mock.calls.some(([args]) => args.includes('put-object'))).toBe(false);
+  });
+
+  test('rejects an existing immutable object with different content', async () => {
+    const { filePath, artifact } = await candidateArtifact();
+    const runAws = vi.fn(() =>
+      result(0, JSON.stringify({ size: artifact.size, sha256: '0'.repeat(64), sha512: artifact.sha512 })),
+    );
+    const upload = createImmutableUploader({ bucket: 'test', releaseVersion: VERSION, runAws });
+
+    await expect(upload(filePath, artifact, new Map())).rejects.toThrow(
+      'Immutable object already exists with different content',
+    );
+  });
+
+  test('rejects local bytes changed after candidate validation before calling R2', async () => {
+    const { filePath, artifact } = await candidateArtifact();
+    await fs.writeFile(filePath, 'changed after validation');
+    const runAws = vi.fn();
+    const upload = createImmutableUploader({ bucket: 'test', releaseVersion: VERSION, runAws });
+
+    await expect(upload(filePath, artifact, new Map())).rejects.toThrow('Candidate bytes changed before upload');
+    expect(runAws).not.toHaveBeenCalled();
+  });
+
+  test('uploads one object for installer and updater roles sharing the same bytes', async () => {
+    const { filePath, artifact: installer } = await candidateArtifact();
+    const updater = { ...installer, kind: 'updater' };
+    let exists = false;
+    const runAws = vi.fn((args: string[]) => {
+      if (args.includes('put-object')) {
+        exists = true;
+        return result(0);
+      }
+      if (args.includes('{size:ContentLength,sha256:Metadata.sha256,sha512:Metadata.sha512}')) {
+        return exists
+          ? result(
+              0,
+              JSON.stringify({ size: installer.size, sha256: installer.sha256, sha512: installer.sha512 }),
+            )
+          : result(1, '', 'NoSuchKey');
+      }
+      return result(0, String(installer.size));
+    });
+    const upload = createImmutableUploader({ bucket: 'test', releaseVersion: VERSION, runAws });
+    const uploadedObjects = new Map();
+
+    const installerKey = await upload(filePath, installer, uploadedObjects);
+    const updaterKey = await upload(filePath, updater, uploadedObjects);
+
+    expect(updaterKey).toBe(installerKey);
+    expect(runAws.mock.calls.filter(([args]) => args.includes('put-object'))).toHaveLength(1);
+  });
+
+  test('accepts an identical object won by another uploader after a conditional write race', async () => {
+    const { filePath, artifact } = await candidateArtifact();
+    let headCalls = 0;
+    const runAws = vi.fn((args: string[]) => {
+      if (args.includes('put-object')) return result(1, '', 'PreconditionFailed');
+      if (args.includes('{size:ContentLength,sha256:Metadata.sha256,sha512:Metadata.sha512}')) {
+        headCalls += 1;
+        return headCalls === 1
+          ? result(1, '', 'NoSuchKey')
+          : result(
+              0,
+              JSON.stringify({ size: artifact.size, sha256: artifact.sha256, sha512: artifact.sha512 }),
+            );
+      }
+      return result(0, String(artifact.size));
+    });
+    const upload = createImmutableUploader({
+      bucket: 'test',
+      releaseVersion: VERSION,
+      runAws,
+      wait: async () => {},
+    });
+
+    await expect(upload(filePath, artifact, new Map())).resolves.toBeTruthy();
+    expect(headCalls).toBe(2);
+  });
+});

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -289,6 +289,7 @@ test("manual release candidates preserve immutable artifacts without publishing 
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /release_version:/);
   assert.match(workflow, /source_ref:/);
+  assert.match(workflow, /GITHUB_REF.*refs\/heads\/main/);
   assert.match(workflow, /git merge-base --is-ancestor/);
   assert.match(workflow, /APP_BUILD_VERSION:/);
   assert.match(workflow, /create-release-candidate\.mjs/);
@@ -300,6 +301,70 @@ test("manual release candidates preserve immutable artifacts without publishing 
   assert.doesNotMatch(workflow, /CLOUDFLARE_ACCOUNT_ID/);
   assert.doesNotMatch(workflow, /aws s3/);
   assert.doesNotMatch(workflow, /upload-update-artifacts\.mjs/);
+});
+
+test("manual candidate promotion verifies exact artifacts before protected publication", () => {
+  const workflowPath = path.join(
+    root,
+    ".github",
+    "workflows",
+    "release-candidate-promotion.yml",
+  );
+  const workflowText = readFileSync(workflowPath, "utf8");
+  const preflightStart = workflowText.indexOf("  preflight:");
+  const promoteStart = workflowText.indexOf("  promote:");
+  assert.ok(preflightStart >= 0 && promoteStart > preflightStart);
+  const preflight = workflowText.slice(preflightStart, promoteStart);
+  const promote = workflowText.slice(promoteStart);
+
+  assert.match(workflowText, /workflow_dispatch:/);
+  assert.match(workflowText, /candidate_run_id:/);
+  assert.match(workflowText, /release_version:/);
+  assert.match(workflowText, /source_commit:/);
+  assert.match(promote, /needs: preflight/);
+  assert.match(promote, /environment: release/);
+  assert.match(promote, /ref: main/);
+  assert.match(preflight, /release-candidate\.yml/);
+  assert.match(preflight, /workflow_dispatch/);
+  assert.match(preflight, /head_branch.*main/);
+  assert.match(preflight, /run-id/);
+  assert.match(preflight, /verify-release-candidate\.mjs/);
+  assert.doesNotMatch(
+    preflight,
+    /R2_ACCESS_KEY_ID|R2_SECRET_ACCESS_KEY|aws s3/,
+  );
+  assert.match(promote, /run-id/);
+  assert.match(promote, /Configure protected R2 access/);
+  assert.ok(
+    promote.indexOf("Configure protected R2 access") >
+      promote.lastIndexOf("actions/download-artifact@v8"),
+  );
+  assert.match(promote, /upload-release-candidate\.mjs/);
+  assert.match(promote, /publish-update-manifest\.mjs/);
+  assert.match(
+    promote,
+    /UPDATE_SOURCE_PIPELINE_ID: \$\{\{ inputs\.candidate_run_id \}\}/,
+  );
+  assert.match(promote, /--if-none-match/);
+  assert.match(promote, /--if-match/);
+  assert.match(promote, /verify-published-update\.mjs/);
+
+  const uploader = readFileSync(
+    path.join(root, "scripts", "release", "upload-release-candidate.mjs"),
+    "utf8",
+  );
+  assert.match(uploader, /verifyCandidateManifests/);
+  assert.match(
+    uploader,
+    /Immutable object already exists with different content/,
+  );
+
+  const tagRelease = readFileSync(
+    path.join(root, ".github", "workflows", "online-update-release.yml"),
+    "utf8",
+  );
+  assert.match(tagRelease, /tags:/);
+  assert.match(tagRelease, /publish-update-manifest\.mjs/);
 });
 
 test("DOCX smoke validator accepts the bundled Markdown converter output", () => {


### PR DESCRIPTION
## Summary

- add a manual promotion workflow for an already validated release-candidate run
- verify candidate workflow provenance, version, source commit, run ID, sizes, SHA-256, and SHA-512 before approval and again before upload
- upload the exact candidate bytes to immutable R2 keys, then reuse the signed stable-manifest, monotonic-version, ETag concurrency, smoke-test, and rollback protocol
- keep the existing tag-based release workflow unchanged

## Safety boundaries

- promotion and candidate creation must be dispatched from `main`
- preflight has no R2 credentials and performs no external publication
- the protected `release` environment is entered only after preflight
- R2 credentials are injected only after all cross-run artifacts have downloaded
- immutable key collisions with different bytes are rejected
- signed manifests retain the candidate build run ID, not the promotion run ID

## Verification

- `bun run lint`
- release candidate uploader, manifest, and workflow tests: 22 passed
- focused signed-manifest pipeline-ID test: 1 passed
- workflow YAML parse, Node syntax checks, and `git diff --check`

The full release-tools suite has four pre-existing Windows-only failures because colon-delimited local artifact specs parse `C:\...` as file `C`; the changed metadata-path test passes, and Linux CI is unaffected.
