### PR TITLE
fix(pi): decouple model catalog refresh from conversation startup

### DIFF
--- a/src/main/libs/agentEngine/piModelCatalogRefresh.test.ts
+++ b/src/main/libs/agentEngine/piModelCatalogRefresh.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PiModelCatalogRefreshCoordinator } from './piModelCatalogRefresh';
+
+describe('PiModelCatalogRefreshCoordinator', () => {
+  const setRuntimeApiKey = vi.fn(async () => undefined);
+  const refresh = vi.fn(async () => ({ aborted: false, errors: new Map() }));
+  const createRuntime = vi.fn(async () => ({ setRuntimeApiKey, refresh }));
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    setRuntimeApiKey.mockReset();
+    setRuntimeApiKey.mockImplementation(async () => undefined);
+    refresh.mockReset();
+    refresh.mockImplementation(async () => ({ aborted: false, errors: new Map() }));
+    createRuntime.mockReset();
+    createRuntime.mockImplementation(async () => ({ setRuntimeApiKey, refresh }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('registers configured Pi providers before a bounded network refresh', async () => {
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek', MINIMAX: 'sk-minimax' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    await coordinator.requestRefresh(false);
+
+    expect(createRuntime).toHaveBeenCalledOnce();
+    expect(setRuntimeApiKey.mock.calls).toEqual([
+      ['deepseek', 'sk-deepseek'],
+      ['minimax-cn', 'sk-minimax'],
+    ]);
+    expect(refresh).toHaveBeenCalledWith({
+      allowNetwork: true,
+      signal: expect.any(AbortSignal),
+    });
+    await coordinator.stop();
+  });
+
+  test('does not create a runtime when no Pi catalog provider is configured', async () => {
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ CUSTOM_0: 'sk-custom' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    await coordinator.requestRefresh(false);
+
+    expect(createRuntime).not.toHaveBeenCalled();
+    await coordinator.stop();
+  });
+
+  test('ignores configuration writes when Pi provider credentials are unchanged', async () => {
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    await coordinator.requestRefresh(false);
+    coordinator.notifyConfigurationChanged();
+    await Promise.resolve();
+
+    expect(createRuntime).toHaveBeenCalledOnce();
+    await coordinator.stop();
+  });
+
+  test('refreshes configured provider catalogs on the periodic interval', async () => {
+    vi.useFakeTimers();
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+      refreshIntervalMs: 100,
+    });
+
+    coordinator.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(createRuntime).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(createRuntime).toHaveBeenCalledTimes(2);
+    await coordinator.stop();
+  });
+
+  test('coalesces concurrent refresh requests', async () => {
+    let finishRefresh: ((value: PiCatalogRefreshResult) => void) | undefined;
+    type PiCatalogRefreshResult = { aborted: boolean; errors: Map<string, unknown> };
+    refresh.mockImplementationOnce(
+      () =>
+        new Promise<PiCatalogRefreshResult>(resolve => {
+          finishRefresh = resolve;
+        }),
+    );
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    const first = coordinator.requestRefresh(true);
+    const second = coordinator.requestRefresh(true);
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    finishRefresh?.({ aborted: false, errors: new Map() });
+    await Promise.all([first, second]);
+
+    expect(createRuntime).toHaveBeenCalledOnce();
+    await coordinator.stop();
+  });
+
+  test('runs one follow-up refresh when credentials change during an active refresh', async () => {
+    let apiKeys = { DEEPSEEK: 'sk-old' };
+    let finishRefresh: ((value: PiCatalogRefreshResult) => void) | undefined;
+    type PiCatalogRefreshResult = { aborted: boolean; errors: Map<string, unknown> };
+    refresh.mockImplementationOnce(
+      () =>
+        new Promise<PiCatalogRefreshResult>(resolve => {
+          finishRefresh = resolve;
+        }),
+    );
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => apiKeys,
+      createRuntime,
+    });
+
+    coordinator.start();
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    apiKeys = { DEEPSEEK: 'sk-new' };
+    coordinator.notifyConfigurationChanged();
+    finishRefresh?.({ aborted: false, errors: new Map() });
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
+
+    expect(setRuntimeApiKey).toHaveBeenLastCalledWith('deepseek', 'sk-new');
+    await coordinator.stop();
+  });
+
+  test('aborts a stalled network refresh at the configured deadline', async () => {
+    vi.useFakeTimers();
+    refresh.mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise(resolve => {
+          signal.addEventListener('abort', () => resolve({ aborted: true, errors: new Map() }), {
+            once: true,
+          });
+        }),
+    );
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+      refreshTimeoutMs: 25,
+    });
+
+    coordinator.start();
+    await vi.advanceTimersByTimeAsync(25);
+    await coordinator.requestRefresh(false);
+
+    const signal = refresh.mock.calls[0]?.[0]?.signal as AbortSignal;
+    expect(signal.aborted).toBe(true);
+    await coordinator.stop();
+  });
+
+  test('aborts an active network refresh when stopped', async () => {
+    refresh.mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise(resolve => {
+          signal.addEventListener('abort', () => resolve({ aborted: true, errors: new Map() }), {
+            once: true,
+          });
+        }),
+    );
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    const signal = refresh.mock.calls[0]?.[0]?.signal as AbortSignal;
+    await coordinator.stop();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  test('allows a later refresh after Pi reports provider errors', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    refresh
+      .mockResolvedValueOnce({
+        aborted: false,
+        errors: new Map([['deepseek', new Error('catalog unavailable')]]),
+      })
+      .mockResolvedValueOnce({ aborted: false, errors: new Map() });
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => ({ DEEPSEEK: 'sk-deepseek' }),
+      createRuntime,
+    });
+
+    coordinator.start();
+    await coordinator.requestRefresh(false);
+    await coordinator.requestRefresh(true);
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      '[PiModelCatalog] background refresh kept the existing cache after 1 provider error(s)',
+    );
+    warn.mockRestore();
+    await coordinator.stop();
+  });
+
+  test('contains credential resolver failures', async () => {
+    const error = new Error('store unavailable');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const coordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: () => {
+        throw error;
+      },
+      createRuntime,
+    });
+
+    coordinator.start();
+    await coordinator.requestRefresh(false);
+
+    expect(createRuntime).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[PiModelCatalog] could not read provider credentials:',
+      error,
+    );
+    warn.mockRestore();
+    await coordinator.stop();
+  });
+});

