### PR TITLE
fix(ui): restore cowork Tailwind source scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,6 @@ ppt-assets/
 documents.md
 reasonix.toml
 
-# App runtime output
-cowork/
-logs/
+# App runtime output (root-scoped so build tools can scan same-named source directories)
+/cowork/
+/logs/

--- a/tests/gitignoreSourceDiscovery.test.ts
+++ b/tests/gitignoreSourceDiscovery.test.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const repositoryRoot = path.resolve(__dirname, '..');
+
+function isIgnored(relativePath: string): boolean {
+  const result = spawnSync('git', ['check-ignore', '--no-index', '--quiet', '--', relativePath], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  });
+
+  expect(result.error).toBeUndefined();
+  expect([0, 1]).toContain(result.status);
+  return result.status === 0;
+}
+
+describe('root runtime output ignore rules', () => {
+  test('ignore runtime output without hiding same-named source directories', () => {
+    expect(isIgnored('cowork/runtime.json')).toBe(true);
+    expect(isIgnored('logs/app.log')).toBe(true);
+    expect(isIgnored('src/renderer/components/cowork/CoworkPromptInput.tsx')).toBe(false);
+    expect(isIgnored('src/renderer/components/cowork/PromptPlusMenu.tsx')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- restore Tailwind v4 source discovery for Cowork renderer components
- keep application runtime `cowork/` and `logs/` directories ignored at the repository root
- add a regression test for the Git ignore contract used by Tailwind source scanning

## Root cause

PR #512 added unanchored `cowork/` and `logs/` patterns to `.gitignore`. Because Tailwind v4 respects Git ignore rules during automatic source discovery, the `cowork/` pattern also excluded `src/renderer/components/cowork/`.

The missing generated utilities included the skill menu's `w-80` / `max-h-80` sizing and the prompt input's `rounded-3xl` descendant rule. This made the skills menu expand and left the prompt input's inner border radius out of alignment.

## Changes

- anchor runtime output patterns as `/cowork/` and `/logs/`
- verify root runtime outputs remain ignored
- verify `CoworkPromptInput.tsx` and `PromptPlusMenu.tsx` remain visible to source discovery

## Verification

- `npx vitest run tests/gitignoreSourceDiscovery.test.ts`
- `npm run lint`
- `npm run build`
- `npx oxfmt --check tests/gitignoreSourceDiscovery.test.ts`
- `git diff --check`
- confirmed the production CSS contains `.w-80`, `.max-h-80`, `rounded-3xl`, and the input-group descendant selector

The full test suite was also attempted: 292 of 321 test files passed. The remaining 29 files are blocked by local environment prerequisites unrelated to this change, primarily the shared Electron/Node `better-sqlite3` ABI, unavailable `python3`, and unavailable PowerShell commands. The Electron native module was rebuilt successfully afterward.

## UI impact

This restores the existing skill menu dimensions and concentric prompt input border radius. It does not change component markup, interaction behavior, or the approved design system. No new screenshot is included because this is a build source-discovery correction that restores the previously shipped styling.
