### PR TITLE
fix(memory): isolate session summary recall

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -1058,6 +1058,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const projectMemoryContext = await buildProjectMemoryContextSafe(
         this.projectMemoryService,
         workspaceRoot,
+        sessionId,
         prompt,
       );
       if (this.activeSessions.get(sessionId) !== active || abortController.signal.aborted) return;
@@ -1361,6 +1362,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const projectMemoryContext = await buildProjectMemoryContextSafe(
         this.projectMemoryService,
         active.workspaceRoot,
+        sessionId,
         prompt,
       );
       if (projectMemoryContext) nextPrompt = `${projectMemoryContext}\n\n${nextPrompt}`;

--- a/src/main/memory/personalMemoryService.test.ts
+++ b/src/main/memory/personalMemoryService.test.ts
@@ -105,8 +105,10 @@ class PersonalRepositoryFake {
     }
   }
 
-  filterRecallableMemoryIds(_projectId: string, ids: number[]) {
-    return new Set(ids.filter(id => [...this.links.values()].some(link => link.memoryId === id)));
+  filterRecallableMemoryIds(input: { memoryIds: number[] }) {
+    return new Set(
+      input.memoryIds.filter(id => [...this.links.values()].some(link => link.memoryId === id)),
+    );
   }
 }
 

--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -33,8 +33,8 @@ class FakeRepository {
     return this.items.filter(item => item.status === MemoryOutboxStatus.Pending);
   }
 
