### PR TITLE
feat(cowork): 聊天快捷技能自动放行工具权限

### DIFF
--- a/src/renderer/components/chat/constants.test.ts
+++ b/src/renderer/components/chat/constants.test.ts
@@ -14,7 +14,12 @@ import { resolveShortcutWorkflowKind } from '../../../main/libs/agentEngine/piSh
 
 import { expect, test } from 'vitest';
 
-import { CHAT_SKILL_SHORTCUTS, isChatSkillShortcutActive } from './constants';
+import { CoworkPermissionMode } from '../../../shared/cowork/constants';
+import {
+  CHAT_SKILL_SHORTCUTS,
+  isChatSkillShortcutActive,
+  resolveChatSkillShortcutPermissionMode,
+} from './constants';
 
 test('every chat quick-skill shortcut points at a core skill', () => {
   // Core skills are always enabled (skillManager forces enabled=true), so a
@@ -82,6 +87,23 @@ test('quick skill selection requires an exact skill set', () => {
       'web-search',
     ]),
   ).toBe(false);
+});
+
+test('quick skill selections automatically allow tools for their chat session only', () => {
+  for (const shortcut of CHAT_SKILL_SHORTCUTS) {
+    expect(
+      resolveChatSkillShortcutPermissionMode(
+        shortcut.skillIds ?? [shortcut.skillId],
+        CoworkPermissionMode.Ask,
+      ),
+    ).toBe(CoworkPermissionMode.AllowAll);
+  }
+  expect(
+    resolveChatSkillShortcutPermissionMode(['presentation-studio', 'web-search'], CoworkPermissionMode.Ask),
+  ).toBe(CoworkPermissionMode.Ask);
+  expect(resolveChatSkillShortcutPermissionMode([], CoworkPermissionMode.AllowAll)).toBe(
+    CoworkPermissionMode.AllowAll,
+  );
 });
 
 test('every sidebar shortcut is protected by a Pi completion controller', () => {

--- a/src/renderer/components/chat/constants.ts
+++ b/src/renderer/components/chat/constants.ts
@@ -1,5 +1,6 @@
 import { FileText, Globe, GraduationCap, Presentation, Table, Telescope } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { CoworkPermissionMode, type CoworkPermissionMode as CoworkPermissionModeType } from '../../../shared/cowork/constants';
 import { AcademicResearchSkillIds, CoreSkillId } from '@shared/skills/constants';
 
 /**
@@ -84,6 +85,15 @@ export const isChatSkillShortcutActive = (
     shortcutSkillIds.every(skillId => activeSkillIds.includes(skillId))
   );
 };
+
+export const isChatSkillShortcutSelection = (skillIds: readonly string[]): boolean =>
+  CHAT_SKILL_SHORTCUTS.some(entry => isChatSkillShortcutActive(entry, skillIds));
+
+export const resolveChatSkillShortcutPermissionMode = (
+  skillIds: readonly string[],
+  fallback: CoworkPermissionModeType,
+): CoworkPermissionModeType =>
+  isChatSkillShortcutSelection(skillIds) ? CoworkPermissionMode.AllowAll : fallback;
 
 /**
  * Returns the placeholder i18n key of the first active shortcut skill, so

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -15,7 +15,11 @@ import {
   ChatExecution,
   resolveChatExecution,
 } from '../../services/chatExecutionRouter';
-import { resolveSkillPlaceholderKey } from '../chat/constants';
+import {
+  isChatSkillShortcutSelection,
+  resolveChatSkillShortcutPermissionMode,
+  resolveSkillPlaceholderKey,
+} from '../chat/constants';
 import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import { coworkService } from '../../services/cowork';
 import { coworkQueueService } from '../../services/coworkQueue';
@@ -829,6 +833,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       const sessionModelOverride = currentAgentSelectedModel
         ? toAgentModelRef(currentAgentSelectedModel)
         : '';
+      const shouldAutoAllowChatSkill =
+        workMode === WorkMode.Chat &&
+        isChatAgentExecution &&
+        isChatSkillShortcutSelection(sessionSkillIds);
+      const sessionPermissionMode =
+        shouldAutoAllowChatSkill
+          ? resolveChatSkillShortcutPermissionMode(sessionSkillIds, config.permissionMode)
+          : config.permissionMode;
       console.log('[CoworkView] creating session:', {
         modelId: currentAgentSelectedModel?.id,
         providerKey: currentAgentSelectedModel?.providerKey,
@@ -854,7 +866,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         expertIds,
         goalMode,
         modelOverride: sessionModelOverride,
-        permissionMode: config.permissionMode,
+        permissionMode: sessionPermissionMode,
         imageAttachments,
         fileAttachments,
       });
@@ -879,6 +891,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       }
 
       if (startedSession) {
+        if (shouldAutoAllowChatSkill) {
+          await coworkService.updateConfig({
+            permissionModeBySession: {
+              ...(store.getState().cowork.config.permissionModeBySession ?? {}),
+              [startedSession.id]: CoworkPermissionMode.AllowAll,
+            },
+          });
+        }
         clearUnmanagedWorkingDirectory();
         // coworkService.startSession already selected the real session.
         // Remove only the temporary list entry after that replacement.


### PR DESCRIPTION
## Summary

当会话以「聊天 + 快捷技能」方式启动时，自动将该会话的权限模式解析为 `AllowAll`（工具全部放行），并按会话持久化到 `permissionModeBySession`，避免快捷技能聊天流程在工具权限弹窗处卡住。

## Related Issue

无

## Changes Made

- `chat/constants.ts`：新增 `isChatSkillShortcutSelection()` 与 `resolveChatSkillShortcutPermissionMode()`
- `CoworkView.tsx`：创建聊天会话时，若命中快捷技能选择则使用 `AllowAll` 作为该会话权限模式，并在会话启动后写入 `permissionModeBySession`
- `chat/constants.test.ts`：新增对应单测

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

验证：
- `npm run build:tsc` 通过（renderer）
- `npm test` 全量 → 322 个测试文件、2193 个用例全部通过

## Screenshots (if applicable)

无

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

无