### PR TITLE
fix(cowork): restore conversation content layout

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionLayout.test.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLayout.test.tsx
@@ -62,6 +62,9 @@ test('renders the title above tabs and preserves conversation state across tab s
   });
   const traceTab = screen.getByRole('tab', { name: i18nService.t('coworkTraceTab') });
   expect(conversationTab.getAttribute('aria-selected')).toBe('true');
+  expect(
+    screen.getByRole('tabpanel', { name: i18nService.t('coworkConversationTab') }),
+  ).toHaveClass('flex', 'flex-col');
 
   const draft = screen.getByRole('textbox', { name: 'conversation draft' });
   await user.type(draft, '保留草稿');

--- a/src/renderer/components/cowork/CoworkSessionLayout.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLayout.tsx
@@ -31,7 +31,7 @@ interface CoworkSessionLayoutProps {
 }
 
 const panelTransitionClassName = cn(
-  'absolute inset-0 min-h-0 overflow-hidden transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none',
+  'absolute inset-0 flex min-h-0 flex-col overflow-hidden transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none',
   'data-starting-style:opacity-0 data-ending-style:opacity-0',
   'data-[activation-direction=right]:data-starting-style:translate-x-7',
   'data-[activation-direction=right]:data-ending-style:-translate-x-7',


### PR DESCRIPTION
## Summary

- Restore the session tab panels as full-height column flex containers.
- Reestablish the height chain used by the conversation, prompt input, and right-side artifact preview.
- Add a regression assertion for the panel layout contract.

## Root cause

The header and view tabs introduced in #519 moved the conversation under `TabsContent`, but the new panel remained a block container. Its children still depended on the previous `flex flex-col` parent, so their `flex-1` sizing no longer resolved and both the conversation and artifact split layout lost their usable height.

## Verification

- `npm test -- CoworkSessionLayout` (1 test passed)
- `npm run build:tsc`
- `npm run lint`
- Targeted `oxfmt --check` for changed files
- `git diff --check`
- Live preview verification at the default viewport and 420px width
- Light and dark theme checks with no horizontal overflow

## Related PR

Follow-up fix for the session tabs introduced in #519.

## Electron impact

Renderer-only layout fix. No IPC, storage, or window lifecycle behavior changed.
