### PR TITLE
fix(ui): 收敛 cowork 图片附件预览尺寸

### DIFF
--- a/src/renderer/components/cowork/ImagePreviewModal.tsx
+++ b/src/renderer/components/cowork/ImagePreviewModal.tsx
@@ -86,11 +86,11 @@ const ImagePreviewModal: React.FC<ImagePreviewModalProps> = ({ image, onClose })
           <div className="max-w-[min(90vw,720px)] truncate rounded-full bg-black/35 px-3 py-1 text-center text-xs font-medium text-white/85 ring-1 ring-white/10">
             {label}
           </div>
-          <div className="flex max-h-full max-w-full items-center justify-center rounded-xl bg-white/95 p-1 shadow-2xl ring-1 ring-white/15">
+          <div className="flex max-h-full max-w-[75vw] items-center justify-center rounded-xl bg-white/95 p-1 shadow-2xl ring-1 ring-white/15">
             <img
               src={image.src}
               alt={image.alt ?? label}
-              className="block max-h-[calc(100vh-11rem)] max-w-[calc(100vw-3.5rem)] object-contain rounded-lg"
+              className="block max-h-[72vh] max-w-[min(75vw,960px)] object-contain rounded-lg"
               draggable={false}
             />
           </div>

--- a/src/renderer/components/cowork/components/UserBubble.test.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.test.tsx
@@ -77,6 +77,35 @@ describe('UserBubble', () => {
     expect(screen.queryByText('minimax-docx')).not.toBeInTheDocument();
   });
 
+  test('bounds inline image attachments to a compact preview', () => {
+    render(
+      <UserBubble
+        message={{
+          ...message,
+          metadata: {
+            imageAttachments: [
+              { name: 'screenshot.png', mimeType: 'image/png', base64Data: 'aW1hZ2U=' },
+            ],
+          },
+        }}
+        skills={[]}
+      />,
+    );
+
+    const image = screen.getByRole('img', { name: 'screenshot.png' });
+
+    expect(image).toHaveClass('h-36');
+    expect(image).toHaveClass('w-64');
+    expect(image).not.toHaveClass('border');
+    expect(image).not.toHaveClass('border-border');
+
+    fireEvent.click(image);
+
+    const expandedImage = screen.getAllByRole('img', { name: 'screenshot.png' })[1];
+    expect(expandedImage).toHaveClass('max-h-[72vh]');
+    expect(expandedImage).toHaveClass('max-w-[min(75vw,960px)]');
+  });
+
   test('renders a local preview for an image kept as a file attachment', async () => {
     Object.defineProperty(window, 'electron', {
       configurable: true,

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -128,7 +128,7 @@ const LocalImageAttachmentPreview: React.FC<{
       <img
         src={dataUrl}
         alt={file.name || 'image'}
-        className="block h-40 w-auto max-w-80 rounded-lg border border-border object-contain"
+        className="block h-36 w-64 max-w-full rounded-lg object-contain"
       />
     </Button>
   );
@@ -225,7 +225,7 @@ export const UserBubble: React.FC<{
                 <img
                   src={`data:${img.mimeType};base64,${img.base64Data}`}
                   alt={img.name || 'image'}
-                  className="block h-40 w-auto max-w-80 rounded-lg border border-border object-contain"
+                  className="block h-36 w-64 max-w-full rounded-lg object-contain"
                 />
               </Button>
             ))}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -6,6 +6,9 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+/* cowork/ is an ignored runtime-output directory name, so opt it into Tailwind scanning. */
+@source "./components/cowork";
+
 @plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/src/shared/components/ui/dropdown-menu.test.tsx
+++ b/src/shared/components/ui/dropdown-menu.test.tsx
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/shared/components/ui/dropdown-menu.tsx'),
+  'utf8',
+);
+const tailwindSource = readFileSync(resolve(process.cwd(), 'src/renderer/index.css'), 'utf8');
+
+describe('DropdownMenuContent', () => {
+  test('does not force popup width to the runtime anchor width', () => {
+    expect(source).not.toContain('w-(--anchor-width)');
+  });
+
+  test('includes cowork components in Tailwind source detection', () => {
+    expect(tailwindSource).toContain('@source "./components/cowork";');
+  });
+});

--- a/src/shared/components/ui/dropdown-menu.tsx
+++ b/src/shared/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            'z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none',
+            'z-50 max-h-(--available-height) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md outline-none',
             animated &&
               'duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95 data-[closed]:animate-out data-closed:overflow-hidden data-[closed]:fade-out-0 data-[closed]:zoom-out-95',
             className,


### PR DESCRIPTION
## Summary

修复 cowork 会话中图片附件预览的尺寸问题：

- 内联图片预览改为固定紧凑尺寸并去掉边框，避免撑开消息气泡；
- 点击展开后的大图预览限制在 `72vh / 75vw` 以内，不再接近整个视口大小；
- DropdownMenu 弹层内容不再强制匹配触发锚点宽度；
- 将 cowork 组件目录显式加入 Tailwind 源码扫描，确保新工具类能正确生成。

## Related Issue

无

## Changes Made

- `UserBubble.tsx`：内联图片附件预览改为 `h-36 w-64` 固定紧凑尺寸，移除边框
- `ImagePreviewModal.tsx`：展开大图上限改为 `max-h-[72vh]`、`max-w-[min(75vw,960px)]`，容器同步收窄
- `dropdown-menu.tsx`：移除 `w-(--anchor-width)`，弹层宽度不再受锚点宽度限制
- `index.css`：添加 `@source "./components/cowork"`，让 Tailwind 扫描该目录
- 测试：`UserBubble.test.tsx` 新增内联图片紧凑预览断言，新增 `dropdown-menu.test.tsx`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

验证：`npm test -- UserBubble dropdown-menu` → 2 个测试文件、10 个用例全部通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

无