### PR TITLE
fix(cowork): isolate Pi session resources

### DIFF
--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -20,6 +20,7 @@ declare module '@earendil-works/pi-coding-agent' {
 
   export class SettingsManager {
     static create(cwd: string, agentDir?: string): SettingsManager;
+    static inMemory(): SettingsManager;
     applyOverrides(overrides: { shellPath?: string }): void;
     getShellPath(): string | undefined;
   }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -46,10 +46,15 @@ const hoisted = vi.hoisted(() => {
     applyOverrides: vi.fn(),
     getShellPath: vi.fn(),
   }));
+  const mockSettingsManagerInMemory = vi.fn(() => ({
+    applyOverrides: vi.fn(),
+    getShellPath: vi.fn(),
+  }));
 
   return {
     mockSession,
     mockSettingsManagerCreate,
+    mockSettingsManagerInMemory,
     mockCreateAgentSession: vi.fn().mockResolvedValue({ session: mockSession }),
     mockDefaultResourceLoader: vi.fn(function (this: { reload: () => Promise<void> }) {
       this.reload = vi.fn().mockResolvedValue(undefined);
@@ -167,6 +172,7 @@ const mockSession = hoisted.mockSession;
 const mockCreateAgentSession = hoisted.mockCreateAgentSession;
 const mockDefaultResourceLoader = hoisted.mockDefaultResourceLoader;
 const mockSettingsManagerCreate = hoisted.mockSettingsManagerCreate;
+const mockSettingsManagerInMemory = hoisted.mockSettingsManagerInMemory;
 const mockGetModel = hoisted.mockGetModel;
 const mockModelRuntime = hoisted.mockModelRuntime;
 const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
@@ -178,7 +184,10 @@ const mockApplyApplicationRuntimeEnv = hoisted.mockApplyApplicationRuntimeEnv;
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: hoisted.mockCreateAgentSession,
   DefaultResourceLoader: hoisted.mockDefaultResourceLoader,
-  SettingsManager: { create: hoisted.mockSettingsManagerCreate },
+  SettingsManager: {
+    create: hoisted.mockSettingsManagerCreate,
+    inMemory: hoisted.mockSettingsManagerInMemory,
+  },
   getAgentDir: hoisted.mockGetAgentDir,
   ModelRuntime: {
     create: hoisted.mockModelRuntimeCreate,
@@ -769,6 +778,10 @@ describe('PiRuntimeAdapter', () => {
         expect.objectContaining({
           agentDir: '/tmp/pi-agent',
           cwd: process.cwd(),
+          noExtensions: true,
+          noPromptTemplates: true,
+          noSkills: true,
+          noThemes: true,
           appendSystemPromptOverride: expect.any(Function),
           systemPromptOverride: expect.any(Function),
         }),
@@ -787,11 +800,12 @@ describe('PiRuntimeAdapter', () => {
       expect(mockCreateAgentSession.mock.calls[0]?.[0]).not.toHaveProperty('systemPrompt');
     });
 
-    it('shares one Pi SettingsManager with resource loading and the agent session', async () => {
+    it('shares one isolated Pi SettingsManager with resource loading and the agent session', async () => {
       await adapter.startSession('settings-manager', 'Hello Pi');
 
-      expect(mockSettingsManagerCreate).toHaveBeenCalledWith(process.cwd(), '/tmp/pi-agent');
-      const settingsManager = mockSettingsManagerCreate.mock.results[0]?.value;
+      expect(mockSettingsManagerInMemory).toHaveBeenCalledOnce();
+      expect(mockSettingsManagerCreate).not.toHaveBeenCalled();
+      const settingsManager = mockSettingsManagerInMemory.mock.results[0]?.value;
       expect(mockDefaultResourceLoader.mock.calls[0]?.[0]).toEqual(
         expect.objectContaining({ settingsManager }),
       );

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -290,6 +290,7 @@ interface PiModules {
   DefaultResourceLoader: new (options: Record<string, unknown>) => PiResourceLoader;
   SettingsManager?: {
     create(cwd: string, agentDir?: string): PiSettingsManager;
+    inMemory?(): PiSettingsManager;
   };
   getAgentDir: () => string;
   getModel: (provider: string, modelId: string) => unknown;
@@ -740,6 +741,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionOptions.modelRuntime = resolvedModel.modelRuntime;
       }
 
+      console.debug(`[PiRuntime] loading isolated resources for session ${sessionId}`);
       const settingsManager = this.createPiSettingsManager(pi, workspaceRoot);
       const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState, {
         sessionId,
@@ -955,6 +957,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionOptions.noTools = 'all';
       }
 
+      console.debug(`[PiRuntime] creating agent session for ${sessionId}`);
       const result = await pi.createAgentSession(sessionOptions);
       const session = result.session;
       if (!isCurrentInitialization()) {
@@ -1064,6 +1067,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // open. Do not revive an aborted Pi turn when that question resolves.
       if (abortController.signal.aborted) return;
 
+      console.debug(`[PiRuntime] dispatching initial prompt for session ${sessionId}`);
       await sendPiPrompt(
         session,
         initialPrompt,
@@ -1824,7 +1828,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   private createPiSettingsManager(pi: PiModules, cwd: string): PiSettingsManager | null {
     if (!pi.SettingsManager) return null;
-    return pi.SettingsManager.create(cwd, pi.getAgentDir());
+    // Cowork owns its runtime configuration. Loading Pi's user/project settings here can
+    // trigger package installation or third-party extensions that differ between machines.
+    return pi.SettingsManager.inMemory?.() ?? pi.SettingsManager.create(cwd, pi.getAgentDir());
   }
 
   private applyPiShellOverride(settingsManager: PiSettingsManager | null): void {
@@ -1856,7 +1862,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // ZhiYuanAgent skills come exclusively from the app-managed SKILLs dirs —
       // never from the developer's global ~/.agents/skills (which would leak
       // dev-only tooling skills like ai-sdk/shadcn into user sessions).
+      noExtensions: true,
       noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
       additionalSkillPaths: [
         ...this.resolveZhiyuanSkillDirs(),
         ...resourceState.expertSkillDirs,


### PR DESCRIPTION
## Summary

Isolate Cowork Pi sessions from machine-local Pi settings so global or project package configuration cannot change session startup behavior across installations.

This also adds phase-level debug logging around resource loading, agent session creation, and initial prompt dispatch to make pre-stream stalls diagnosable from production logs.

## Related Issue

No linked issue.

## Changes Made

- Create the shared Pi SettingsManager in memory instead of loading user-level or project-level Pi settings.
- Disable externally discovered Pi extensions, prompt templates, and themes while preserving application-managed skills, expert skill directories, inline tools, and project context files.
- Add debug markers for isolated resource loading, agent session creation, and initial prompt dispatch.
- Update Pi module declarations and regression tests for the isolated settings path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

Commands run:

- `npm test -- piRuntimeAdapter` (94 tests passed)
- `npm run lint`
- `npx tsc --project electron-tsconfig.json --noEmit`

## Screenshots (if applicable)

Not applicable. This PR has no UI changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the isolation behavior
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)
- [ ] Changes to preload script (`src/main/preload.ts`)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

The reported production log shows Cowork session creation and model configuration resolution, but no subsequent Pi runtime event. It does not prove that a remote model request was sent or that the model protocol caused the stall.

The affected machine encountered the problem on its first conversation after the application was installed for the first time. This rules out stale application data and any package download previously initiated by this application. It does not establish whether another Pi-compatible tool had already created machine-level `~/.pi` settings, and the supplied log contains no evidence that package resolution or downloading occurred.

Accordingly, this PR should be treated as runtime isolation hardening plus diagnostic instrumentation, not as a confirmed root-cause fix for the reported first-install failure. On a machine with no pre-existing Pi user or project settings, the isolation change should not alter startup behavior. The new debug markers are the part that will distinguish resource loading, agent session creation, and initial prompt dispatch on the next reproduction.
