### PR TITLE
fix(mcp): 修复飞书 MCP 安装时未应用应用运行时环境

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -170,7 +170,12 @@ import {
   startCoworkOpenAICompatProxy,
   stopCoworkOpenAICompatProxy,
 } from './libs/coworkOpenAICompatProxy';
-import { generateSessionTitle, getSkillsRoot, probeCoworkModelReadiness } from './libs/coworkUtil';
+import {
+  applyApplicationRuntimeEnv,
+  generateSessionTitle,
+  getSkillsRoot,
+  probeCoworkModelReadiness,
+} from './libs/coworkUtil';
 import { resolveBundledNpmRuntime, NpmCli } from './libs/npmRuntime';
 import { refreshEndpointsTestMode } from './libs/endpoints';
 import { resolveEnterpriseConfigPath, syncEnterpriseConfig } from './libs/enterpriseConfigSync';
@@ -1544,13 +1549,17 @@ const runFeishuCliCommand = (
   signal?: AbortSignal,
 ): Promise<string> =>
   new Promise((resolve, reject) => {
+    const env: Record<string, string | undefined> = { ...process.env };
+    // lark-cli's generated launcher invokes `node` through PATH. Use the
+    // application runtime here as well as for its initial npm installation.
+    applyApplicationRuntimeEnv(env);
     const child = spawn(command, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
       cwd,
       shell: process.platform === 'win32' && command.toLowerCase().endsWith('.cmd'),
       env: {
-        ...process.env,
+        ...env,
         ...(args[0]?.toLowerCase().endsWith('npm-cli.js') ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
       },
     });


### PR DESCRIPTION
## Summary

修复飞书 MCP 安装失败的问题：`runFeishuCliCommand` 在通过 spawn 执行 lark-cli 命令时，此前仅传入 `process.env`，未注入应用运行时环境。lark-cli 生成的启动脚本会通过 PATH 调用 `node`，在缺少应用 Node shim / Windows git-bash PATH / UTF-8 locale 的环境下，安装可能失败或输出乱码。

现在 spawn 前先对 env 副本调用 `applyApplicationRuntimeEnv()`，与应用内其他运行时调用保持一致。

## Related Issue

无

## Changes Made

- `src/main/main.ts`：`runFeishuCliCommand` 在 spawn 前对 `process.env` 副本应用 `applyApplicationRuntimeEnv()`，注入应用运行时 PATH 与 Windows 环境处理
- 从 `./libs/coworkUtil` 补充导入 `applyApplicationRuntimeEnv`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

验证：`npm test` 全量测试 → 318 个测试文件、2171 个用例全部通过。

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

无