### PR TITLE
fix(channels): 归一化 sidecar turn 请求的空媒体字段

### DIFF
--- a/src/main/libs/ccConnectBridgeServer.test.ts
+++ b/src/main/libs/ccConnectBridgeServer.test.ts
@@ -272,3 +272,88 @@ test('accepts a quoted-context-only turn', async () => {
   });
   expect(response.status).toBe(200);
 });
+
+test('accepts a text turn with null media fields from the Go sidecar', async () => {
+  let normalized: { images?: unknown; files?: unknown; audio?: unknown } | null = null;
+  const server = new CcConnectBridgeServer('secret', {
+    onTurn: async request => {
+      normalized = {
+        images: request.message.images,
+        files: request.message.files,
+        audio: request.message.audio,
+      };
+      return { content: `reply:${request.message.content}` };
+    },
+    onCronTrigger: async () => undefined,
+  });
+  servers.push(server);
+  const url = await server.start();
+  // The Go sidecar marshals its turn message from a map, so absent media
+  // arrives as explicit null rather than omitted keys.
+  const response = await fetch(`${url}/v1/cc-connect/turn`, {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer secret',
+      'content-type': 'application/json',
+      ...createCcConnectProtocolHeaders('null-media'),
+    },
+    body: JSON.stringify({
+      requestId: 'null-media',
+      accountId: 'weixin-account',
+      message: {
+        sessionKey: 'weixin:dm:user',
+        platform: 'weixin',
+        messageId: 'message',
+        userId: 'user',
+        chatType: 'direct',
+        content: 'hello',
+        images: null,
+        files: null,
+        audio: null,
+        userMessageTimeMs: 0,
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ content: 'reply:hello' });
+  // The nulls are normalized before the handler runs, so downstream code
+  // never observes them.
+  expect(normalized).toEqual({ images: undefined, files: undefined, audio: undefined });
+});
+
+test('still rejects malformed media payloads', async () => {
+  const server = new CcConnectBridgeServer('secret', {
+    onTurn: async () => ({ content: 'unused' }),
+    onCronTrigger: async () => undefined,
+  });
+  servers.push(server);
+  const url = await server.start();
+  for (const malformed of [
+    { images: 'not-an-array' },
+    { files: [123] },
+    { audio: { MimeType: 'audio/amr' } },
+  ]) {
+    const response = await fetch(`${url}/v1/cc-connect/turn`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer secret',
+        'content-type': 'application/json',
+        ...createCcConnectProtocolHeaders('malformed-media'),
+      },
+      body: JSON.stringify({
+        requestId: 'malformed-media',
+        accountId: 'account',
+        message: {
+          sessionKey: 'weixin:dm:user',
+          platform: 'weixin',
+          messageId: 'message',
+          userId: 'user',
+          chatType: 'direct',
+          content: 'hello',
+          ...malformed,
+        },
+      }),
+    });
+    expect(response.status).toBe(400);
+  }
+});

--- a/src/main/libs/ccConnectBridgeServer.ts
+++ b/src/main/libs/ccConnectBridgeServer.ts
@@ -107,7 +107,8 @@ export class CcConnectBridgeServer {
       if (request.method !== 'POST') return void response.writeHead(404).end();
       const body = await readJson(request);
       if (request.url === '/v1/cc-connect/turn') {
-        if (!isTurnRequest(body)) return void response.writeHead(400).end('invalid turn request');
+        if (!isTurnRequest(normalizeMediaFields(body)))
+          return void response.writeHead(400).end('invalid turn request');
         const abortController = new AbortController();
         const abortTurn = () => abortController.abort();
         request.once('aborted', abortTurn);
@@ -152,6 +153,22 @@ async function readJson(request: http.IncomingMessage): Promise<unknown> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The Go sidecar serializes turn messages from a map, so absent media is
+ * emitted as explicit JSON null ("images": null) rather than an omitted key.
+ * Normalize those nulls away before validation so the strict media checks
+ * below treat them exactly like undefined, while still rejecting malformed
+ * media payloads.
+ */
+function normalizeMediaFields(value: unknown): unknown {
+  if (!isRecord(value) || !isRecord(value.message)) return value;
+  const message = value.message;
+  for (const key of ['images', 'files', 'audio']) {
+    if (message[key] === null) delete message[key];
+  }
+  return value;
 }
 
 function nonEmptyString(value: unknown): value is string {

--- a/src/main/libs/ccConnectBridgeServer.ts
+++ b/src/main/libs/ccConnectBridgeServer.ts
@@ -107,7 +107,8 @@ export class CcConnectBridgeServer {
       if (request.method !== 'POST') return void response.writeHead(404).end();
       const body = await readJson(request);
       if (request.url === '/v1/cc-connect/turn') {
-        if (!isTurnRequest(normalizeMediaFields(body)))
+        const turnRequest = normalizeMediaFields(body);
+        if (!isTurnRequest(turnRequest))
           return void response.writeHead(400).end('invalid turn request');
         const abortController = new AbortController();
         const abortTurn = () => abortController.abort();
@@ -115,7 +116,7 @@ export class CcConnectBridgeServer {
         response.once('close', abortTurn);
         let result: CcConnectTurnResponse;
         try {
-          result = await this.handlers.onTurn(body, abortController.signal);
+          result = await this.handlers.onTurn(turnRequest, abortController.signal);
         } finally {
           request.off('aborted', abortTurn);
           response.off('close', abortTurn);


### PR DESCRIPTION
## 问题

微信等频道无法正常对话，sidecar 日志报 `ZhiYuan bridge returned HTTP 400`，用户收到"暂时无法处理这条消息，请稍后重试。"。

### 根因

sidecar（`rongxinzy/pi-connect` @ 413cbca，cmd/zhiyuan-sidecar/main.go:76-83）用 Go `map[string]any` 序列化 turn 请求：

```go
json.Marshal(map[string]any{
    "message": map[string]any{
        "images": msg.Images, "files": msg.Files, "audio": msg.Audio, // nil → "images":null
```

map 序列化没有 omitempty，nil slice/pointer 输出为显式 `null`。**所有无媒体文本消息**都带 `images: null, files: null, audio: null`。

应用侧契约校验（ccConnectBridgeServer.ts:161-192）：

```ts
optionalMediaArray(value) → value === undefined || (Array.isArray(value) && ...)
// null 不是 undefined 也不是数组 → false → 400 "invalid turn request"
```

PR #499（8/13）引入该严格校验时未把 null 视为"无媒体"。影响**所有走 cc-connect 桥的频道平台**（weixin/feishu/dingtalk/telegram 等）的普通文本消息——不只是微信。

## 修复

- 契约校验前归一化：turn 消息的 `images/files/audio` 为 `null` 时删除字段，与 `undefined` 等价（ccConnectBridgeServer.ts:110）
- **严格校验语义保留**：畸形媒体 payload（非数组、非法元素、缺 Data 的 audio）仍返回 400，不会因宽松而引入新洞
- **类型契约不放宽**：`CcConnectTurnRequest` 的 `images?: CcConnectInboundImage[]` 不变，下游 ccConnectPiBridge.ts:101-103 拿到的永远是 `undefined` 或合法媒体数组，无技术债务

## 验证

- 新增 2 个回归测试：空媒体文本消息（模拟 sidecar 实际 payload）通过且归一化后进 handler；畸形媒体仍被拒绝
- 桥测试 10/10 通过
- `npx tsc` ✅　`npx oxlint src/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