-  filterRecallableMemoryIds(_projectId: string, memoryIds: number[]) {
-    return new Set(memoryIds);
+  filterRecallableMemoryIds(input: { memoryIds: number[] }) {
+    return new Set(input.memoryIds);
   }
 
   listManaged() {
@@ -169,6 +169,7 @@ test('enforces the project context token budget', async () => {
 
   const context = await service.buildProjectContext({
     workingDirectory: 'alpha',
+    sessionId: 'session-1',
     query: 'database',
     tokenBudget: 30,
   });
@@ -279,15 +280,25 @@ test('stores rolling session summaries with a 30 day expiration', async () => {
   vi.useRealTimers();
 });
 
-test('injects session recall under its own context budget', async () => {
+test('injects only the current session recall under its own context budget', async () => {
   const adapter = {
     recall: vi.fn(async (input: { scope: string }) =>
       input.scope === EngramMemoryScope.Session
         ? [
             {
               id: 31,
+              session_id: 'session-1',
+              type: EngramObservationType.SessionSummary,
               title: 'Session summary',
               content: 'The previous session fixed CJK recall.',
+              updated_at: '2026-08-11T00:00:00.000Z',
+            },
+            {
+              id: 32,
+              session_id: 'session-2',
+              type: EngramObservationType.SessionSummary,
+              title: 'Other session summary',
+              content: 'Private result from another session.',
               updated_at: '2026-08-11T00:00:00.000Z',
             },
           ]
@@ -301,8 +312,51 @@ test('injects session recall under its own context budget', async () => {
   );
 
   await expect(
-    service.buildProjectContext({ workingDirectory: 'alpha', query: 'CJK recall' }),
+    service.buildProjectContext({
+      workingDirectory: 'alpha',
+      sessionId: 'session-1',
+      query: 'CJK recall',
+    }),
   ).resolves.toContain('Session:\n- [memory:31]');
+  await expect(
+    service.recallSession({
+      workingDirectory: 'alpha',
+      sessionId: 'session-1',
+      query: 'CJK recall',
+    }),
+  ).resolves.not.toContainEqual(expect.objectContaining({ id: 32 }));
+});
+
+test('excludes session summaries returned by project recall', async () => {
+  const adapter = {
+    recall: vi.fn(async () => [
+      {
+        id: 51,
+        session_id: 'session-2',
+        type: EngramObservationType.SessionSummary,
+        title: 'Leaked session summary',
+        content: 'Private result from another session.',
+        updated_at: '2026-08-11T00:00:00.000Z',
+      },
+      {
+        id: 52,
+        session_id: 'session-2',
+        type: EngramObservationType.Decision,
+        title: 'Project decision',
+        content: 'Use SQLite.',
+        updated_at: '2026-08-11T00:00:00.000Z',
+      },
+    ]),
+  };
+  const service = new ProjectMemoryService(
+    new FakeRepository() as never,
+    adapter as never,
+    identityFor,
+  );
+
+  await expect(
+    service.recallProject({ workingDirectory: 'alpha', query: 'database' }),
+  ).resolves.toEqual([expect.objectContaining({ id: 52 })]);
 });
 
 test('counts CJK characters conservatively against context budgets', async () => {
@@ -322,6 +376,7 @@ test('counts CJK characters conservatively against context budgets', async () =>
   await expect(
     service.buildProjectContext({
       workingDirectory: 'alpha',
+      sessionId: 'session-1',
       query: 'budget',
       tokenBudget: 30,
     }),

--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -282,9 +282,17 @@ test('stores rolling session summaries with a 30 day expiration', async () => {
 
 test('injects only the current session recall under its own context budget', async () => {
   const adapter = {
-    recall: vi.fn(async (input: { scope: string }) =>
+    recall: vi.fn(async (input: { scope: string; limit: number }) =>
       input.scope === EngramMemoryScope.Session
         ? [
+            ...Array.from({ length: 8 }, (_, index) => ({
+              id: 100 + index,
+              session_id: `other-session-${index}`,
+              type: EngramObservationType.SessionSummary,
+              title: 'Other session summary',
+              content: 'Private result from another session.',
+              updated_at: '2026-08-12T00:00:00.000Z',
+            })),
             {
               id: 31,
               session_id: 'session-1',
@@ -293,15 +301,7 @@ test('injects only the current session recall under its own context budget', asy
               content: 'The previous session fixed CJK recall.',
               updated_at: '2026-08-11T00:00:00.000Z',
             },
-            {
-              id: 32,
-              session_id: 'session-2',
-              type: EngramObservationType.SessionSummary,
-              title: 'Other session summary',
-              content: 'Private result from another session.',
-              updated_at: '2026-08-11T00:00:00.000Z',
-            },
-          ]
+          ].slice(0, input.limit)
         : [],
     ),
   };
@@ -318,13 +318,16 @@ test('injects only the current session recall under its own context budget', asy
       query: 'CJK recall',
     }),
   ).resolves.toContain('Session:\n- [memory:31]');
+  expect(adapter.recall).toHaveBeenCalledWith(
+    expect.objectContaining({ scope: EngramMemoryScope.Session, limit: 20 }),
+  );
   await expect(
     service.recallSession({
       workingDirectory: 'alpha',
       sessionId: 'session-1',
       query: 'CJK recall',
     }),
-  ).resolves.not.toContainEqual(expect.objectContaining({ id: 32 }));
+  ).resolves.toEqual([expect.objectContaining({ id: 31 })]);
 });
 
 test('excludes session summaries returned by project recall', async () => {

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -29,6 +29,7 @@ import { redactPrivateBlocks } from './zhiyuanEngramAdapter';
 const DEFAULT_PROJECT_RECALL_TOKEN_BUDGET = 900;
 const DEFAULT_PERSONAL_RECALL_TOKEN_BUDGET = 250;
 const DEFAULT_SESSION_RECALL_TOKEN_BUDGET = 350;
+const MAX_ENGRAM_RECALL_LIMIT = 20;
 
 interface ConfirmPayload {
   sessionId: string;
@@ -385,13 +386,14 @@ export class ProjectMemoryService {
     const plan = planRecallQuery(input.query);
     if (!plan.exactQuery) return [];
     const limit = Math.min(Math.max(input.limit ?? 8, 1), 20);
+    const retrievalLimit = input.scope === MemoryScope.Session ? MAX_ENGRAM_RECALL_LIMIT : limit;
     let observations = this.filterRecallable(
       input,
       await this.adapter.recall({
         query: plan.exactQuery,
         project: input.projectId,
         scope: input.scope,
-        limit,
+        limit: retrievalLimit,
         matchMode: EngramSearchMatchMode.All,
       }),
     );
@@ -402,7 +404,7 @@ export class ProjectMemoryService {
           query: plan.broadQuery,
           project: input.projectId,
           scope: input.scope,
-          limit,
+          limit: retrievalLimit,
           matchMode: EngramSearchMatchMode.Any,
         }),
       );
@@ -410,7 +412,11 @@ export class ProjectMemoryService {
     if (observations.length === 0 && plan.explicitMemoryIntent) {
       observations = this.filterRecallable(
         input,
-        await this.adapter.recent({ project: input.projectId, scope: input.scope, limit }),
+        await this.adapter.recent({
+          project: input.projectId,
+          scope: input.scope,
+          limit: retrievalLimit,
+        }),
       );
     }
     const unique = [

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -91,12 +91,18 @@ export class ProjectMemoryService {
     });
   }
 
-  async recallSession(input: { workingDirectory: string; query: string; limit?: number }) {
+  async recallSession(input: {
+    workingDirectory: string;
+    sessionId: string;
+    query: string;
+    limit?: number;
+  }) {
     const project = this.resolveIdentity(input.workingDirectory);
     return await this.recallScope({
       query: input.query,
       projectId: project.id,
       scope: MemoryScope.Session,
+      sessionId: input.sessionId,
       limit: input.limit,
     });
   }
@@ -121,6 +127,7 @@ export class ProjectMemoryService {
 
   async buildProjectContext(input: {
     workingDirectory: string;
+    sessionId: string;
     query: string;
     tokenBudget?: number;
   }): Promise<string> {
@@ -372,13 +379,14 @@ export class ProjectMemoryService {
     query: string;
     projectId: string;
     scope: typeof MemoryScope.Project | typeof MemoryScope.Personal | typeof MemoryScope.Session;
+    sessionId?: string;
     limit?: number;
   }) {
     const plan = planRecallQuery(input.query);
     if (!plan.exactQuery) return [];
     const limit = Math.min(Math.max(input.limit ?? 8, 1), 20);
     let observations = this.filterRecallable(
-      input.projectId,
+      input,
       await this.adapter.recall({
         query: plan.exactQuery,
         project: input.projectId,
@@ -389,7 +397,7 @@ export class ProjectMemoryService {
     );
     if (observations.length === 0 && plan.broadQuery) {
       observations = this.filterRecallable(
-        input.projectId,
+        input,
         await this.adapter.recall({
           query: plan.broadQuery,
           project: input.projectId,
@@ -401,7 +409,7 @@ export class ProjectMemoryService {
     }
     if (observations.length === 0 && plan.explicitMemoryIntent) {
       observations = this.filterRecallable(
-        input.projectId,
+        input,
         await this.adapter.recent({ project: input.projectId, scope: input.scope, limit }),
       );
     }
@@ -416,12 +424,27 @@ export class ProjectMemoryService {
     return rankRecallResults(plan.exactQuery, unique, metadata).slice(0, limit);
   }
 
-  private filterRecallable<T extends { id: number }>(projectId: string, observations: T[]): T[] {
-    const allowed = this.repository.filterRecallableMemoryIds(
-      projectId,
-      observations.map(observation => observation.id),
-    );
-    return observations.filter(observation => allowed.has(observation.id));
+  private filterRecallable<T extends { id: number; type?: string; session_id?: string }>(
+    input: {
+      projectId: string;
+      scope: typeof MemoryScope.Project | typeof MemoryScope.Personal | typeof MemoryScope.Session;
+      sessionId?: string;
+    },
+    observations: T[],
+  ): T[] {
+    const observationsInScope = observations.filter(observation => {
+      if (input.scope === MemoryScope.Session) {
+        return Boolean(input.sessionId) && observation.session_id === input.sessionId;
+      }
+      return observation.type !== MemoryKind.SessionSummary;
+    });
+    const allowed = this.repository.filterRecallableMemoryIds({
+      projectId: input.projectId,
+      memoryIds: observationsInScope.map(observation => observation.id),
+      scope: input.scope,
+      sessionId: input.sessionId,
+    });
+    return observationsInScope.filter(observation => allowed.has(observation.id));
   }
 
   private findPending(id: string): MemoryOutboxItem | null {
@@ -588,11 +611,12 @@ function estimateMemoryTokens(value: string): number {
 export async function buildProjectMemoryContextSafe(
   service: ProjectMemoryService | null,
   workingDirectory: string,
+  sessionId: string,
   query: string,
 ): Promise<string> {
   if (!service) return '';
   try {
-    return await service.buildProjectContext({ workingDirectory, query });
+    return await service.buildProjectContext({ workingDirectory, sessionId, query });
   } catch (error) {
     console.warn('[ProjectMemory] Failed to recall project context:', error);
     return '';

--- a/src/main/memory/repository.test.ts
+++ b/src/main/memory/repository.test.ts
@@ -1,6 +1,12 @@
+import Database from 'better-sqlite3';
 import { expect, test, vi } from 'vitest';
 
-import { MemoryLifecycleStatus, MemoryScope } from '../../shared/memory';
+import {
+  MemoryKind,
+  MemoryLifecycleStatus,
+  MemoryScope,
+  MemorySourceKind,
+} from '../../shared/memory';
 import { MemoryRepository } from './repository';
 
 test('creates the link and outbox schema without importing the memory kernel database', () => {
@@ -19,49 +25,69 @@ test('creates the link and outbox schema without importing the memory kernel dat
   expect(schema).toContain('idx_memory_outbox_pending');
 });
 
-test('authorizes recall by projected scope and current session', () => {
-  const all = vi.fn(() => [{ memory_id: 17 }]);
-  const prepare = vi.fn((sql: string) => {
-    if (sql.includes('SELECT memory_id')) return { all };
-    if (sql.includes('PRAGMA table_info')) return { all: vi.fn(() => []) };
-    return { run: vi.fn() };
-  });
-  const repository = new MemoryRepository({ exec: vi.fn(), prepare } as never);
-
-  expect(
-    repository.filterRecallableMemoryIds({
+test('authorizes recall against projected scope, session, and lifecycle state', () => {
+  const db = new Database(':memory:');
+  const repository = new MemoryRepository(db);
+  const createLink = (
+    memoryId: number,
+    scope: MemoryScope,
+    sessionId: string,
+    expiresAt?: string,
+  ) =>
+    repository.createLink({
+      id: `link-${memoryId}`,
+      memoryId,
       projectId: 'project-a',
-      memoryIds: [16, 17],
-      scope: MemoryScope.Session,
-      sessionId: 'session-a',
-    }),
-  ).toEqual(new Set([17]));
+      scope,
+      sessionId,
+      sourceKind:
+        scope === MemoryScope.Session ? MemorySourceKind.SessionSummary : MemorySourceKind.Explicit,
+      title: `Memory ${memoryId}`,
+      content: `Content ${memoryId}`,
+      kind: scope === MemoryScope.Session ? MemoryKind.SessionSummary : MemoryKind.Decision,
+      expiresAt,
+    });
 
-  const recallSql = prepare.mock.calls.find(([sql]) => String(sql).includes('SELECT memory_id'))?.[0];
-  expect(recallSql).toContain('scope = ?');
-  expect(recallSql).toContain('session_id = ?');
-  expect(all).toHaveBeenCalledWith(
-    'project-a',
-    MemoryLifecycleStatus.Active,
-    MemoryScope.Session,
-    16,
-    17,
-    'session-a',
-  );
-});
+  try {
+    createLink(1, MemoryScope.Project, 'session-origin');
+    createLink(2, MemoryScope.Session, 'session-a');
+    createLink(3, MemoryScope.Session, 'session-b');
+    const archivedLinkId = createLink(4, MemoryScope.Project, 'session-origin');
+    createLink(5, MemoryScope.Project, 'session-origin', '2000-01-01T00:00:00.000Z');
+    repository.setLinkStatus(archivedLinkId, MemoryLifecycleStatus.Archived);
+    const memoryIds = [1, 2, 3, 4, 5];
 
-test('rejects session recall without a current session id', () => {
-  const prepare = vi.fn((sql: string) => ({
-    run: vi.fn(),
-    all: vi.fn(() => (sql.includes('PRAGMA table_info') ? [] : undefined)),
-  }));
-  const repository = new MemoryRepository({ exec: vi.fn(), prepare } as never);
-
-  expect(
-    repository.filterRecallableMemoryIds({
-      projectId: 'project-a',
-      memoryIds: [17],
-      scope: MemoryScope.Session,
-    }),
-  ).toEqual(new Set());
+    expect(
+      repository.filterRecallableMemoryIds({
+        projectId: 'project-a',
+        memoryIds,
+        scope: MemoryScope.Project,
+      }),
+    ).toEqual(new Set([1]));
+    expect(
+      repository.filterRecallableMemoryIds({
+        projectId: 'project-a',
+        memoryIds,
+        scope: MemoryScope.Session,
+        sessionId: 'session-a',
+      }),
+    ).toEqual(new Set([2]));
+    expect(
+      repository.filterRecallableMemoryIds({
+        projectId: 'project-a',
+        memoryIds,
+        scope: MemoryScope.Session,
+        sessionId: 'session-b',
+      }),
+    ).toEqual(new Set([3]));
+    expect(
+      repository.filterRecallableMemoryIds({
+        projectId: 'project-a',
+        memoryIds,
+        scope: MemoryScope.Session,
+      }),
+    ).toEqual(new Set());
+  } finally {
+    db.close();
+  }
 });

--- a/src/main/memory/repository.test.ts
+++ b/src/main/memory/repository.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest';
 
+import { MemoryLifecycleStatus, MemoryScope } from '../../shared/memory';
 import { MemoryRepository } from './repository';
 
 test('creates the link and outbox schema without importing the memory kernel database', () => {
@@ -16,4 +17,51 @@ test('creates the link and outbox schema without importing the memory kernel dat
   expect(schema).toContain('superseded_by TEXT');
   expect(schema).toContain('sensitivity TEXT');
   expect(schema).toContain('idx_memory_outbox_pending');
+});
+
+test('authorizes recall by projected scope and current session', () => {
+  const all = vi.fn(() => [{ memory_id: 17 }]);
+  const prepare = vi.fn((sql: string) => {
+    if (sql.includes('SELECT memory_id')) return { all };
+    if (sql.includes('PRAGMA table_info')) return { all: vi.fn(() => []) };
+    return { run: vi.fn() };
+  });
+  const repository = new MemoryRepository({ exec: vi.fn(), prepare } as never);
+
+  expect(
+    repository.filterRecallableMemoryIds({
+      projectId: 'project-a',
+      memoryIds: [16, 17],
+      scope: MemoryScope.Session,
+      sessionId: 'session-a',
+    }),
+  ).toEqual(new Set([17]));
+
+  const recallSql = prepare.mock.calls.find(([sql]) => String(sql).includes('SELECT memory_id'))?.[0];
+  expect(recallSql).toContain('scope = ?');
+  expect(recallSql).toContain('session_id = ?');
+  expect(all).toHaveBeenCalledWith(
+    'project-a',
+    MemoryLifecycleStatus.Active,
+    MemoryScope.Session,
+    16,
+    17,
+    'session-a',
+  );
+});
+
+test('rejects session recall without a current session id', () => {
+  const prepare = vi.fn((sql: string) => ({
+    run: vi.fn(),
+    all: vi.fn(() => (sql.includes('PRAGMA table_info') ? [] : undefined)),
+  }));
+  const repository = new MemoryRepository({ exec: vi.fn(), prepare } as never);
+
+  expect(
+    repository.filterRecallableMemoryIds({
+      projectId: 'project-a',
+      memoryIds: [17],
+      scope: MemoryScope.Session,
+    }),
+  ).toEqual(new Set());
 });

--- a/src/main/memory/repository.ts
+++ b/src/main/memory/repository.ts
@@ -67,6 +67,13 @@ export interface MemoryRecallMetadata {
   updatedAt: string;
 }
 
+export interface RecallableMemoryFilter {
+  projectId: string;
+  memoryIds: number[];
+  scope: MemoryScope;
+  sessionId?: string;
+}
+
 interface MemoryOutboxRow {
   id: string;
   link_id: string | null;
@@ -318,16 +325,26 @@ export class MemoryRepository {
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
   }
 
-  filterRecallableMemoryIds(projectId: string, memoryIds: number[]): Set<number> {
-    if (memoryIds.length === 0) return new Set();
+  filterRecallableMemoryIds(input: RecallableMemoryFilter): Set<number> {
+    if (input.memoryIds.length === 0) return new Set();
     this.expireDue();
-    const placeholders = memoryIds.map(() => '?').join(', ');
+    const placeholders = input.memoryIds.map(() => '?').join(', ');
+    const sessionClause = input.scope === MemoryScope.Session ? ' AND session_id = ?' : '';
+    if (input.scope === MemoryScope.Session && !input.sessionId) return new Set();
+    const parameters = [
+      input.projectId,
+      MemoryLifecycleStatus.Active,
+      input.scope,
+      ...input.memoryIds,
+      ...(input.scope === MemoryScope.Session ? [input.sessionId] : []),
+    ];
     const rows = this.db
       .prepare(
         `SELECT memory_id FROM memory_links
-         WHERE project_id = ? AND status = ? AND memory_id IN (${placeholders})`,
+         WHERE project_id = ? AND status = ? AND scope = ?
+           AND memory_id IN (${placeholders})${sessionClause}`,
       )
-      .all(projectId, MemoryLifecycleStatus.Active, ...memoryIds) as Array<{ memory_id: number }>;
+      .all(...parameters) as Array<{ memory_id: number }>;
     return new Set(rows.map(row => row.memory_id));
   }
 

--- a/src/main/memory/sessionSummaryService.test.ts
+++ b/src/main/memory/sessionSummaryService.test.ts
@@ -70,3 +70,28 @@ test('reduces markdown-heavy outcomes to one bounded conclusion sentence', () =>
   expect(summary).not.toContain('Additional implementation details');
   expect(summary).not.toContain('privateData');
 });
+
+test('ends Chinese outcomes at punctuation without requiring whitespace', () => {
+  const summary = buildSessionSummary([
+    message('user', '修复会话记忆隔离。'),
+    message('assistant', '已完成会话隔离。后续实现细节不应进入摘要。'),
+  ]);
+
+  expect(summary).toContain('Latest outcome: 已完成会话隔离。');
+  expect(summary).not.toContain('后续实现细节');
+});
+
+test('keeps heading text and skips summaries with no natural-language outcome', () => {
+  expect(
+    buildSessionSummary([
+      message('user', 'Fix recall.'),
+      message('assistant', '## Isolation fixed.\n| Key | Value |\n| --- | --- |'),
+    ]),
+  ).toContain('Latest outcome: Isolation fixed.');
+  expect(
+    buildSessionSummary([
+      message('user', 'Run code.'),
+      message('assistant', '```ts\nconst result = true;\n```'),
+    ]),
+  ).toBeNull();
+});

--- a/src/main/memory/sessionSummaryService.test.ts
+++ b/src/main/memory/sessionSummaryService.test.ts
@@ -46,3 +46,27 @@ test('serializes rolling writes for the same session', async () => {
   await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
   expect(saveSessionSummary).toHaveBeenCalledTimes(2);
 });
+
+test('reduces markdown-heavy outcomes to one bounded conclusion sentence', () => {
+  const summary = buildSessionSummary([
+    message('user', 'Fix session memory isolation.'),
+    message(
+      'assistant',
+      [
+        '## Result',
+        '| Session | Secret |',
+        '| --- | --- |',
+        '| other | private table data |',
+        '**Fixed session isolation.** Additional implementation details should not be copied.',
+        '```ts',
+        'const privateData = true;',
+        '```',
+      ].join('\n'),
+    ),
+  ]);
+
+  expect(summary).toContain('Latest outcome: Fixed session isolation.');
+  expect(summary).not.toContain('private table data');
+  expect(summary).not.toContain('Additional implementation details');
+  expect(summary).not.toContain('privateData');
+});

--- a/src/main/memory/sessionSummaryService.ts
+++ b/src/main/memory/sessionSummaryService.ts
@@ -4,7 +4,7 @@ import type { ProjectMemoryService } from './projectMemoryService';
 const MAX_SUMMARY_MESSAGES = 8;
 const MAX_SOURCE_MESSAGES = 32;
 const MAX_OBJECTIVE_CHARACTERS = 320;
-const MAX_OUTCOME_CHARACTERS = 720;
+const MAX_OUTCOME_CHARACTERS = 240;
 const MAX_EARLIER_TOPIC_CHARACTERS = 160;
 
 export class SessionSummaryService {
@@ -61,13 +61,35 @@ export function buildSessionSummary(messages: CoworkMessage[]): string | null {
     .map(message => summarizeText(message.content, MAX_EARLIER_TOPIC_CHARACTERS));
   return [
     `Session objective: ${summarizeText(objective.content, MAX_OBJECTIVE_CHARACTERS)}`,
-    `Latest outcome: ${summarizeText(outcome.content, MAX_OUTCOME_CHARACTERS)}`,
+    `Latest outcome: ${summarizeText(outcome.content, MAX_OUTCOME_CHARACTERS, true)}`,
     ...(earlierTopics.length > 0 ? [`Earlier topics: ${earlierTopics.join(' | ')}`] : []),
   ].join('\n');
 }
 
-function summarizeText(value: string, limit: number): string {
-  const normalized = value.replace(/\s+/g, ' ').trim();
+function summarizeText(value: string, limit: number, firstSentenceOnly = false): string {
+  const normalized = extractNaturalLanguage(value, firstSentenceOnly);
   if (normalized.length <= limit) return normalized;
   return `${normalized.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
+function extractNaturalLanguage(value: string, firstSentenceOnly: boolean): string {
+  const paragraphs = value
+    .replace(/```[\s\S]*?```/g, ' ')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .filter(line => !/^#{1,6}\s/.test(line))
+    .filter(line => !/^\|.*\|$/.test(line))
+    .filter(line => !/^\s*[-:|]+\s*$/.test(line))
+    .map(line =>
+      line
+        .replace(/^[-*+]\s+/, '')
+        .replace(/^\d+[.)]\s+/, '')
+        .replace(/[*_~`]+/g, '')
+        .trim(),
+    )
+    .filter(Boolean);
+  const normalized = paragraphs.join(' ').replace(/\s+/g, ' ').trim();
+  if (!firstSentenceOnly) return normalized;
+  return normalized.match(/^.*?[.!?。！？](?:\s|$)/u)?.[0]?.trim() || normalized;
 }

--- a/src/main/memory/sessionSummaryService.ts
+++ b/src/main/memory/sessionSummaryService.ts
@@ -59,9 +59,12 @@ export function buildSessionSummary(messages: CoworkMessage[]): string | null {
     .slice(0, -1)
     .slice(-3)
     .map(message => summarizeText(message.content, MAX_EARLIER_TOPIC_CHARACTERS));
+  const objectiveSummary = summarizeText(objective.content, MAX_OBJECTIVE_CHARACTERS);
+  const outcomeSummary = summarizeText(outcome.content, MAX_OUTCOME_CHARACTERS, true);
+  if (!objectiveSummary || !outcomeSummary) return null;
   return [
-    `Session objective: ${summarizeText(objective.content, MAX_OBJECTIVE_CHARACTERS)}`,
-    `Latest outcome: ${summarizeText(outcome.content, MAX_OUTCOME_CHARACTERS, true)}`,
+    `Session objective: ${objectiveSummary}`,
+    `Latest outcome: ${outcomeSummary}`,
     ...(earlierTopics.length > 0 ? [`Earlier topics: ${earlierTopics.join(' | ')}`] : []),
   ].join('\n');
 }
@@ -78,11 +81,11 @@ function extractNaturalLanguage(value: string, firstSentenceOnly: boolean): stri
     .split(/\r?\n/)
     .map(line => line.trim())
     .filter(line => line.length > 0)
-    .filter(line => !/^#{1,6}\s/.test(line))
     .filter(line => !/^\|.*\|$/.test(line))
     .filter(line => !/^\s*[-:|]+\s*$/.test(line))
     .map(line =>
       line
+        .replace(/^#{1,6}\s+/, '')
         .replace(/^[-*+]\s+/, '')
         .replace(/^\d+[.)]\s+/, '')
         .replace(/[*_~`]+/g, '')
@@ -91,5 +94,9 @@ function extractNaturalLanguage(value: string, firstSentenceOnly: boolean): stri
     .filter(Boolean);
   const normalized = paragraphs.join(' ').replace(/\s+/g, ' ').trim();
   if (!firstSentenceOnly) return normalized;
-  return normalized.match(/^.*?[.!?。！？](?:\s|$)/u)?.[0]?.trim() || normalized;
+  for (const paragraph of paragraphs) {
+    const sentence = paragraph.match(/^.*?(?:[。！？]|[.!?](?=\s|$))/u)?.[0]?.trim();
+    if (sentence) return sentence;
+  }
+  return normalized;
 }


### PR DESCRIPTION
## Summary

- authorize recalled observations against local memory link scope and current session
- exclude session summaries from project and personal recall even when the external runtime normalizes scope incorrectly
- reduce rolling session outcomes to a bounded natural-language conclusion

## Verification

- `npm test -- projectMemoryService sessionSummaryService personalMemoryService repository`
- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