--- a/src/main/libs/agentEngine/piModelCatalogRefresh.ts
+++ b/src/main/libs/agentEngine/piModelCatalogRefresh.ts
@@ -1,0 +1,172 @@
+import { createHash } from 'node:crypto';
+
+import { PiCatalogProviderIdByApiKeyPrefix } from './piProviderIds';
+
+const PI_MODEL_CATALOG_REFRESH_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const PI_MODEL_CATALOG_REFRESH_TIMEOUT_MS = 15_000;
+
+interface PiCatalogCredential {
+  providerId: string;
+  apiKey: string;
+}
+
+interface PiCatalogRefreshResult {
+  aborted?: boolean;
+  errors?: ReadonlyMap<string, unknown>;
+}
+
+interface PiCatalogRuntime {
+  setRuntimeApiKey(providerId: string, apiKey: string): Promise<void>;
+  refresh(options: { allowNetwork: boolean; signal: AbortSignal }): Promise<PiCatalogRefreshResult>;
+}
+
+export interface PiModelCatalogRefreshCoordinatorOptions {
+  resolveApiKeys: () => Record<string, string>;
+  createRuntime?: () => Promise<PiCatalogRuntime>;
+  refreshIntervalMs?: number;
+  refreshTimeoutMs?: number;
+}
+
+function resolveCatalogCredentials(apiKeys: Record<string, string>): PiCatalogCredential[] {
+  return Object.entries(PiCatalogProviderIdByApiKeyPrefix).flatMap(([apiKeyPrefix, providerId]) => {
+    const apiKey = apiKeys[apiKeyPrefix]?.trim();
+    return apiKey ? [{ providerId, apiKey }] : [];
+  });
+}
+
+function credentialSignature(credentials: PiCatalogCredential[]): string {
+  const hash = createHash('sha256');
+  for (const { providerId, apiKey } of credentials) {
+    hash.update(providerId);
+    hash.update('\u0000');
+    hash.update(apiKey);
+    hash.update('\u0001');
+  }
+  return hash.digest('hex');
+}
+
+async function createOfflinePiCatalogRuntime(): Promise<PiCatalogRuntime> {
+  const { ModelRuntime } = await import('@earendil-works/pi-coding-agent');
+  return ModelRuntime.create({ allowModelNetwork: false });
+}
+
+export class PiModelCatalogRefreshCoordinator {
+  private readonly resolveApiKeys: () => Record<string, string>;
+  private readonly createRuntime: () => Promise<PiCatalogRuntime>;
+  private readonly refreshIntervalMs: number;
+  private readonly refreshTimeoutMs: number;
+  private interval: NodeJS.Timeout | null = null;
+  private activeController: AbortController | null = null;
+  private inFlight: Promise<void> | null = null;
+  private activeSignature: string | null = null;
+  private lastAttemptedSignature: string | null = null;
+  private pendingRefresh = false;
+  private stopped = true;
+
+  constructor(options: PiModelCatalogRefreshCoordinatorOptions) {
+    this.resolveApiKeys = options.resolveApiKeys;
+    this.createRuntime = options.createRuntime ?? createOfflinePiCatalogRuntime;
+    this.refreshIntervalMs = options.refreshIntervalMs ?? PI_MODEL_CATALOG_REFRESH_INTERVAL_MS;
+    this.refreshTimeoutMs = options.refreshTimeoutMs ?? PI_MODEL_CATALOG_REFRESH_TIMEOUT_MS;
+  }
+
+  start(): void {
+    if (this.interval) return;
+    this.stopped = false;
+    void this.requestRefresh(true);
+    this.interval = setInterval(() => void this.requestRefresh(true), this.refreshIntervalMs);
+    this.interval.unref?.();
+  }
+
+  notifyConfigurationChanged(): void {
+    void this.requestRefresh(false);
+  }
+
+  async requestRefresh(force: boolean): Promise<void> {
+    if (this.stopped) return;
+
+    let credentials: PiCatalogCredential[];
+    try {
+      credentials = resolveCatalogCredentials(this.resolveApiKeys());
+    } catch (error) {
+      console.warn('[PiModelCatalog] could not read provider credentials:', error);
+      return;
+    }
+    const signature = credentialSignature(credentials);
+    if (this.inFlight) {
+      if (signature !== this.activeSignature) this.pendingRefresh = true;
+      return this.inFlight;
+    }
+    if (!force && signature === this.lastAttemptedSignature) return;
+
+    this.activeSignature = signature;
+    this.lastAttemptedSignature = signature;
+    const refresh = this.runRefresh(credentials)
+      .catch(error => {
+        if (!this.stopped) {
+          console.warn('[PiModelCatalog] background refresh failed:', error);
+        }
+      })
+      .finally(() => {
+        if (this.inFlight !== refresh) return;
+        this.inFlight = null;
+        this.activeSignature = null;
+        if (!this.stopped && this.pendingRefresh) {
+          this.pendingRefresh = false;
+          void this.requestRefresh(true);
+        }
+      });
+    this.inFlight = refresh;
+    return refresh;
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.pendingRefresh = false;
+    if (this.interval) clearInterval(this.interval);
+    this.interval = null;
+    this.activeController?.abort();
+    await this.inFlight;
+  }
+
+  private async runRefresh(credentials: PiCatalogCredential[]): Promise<void> {
+    if (credentials.length === 0 || this.stopped) return;
+
+    const runtime = await this.createRuntime();
+    for (const { providerId, apiKey } of credentials) {
+      if (this.stopped) return;
+      await runtime.setRuntimeApiKey(providerId, apiKey);
+    }
+    if (this.stopped) return;
+
+    const controller = new AbortController();
+    this.activeController = controller;
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, this.refreshTimeoutMs);
+    timeout.unref?.();
+
+    try {
+      const result = await runtime.refresh({ allowNetwork: true, signal: controller.signal });
+      if (timedOut) {
+        console.warn('[PiModelCatalog] background refresh timed out; keeping the existing cache');
+        return;
+      }
+      if (this.stopped || result.aborted) return;
+      if (result.errors?.size) {
+        console.warn(
+          `[PiModelCatalog] background refresh kept the existing cache after ${result.errors.size} provider error(s)`,
+        );
+        return;
+      }
+      console.debug(
+        `[PiModelCatalog] refreshed ${credentials.length} configured provider catalog(s)`,
+      );
+    } finally {
+      clearTimeout(timeout);
+      if (this.activeController === controller) this.activeController = null;
+    }
+  }
+}

