### PR TITLE
build(runtime): pin zhiyuan-sidecar-v2 channel runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     }
   },
   "channelRuntime": {
-    "version": "zhiyuan-sidecar-v1",
+    "version": "zhiyuan-sidecar-v2",
     "repo": "rongxinzy/pi-connect",
-    "sourceRevision": "dcbff6603d39c0dc88877b91bb3e5442a2ec17da",
+    "sourceRevision": "413cbcafe154b3da87e27d2c48392be5500366a6",
     "runtimeAssets": {
       "mac-x64": "cc-connect-sidecar-darwin-amd64",
       "mac-arm64": "cc-connect-sidecar-darwin-arm64",
@@ -55,10 +55,10 @@
       "linux-x64": "cc-connect-sidecar-linux-amd64"
     },
     "runtimeChecksums": {
-      "mac-x64": "67d068e20b46499f99c2cf51f7ff38b115d26b5708ae0c3cfaf80f439986225b",
-      "mac-arm64": "2753cc1a345c48a76c25be0c6f581077039d41b26edef31cd78c917d9c93fa22",
-      "win-x64": "de7d99b503cdea36abe89127fe31b893f83e5a114f8389d6dd1738129280ee98",
-      "linux-x64": "13996aa4e62ef817baf8898c44dd480705a59774b48213d90863dcd1bd7184d1"
+      "mac-x64": "be25d3496a36f2001f7479d6a49ccd3964a754c9ba6b9cd1dda35af39e4ffb92",
+      "mac-arm64": "8eab491878cb5c38efff7bfb5934b8437b3f8e51007283e6cf9528629bb276f8",
+      "win-x64": "f78f2807ecc7d7ec0254cf64e1e47446e492e3036078a5b42b84e7fca277c566",
+      "linux-x64": "5d32d35a69433072100ab20f01d7fff8b3c8ebde3225e66139b5b6c984c6eba5"
     }
   },
   "main": "dist-electron/main.js",

--- a/scripts/ci/check-openclaw-decoupling.mjs
+++ b/scripts/ci/check-openclaw-decoupling.mjs
@@ -3,8 +3,8 @@ import path from 'node:path';
 import process from 'node:process';
 
 const root = process.cwd();
-const expectedSidecarVersion = 'zhiyuan-sidecar-v1';
-const expectedSidecarRevision = 'dcbff6603d39c0dc88877b91bb3e5442a2ec17da';
+const expectedSidecarVersion = 'zhiyuan-sidecar-v2';
+const expectedSidecarRevision = '413cbcafe154b3da87e27d2c48392be5500366a6';
 const forbiddenRuntimePattern = /openclaw|cfmind/i;
 const forbiddenStoragePattern =
   /(?:\.openclaw|openclaw\.json|im_session_mappings|openclaw_session_key|telegramOpenClaw|feishuOpenClaw|dingtalkOpenClaw)/i;

--- a/scripts/download-channel-runtime.test.ts
+++ b/scripts/download-channel-runtime.test.ts
@@ -55,7 +55,7 @@ describe('Channel runtime downloader', () => {
   beforeEach(() => {
     rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'channel-runtime-root-'));
     config = {
-      version: 'zhiyuan-sidecar-v1',
+      version: 'zhiyuan-sidecar-v2',
       repo: 'rongxinzy/pi-connect',
       sourceRevision: 'a'.repeat(40),
       runtimeAssets: { [targetId]: 'sidecar.exe' },


### PR DESCRIPTION
## Summary

将 cc-connect 频道 sidecar 固定到不可变发布版 **zhiyuan-sidecar-v2**（rongxinzy/pi-connect `413cbcafe`，即 PR #4 合并提交）。

v1 二进制（`dcbff66`）早于频道传输契约能力（channel-policy / media-reply / runtime-activity），其健康接口只上报 `channel-transport` / `delivery` / `trigger-only-cron` 三项。桌面端 `CcConnectCronClient.healthCheck` 要求四项能力，每次检查都会抛出 `cc-connect returned an incompatible health contract`，导致：

- sidecar 被 reconciliation 以约 10 秒周期杀重启（SIGTERM 循环）；
- 所有频道的「测试连接」运行时检查（`channel_runtime_not_running`）永远失败——即使飞书凭据校验与 WebSocket 长连接实际已经成功。

v2 二进制补齐了全部六项能力，契约两侧对齐。

## Related Issue

关联 #504（runtime connectivity）、#508（Feishu runtime routing）之后的 sidecar 契约收尾。

## Changes Made

- `package.json`
  - `channelRuntime.version`: `zhiyuan-sidecar-v1` → `zhiyuan-sidecar-v2`
  - `channelRuntime.sourceRevision`: `dcbff6603d39c0dc88877b91bb3e5442a2ec17da` → `413cbcafe154b3da87e27d2c48392be5500366a6`
  - `channelRuntime.runtimeChecksums`: 四个平台全部替换为 `zhiyuan-sidecar-v2` release 中 `runtime-manifest.json` 发布的 sha256
- `scripts/ci/check-openclaw-decoupling.mjs`：期望的 sidecar 版本/修订同步为 v2 与 `413cbca…`
- `scripts/download-channel-runtime.test.ts`：fixture 中的版本号同步为 `zhiyuan-sidecar-v2`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] Added new tests
- [x] Updated existing tests
- [x] Manual testing performed

验证明细：

1. `npx vitest run scripts/download-channel-runtime.test.ts` — 8/8 通过；
2. `node scripts/ci/check-openclaw-decoupling.mjs` — 通过（pin 校验为 v2 + `413cbca…`）；
3. 端到端真实下载：`node scripts/download-channel-runtime.cjs`（win-x64）成功从 `zhiyuan-sidecar-v2` release 下载，sha256 与新 pin 一致，`runtime-build-info.json` 正确落盘；
4. 对下载的 v2 二进制做字符串校验：`channel-transport` / `channel-policy` / `media-reply` / `runtime-activity` / `delivery` / `trigger-only-cron` 六项能力字符串全部存在。

checksums（取自 release `runtime-manifest.json`）：

| target | sha256 |
|--------|--------|
| mac-x64 | `be25d3496a36f2001f7479d6a49ccd3964a754c9ba6b9cd1dda35af39e4ffb92` |
| mac-arm64 | `8eab491878cb5c38efff7bfb5934b8437b3f8e51007283e6cf9528629bb276f8` |
| win-x64 | `f78f2807ecc7d7ec0254cf64e1e47446e492e3036078a5b42b84e7fca277c566` |
| linux-x64 | `5d32d35a69433072100ab20f01d7fff8b3c8ebde3225e66139b5b6c984c6eba5` |

## Screenshots (if applicable)

无。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

- 上游发布：https://github.com/rongxinzy/pi-connect/releases/tag/zhiyuan-sidecar-v2
- 旧 pin 的下载缓存会因 `sourceRevision` 不匹配自动失效并重新下载 v2，无需手动清理；老用户首次启动会自动拉取新二进制。
- 该 PR 只更新 pin 与校验值，不改动任何运行时代码路径。
