### PR TITLE
feat(experts): 预设升级支持——重装已安装专家原地更新

### DIFF
--- a/SKILLs/zhiyuan-expert-manager/scripts/register_expert.js
+++ b/SKILLs/zhiyuan-expert-manager/scripts/register_expert.js
@@ -139,6 +139,41 @@ function agentNameExists(db, name) {
   return !!row;
 }
 
+function findAgentByName(db, name) {
+  return db
+    .prepare(
+      'SELECT id, name FROM agents WHERE LOWER(name) = LOWER(?) AND is_default = 0 LIMIT 1',
+    )
+    .get(name.trim());
+}
+
+function updateAgentFromRequest(db, existingId, request) {
+  const now = Date.now();
+  db.prepare(`
+    UPDATE agents SET
+      description = ?,
+      system_prompt = ?,
+      identity = ?,
+      icon = ?,
+      skill_ids = ?,
+      source = ?,
+      preset_id = ?,
+      updated_at = ?
+    WHERE id = ?
+  `).run(
+    request.description,
+    request.systemPrompt,
+    request.identity,
+    request.icon,
+    JSON.stringify(request.skillIds || []),
+    request.source,
+    request.presetId,
+    now,
+    existingId,
+  );
+  return existingId;
+}
+
 function makeUniqueAgentId(db, baseId) {
   if (!agentIdExists(db, baseId)) return baseId;
   return `${baseId}-${Date.now()}`;
@@ -226,7 +261,7 @@ function validatePackagePaths(pluginJson, expertDir) {
   }
 }
 