--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -28,10 +28,14 @@ declare module '@earendil-works/pi-coding-agent' {
   export function getAgentDir(): string;
 
   export const ModelRuntime: {
-    create(): Promise<{
+    create(options?: { allowModelNetwork?: boolean }): Promise<{
       registerProvider(provider: string, config: Record<string, unknown>): void;
       setRuntimeApiKey(provider: string, apiKey: string): Promise<void>;
       getModel(provider: string, modelId: string): unknown;
+      refresh(options?: {
+        allowNetwork?: boolean;
+        signal?: AbortSignal;
+      }): Promise<{ aborted?: boolean; errors?: ReadonlyMap<string, unknown> }>;
       completeSimple(
         model: unknown,
         context: { messages: Array<{ role: string; content: string }> },

--- a/src/main/libs/agentEngine/piProviderIds.ts
+++ b/src/main/libs/agentEngine/piProviderIds.ts
@@ -1,0 +1,32 @@
+import { ProviderName } from '../../../shared/providers';
+
+export const PiBuiltinProviderId = {
+  [ProviderName.OpenAI]: 'openai',
+  [ProviderName.Anthropic]: 'anthropic',
+  [ProviderName.Gemini]: 'google',
+  [ProviderName.DeepSeek]: 'deepseek',
+  [ProviderName.Moonshot]: 'moonshotai-cn',
+  [ProviderName.Zhipu]: 'zai',
+  [ProviderName.Minimax]: 'minimax-cn',
+  [ProviderName.Xiaomi]: 'xiaomi',
+  [ProviderName.OpenRouter]: 'openrouter',
+  [ProviderName.Copilot]: 'github-copilot',
+} as const;
+
+export const PiCatalogProviderIdByApiKeyPrefix = {
+  OPENAI: PiBuiltinProviderId[ProviderName.OpenAI],
+  ANTHROPIC: PiBuiltinProviderId[ProviderName.Anthropic],
+  GEMINI: PiBuiltinProviderId[ProviderName.Gemini],
+  DEEPSEEK: PiBuiltinProviderId[ProviderName.DeepSeek],
+  MOONSHOT: PiBuiltinProviderId[ProviderName.Moonshot],
+  ZHIPU: PiBuiltinProviderId[ProviderName.Zhipu],
+  MINIMAX: PiBuiltinProviderId[ProviderName.Minimax],
+  XIAOMI: PiBuiltinProviderId[ProviderName.Xiaomi],
+  OPENROUTER: PiBuiltinProviderId[ProviderName.OpenRouter],
+  GITHUB_COPILOT: PiBuiltinProviderId[ProviderName.Copilot],
+} as const;
+
+export function resolvePiBuiltinProviderId(providerName?: string): string | null {
+  if (!providerName) return null;
+  return PiBuiltinProviderId[providerName as keyof typeof PiBuiltinProviderId] ?? null;
+}

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -828,7 +828,7 @@ describe('PiRuntimeAdapter', () => {
         }),
       );
       expect(mockGetModel).not.toHaveBeenCalled();
-      expect(mockModelRuntimeCreate).toHaveBeenCalledOnce();
+      expect(mockModelRuntimeCreate).toHaveBeenCalledWith({ allowModelNetwork: false });
       expect(mockModelRuntime.registerProvider).toHaveBeenCalledWith(
         'llamacpp',
         expect.objectContaining({
@@ -859,7 +859,7 @@ describe('PiRuntimeAdapter', () => {
       // The built-in model stays on Pi's catalog, but the user's API key must
       // still be registered under the built-in provider id — otherwise the
       // session fails with "No API key found for <provider>".
-      expect(mockModelRuntimeCreate).toHaveBeenCalledOnce();
+      expect(mockModelRuntimeCreate).toHaveBeenCalledWith({ allowModelNetwork: false });
       expect(mockModelRuntime.registerProvider).not.toHaveBeenCalled();
       expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith('openai', 'sk-openai');
       expect(mockCreateAgentSession).toHaveBeenCalledWith(

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -54,7 +54,6 @@ import {
   type ModelCapabilities,
   ModelCapabilityStatus,
   ProviderModelPiApi,
-  ProviderName,
   resolveProviderModelPiReasoning,
 } from '../../../shared/providers';
 import type { CoworkMessage } from '../../coworkStore';
@@ -111,6 +110,7 @@ import { extractPiSubagentExecutionMetadata } from './piSubagentExecution';
 import { buildPiSubagentTool, PiSubagentToolName } from './piSubagentTool';
 import { buildPiSkillScriptTool } from './piSkillScriptTool';
 import { buildPiSkillRuntimeCapabilitiesTool } from './piSkillRuntimeCapabilitiesTool';
+import { resolvePiBuiltinProviderId } from './piProviderIds';
 import { buildPiDocumentReaderTool, PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
 import { buildDeclareArtifactTool, DeclareArtifactSystemPrompt } from '../../declareArtifact/tool';
 import { PiThinkingLifecycle } from './piThinkingLifecycle';
@@ -295,7 +295,7 @@ interface PiModules {
   getAgentDir: () => string;
   getModel: (provider: string, modelId: string) => unknown;
   ModelRuntime: {
-    create(): Promise<PiModelRuntime>;
+    create(options?: PiModelRuntimeCreateOptions): Promise<PiModelRuntime>;
   };
   completeSimple: (
     model: unknown,
@@ -336,6 +336,10 @@ interface PiModelRuntime {
     model: unknown,
     context: { messages: Array<{ role: string; content: string }> },
   ): Promise<{ content: Array<{ text: string }> }>;
+}
+
+interface PiModelRuntimeCreateOptions {
+  allowModelNetwork?: boolean;
 }
 
 type PiResolvedModel = {
@@ -3109,24 +3113,6 @@ const DEFAULT_PI_CLOUD_CONTEXT_WINDOW = 256000;
 const DEFAULT_PI_CLOUD_MAX_TOKENS = 32768;
 const PI_LOCAL_API_KEY = 'sk-zhiyuan-local';
 
-const PI_BUILTIN_PROVIDER_ID = {
-  [ProviderName.OpenAI]: 'openai',
-  [ProviderName.Anthropic]: 'anthropic',
-  [ProviderName.Gemini]: 'google',
-  [ProviderName.DeepSeek]: 'deepseek',
-  [ProviderName.Moonshot]: 'moonshotai-cn',
-  [ProviderName.Zhipu]: 'zai',
-  [ProviderName.Minimax]: 'minimax-cn',
-  [ProviderName.Xiaomi]: 'xiaomi',
-  [ProviderName.OpenRouter]: 'openrouter',
-  [ProviderName.Copilot]: 'github-copilot',
-} as const;
-
-function resolvePiBuiltinProviderId(providerName?: string): string | null {
-  if (!providerName) return null;
-  return PI_BUILTIN_PROVIDER_ID[providerName as keyof typeof PI_BUILTIN_PROVIDER_ID] ?? null;
-}
-
 function resolvePiCustomModelApi(resolution: ApiConfigResolution): ProviderModelPiApi {
   const configuredApi = resolution.providerMetadata?.piRuntime?.api;
   if (configuredApi) return configuredApi;
@@ -3261,12 +3247,14 @@ async function resolvePiCustomModelRuntime(
     if (!apiKey || !builtinProviderId) {
       return { modelRuntime: existingModelRuntime ?? null, customModel: null };
     }
-    const modelRuntime = existingModelRuntime ?? (await pi.ModelRuntime.create());
+    const modelRuntime =
+      existingModelRuntime ?? (await pi.ModelRuntime.create({ allowModelNetwork: false }));
     await modelRuntime.setRuntimeApiKey(builtinProviderId, apiKey);
     return { modelRuntime, customModel: null };
   }
 
-  const modelRuntime = existingModelRuntime ?? (await pi.ModelRuntime.create());
+  const modelRuntime =
+    existingModelRuntime ?? (await pi.ModelRuntime.create({ allowModelNetwork: false }));
   const api = resolvePiCustomModelApi(resolution);
   const runtimeBaseUrl = await resolvePiCustomModelBaseUrl(resolution, api);
   const model = buildPiCustomModel(resolution, runtimeBaseUrl);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -148,6 +148,7 @@ import { registerTriageIpcHandlers } from './ipcHandlers/triage';
 import { registerWorkbenchTaskIpcHandlers } from './workbenchTask/ipc';
 import { WorkbenchTaskService } from './workbenchTask/taskService';
 import { type PermissionResult, PiRuntimeAdapter } from './libs/agentEngine';
+import { PiModelCatalogRefreshCoordinator } from './libs/agentEngine/piModelCatalogRefresh';
 import { AppUpdateCoordinator } from './libs/appUpdateCoordinator';
 import {
   getCurrentApiConfig,
@@ -806,6 +807,7 @@ process.on('exit', code => {
 let store: SqliteStore | null = null;
 let coworkStore: CoworkStore | null = null;
 let piRuntimeAdapter: PiRuntimeAdapter | null = null;
+let piModelCatalogRefreshCoordinator: PiModelCatalogRefreshCoordinator | null = null;
 let workbenchTaskService: WorkbenchTaskService | null = null;
 let engramManager: EngramManager | null = null;
 let engramAdapter: ZhiYuanEngramAdapter | null = null;
@@ -6476,6 +6478,9 @@ if (!gotTheLock) {
     console.log('[Main] Stopping cowork sessions...');
     if (piRuntimeAdapter) piRuntimeAdapter.stopAllSessions();
 
+    await piModelCatalogRefreshCoordinator?.stop();
+    piModelCatalogRefreshCoordinator = null;
+
     await stopCoworkOpenAICompatProxy().catch(error => {
       console.error('Failed to stop OpenAI compatibility proxy:', error);
     });
@@ -6710,6 +6715,12 @@ if (!gotTheLock) {
     registerMemoryIpcHandlers({ getService: getProjectMemoryService });
     // Inject store getter into claudeSettings
     setStoreGetter(() => store);
+    piModelCatalogRefreshCoordinator = new PiModelCatalogRefreshCoordinator({
+      resolveApiKeys: resolveAllProviderApiKeys,
+    });
+    getStore().onDidChange<AppConfigSettings>('app_config', () => {
+      piModelCatalogRefreshCoordinator?.notifyConfigurationChanged();
+    });
     registerLlamaCppIpcHandlers(getLlamaCppManager(), { getStore });
     registerTriageIpcHandlers({ getStore });
     registerOllamaIpcHandlers(getOllamaManager(), {
@@ -6862,6 +6873,7 @@ if (!gotTheLock) {
     createWindow();
     profiler.measure('createWindow');
     console.log('[Main] initApp: window created');
+    piModelCatalogRefreshCoordinator.start();
     startAppUpdatePolling();
 
     // ── Step 2-4: Skill bootstrap (non-blocking) ────────────────────


### PR DESCRIPTION
## Summary

- Prevent Work, Chat, Channel, and Cron runs from waiting on Pi model-catalog network refreshes.
- Keep Pi built-in definitions and the persisted model catalog available to every conversation runtime.
- Move network catalog refreshes to a bounded background coordinator.

## Root cause

Conversation startup created `ModelRuntime` with network access enabled. `ModelRuntime.create()` performed a bounded catalog refresh, while the subsequent `setRuntimeApiKey()` triggered another refresh without a timeout. An unavailable `pi.dev` catalog endpoint could therefore block agent startup before Pi received the prompt.

## Changes

- Create all conversation-owned model runtimes with `allowModelNetwork: false`.
- Centralize RongxinAI provider names to Pi built-in provider IDs.
- Add a background catalog refresh coordinator that:
  - starts after the Electron window is created;
  - reacts to provider credential changes;
  - refreshes every four hours;
  - coalesces concurrent requests and queues one credential-change rerun;
  - aborts network work after 15 seconds and during app shutdown;
  - retains the existing Pi cache on timeout or provider errors;
  - stores only a SHA-256 credential signature for change detection.
- Keep refreshed catalog state isolated from active sessions so updates apply only to future sessions.

## Validation

- [x] `npx vitest run src/main/libs/agentEngine/piModelCatalogRefresh.test.ts --config vitest.config.ts` (10 tests)
- [x] Pi runtime adapter model-path tests (3 focused tests)
- [x] `npm run compile:electron`
- [x] `oxlint` on all changed files
- [x] Formatting and `git diff --check`
- [ ] Full adapter suite: 84 tests pass; 10 SQLite-backed tests cannot start locally because shared `better-sqlite3` uses Electron ABI 143 while the Node test process requires ABI 137.

## Scope

- No `pi-connect` changes.
- Settings model discovery remains on its existing provider `/models` path.
- No Channel- or Cron-specific execution timeout is introduced.

Related to #449.