### PR TITLE
fix(channels): align Feishu and Lark runtime routing

### DIFF
--- a/src/main/im/ccConnectPiBridge.test.ts
+++ b/src/main/im/ccConnectPiBridge.test.ts
@@ -1,6 +1,17 @@
 import { expect, test } from 'vitest';
 
-import { getCcConnectScopedConversationId, parseCcConnectScopedConversationId } from './ccConnectPiBridge';
+import {
+  getCcConnectScopedConversationId,
+  normalizeCcConnectPlatform,
+  parseCcConnectScopedConversationId,
+} from './ccConnectPiBridge';
+
+test('normalizes Lark transport events to the Feishu product channel', () => {
+  expect(normalizeCcConnectPlatform('lark')).toBe('feishu');
+  expect(normalizeCcConnectPlatform('feishu')).toBe('feishu');
+  expect(normalizeCcConnectPlatform('qqbot')).toBe('qq');
+  expect(normalizeCcConnectPlatform('unknown')).toBeNull();
+});
 
 test('separates the same platform conversation for distinct ChannelAccounts', () => {
   const first = getCcConnectScopedConversationId('telegram-primary', 'chat-1');

--- a/src/main/im/ccConnectPiBridge.ts
+++ b/src/main/im/ccConnectPiBridge.ts
@@ -18,16 +18,21 @@ import type {
 } from './imScheduledTaskHandler';
 import type { IMMessage, Platform } from './types';
 
-const SUPPORTED_PLATFORMS = new Set<string>([
-  'telegram',
-  'discord',
-  'dingtalk',
-  'feishu',
-  'qq',
-  'qqbot',
-  'wecom',
-  'weixin',
-]);
+const PLATFORM_MAPPING = {
+  telegram: 'telegram',
+  discord: 'discord',
+  dingtalk: 'dingtalk',
+  feishu: 'feishu',
+  lark: 'feishu',
+  qq: 'qq',
+  qqbot: 'qq',
+  wecom: 'wecom',
+  weixin: 'weixin',
+} as const satisfies Readonly<Record<string, Platform>>;
+
+export function normalizeCcConnectPlatform(platform: string): Platform | null {
+  return PLATFORM_MAPPING[platform as keyof typeof PLATFORM_MAPPING] ?? null;
+}
 
 export class CcConnectPiBridge {
   private readonly handler: IMCoworkHandler;
@@ -71,11 +76,10 @@ export class CcConnectPiBridge {
     request: CcConnectTurnRequest,
     signal?: AbortSignal,
   ): Promise<CcConnectTurnResponse> {
-    if (!SUPPORTED_PLATFORMS.has(request.message.platform)) {
+    const platform = normalizeCcConnectPlatform(request.message.platform);
+    if (!platform) {
       throw new Error(`Unsupported cc-connect platform: ${request.message.platform}`);
     }
-    const platform =
-      request.message.platform === 'qqbot' ? 'qq' : (request.message.platform as Platform);
     const nativeConversationId = resolveNativeConversationId(request.message);
     const conversationId = getCcConnectScopedConversationId(
       request.accountId,

--- a/src/main/im/channelAccountManager.ts
+++ b/src/main/im/channelAccountManager.ts
@@ -6,6 +6,7 @@ import { fetchJsonWithTimeout } from './http';
 import { IMStore } from './imStore';
 import {
   appendRuntimeConnectivity,
+  resolveFeishuAuthEndpoint,
   resolveConnectivityAccount,
   selectConnectivityInstance,
 } from './channelConnectivity';
@@ -216,7 +217,11 @@ export class ChannelAccountManager {
     } else if (platform === 'feishu') {
       const instance = selectConnectivityInstance(config.feishu.instances, accountId);
       if (!instance?.appId || !instance.appSecret) throw new Error('App credentials are required.');
-      const result = await this.verifyFeishuCredentials(instance.appId, instance.appSecret);
+      const result = await this.verifyFeishuCredentials(
+        instance.appId,
+        instance.appSecret,
+        instance.domain,
+      );
       if (!result.success) throw new Error(result.error || 'Feishu authentication failed.');
     } else if (platform === 'dingtalk') {
       const instance = selectConnectivityInstance(config.dingtalk.instances, accountId);
@@ -248,10 +253,11 @@ export class ChannelAccountManager {
   async verifyFeishuCredentials(
     appId: string,
     appSecret: string,
+    domain = 'feishu',
   ): Promise<{ success: boolean; error?: string }> {
     try {
       const result = await fetchJsonWithTimeout<{ code?: number; msg?: string }>(
-        'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+        resolveFeishuAuthEndpoint(domain),
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/main/im/channelConnectivity.test.ts
+++ b/src/main/im/channelConnectivity.test.ts
@@ -3,10 +3,20 @@ import { expect, test } from 'vitest';
 import type { IMGatewayConfig } from './types';
 import {
   appendRuntimeConnectivity,
+  resolveFeishuAuthEndpoint,
   resolveConnectivityAccount,
   selectConnectivityInstance,
 } from './channelConnectivity';
 import { ConnectivityCheckCode, ConnectivityCheckLevel } from './constants';
+
+test('uses the matching authentication endpoint for Feishu and Lark', () => {
+  expect(resolveFeishuAuthEndpoint('feishu')).toContain('open.feishu.cn');
+  expect(resolveFeishuAuthEndpoint('lark')).toContain('open.larksuite.com');
+  expect(resolveFeishuAuthEndpoint('https://open.example.invalid')).toBe(
+    'https://open.example.invalid/open-apis/auth/v3/tenant_access_token/internal',
+  );
+  expect(() => resolveFeishuAuthEndpoint('invalid-domain')).toThrow();
+});
 
 const config = {
   telegram: {

--- a/src/main/im/channelConnectivity.ts
+++ b/src/main/im/channelConnectivity.ts
@@ -15,6 +15,22 @@ export function selectConnectivityInstance<T extends ChannelInstance>(
     : (instances.find(item => item.enabled) ?? instances[0]);
 }
 
+export function resolveFeishuAuthEndpoint(domain: string): string {
+  const service = domain.trim();
+  if (!service || service.toLowerCase() === 'feishu') {
+    return 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal';
+  }
+  if (service.toLowerCase() === 'lark') {
+    return 'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal';
+  }
+
+  const baseUrl = new URL(service);
+  if (baseUrl.protocol !== 'https:' && baseUrl.protocol !== 'http:') {
+    throw new Error('Feishu service domain must use HTTP or HTTPS.');
+  }
+  return new URL('/open-apis/auth/v3/tenant_access_token/internal', baseUrl).toString();
+}
+
 export function resolveConnectivityAccount(
   platform: Platform,
   config: IMGatewayConfig,

--- a/src/main/libs/ccConnectAccountConfig.test.ts
+++ b/src/main/libs/ccConnectAccountConfig.test.ts
@@ -88,11 +88,7 @@ test('maps only enabled accounts with complete, platform-native credentials', ()
       }),
       expect.objectContaining({ accountId: 'discord-123456', platform: 'discord' }),
       expect.objectContaining({ accountId: 'dingtalk-123456', platform: 'dingtalk' }),
-      expect.objectContaining({
-        accountId: 'feishu-123456',
-        platform: 'feishu',
-        options: expect.objectContaining({ domain: 'lark' }),
-      }),
+      expect.objectContaining({ accountId: 'feishu-123456', platform: 'lark' }),
       expect.objectContaining({ accountId: 'qq-123456', platform: 'qqbot' }),
       expect.objectContaining({
         accountId: 'wecom-123456',
@@ -115,6 +111,51 @@ test('maps only enabled accounts with complete, platform-native credentials', ()
     ]),
   );
   expect(accounts).toHaveLength(7);
+  expect(
+    accounts.find(account => account.accountId === 'feishu-123456')?.options,
+  ).not.toHaveProperty('domain');
+});
+
+test('keeps custom Feishu API URLs separate from the service-region selector', () => {
+  const accounts = listCcConnectAccountConfigs({
+    getTelegramInstances: () => [],
+    getDiscordInstances: () => [],
+    getDingTalkInstances: () => [],
+    getFeishuInstances: () => [
+      {
+        ...disabled,
+        enabled: true,
+        instanceId: 'feishu-domestic',
+        appId: 'domestic-app',
+        appSecret: 'domestic-secret',
+        domain: 'feishu',
+      },
+      {
+        ...disabled,
+        enabled: true,
+        instanceId: 'feishu-custom',
+        appId: 'custom-app',
+        appSecret: 'custom-secret',
+        domain: 'https://open.example.invalid',
+      },
+    ],
+    getQQInstances: () => [],
+    getWecomInstances: () => [],
+    getWeixinConfig: () => ({ enabled: false }),
+  } as never);
+
+  expect(accounts).toEqual([
+    expect.objectContaining({
+      accountId: 'feishu-domestic',
+      platform: 'feishu',
+      options: expect.not.objectContaining({ domain: expect.anything() }),
+    }),
+    expect.objectContaining({
+      accountId: 'feishu-custom',
+      platform: 'feishu',
+      options: expect.objectContaining({ domain: 'https://open.example.invalid' }),
+    }),
+  ]);
 });
 
 test('omits enabled accounts without a workspace binding', () => {

--- a/src/main/libs/ccConnectAccountConfig.ts
+++ b/src/main/libs/ccConnectAccountConfig.ts
@@ -2,7 +2,7 @@ import type { IMStore } from '../im/imStore';
 
 export type CcConnectAccountConfig = {
   accountId: string;
-  platform: 'telegram' | 'discord' | 'dingtalk' | 'feishu' | 'qqbot' | 'wecom' | 'weixin';
+  platform: 'telegram' | 'discord' | 'dingtalk' | 'feishu' | 'lark' | 'qqbot' | 'wecom' | 'weixin';
   options: Readonly<Record<string, string | number | boolean | readonly string[]>>;
 };
 
@@ -73,27 +73,19 @@ export function listCcConnectAccountConfigs(
           ]
         : [],
     ),
-    ...store.getFeishuInstances().flatMap(instance =>
-      enabled(
-        instance.enabled,
-        workspaceExists,
-        instance.workspaceId,
-        instance.appId,
-        instance.appSecret,
-      )
-        ? [
-            {
-              accountId: accountId(instance.instanceId),
-              platform: 'feishu' as const,
-              options: channelOptions(instance, {
-                app_id: instance.appId,
-                app_secret: instance.appSecret,
-                domain: instance.domain,
-              }),
-            },
-          ]
-        : [],
-    ),
+    ...store
+      .getFeishuInstances()
+      .flatMap(instance =>
+        enabled(
+          instance.enabled,
+          workspaceExists,
+          instance.workspaceId,
+          instance.appId,
+          instance.appSecret,
+        )
+          ? [feishuAccountConfig(instance)]
+          : [],
+      ),
     ...store.getQQInstances().flatMap(instance =>
       enabled(
         instance.enabled,
@@ -155,6 +147,32 @@ export function listCcConnectAccountConfigs(
         ]
       : []),
   ];
+}
+
+function feishuAccountConfig(instance: {
+  instanceId: string;
+  appId: string;
+  appSecret: string;
+  domain: string;
+  dmPolicy?: string;
+  allowFrom?: readonly string[];
+  groupPolicy?: string;
+  groupAllowFrom?: readonly string[];
+  mediaMaxMb?: number;
+}): CcConnectAccountConfig {
+  const domain = instance.domain.trim();
+  const service = domain.toLowerCase();
+  const logicalService = service === 'feishu' || service === 'lark';
+  return {
+    accountId: accountId(instance.instanceId),
+    platform: service === 'lark' ? 'lark' : 'feishu',
+    options: channelOptions(instance, {
+      app_id: instance.appId,
+      app_secret: instance.appSecret,
+      // pi-connect reserves domain for an absolute custom API base URL.
+      domain: logicalService ? undefined : domain,
+    }),
+  };
 }
 
 function accountId(instanceId: string): string {

--- a/src/main/libs/ccConnectAccountRuntimeStatus.test.ts
+++ b/src/main/libs/ccConnectAccountRuntimeStatus.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'vitest';
+
+import { resolveCcConnectAccountRuntimeStatus } from './ccConnectAccountRuntimeStatus';
+import { CcConnectRuntimeStatusRegistry } from './ccConnectRuntimeStatusRegistry';
+
+test('does not leak a failed Feishu account error into Weixin status', () => {
+  const statuses = new CcConnectRuntimeStatusRegistry();
+  statuses.replace([
+    {
+      accountId: 'feishu-account',
+      platform: 'feishu',
+      state: 'unavailable',
+      lastError: 'feishu: invalid domain',
+    },
+    {
+      accountId: 'weixin-account',
+      platform: 'weixin',
+      state: 'ready',
+    },
+  ]);
+
+  expect(resolveCcConnectAccountRuntimeStatus(statuses, 'feishu-account', true)).toMatchObject({
+    connected: false,
+    lastError: 'feishu: invalid domain',
+  });
+  expect(resolveCcConnectAccountRuntimeStatus(statuses, 'weixin-account', true)).toMatchObject({
+    connected: true,
+    lastError: null,
+  });
+  expect(
+    resolveCcConnectAccountRuntimeStatus(statuses, 'missing-weixin-account', true),
+  ).toMatchObject({
+    connected: false,
+    lastError: null,
+  });
+});
+
+test('never reports an account as connected after the sidecar stops', () => {
+  const statuses = new CcConnectRuntimeStatusRegistry();
+  statuses.replace([{ accountId: 'account', platform: 'weixin', state: 'ready' }]);
+
+  expect(resolveCcConnectAccountRuntimeStatus(statuses, 'account', false).connected).toBe(false);
+});

--- a/src/main/libs/ccConnectAccountRuntimeStatus.ts
+++ b/src/main/libs/ccConnectAccountRuntimeStatus.ts
@@ -1,0 +1,14 @@
+import type { CcConnectAccountRuntimeStatus } from './ccConnectRuntimeStatusRegistry';
+import { CcConnectRuntimeStatusRegistry } from './ccConnectRuntimeStatusRegistry';
+
+export function resolveCcConnectAccountRuntimeStatus(
+  statuses: CcConnectRuntimeStatusRegistry,
+  accountId: string,
+  runtimeRunning: boolean,
+): CcConnectAccountRuntimeStatus {
+  const status = statuses.get(accountId);
+  return {
+    ...status,
+    connected: runtimeRunning && status.connected,
+  };
+}

--- a/src/main/libs/ccConnectRuntimeStatusRegistry.ts
+++ b/src/main/libs/ccConnectRuntimeStatusRegistry.ts
@@ -50,8 +50,8 @@ export class CcConnectRuntimeStatusRegistry {
     this.statuses.clear();
   }
 
-  get(accountId: string, fallbackError: string | null = null): CcConnectAccountRuntimeStatus {
-    return this.statuses.get(accountId) ?? { ...EMPTY_STATUS, lastError: fallbackError };
+  get(accountId: string): CcConnectAccountRuntimeStatus {
+    return this.statuses.get(accountId) ?? { ...EMPTY_STATUS };
   }
 }
 

--- a/src/main/libs/ccConnectSidecarConfig.test.ts
+++ b/src/main/libs/ccConnectSidecarConfig.test.ts
@@ -13,7 +13,13 @@ const base = {
 test('serializes only a ZhiYuan bridge project and disables upstream control planes', () => {
   const config = serializeCcConnectSidecarConfig({
     ...base,
-    projects: [{ accountId: 'telegram-primary', platform: 'telegram', options: { token: 'token', allow_from: ['u1'] } }],
+    projects: [
+      {
+        accountId: 'telegram-primary',
+        platform: 'telegram',
+        options: { token: 'token', allow_from: ['u1'] },
+      },
+    ],
   });
   expect(config).toContain('type = "zhiyuan-bridge"');
   expect(config).toContain('bridge_url = "http://127.0.0.1:34567"');
@@ -24,27 +30,75 @@ test('serializes only a ZhiYuan bridge project and disables upstream control pla
 });
 
 test('accepts qqbot, the cc-connect QQ adapter identifier', () => {
-  expect(() => serializeCcConnectSidecarConfig({
+  expect(() =>
+    serializeCcConnectSidecarConfig({
+      ...base,
+      projects: [
+        {
+          accountId: 'qq-primary',
+          platform: 'qqbot',
+          options: { app_id: 'id', app_secret: 'secret' },
+        },
+      ],
+    }),
+  ).not.toThrow();
+});
+
+test('accepts lark as the international Feishu adapter identifier', () => {
+  const config = serializeCcConnectSidecarConfig({
     ...base,
-    projects: [{ accountId: 'qq-primary', platform: 'qqbot', options: { app_id: 'id', app_secret: 'secret' } }],
-  })).not.toThrow();
+    projects: [
+      {
+        accountId: 'lark-primary',
+        platform: 'lark',
+        options: { app_id: 'id', app_secret: 'secret' },
+      },
+    ],
+  });
+  expect(config).toContain('type = "lark"');
+  expect(config).not.toContain('domain = "lark"');
 });
 
 test('serializes multiple account projects into one channel runtime', () => {
-  const config = serializeCcConnectSidecarConfig({ ...base, projects: [
-    { accountId: 'a', platform: 'dingtalk', options: { client_id: 'id-a', client_secret: 'secret-a' } },
-    { accountId: 'b', platform: 'dingtalk', options: { client_id: 'id-b', client_secret: 'secret-b' } },
-  ] });
+  const config = serializeCcConnectSidecarConfig({
+    ...base,
+    projects: [
+      {
+        accountId: 'a',
+        platform: 'dingtalk',
+        options: { client_id: 'id-a', client_secret: 'secret-a' },
+      },
+      {
+        accountId: 'b',
+        platform: 'dingtalk',
+        options: { client_id: 'id-b', client_secret: 'secret-b' },
+      },
+    ],
+  });
   expect(config.match(/\[\[projects\]\]/g)).toHaveLength(2);
   expect(config).toContain('name = "a"');
   expect(config).toContain('name = "b"');
 });
 
 test('rejects remote control planes, unsupported platforms, and unsafe option keys', () => {
-  expect(() => serializeCcConnectSidecarConfig({ ...base, bridgeUrl: 'http://10.0.0.1:1234', projects: [] })).toThrow('loopback');
-  expect(() => serializeCcConnectSidecarConfig({ ...base, projects: [] })).toThrow('requires a project');
-  expect(() => serializeCcConnectSidecarConfig({ ...base, projects: [{ accountId: 'a', platform: 'slack', options: {} }] })).toThrow('Unsupported');
-  expect(() => serializeCcConnectSidecarConfig({ ...base, projects: [{ accountId: 'a', platform: 'qq', options: { 'bad.key': 'x' } }] })).toThrow('Unsafe');
+  expect(() =>
+    serializeCcConnectSidecarConfig({ ...base, bridgeUrl: 'http://10.0.0.1:1234', projects: [] }),
+  ).toThrow('loopback');
+  expect(() => serializeCcConnectSidecarConfig({ ...base, projects: [] })).toThrow(
+    'requires a project',
+  );
+  expect(() =>
+    serializeCcConnectSidecarConfig({
+      ...base,
+      projects: [{ accountId: 'a', platform: 'slack', options: {} }],
+    }),
+  ).toThrow('Unsupported');
+  expect(() =>
+    serializeCcConnectSidecarConfig({
+      ...base,
+      projects: [{ accountId: 'a', platform: 'qq', options: { 'bad.key': 'x' } }],
+    }),
+  ).toThrow('Unsafe');
 });
 
 test('serializes a credential-free scheduler clock without channel platforms', () => {

--- a/src/main/libs/ccConnectSidecarConfig.ts
+++ b/src/main/libs/ccConnectSidecarConfig.ts
@@ -1,7 +1,15 @@
 import net from 'node:net';
 
 const SUPPORTED_PLATFORMS = new Set([
-  'telegram', 'discord', 'dingtalk', 'feishu', 'qq', 'qqbot', 'wecom', 'weixin',
+  'telegram',
+  'discord',
+  'dingtalk',
+  'feishu',
+  'lark',
+  'qq',
+  'qqbot',
+  'wecom',
+  'weixin',
 ]);
 
 type TomlValue = string | number | boolean | readonly string[];
@@ -39,9 +47,15 @@ export function serializeCcConnectSidecarConfig(config: CcConnectSidecarConfig):
   const lines = [
     `data_dir = ${tomlString(config.dataDir)}`,
     '',
-    '[webhook]', 'enabled = false', '',
-    '[bridge]', 'enabled = false', '',
-    '[management]', 'enabled = false', '',
+    '[webhook]',
+    'enabled = false',
+    '',
+    '[bridge]',
+    'enabled = false',
+    '',
+    '[management]',
+    'enabled = false',
+    '',
   ];
 
   for (const project of config.projects) {
@@ -67,7 +81,9 @@ export function serializeCcConnectSidecarConfig(config: CcConnectSidecarConfig):
     );
     if (project.platform) {
       lines.push('[[projects.platforms]]', `type = ${tomlString(project.platform)}`);
-      const entries = Object.entries(project.options ?? {}).sort(([left], [right]) => left.localeCompare(right));
+      const entries = Object.entries(project.options ?? {}).sort(([left], [right]) =>
+        left.localeCompare(right),
+      );
       if (entries.length > 0) lines.push('[projects.platforms.options]');
       for (const [key, value] of entries) {
         if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
@@ -88,7 +104,11 @@ function assertNonEmpty(name: string, value: string): void {
 
 function assertLoopbackUrl(value: string): void {
   let url: URL;
-  try { url = new URL(value); } catch { throw new Error('cc-connect bridgeUrl must be a URL'); }
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('cc-connect bridgeUrl must be a URL');
+  }
   if (!['http:', 'https:'].includes(url.protocol) || !isLoopback(url.hostname)) {
     throw new Error('cc-connect bridgeUrl must target loopback');
   }
@@ -105,7 +125,9 @@ function assertLoopbackListen(value: string): void {
 }
 
 function isLoopback(host: string): boolean {
-  return host === 'localhost' || net.isIP(host) > 0 && (host === '::1' || host.startsWith('127.'));
+  return (
+    host === 'localhost' || (net.isIP(host) > 0 && (host === '::1' || host.startsWith('127.')))
+  );
 }
 
 function tomlString(value: string): string {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -178,6 +178,7 @@ import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
 import { serializeCcConnectSidecarConfig } from './libs/ccConnectSidecarConfig';
 import { listCcConnectAccountConfigs } from './libs/ccConnectAccountConfig';
+import { resolveCcConnectAccountRuntimeStatus } from './libs/ccConnectAccountRuntimeStatus';
 import { CcConnectRuntimeStatusRegistry } from './libs/ccConnectRuntimeStatusRegistry';
 import { CcConnectSidecarManager } from './libs/ccConnectSidecarManager';
 import { runCcConnectWeixinSetup } from './libs/ccConnectWeixinSetup';
@@ -1892,7 +1893,11 @@ const getIMGatewayManager = () => {
   if (!imGatewayManager) {
     imGatewayManager = new ChannelAccountManager(getStore().getDatabase(), async accountId => {
       await refreshCcConnectPlatformStatuses();
-      return ccConnectRuntimeStatuses.get(accountId, ccConnectSidecarManager?.lastError ?? null);
+      return resolveCcConnectAccountRuntimeStatus(
+        ccConnectRuntimeStatuses,
+        accountId,
+        ccConnectSidecarManager?.running === true,
+      );
     });
   }
   return imGatewayManager;
@@ -5004,18 +5009,15 @@ if (!gotTheLock) {
     },
   );
 
-  ipcMain.handle('im:status:get', async () => {
+  ipcMain.handle(ImIpc.StatusGet, async () => {
     try {
       await refreshCcConnectPlatformStatuses();
       const status = getIMGatewayManager().getStatus(instanceId => {
-        const runtimeStatus = ccConnectRuntimeStatuses.get(
+        return resolveCcConnectAccountRuntimeStatus(
+          ccConnectRuntimeStatuses,
           instanceId,
-          ccConnectSidecarManager?.lastError ?? null,
+          ccConnectSidecarManager?.running === true,
         );
-        return {
-          ...runtimeStatus,
-          connected: ccConnectSidecarManager?.running === true && runtimeStatus.connected,
-        };
       });
       return { success: true, status };
     } catch (error) {


### PR DESCRIPTION
## Summary

- map the Feishu service-region selector to the correct `feishu` or `lark` sidecar platform instead of passing it as an API URL
- normalize Lark inbound events to the Feishu product channel while preserving the native transport key for replies
- probe credentials against the selected service endpoint and isolate runtime errors by channel account

## Root cause

The renderer stores `feishu` and `lark` as logical service-region values. The desktop config adapter forwarded that value through the sidecar `domain` option, whose contract requires an absolute API base URL. Credential probing still succeeded against the Feishu API, but sidecar platform creation failed before inbound messages could be handled.

Separately, account status lookup used the sidecar process's most recent stderr error as a fallback for every account. A Feishu creation failure could therefore appear in the Weixin settings page when Weixin had no current health entry.

## Validation

- `npm test -- ccConnectAccountConfig ccConnectSidecarConfig channelConnectivity ccConnectPiBridge ccConnectAccountRuntimeStatus`
- `npm run compile:electron`
- `npm run lint`
- `npm run build:vite`
- `go test ./platform/feishu -run "TestNewFeishu|TestLark" -count=1` against the released sidecar source

## Stack

- Base: `main`
- Preceded by merged PRs #503 and #504
- Issue: #449

No renderer layout or user-visible copy changed.
