### PR TITLE
fix(local-inference): 移除未使用图标导入，修复 installer gate tsc 失败

### DIFF
--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@shared/components/ui/dropdown-menu';
 import { LayeredTabsContent } from '@shared/components/ui/layered-tabs';
 import { Tabs } from '@shared/components/ui/tabs';
-import { Cpu, FolderOpen, Globe, MemoryStick, PanelLeft, Pencil, Settings2 } from 'lucide-react';
+import { MemoryStick, PanelLeft, Pencil } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type {


### PR DESCRIPTION
## 背景

PR #465(fix(ppt): 让演示验证报错可收敛)在 installer gate(Windows installer gate / package-and-install)失败,报错与 #465 的改动无关:

```
src/renderer/components/localInference/LocalInferenceView.tsx(16,10): error TS6133: 'Cpu' is declared but its value is never read.
src/renderer/components/localInference/LocalInferenceView.tsx(16,15): error TS6133: 'FolderOpen' is declared but its value is never read.
src/renderer/components/localInference/LocalInferenceView.tsx(16,27): error TS6133: 'Globe' is declared but its value is never read.
src/renderer/components/localInference/LocalInferenceView.tsx(16,66): error TS6133: 'Settings2' is declared but its value is never read.
```

## 根因

1. #467(8/12)曾将 lucide 图标导入清理为 `PanelLeft, Pencil`
2. #497 的提交 56e945c1(8/13)基于旧基线开发,把导入行改回 `Cpu, FolderOpen, Globe, MemoryStick, PanelLeft, Pencil, Settings2`,但功能只用了 `MemoryStick`(新增的内存设置菜单),其余 4 个是死引用
3. installer gate 的 path 过滤不含 `src/**`,#497 合并时未触发该门禁;lint 又不报 TS6133 → main 的 `build:tsc` 静默失败
4. 任何触及 `SKILLs/**`、`scripts/**` 等门禁路径的 PR(如 #465)都会因此失败——失败的是 main 的继承状态,不是 PR 自身

## 修复

- 导入行缩减为实际使用的 `MemoryStick, PanelLeft, Pencil`,删除 4 个死引用
- 本地 `npx tsc` 全量校验通过(exit 0)

## 验证

- lint / test / bundle-budget / installer gate 待 CI 确认
- 合并后需重新触发 #465 的 installer gate(当前分支已 0 behind main,合并本 PR 后 push 或 rerun 即可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)