### PR TITLE
fix(channels): verify pi-connect runtime connectivity

### DIFF
--- a/src/main/im/channelAccountManager.ts
+++ b/src/main/im/channelAccountManager.ts
@@ -1,8 +1,15 @@
 import Database from 'better-sqlite3';
 
 import { t } from '../i18n';
+import type { CcConnectAccountRuntimeStatus } from '../libs/ccConnectRuntimeStatusRegistry';
 import { fetchJsonWithTimeout } from './http';
 import { IMStore } from './imStore';
+import {
+  appendRuntimeConnectivity,
+  resolveConnectivityAccount,
+  selectConnectivityInstance,
+} from './channelConnectivity';
+import { ConnectivityCheckCode, ConnectivityCheckLevel } from './constants';
 import type { IMGatewayConfigPatch } from './configPatch';
 import type {
   IMConnectivityCheck,
@@ -14,10 +21,15 @@ import type {
 
 const CONNECTIVITY_TIMEOUT_MS = 10_000;
 
+export type ChannelRuntimeProbe = (accountId: string) => Promise<CcConnectAccountRuntimeStatus>;
+
 export class ChannelAccountManager {
   private readonly imStore: IMStore;
 
-  constructor(db: Database.Database) {
+  constructor(
+    db: Database.Database,
+    private readonly runtimeProbe?: ChannelRuntimeProbe,
+  ) {
     this.imStore = new IMStore(db);
   }
 
@@ -133,35 +145,57 @@ export class ChannelAccountManager {
   async testGateway(
     platform: Platform,
     configOverride?: Partial<IMGatewayConfig>,
+    accountId?: string,
   ): Promise<IMConnectivityTestResult> {
     const config = { ...this.getConfig(), ...configOverride } as IMGatewayConfig;
     const testedAt = Date.now();
     const checks: IMConnectivityCheck[] = [];
     try {
-      const message = await this.probe(platform, config);
-      checks.push({ code: 'auth_check', level: 'pass', message });
+      const message = await this.probe(platform, config, accountId);
+      checks.push({
+        code: ConnectivityCheckCode.Auth,
+        level: ConnectivityCheckLevel.Pass,
+        message,
+      });
     } catch (error) {
       checks.push({
-        code: 'auth_check',
-        level: 'fail',
+        code: ConnectivityCheckCode.Auth,
+        level: ConnectivityCheckLevel.Fail,
         message: t('imAuthFailed', {
           error: error instanceof Error ? error.message : String(error),
         }),
         suggestion: t('imAuthFailedSuggestion'),
       });
     }
-    return {
+    const result: IMConnectivityTestResult = {
       platform,
       testedAt,
-      verdict: checks.some(check => check.level === 'fail') ? 'fail' : 'pass',
+      verdict: checks.some(check => check.level === ConnectivityCheckLevel.Fail)
+        ? ConnectivityCheckLevel.Fail
+        : ConnectivityCheckLevel.Pass,
       checks,
     };
+    if (!this.runtimeProbe) return result;
+
+    const account = resolveConnectivityAccount(platform, config, accountId);
+    if (!account.enabled || !account.accountId) {
+      return appendRuntimeConnectivity(result, account, null);
+    }
+    try {
+      const runtimeStatus = await this.runtimeProbe(account.accountId);
+      return appendRuntimeConnectivity(result, account, runtimeStatus);
+    } catch (error) {
+      return appendRuntimeConnectivity(result, account, null, error);
+    }
   }
 
-  private async probe(platform: Platform, config: IMGatewayConfig): Promise<string> {
+  private async probe(
+    platform: Platform,
+    config: IMGatewayConfig,
+    accountId?: string,
+  ): Promise<string> {
     if (platform === 'telegram') {
-      const instance =
-        config.telegram.instances.find(item => item.enabled) ?? config.telegram.instances[0];
+      const instance = selectConnectivityInstance(config.telegram.instances, accountId);
       if (!instance?.botToken) throw new Error('Bot token is required.');
       const result = await fetchJsonWithTimeout<{ ok?: boolean; description?: string }>(
         `https://api.telegram.org/bot${instance.botToken}/getMe`,
@@ -170,8 +204,7 @@ export class ChannelAccountManager {
       );
       if (!result.ok) throw new Error(result.description || 'Telegram authentication failed.');
     } else if (platform === 'discord') {
-      const instance =
-        config.discord.instances.find(item => item.enabled) ?? config.discord.instances[0];
+      const instance = selectConnectivityInstance(config.discord.instances, accountId);
       if (!instance?.botToken) throw new Error('Bot token is required.');
       await fetchJsonWithTimeout(
         'https://discord.com/api/v10/users/@me',
@@ -181,20 +214,18 @@ export class ChannelAccountManager {
         CONNECTIVITY_TIMEOUT_MS,
       );
     } else if (platform === 'feishu') {
-      const instance =
-        config.feishu.instances.find(item => item.enabled) ?? config.feishu.instances[0];
+      const instance = selectConnectivityInstance(config.feishu.instances, accountId);
       if (!instance?.appId || !instance.appSecret) throw new Error('App credentials are required.');
       const result = await this.verifyFeishuCredentials(instance.appId, instance.appSecret);
       if (!result.success) throw new Error(result.error || 'Feishu authentication failed.');
     } else if (platform === 'dingtalk') {
-      const instance =
-        config.dingtalk.instances.find(item => item.enabled) ?? config.dingtalk.instances[0];
+      const instance = selectConnectivityInstance(config.dingtalk.instances, accountId);
       if (!instance?.clientId || !instance.clientSecret)
         throw new Error('App credentials are required.');
       const result = await this.verifyDingTalkCredentials(instance.clientId, instance.clientSecret);
       if (!result.success) throw new Error(result.error || 'DingTalk authentication failed.');
     } else if (platform === 'qq') {
-      const instance = config.qq.instances.find(item => item.enabled) ?? config.qq.instances[0];
+      const instance = selectConnectivityInstance(config.qq.instances, accountId);
       if (!instance?.appId || !instance.appSecret) throw new Error('App credentials are required.');
       await fetchJsonWithTimeout(
         'https://bots.qq.com/app/getAppAccessToken',
@@ -206,8 +237,7 @@ export class ChannelAccountManager {
         CONNECTIVITY_TIMEOUT_MS,
       );
     } else if (platform === 'wecom') {
-      const instance =
-        config.wecom.instances.find(item => item.enabled) ?? config.wecom.instances[0];
+      const instance = selectConnectivityInstance(config.wecom.instances, accountId);
       if (!instance?.botId || !instance.secret) throw new Error('Bot credentials are required.');
     } else if (!config.weixin.accountId) {
       throw new Error('Weixin account is not configured.');

--- a/src/main/im/channelConnectivity.test.ts
+++ b/src/main/im/channelConnectivity.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from 'vitest';
+
+import type { IMGatewayConfig } from './types';
+import {
+  appendRuntimeConnectivity,
+  resolveConnectivityAccount,
+  selectConnectivityInstance,
+} from './channelConnectivity';
+import { ConnectivityCheckCode, ConnectivityCheckLevel } from './constants';
+
+const config = {
+  telegram: {
+    instances: [
+      { instanceId: 'disabled-account', enabled: false },
+      { instanceId: 'enabled-account-with-complete-uuid', enabled: true },
+    ],
+  },
+  weixin: { accountId: 'weixin-native-account', enabled: true },
+} as IMGatewayConfig;
+
+test('resolves the requested complete account identity for multi-instance channels', () => {
+  expect(resolveConnectivityAccount('telegram', config, 'disabled-account')).toEqual({
+    accountId: 'disabled-account',
+    enabled: false,
+  });
+  expect(resolveConnectivityAccount('telegram', config)).toEqual({
+    accountId: 'enabled-account-with-complete-uuid',
+    enabled: true,
+  });
+  expect(resolveConnectivityAccount('weixin', config)).toEqual({
+    accountId: 'weixin-native-account',
+    enabled: true,
+  });
+  expect(resolveConnectivityAccount('telegram', config, 'missing-account')).toEqual({
+    accountId: 'missing-account',
+    enabled: false,
+  });
+  expect(selectConnectivityInstance(config.telegram.instances, 'missing-account')).toBeUndefined();
+});
+
+test('requires an enabled account to be ready in the sidecar', () => {
+  const result = appendRuntimeConnectivity(
+    {
+      platform: 'telegram',
+      testedAt: Date.now(),
+      verdict: ConnectivityCheckLevel.Pass,
+      checks: [
+        { code: ConnectivityCheckCode.Auth, level: ConnectivityCheckLevel.Pass, message: 'ok' },
+      ],
+    },
+    { accountId: 'enabled-account-with-complete-uuid', enabled: true },
+    {
+      connected: false,
+      lastError: 'stream disconnected',
+      startedAt: null,
+      lastInboundAt: null,
+      lastOutboundAt: null,
+    },
+  );
+  expect(result.verdict).toBe(ConnectivityCheckLevel.Fail);
+  expect(result.checks.at(-1)).toMatchObject({
+    code: ConnectivityCheckCode.RuntimeUnavailable,
+    level: ConnectivityCheckLevel.Fail,
+  });
+});
+
+test('reports disabled accounts without treating expected inactivity as a failure', () => {
+  const result = appendRuntimeConnectivity(
+    {
+      platform: 'telegram',
+      testedAt: Date.now(),
+      verdict: ConnectivityCheckLevel.Pass,
+      checks: [
+        { code: ConnectivityCheckCode.Auth, level: ConnectivityCheckLevel.Pass, message: 'ok' },
+      ],
+    },
+    { accountId: 'disabled-account', enabled: false },
+    null,
+  );
+  expect(result.verdict).toBe(ConnectivityCheckLevel.Warn);
+  expect(result.checks.at(-1)).toMatchObject({
+    code: ConnectivityCheckCode.RuntimeUnavailable,
+    level: ConnectivityCheckLevel.Info,
+  });
+});
+
+test('reports a ready sidecar account as connected', () => {
+  const result = appendRuntimeConnectivity(
+    {
+      platform: 'telegram',
+      testedAt: Date.now(),
+      verdict: ConnectivityCheckLevel.Pass,
+      checks: [
+        { code: ConnectivityCheckCode.Auth, level: ConnectivityCheckLevel.Pass, message: 'ok' },
+      ],
+    },
+    { accountId: 'enabled-account-with-complete-uuid', enabled: true },
+    {
+      connected: true,
+      lastError: null,
+      startedAt: Date.now(),
+      lastInboundAt: null,
+      lastOutboundAt: null,
+    },
+  );
+  expect(result.verdict).toBe(ConnectivityCheckLevel.Pass);
+  expect(result.checks.at(-1)).toMatchObject({
+    code: ConnectivityCheckCode.RuntimeReady,
+    level: ConnectivityCheckLevel.Pass,
+  });
+});

--- a/src/main/im/channelConnectivity.ts
+++ b/src/main/im/channelConnectivity.ts
@@ -1,0 +1,80 @@
+import { t } from '../i18n';
+import type { CcConnectAccountRuntimeStatus } from '../libs/ccConnectRuntimeStatusRegistry';
+import { ConnectivityCheckCode, ConnectivityCheckLevel } from './constants';
+import type { IMConnectivityTestResult, IMGatewayConfig, Platform } from './types';
+
+type ChannelInstance = { instanceId: string; enabled: boolean };
+
+export function selectConnectivityInstance<T extends ChannelInstance>(
+  instances: T[],
+  requestedAccountId?: string,
+): T | undefined {
+  const requested = requestedAccountId?.trim();
+  return requested
+    ? instances.find(item => item.instanceId === requested)
+    : (instances.find(item => item.enabled) ?? instances[0]);
+}
+
+export function resolveConnectivityAccount(
+  platform: Platform,
+  config: IMGatewayConfig,
+  requestedAccountId?: string,
+): { accountId: string | null; enabled: boolean } {
+  if (platform === 'weixin') {
+    const accountId = config.weixin.accountId.trim();
+    return { accountId: accountId || null, enabled: config.weixin.enabled };
+  }
+
+  const instances = config[platform].instances as ChannelInstance[];
+  const requested = requestedAccountId?.trim();
+  const instance = selectConnectivityInstance(instances, requested);
+  return {
+    accountId: instance?.instanceId ?? requested ?? null,
+    enabled: instance?.enabled ?? false,
+  };
+}
+
+export function appendRuntimeConnectivity(
+  result: IMConnectivityTestResult,
+  account: { accountId: string | null; enabled: boolean },
+  runtimeStatus: CcConnectAccountRuntimeStatus | null,
+  runtimeError?: unknown,
+): IMConnectivityTestResult {
+  const checks = [...result.checks];
+  if (!account.enabled) {
+    checks.push({
+      code: ConnectivityCheckCode.RuntimeUnavailable,
+      level: ConnectivityCheckLevel.Info,
+      message: t('imChannelNotEnabled'),
+      suggestion: t('imChannelNotEnabledSuggestion'),
+    });
+  } else if (runtimeStatus?.connected) {
+    checks.push({
+      code: ConnectivityCheckCode.RuntimeReady,
+      level: ConnectivityCheckLevel.Pass,
+      message: t('imChannelRunning'),
+    });
+  } else {
+    const detail =
+      runtimeError instanceof Error
+        ? runtimeError.message
+        : runtimeStatus?.lastError || (runtimeError ? String(runtimeError) : null);
+    checks.push({
+      code: ConnectivityCheckCode.RuntimeUnavailable,
+      level: ConnectivityCheckLevel.Fail,
+      message: detail
+        ? `${t('imChannelEnabledNotConnected')} ${detail}`
+        : t('imChannelEnabledNotConnected'),
+      suggestion: t('imChannelEnabledNotConnectedSuggestion'),
+    });
+  }
+  return {
+    ...result,
+    verdict: checks.some(check => check.level === ConnectivityCheckLevel.Fail)
+      ? ConnectivityCheckLevel.Fail
+      : !account.enabled && result.verdict === ConnectivityCheckLevel.Pass
+        ? ConnectivityCheckLevel.Warn
+        : result.verdict,
+    checks,
+  };
+}

--- a/src/main/im/constants.ts
+++ b/src/main/im/constants.ts
@@ -1,0 +1,12 @@
+export const ConnectivityCheckCode = {
+  Auth: 'auth_check',
+  RuntimeReady: 'gateway_running',
+  RuntimeUnavailable: 'channel_runtime_not_running',
+} as const;
+
+export const ConnectivityCheckLevel = {
+  Pass: 'pass',
+  Info: 'info',
+  Warn: 'warn',
+  Fail: 'fail',
+} as const;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4973,7 +4973,7 @@ if (!gotTheLock) {
   });
 
   ipcMain.handle(
-    'im:gateway:test',
+    ImIpc.GatewayTest,
     async (
       _event,
       platform: Platform,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1883,7 +1883,10 @@ const refreshMcpBridge = (): Promise<{ tools: number; error?: string }> => {
 
 const getIMGatewayManager = () => {
   if (!imGatewayManager) {
-    imGatewayManager = new ChannelAccountManager(getStore().getDatabase());
+    imGatewayManager = new ChannelAccountManager(getStore().getDatabase(), async accountId => {
+      await refreshCcConnectPlatformStatuses();
+      return ccConnectRuntimeStatuses.get(accountId, ccConnectSidecarManager?.lastError ?? null);
+    });
   }
   return imGatewayManager;
 };
@@ -4971,9 +4974,14 @@ if (!gotTheLock) {
 
   ipcMain.handle(
     'im:gateway:test',
-    async (_event, platform: Platform, configOverride?: Partial<IMGatewayConfig>) => {
+    async (
+      _event,
+      platform: Platform,
+      configOverride?: Partial<IMGatewayConfig>,
+      accountId?: string,
+    ) => {
       try {
-        const result = await getIMGatewayManager().testGateway(platform, configOverride);
+        const result = await getIMGatewayManager().testGateway(platform, configOverride, accountId);
         return { success: true, result };
       } catch (error) {
         return {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -679,8 +679,8 @@ contextBridge.exposeInMainWorld('electron', {
 
     startGateway: (platform: Platform) => ipcRenderer.invoke(ImIpc.GatewayStart, platform),
     stopGateway: (platform: Platform) => ipcRenderer.invoke(ImIpc.GatewayStop, platform),
-    testGateway: (platform: Platform, configOverride?: unknown) =>
-      ipcRenderer.invoke(ImIpc.GatewayTest, platform, configOverride),
+    testGateway: (platform: Platform, configOverride?: unknown, accountId?: string) =>
+      ipcRenderer.invoke(ImIpc.GatewayTest, platform, configOverride, accountId),
 
     getStatus: () => ipcRenderer.invoke(ImIpc.StatusGet),
     getLocalIp: () => ipcRenderer.invoke(ImIpc.GetLocalIp) as Promise<string>,

--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -241,6 +241,7 @@ const IMSettings: React.FC = () => {
   const runConnectivityTest = async (
     platform: Platform,
     configOverride?: Partial<IMGatewayConfig>,
+    accountId?: string,
   ): Promise<IMConnectivityTestResult | null> => {
     setConnectivityResults(prev => {
       const { [platform]: _, ...remaining } = prev;
@@ -252,7 +253,11 @@ const IMSettings: React.FC = () => {
     });
 
     try {
-    const result = await imService.testGateway(platform, configOverride);
+    if (!(await imService.syncPendingConfig())) {
+      setConnectivityFailures(prev => ({ ...prev, [platform]: true }));
+      return null;
+    }
+    const result = await imService.testGateway(platform, configOverride, accountId);
     if (result) {
       setConnectivityResults(prev => ({ ...prev, [platform]: result }));
       } else {
@@ -416,7 +421,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ telegram: tgMultiConfig });
       const result = await runConnectivityTest(platform, {
         telegram: tgMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeTelegramInstanceId ?? undefined);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeTelegramInstanceId && result) {
         const inst = tgMultiConfig.instances.find(i => i.instanceId === activeTelegramInstanceId);
@@ -443,7 +448,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ dingtalk: dingtalkMultiConfig });
       const result = await runConnectivityTest(platform, {
         dingtalk: dingtalkMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeDingTalkInstanceId ?? undefined);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeDingTalkInstanceId && result) {
         const inst = dingtalkMultiConfig.instances.find(
@@ -472,7 +477,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ qq: qqMultiConfig });
       const result = await runConnectivityTest(platform, {
         qq: qqMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeQQInstanceId ?? undefined);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeQQInstanceId && result) {
         const inst = qqMultiConfig.instances.find(i => i.instanceId === activeQQInstanceId);
@@ -495,7 +500,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ wecom: wecomMultiConfig });
       const result = await runConnectivityTest(platform, {
         wecom: wecomMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeWecomInstanceId ?? undefined);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeWecomInstanceId && result) {
         const inst = wecomMultiConfig.instances.find(i => i.instanceId === activeWecomInstanceId);
@@ -532,7 +537,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ feishu: feishuMultiConfig });
       const result = await runConnectivityTest(platform, {
         feishu: feishuMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeFeishuInstanceId ?? undefined);
       // Auto-enable: if the active instance is OFF and auth_check passed, turn on automatically
       if (activeFeishuInstanceId && result) {
           const inst = feishuMultiConfig.instances.find(
@@ -558,7 +563,7 @@ const IMSettings: React.FC = () => {
       await imService.persistConfig({ discord: discordMultiConfig });
       const result = await runConnectivityTest(platform, {
         discord: discordMultiConfig,
-      } as Partial<IMGatewayConfig>);
+      } as Partial<IMGatewayConfig>, activeDiscordInstanceId ?? undefined);
       if (activeDiscordInstanceId && result) {
         const inst = discordMultiConfig.instances.find(
           i => i.instanceId === activeDiscordInstanceId,

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -2217,7 +2217,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityVerdict_fail: '不可用',
     imConnectivityCheckTitle_missing_credentials: '配置项缺失',
     imConnectivityCheckTitle_auth_check: '凭证鉴权',
-    imConnectivityCheckTitle_gateway_running: 'IM 渠道启用状态',
+    imConnectivityCheckTitle_gateway_running: '频道运行时',
+    imConnectivityCheckTitle_channel_runtime_not_running: '频道运行时',
     imConnectivityCheckTitle_inbound_activity: '入站消息活动',
     imConnectivityCheckTitle_outbound_activity: '出站消息活动',
     imConnectivityCheckTitle_platform_last_error: '平台最近错误',
@@ -2232,6 +2233,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityCheckSuggestion_auth_check: '核对平台凭证、应用权限和发布状态。',
     imConnectivityCheckSuggestion_gateway_running:
       '若显示未启用，请点击对应 IM 渠道胶囊按钮启用；启用后确认网络可访问平台服务。',
+    imConnectivityCheckSuggestion_channel_runtime_not_running:
+      '请启用该频道，并检查频道运行时、网络与平台侧连接配置。',
     imConnectivityCheckSuggestion_inbound_activity: '向机器人发一条测试消息；群聊场景请 @机器人。',
     imConnectivityCheckSuggestion_outbound_activity:
       '检查机器人发消息权限、可见范围和会话回包权限。',
@@ -5213,7 +5216,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     imConnectivityVerdict_fail: 'Unavailable',
     imConnectivityCheckTitle_missing_credentials: 'Missing Credentials',
     imConnectivityCheckTitle_auth_check: 'Credential Authentication',
-    imConnectivityCheckTitle_gateway_running: 'IM Channel Enablement',
+    imConnectivityCheckTitle_gateway_running: 'Channel Runtime',
+    imConnectivityCheckTitle_channel_runtime_not_running: 'Channel Runtime',
     imConnectivityCheckTitle_inbound_activity: 'Inbound Message Activity',
     imConnectivityCheckTitle_outbound_activity: 'Outbound Message Activity',
     imConnectivityCheckTitle_platform_last_error: 'Recent Platform Error',
@@ -5230,6 +5234,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
       'Verify credentials, permissions, and app release status.',
     imConnectivityCheckSuggestion_gateway_running:
       'If disabled, click the IM channel pill to enable it, then verify platform endpoints are reachable.',
+    imConnectivityCheckSuggestion_channel_runtime_not_running:
+      'Enable the channel, then check the channel runtime, network, and platform connection settings.',
     imConnectivityCheckSuggestion_inbound_activity:
       'Send a test message to the bot; mention it in group chats.',
     imConnectivityCheckSuggestion_outbound_activity:

--- a/src/renderer/services/im.ts
+++ b/src/renderer/services/im.ts
@@ -270,12 +270,14 @@ class IMService {
   async testGateway(
     platform: Platform,
     configOverride?: Partial<IMGatewayConfig>,
+    accountId?: string,
   ): Promise<IMConnectivityTestResult | null> {
     try {
       store.dispatch(setLoading(true));
       const result: IMConnectivityTestResponse = await window.electron.im.testGateway(
         platform,
         configOverride,
+        accountId,
       );
       if (result.success && result.result) {
         return result.result;

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1010,6 +1010,7 @@ interface IElectronAPI {
     testGateway: (
       platform: Platform,
       configOverride?: Partial<IMGatewayConfig>,
+      accountId?: string,
     ) => Promise<{ success: boolean; result?: IMConnectivityTestResult; error?: string }>;
     getStatus: () => Promise<{ success: boolean; status?: IMGatewayStatus; error?: string }>;
     getLocalIp: () => Promise<string>;


### PR DESCRIPTION
## Summary

- require enabled channel accounts to pass pi-connect runtime health before connectivity tests pass
- route multi-instance tests through the complete selected account ID
- apply pending channel configuration before probing runtime readiness
- distinguish disabled accounts from enabled-but-unavailable runtime accounts

## Technical Notes

- credential checks remain platform-specific, while runtime readiness comes from the authenticated pi-connect health contract
- `ChannelAccountManager` receives a runtime probe so the main-process IPC remains a thin transport layer
- no OpenClaw or Agent ID dependency is introduced
- this PR is stacked on #503

## Verification

- 9 targeted connectivity, runtime registry, main-process routing, and config-sync tests passed
- Electron TypeScript check passed
- lint passed with four unrelated baseline warnings in `LocalInferenceView.tsx`
- full local suite reached 292 passing test files; 25 files were blocked by the shared Windows environment (missing Node `better-sqlite3` binding, `python3`, 7-Zip, and existing Windows path harness failures)
- Electron `better-sqlite3` ABI restore completed successfully

Closes #449