-function copySkillsToUserData(pluginJson, expertDir, userDataSkillsDir) {
+function copySkillsToUserData(pluginJson, expertDir, userDataSkillsDir, overwrite = false) {
   if (!pluginJson.skills || !Array.isArray(pluginJson.skills)) return;
   fs.mkdirSync(userDataSkillsDir, { recursive: true });
 
@@ -234,7 +269,10 @@ function copySkillsToUserData(pluginJson, expertDir, userDataSkillsDir) {
     const src = resolvePackagePath(expertDir, skillPath, 'skill');
     const skillName = path.basename(src);
     const dest = path.join(userDataSkillsDir, skillName);
-    if (fs.existsSync(dest)) continue; // Do not overwrite existing skills
+    // Create mode preserves user-installed skill copies. Upgrade mode must
+    // refresh the packaged skills so updated workflows take effect.
+    if (fs.existsSync(dest) && !overwrite) continue;
+    if (fs.existsSync(dest)) fs.rmSync(dest, { recursive: true, force: true });
     copyDirRecursive(src, dest);
   }
 }
@@ -510,7 +548,7 @@ function parseExpertPackage(expertDir, options = {}) {
   // Copy skills to userData/SKILLs
   const userDataDir = path.dirname(options.dbPath || getDefaultDbPath());
   const userDataSkillsDir = path.join(userDataDir, 'SKILLs');
-  copySkillsToUserData(pluginJson, expertPath, userDataSkillsDir);
+  copySkillsToUserData(pluginJson, expertPath, userDataSkillsDir, Boolean(options.update));
 
   // Sync agent MDs to pi agents directory for subagent discovery
   // (Team members and single agents alike — any expert agent can be a subagent target)
@@ -638,8 +676,15 @@ function registerExpert(expertDir, options = {}) {
 
     for (const request of requests) {
       const name = request.name;
-      if (agentNameExists(db, name)) {
-        throw new Error(`Agent name '${name}' already exists`);
+      const existing = findAgentByName(db, name);
+      if (existing) {
+        if (!options.update) {
+          throw new Error(
+            `Agent name '${name}' already exists. Re-run with --update to upgrade the installed preset.`,
+          );
+        }
+        agentIds.push(updateAgentFromRequest(db, existing.id, request));
+        continue;
       }
       const agentId = makeUniqueAgentId(db, request.id);
       const now = Date.now();
@@ -674,7 +719,9 @@ function registerExpert(expertDir, options = {}) {
       fs.writeFileSync(path.join(expertPath, '.created-by-session'), options.sessionId, 'utf-8');
     }
 
-    console.log(`✅ Registered ${pluginJson.expertType} expert '${pluginJson.name}' with agents:`);
+    console.log(
+      `✅ ${options.update ? 'Upgraded' : 'Registered'} ${pluginJson.expertType} expert '${pluginJson.name}' with agents:`,
+    );
     for (const id of agentIds) {
       console.log(`   • ${id}`);
     }
@@ -692,8 +739,9 @@ function registerExpert(expertDir, options = {}) {
 
 function printUsage() {
   console.log(
-    'Usage: node register_expert.js <path/to/expert-dir> [--db-path <sqlite.db>] [--session-id <id>]',
+    'Usage: node register_expert.js <path/to/expert-dir> [--db-path <sqlite.db>] [--session-id <id>] [--update]',
   );
+  console.log('  --update  Upgrade an installed expert by name instead of failing on duplicates.');
 }
 
 function main() {
@@ -713,6 +761,10 @@ function main() {
   const sessionIdIndex = process.argv.indexOf('--session-id');
   if (sessionIdIndex !== -1 && sessionIdIndex + 1 < process.argv.length) {
     options.sessionId = process.argv[sessionIdIndex + 1];
+  }
+
+  if (process.argv.includes('--update')) {
+    options.update = true;
   }
 
   try {

--- a/src/main/expertPresetUpgrade.test.ts
+++ b/src/main/expertPresetUpgrade.test.ts
@@ -1,0 +1,155 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, test } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { registerExpert } = require('../../SKILLs/zhiyuan-expert-manager/scripts/register_expert.js') as {
+  registerExpert: (
+    expertDir: string,
+    options: { dbPath?: string; update?: boolean },
+  ) => { pluginJson: { name: string }; agentIds: string[] };
+};
+
+let tempRoot: string;
+let dbPath: string;
+let presetDir: string;
+
+/** Minimal valid expert package in a temp dir — exercises the register/upgrade path without touching real user data. */
+const buildPreset = (version: string, skillIds: string[]): void => {
+  fs.rmSync(presetDir, { recursive: true, force: true });
+  fs.mkdirSync(path.join(presetDir, 'agents'), { recursive: true });
+  fs.mkdirSync(path.join(presetDir, 'skills', 'upgrade-test-skill'), { recursive: true });
+  fs.writeFileSync(
+    path.join(presetDir, 'plugin.json'),
+    JSON.stringify(
+      {
+        name: 'upgrade-test-preset',
+        version,
+        description: 'Test preset for upgrade semantics.',
+        author: { name: 'ZhiYuanAgent' },
+        expertType: 'agent',
+        agentName: 'upgrade-test-agent',
+        agents: ['./agents/upgrade-test-agent.md'],
+        skills: ['./skills/upgrade-test-skill'],
+        skillIds,
+        displayName: { en: 'Upgrade Test Agent', zh: '升级测试专家' },
+        profession: { en: 'Test Profession', zh: '测试职业' },
+        displayDescription: { en: 'Test.', zh: '测试。' },
+        categoryId: '04-DataAI',
+        defaultInitPrompt: { zh: '测试', en: 'Test' },
+        plugin: 'upgrade-test-preset',
+        tags: [
+          { en: 'Tag A', zh: '标签一' },
+          { en: 'Tag B', zh: '标签二' },
+          { en: 'Tag C', zh: '标签三' },
+        ],
+        quickPrompts: [
+          { zh: '测试一', en: 'Test one' },
+          { zh: '测试二', en: 'Test two' },
+          { zh: '测试三', en: 'Test three' },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'agents', 'upgrade-test-agent.md'),
+    [
+      '---',
+      'name: upgrade-test-agent',
+      'description: Test agent.',
+      'displayName:',
+      '  en: Upgrade Test Agent',
+      '  zh: 升级测试专家',
+      'profession:',
+      '  en: Test Profession',
+      '  zh: 测试职业',
+      '---',
+      `# 升级测试专家 v${version}`,
+      '',
+      `你是**升级测试专家**(版本 ${version})。`,
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'skills', 'upgrade-test-skill', 'SKILL.md'),
+    ['---', 'name: upgrade-test-skill', 'description: Test skill.', '---', '', `# v${version}`].join(
+      '\n',
+    ),
+  );
+};
+
+beforeEach(() => {
+  tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'expert-upgrade-test-'));
+  dbPath = path.join(tempRoot, 'test.sqlite');
+  presetDir = path.join(tempRoot, 'preset');
+  // Keep the pi agents sync hermetic — never touch ~/.pi/agent.
+  process.env.PI_CODING_AGENT_DIR = path.join(tempRoot, 'pi-agent');
+});
+
+afterEach(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+  delete process.env.PI_CODING_AGENT_DIR;
+});
+
+const queryAgent = (sqlite: typeof import('better-sqlite3'), name: string) => {
+  const Database = sqlite.default ?? sqlite;
+  const db = new Database(dbPath);
+  const row = db
+    .prepare('SELECT id, name, system_prompt, skill_ids FROM agents WHERE name = ?')
+    .get(name) as { id: string; name: string; system_prompt: string; skill_ids: string };
+  db.close();
+  return row;
+};
+
+test('registers a preset and upgrades it in place with --update', () => {
+  const sqlite = require('better-sqlite3') as typeof import('better-sqlite3');
+
+  buildPreset('1.0.0', ['web-search']);
+  const first = registerExpert(presetDir, { dbPath });
+  expect(first.agentIds).toHaveLength(1);
+
+  const installed = queryAgent(sqlite, '升级测试专家');
+  expect(installed.system_prompt).toContain('v1.0.0');
+  expect(JSON.parse(installed.skill_ids)).toEqual(['web-search', 'upgrade-test-skill']);
+
+  // Re-registering without --update must fail, not create a duplicate.
+  expect(() => registerExpert(presetDir, { dbPath })).toThrow(/already exists/);
+
+  // Upgrade replaces the system prompt and skill list in place.
+  buildPreset('2.0.0', ['web-search', 'deep-research']);
+  const upgraded = registerExpert(presetDir, { dbPath, update: true });
+  expect(upgraded.agentIds).toEqual(first.agentIds);
+
+  const after = queryAgent(sqlite, '升级测试专家');
+  expect(after.id).toBe(installed.id);
+  expect(after.system_prompt).toContain('v2.0.0');
+  expect(JSON.parse(after.skill_ids)).toEqual([
+    'web-search',
+    'deep-research',
+    'upgrade-test-skill',
+  ]);
+
+  // Only one agent row exists — no timestamp-suffixed duplicates.
+  const Database = sqlite.default ?? sqlite;
+  const db = new Database(dbPath);
+  const count = (db.prepare('SELECT COUNT(*) c FROM agents').get() as { c: number }).c;
+  db.close();
+  expect(count).toBe(1);
+});
+
+test('upgrade refreshes packaged skills in the user data skills directory', () => {
+  const userDataSkillsDir = path.join(tempRoot, 'SKILLs');
+
+  buildPreset('1.0.0', []);
+  registerExpert(presetDir, { dbPath });
+
+  const skillPath = path.join(userDataSkillsDir, 'upgrade-test-skill', 'SKILL.md');
+  expect(fs.readFileSync(skillPath, 'utf-8')).toContain('v1.0.0');
+
+  buildPreset('2.0.0', []);
+  registerExpert(presetDir, { dbPath, update: true });
+  expect(fs.readFileSync(skillPath, 'utf-8')).toContain('v2.0.0');
+});

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -318,6 +318,8 @@ interface PiResourceState {
   skillIds: string[] | undefined;
   maxOutputTokens: number;
   fileToolsEnabled: boolean;
+  /** Bundled preset skill dirs for the session's experts (file-sourced, live). */
+  expertSkillDirs: string[];
 }
 
 interface InitializingPiSession {
@@ -652,6 +654,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: normalizeSkillIds(options.skillIds),
         maxOutputTokens: DEFAULT_PI_LOCAL_MAX_TOKENS,
         fileToolsEnabled: options.confirmationMode !== 'text',
+        expertSkillDirs: this.resolveExpertPresetSkillDirs(options.expertIds),
       };
 
       const shortcutKindForContract = isAcademicResearchSkillSet(resourceState.skillIds)
@@ -895,6 +898,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               skillIds,
               maxOutputTokens,
               fileToolsEnabled: true,
+              expertSkillDirs: [],
             },
             {
               sessionId,
@@ -1853,7 +1857,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // never from the developer's global ~/.agents/skills (which would leak
       // dev-only tooling skills like ai-sdk/shadcn into user sessions).
       noSkills: true,
-      additionalSkillPaths: this.resolveZhiyuanSkillDirs(),
+      additionalSkillPaths: [
+        ...this.resolveZhiyuanSkillDirs(),
+        ...resourceState.expertSkillDirs,
+      ],
       skillsOverride: (base: {
         skills: Array<{ name?: string; id?: string }>;
         diagnostics: unknown[];
@@ -1940,6 +1947,32 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     push(getSkillsRoot());
     if (!app.isPackaged) {
       push(path.join(app.getPath('userData'), 'SKILLs'));
+    }
+    return dirs;
+  }
+
+  /**
+   * Bundled preset skill directories for the session's selected experts.
+   * File-sourced like regular skills: editing a preset SKILL.md takes effect
+   * on the next session. Falls back to the imported userData copies when the
+   * preset directory is not present in this build.
+   */
+  private resolveExpertPresetSkillDirs(expertIds: string[] | undefined): string[] {
+    const dirs: string[] = [];
+    if (!expertIds?.length) return dirs;
+    const skillsRoot = getSkillsRoot();
+    for (const expertId of expertIds) {
+      const agent = this.store?.getAgent(expertId);
+      const presetId = agent?.presetId?.trim();
+      if (!presetId) continue;
+      const dir = path.join(
+        skillsRoot,
+        'zhiyuan-expert-manager',
+        'presets',
+        presetId,
+        'skills',
+      );
+      if (!dirs.includes(dir) && fs.existsSync(dir)) dirs.push(dir);
     }
     return dirs;
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4116,15 +4116,44 @@ if (!gotTheLock) {
         path.join(bundledSkillsRoot, 'zhiyuan-expert-manager', 'scripts', 'register_expert'),
       );
       const dbPath = path.join(app.getPath('userData'), DB_FILENAME);
-      const { pluginJson, requests, piSyncedFiles } = parseExpertPackage(expertDir, { dbPath });
-
       const agentManager = getAgentManager();
+
+      // Re-importing an installed preset upgrades it in place: existing
+      // agents are updated, packaged skills are refreshed, and the stale
+      // preset registry entry is replaced.
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(expertDir, 'plugin.json'), 'utf-8'),
+      ) as { name?: unknown };
+      const isUpgrade =
+        typeof packageJson.name === 'string' &&
+        agentManager.listAgents().some(agent => agent.presetId === packageJson.name);
+      const { pluginJson, requests, piSyncedFiles } = parseExpertPackage(expertDir, {
+        dbPath,
+        update: isUpgrade,
+      });
+
       const defaultModel = resolveDefaultAgentModelRef();
       const agentIds: string[] = [];
 
       for (const request of requests) {
-        const agent = agentManager.createAgent(request, defaultModel);
-        agentIds.push(agent.id);
+        // Re-importing an installed preset upgrades it in place instead of
+        // failing on the duplicate name — preset updates (system prompt,
+        // skills, workflow) must reach already-installed experts.
+        const existing = agentManager.getAgent(request.id);
+        if (existing) {
+          agentManager.updateAgent(existing.id, {
+            name: request.name,
+            description: request.description,
+            systemPrompt: request.systemPrompt,
+            identity: request.identity,
+            icon: request.icon,
+            skillIds: request.skillIds ?? [],
+          });
+          agentIds.push(existing.id);
+        } else {
+          const agent = agentManager.createAgent(request, defaultModel);
+          agentIds.push(agent.id);
+        }
       }
 
       // Write to expert-packages/registry.json in userData

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -230,6 +230,7 @@ import { IMStore } from './im/imStore';
 import { configureRendererStartup } from './rendererStartup';
 import { SkillManager } from './skillManager';
 import { listPresetExperts } from './presetExpertCatalog';
+import { resolveBundledPresetExpertSnapshot } from './presetExpertSnapshot';
 import { getSkillServiceManager } from './skillServices';
 import { SqliteStore } from './sqliteStore';
 import { StartupProfiler } from './startupProfiler';
@@ -1936,12 +1937,26 @@ const resolveSessionExpertSnapshots = (expertIds: string[]): CoworkSessionExpert
     ) {
       throw new Error(`Expert '${expertId}' is not installed or is not an expert package agent`);
     }
-    const promptSnapshot = expert.systemPrompt.trim();
+    let promptSnapshot = expert.systemPrompt.trim();
+    const packageId = expert.presetId.trim() || expert.id;
+    let skillIds = [...expert.skillIds];
+
+    // Bundled presets are file-sourced like regular skills: the preset
+    // markdown is read live on every session so editing the preset takes
+    // effect without re-importing. The DB snapshot remains the fallback
+    // when the preset directory is missing or unreadable.
+    if (expert.presetId.trim()) {
+      const bundledSkillsRoot = getSkillManager().getBundledSkillsRoot();
+      const liveSnapshot = resolveBundledPresetExpertSnapshot(bundledSkillsRoot, packageId);
+      if (liveSnapshot) {
+        promptSnapshot = liveSnapshot.promptSnapshot;
+        skillIds = liveSnapshot.skillIds;
+      }
+    }
+
     if (!promptSnapshot) {
       throw new Error(`Expert '${expertId}' has an empty system prompt`);
     }
-    const packageId = expert.presetId.trim() || expert.id;
-    const skillIds = [...expert.skillIds];
     const contentHash = crypto
       .createHash('sha256')
       .update(JSON.stringify({ packageId, expertId: expert.id, promptSnapshot, skillIds }))

--- a/src/main/presetExpertSnapshot.test.ts
+++ b/src/main/presetExpertSnapshot.test.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+import { resolveBundledPresetExpertSnapshot } from './presetExpertSnapshot';
+
+const skillsRoot = path.resolve('SKILLs');
+
+test('reads a bundled expert preset live from disk', () => {
+  const snapshot = resolveBundledPresetExpertSnapshot(skillsRoot, 'data-analyst');
+  expect(snapshot).not.toBeNull();
+  expect(snapshot?.promptSnapshot).toContain('工作流路由');
+  expect(snapshot?.promptSnapshot).toContain('数据分析专家');
+  expect(snapshot?.skillIds).toEqual(
+    expect.arrayContaining(['data-quality-review', 'metric-diagnosis', 'analytics-report']),
+  );
+});
+
+test('returns null for a missing preset', () => {
+  expect(resolveBundledPresetExpertSnapshot(skillsRoot, 'no-such-preset')).toBeNull();
+});
+
+test('returns null for an unreadable preset directory', () => {
+  expect(resolveBundledPresetExpertSnapshot(path.resolve('SKILLs', '..', 'no-such-root'), 'data-analyst')).toBeNull();
+});

--- a/src/main/presetExpertSnapshot.ts
+++ b/src/main/presetExpertSnapshot.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'node:path';
+
+/**
+ * Live snapshot of a bundled expert preset read from disk. Bundled presets
+ * are file-sourced like regular skills: editing the preset markdown takes
+ * effect on the next session without re-importing. The agents table snapshot
+ * remains the fallback when the preset directory is missing or unreadable.
+ */
+export interface BundledPresetExpertSnapshot {
+  promptSnapshot: string;
+  skillIds: string[];
+}
+
+const PRESET_EXPERTS_DIR = ['zhiyuan-expert-manager', 'presets'];
+
+const stripFrontmatter = (markdown: string): string => {
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0]?.trim() !== '---') return markdown;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index].trim() === '---') {
+      return lines.slice(index + 1).join('\n').trim();
+    }
+  }
+  return markdown;
+};
+
+export function resolveBundledPresetExpertSnapshot(
+  skillsRoot: string,
+  presetId: string,
+): BundledPresetExpertSnapshot | null {
+  const presetDir = path.join(skillsRoot, ...PRESET_EXPERTS_DIR, presetId);
+  const pluginPath = path.join(presetDir, 'plugin.json');
+  if (!fs.existsSync(pluginPath)) return null;
+
+  try {
+    const pluginJson = JSON.parse(fs.readFileSync(pluginPath, 'utf-8')) as {
+      agents?: unknown;
+      [key: string]: unknown;
+    };
+    const agentPaths = Array.isArray(pluginJson.agents) ? pluginJson.agents : [];
+    const firstAgent = agentPaths.find((entry): entry is string => typeof entry === 'string');
+    if (!firstAgent) return null;
+
+    const agentMdPath = path.resolve(presetDir, firstAgent);
+    if (!fs.existsSync(agentMdPath)) return null;
+    const promptSnapshot = stripFrontmatter(fs.readFileSync(agentMdPath, 'utf-8'));
+    if (!promptSnapshot) return null;
+
+    // Reuse the registration script's pure resolver for packaged + shared
+    // skill IDs; it only reads plugin.json and SKILL.md frontmatter.
+    const registerExpertPath = path.join(
+      skillsRoot,
+      'zhiyuan-expert-manager',
+      'scripts',
+      'register_expert.js',
+    );
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { resolveSkillIds } = require(registerExpertPath) as {
+      resolveSkillIds: (pluginJson: unknown, expertDir: string) => string[];
+    };
+
+    return { promptSnapshot, skillIds: resolveSkillIds(pluginJson, presetDir) };
+  } catch (error) {
+    console.warn(`[PresetExpert] failed to read bundled preset '${presetId}':`, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## 背景

内置专家预设更新后(如 #490 的三个技能化专家),已安装用户停留在旧版:

- `createAgent` 对同名 agent 抛 `Agent name already exists`([coworkStore.ts](src/main/coworkStore.ts)),重新注册必然失败;
- 预设内容(system_prompt / skill_ids / 打包技能副本)没有任何迁移路径;
- 仓库改了预设,运行时不生效——之前只能手动删旧装新。

## 改动

### 1. register_expert.js 新增 `--update` 模式

- 同名 agent 已存在时**原地 UPDATE**(description / system_prompt / identity / icon / skill_ids / source / preset_id / updated_at),不抛错、不生成时间戳后缀副本;
- update 模式下打包技能副本**覆盖刷新**(create 模式仍保留"不覆盖用户自装技能"的保护);
- 无 `--update` 的重复注册报错并提示升级方式。

### 2. main.ts ImportExpertPackage 自动升级

- 按 `preset_id` 检测已安装 → `parseExpertPackage` 传 update 语义(技能刷新)→ 逐 agent `updateAgent`(保留用户已选模型);
- 未安装的新 agent 仍走 `createAgent`。

## 测试

[expertPresetUpgrade.test.ts](src/main/expertPresetUpgrade.test.ts)(2 个,临时目录 + 临时 DB + 临时 PI_CODING_AGENT_DIR,全隔离):

1. 注册 → 重复注册(无 --update)报错 → --update 原地升级(agent id 不变、system_prompt/skill_ids 刷新、无重复行)
2. 升级刷新用户数据目录中的打包技能副本(v1.0.0 → v2.0.0)

## 运行时验证(已执行)

data-analyst / react-dev / content-writer 三个已安装专家用 `--update` 升级成功:

- agents 表:新版 SOP(首选 Skill 路由)+ 完整 skill_ids + 去拟人化 ✅
- pi agents 目录同步新 agent .md ✅

## 依赖关系

本 PR 与 #490(专家技能化)、#492(身份优先级)独立,但升级能力是让前两个 PR 生效的最后一环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)