### PR TITLE
fix(memory): align project identity with workspace

### DIFF
--- a/src/main/conversationHistory/service.test.ts
+++ b/src/main/conversationHistory/service.test.ts
@@ -139,6 +139,5 @@ function identityFor(cwd: string): ProjectIdentity {
     id: `project-${project}`,
     displayName: project,
     root: cwd,
-    canonicalSource: `path:${cwd}`,
   };
 }

--- a/src/main/memory/personalMemoryService.test.ts
+++ b/src/main/memory/personalMemoryService.test.ts
@@ -113,7 +113,7 @@ class PersonalRepositoryFake {
 }
 
 function identityFor(cwd: string): ProjectIdentity {
-  return { id: cwd, displayName: cwd, root: cwd, canonicalSource: `path:${cwd}` };
+  return { id: cwd, displayName: cwd, root: cwd };
 }
 
 function recordFor(id: string, input: PersonalMemoryCandidateInput): ManagedMemoryRecord {

--- a/src/main/memory/projectIdentity.test.ts
+++ b/src/main/memory/projectIdentity.test.ts
@@ -1,44 +1,31 @@
 import path from 'path';
 import { expect, test } from 'vitest';
 
-import { normalizeGitRemote, resolveProjectIdentity } from './projectIdentity';
+import { workspaceIdForPath } from '../workspaceUtils';
+import { resolveProjectIdentity } from './projectIdentity';
 
-test('uses the normalized git origin so repository subdirectories share one identity', () => {
-  const gitRoot = path.resolve('workspace', 'repository');
-  const runGit = (_cwd: string, args: string[]) =>
-    args.includes('--show-toplevel') ? gitRoot : 'git@github.com:Example/Repository.git';
+test('uses the application workspace identity as the project identity', () => {
+  const workspaceRoot = path.resolve('workspace', 'repository');
+  const identity = resolveProjectIdentity(workspaceRoot);
 
-  const first = resolveProjectIdentity(path.join(gitRoot, 'src'), {
-    runGit,
-    realpath: candidate => candidate,
+  expect(identity).toEqual({
+    id: workspaceIdForPath(workspaceRoot),
+    displayName: 'repository',
+    root: workspaceRoot,
   });
-  const second = resolveProjectIdentity(path.join(gitRoot, 'tests'), {
-    runGit,
-    realpath: candidate => candidate,
-  });
-
-  expect(first.id).toBe(second.id);
-  expect(first.canonicalSource).toBe('git:github.com/example/repository');
 });
 
-test('keeps unrelated non-git directories isolated', () => {
-  const options = {
-    runGit: () => null,
-    realpath: (candidate: string) => path.resolve(candidate),
-    platform: 'win32' as const,
-  };
-
-  const first = resolveProjectIdentity('C:/projects/alpha', options);
-  const second = resolveProjectIdentity('C:/projects/beta', options);
+test('keeps separate workspace paths isolated even when they belong to one repository', () => {
+  const repositoryRoot = path.resolve('workspace', 'repository');
+  const first = resolveProjectIdentity(path.join(repositoryRoot, 'workspace-a'));
+  const second = resolveProjectIdentity(path.join(repositoryRoot, 'workspace-b'));
 
   expect(first.id).not.toBe(second.id);
 });
 
-test('normalizes common remote URL forms to the same canonical source', () => {
-  expect(normalizeGitRemote('https://github.com/Example/Repository.git')).toBe(
-    'github.com/example/repository',
-  );
-  expect(normalizeGitRemote('git@github.com:Example/Repository.git')).toBe(
-    'github.com/example/repository',
-  );
+test('maps task work directories back to their owning workspace', () => {
+  const workspaceRoot = path.resolve('workspace', 'repository');
+  const taskDirectory = path.join(workspaceRoot, '.zhiyuan-tasks', 'task-123');
+
+  expect(resolveProjectIdentity(taskDirectory)).toEqual(resolveProjectIdentity(workspaceRoot));
 });

--- a/src/main/memory/projectIdentity.ts
+++ b/src/main/memory/projectIdentity.ts
@@ -1,89 +1,20 @@
-import { createHash } from 'crypto';
-import { execFileSync } from 'child_process';
-import fs from 'fs';
-import path from 'path';
+import {
+  normalizeWorkspacePath,
+  workspaceIdForPath,
+  workspaceNameForPath,
+} from '../workspaceUtils';
 
 export interface ProjectIdentity {
   id: string;
   displayName: string;
   root: string;
-  canonicalSource: string;
 }
 
-export interface ResolveProjectIdentityOptions {
-  runGit?: (cwd: string, args: string[]) => string | null;
-  realpath?: (candidate: string) => string;
-  platform?: NodeJS.Platform;
-}
-
-export function resolveProjectIdentity(
-  workingDirectory: string,
-  options: ResolveProjectIdentityOptions = {},
-): ProjectIdentity {
-  const runGit = options.runGit ?? runGitCommand;
-  const realpath = options.realpath ?? resolveRealPath;
-  const platform = options.platform ?? process.platform;
-  const gitRoot = runGit(workingDirectory, ['rev-parse', '--show-toplevel']);
-  const root = realpath(gitRoot || workingDirectory);
-  const remote = gitRoot ? runGit(root, ['config', '--get', 'remote.origin.url']) : null;
-  const canonicalRemote = remote ? normalizeGitRemote(remote) : null;
-  const normalizedRoot = normalizePath(root, platform);
-  const canonicalSource = canonicalRemote ? `git:${canonicalRemote}` : `path:${normalizedRoot}`;
-  const digest = createHash('sha256').update(canonicalSource).digest('hex').slice(0, 24);
-
+export function resolveProjectIdentity(workingDirectory: string): ProjectIdentity {
+  const root = normalizeWorkspacePath(workingDirectory);
   return {
-    id: `project-${digest}`,
-    displayName: path.basename(root),
+    id: workspaceIdForPath(root),
+    displayName: workspaceNameForPath(root),
     root,
-    canonicalSource,
   };
-}
-
-export function normalizeGitRemote(remote: string): string | null {
-  const trimmed = remote.trim().replace(/\\/g, '/');
-  if (!trimmed) return null;
-  const scpMatch = trimmed.match(/^(?:[^@]+@)?([^:]+):(.+)$/);
-  if (scpMatch && !/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
-    return `${scpMatch[1].toLowerCase()}/${stripGitSuffix(scpMatch[2])}`;
-  }
-  try {
-    const url = new URL(trimmed);
-    return `${url.hostname.toLowerCase()}/${stripGitSuffix(url.pathname)}`;
-  } catch {
-    return stripGitSuffix(trimmed).toLowerCase();
-  }
-}
-
-function stripGitSuffix(value: string): string {
-  return value
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '')
-    .replace(/\.git$/i, '')
-    .toLowerCase();
-}
-
-function normalizePath(candidate: string, platform: NodeJS.Platform): string {
-  const normalized = path.normalize(candidate).replace(/\\/g, '/').replace(/\/+$/, '');
-  return platform === 'win32' ? normalized.toLowerCase() : normalized;
-}
-
-function resolveRealPath(candidate: string): string {
-  try {
-    return fs.realpathSync.native(candidate);
-  } catch {
-    return path.resolve(candidate);
-  }
-}
-
-function runGitCommand(cwd: string, args: string[]): string | null {
-  try {
-    return execFileSync('git', ['-C', cwd, ...args], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      windowsHide: true,
-      timeout: 2_000,
-    }).trim();
-  } catch {
-    return null;
-  }
 }

--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -75,7 +75,6 @@ function identityFor(cwd: string): ProjectIdentity {
     id: `project-${cwd}`,
     displayName: cwd,
     root: `/workspace/${cwd}`,
-    canonicalSource: `path:${cwd}`,
   };
 }
 


### PR DESCRIPTION
## Summary

- make memory project identity identical to the application workspace identity
- reuse `normalizeWorkspacePath()`, `workspaceIdForPath()`, and `workspaceNameForPath()` instead of maintaining a second Git-based identity system
- map `.zhiyuan-tasks/<task>` execution directories back to their owning workspace
- remove Git root, remote URL normalization, subprocess lookup, and the unused `canonicalSource` field

## Why

Issue #161 requires Project memory to remain strictly isolated by project. In the product model, a project is a workspace. The previous implementation instead keyed Git directories by normalized `remote.origin.url`, which allowed separate clones, worktrees, or configured workspaces for the same repository to share memory.

This change makes the boundary explicit:

| Scenario | Result |
| --- | --- |
| Two paths for the same Git repository | Separate Project memory |
| Task directory under `.zhiyuan-tasks` | Uses the owning workspace memory |
| Workspace display-name change | Identity remains stable |
| Workspace path change | Treated as a new workspace identity |

## Data behavior

Existing Git-derived `project-*` records are not migrated. They remain stored for audit purposes but are no longer recalled through the new `workspace-*` identity. Engram does not provide a reliable atomic project-key rewrite across its observation store and the application projection, so an implicit compatibility fallback would reintroduce cross-workspace sharing.

## Verification

- `npm test -- projectIdentity projectMemoryService personalMemoryService conversationHistory` (20 tests passed)
- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
- `npx oxfmt --check` for all changed files
- full suite: 2,157 tests passed and 1 skipped; 9 environment-dependent tests failed locally because `python3` and `Get-FileHash` are unavailable and Windows release fixtures mis-handle a drive-letter path

Follow-up to #161 and #511.
