### PR TITLE
feat(cowork): 会话新增 source 来源字段,定时任务按来源归入自动化区域

### DIFF
--- a/src/main/coworkSessionRuntimeState.test.ts
+++ b/src/main/coworkSessionRuntimeState.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest';
 
-import { CoworkSessionMode } from '../shared/cowork/constants';
+import { CoworkSessionMode, CoworkSessionSource } from '../shared/cowork/constants';
 import type { CoworkSessionSummary } from './coworkStore';
 import { reconcileWorkSessionRuntimeState } from './coworkSessionRuntimeState';
 
@@ -13,6 +13,7 @@ const makeSession = (overrides: Partial<CoworkSessionSummary> = {}): CoworkSessi
   pinOrder: null,
   workspaceId: 'workspace-1',
   agentId: 'main',
+  source: CoworkSessionSource.Manual,
   createdAt: 1,
   updatedAt: 1,
   ...overrides,

--- a/src/main/coworkSlicePagination.test.ts
+++ b/src/main/coworkSlicePagination.test.ts
@@ -16,6 +16,7 @@ import coworkReducer, {
   setSessions,
 } from '../renderer/store/slices/coworkSlice';
 import type { CoworkMessage, CoworkSession, CoworkSessionSummary } from '../renderer/types/cowork';
+import { CoworkSessionSource } from '../shared/cowork/constants';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -27,6 +28,7 @@ function makeSession(id: string, updatedAt = Date.now()): CoworkSessionSummary {
     title: `Session ${id}`,
     status: 'idle',
     pinned: false,
+    source: CoworkSessionSource.Manual,
     createdAt: updatedAt,
     updatedAt,
   };
@@ -44,6 +46,7 @@ function makeFullSession(
     claudeSessionId: null,
     status: 'idle',
     pinned: false,
+    source: CoworkSessionSource.Manual,
     cwd: '/tmp',
     systemPrompt: '',
     executionMode: 'local',

--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -58,6 +58,7 @@ function setupDb(): void {
       active_skill_ids TEXT,
       workspace_id TEXT,
       agent_id TEXT NOT NULL DEFAULT 'main',
+      source TEXT NOT NULL DEFAULT 'manual',
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );

--- a/src/main/coworkStore.test.ts
+++ b/src/main/coworkStore.test.ts
@@ -26,7 +26,11 @@ import {
   DefaultAgentAvatarIcon,
   encodeAgentAvatarIcon,
 } from '../shared/agent/avatar';
-import { COWORK_MESSAGE_PAGE_SIZE, CoworkSessionMode } from '../shared/cowork/constants';
+import {
+  COWORK_MESSAGE_PAGE_SIZE,
+  CoworkSessionMode,
+  CoworkSessionSource,
+} from '../shared/cowork/constants';
 import { CoworkSessionExpertSource } from '../shared/cowork/sessionExperts';
 import { initializeCoworkArtifactIndexSchema } from './coworkArtifactIndex';
 import { CoworkStore } from './coworkStore';
@@ -58,7 +62,7 @@ function setupDb(): void {
       active_skill_ids TEXT,
       workspace_id TEXT,
       agent_id TEXT NOT NULL DEFAULT 'main',
-      source TEXT NOT NULL DEFAULT 'manual',
+      source TEXT NOT NULL DEFAULT '${CoworkSessionSource.Manual}',
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
@@ -286,6 +290,44 @@ test('sessions are grouped by workspace independently of their agent snapshot', 
   expect(
     store.listSessions(10, 0, undefined, first.workspaceId).map(session => session.id),
   ).toEqual(expect.arrayContaining([first.id, second.id]));
+});
+
+test('listSessions paginates independently by session source', () => {
+  const workspace = store.ensureWorkspace('/tmp/workspace-source');
+  const scheduled = store.createSession(
+    'scheduled',
+    workspace.path,
+    '',
+    'local',
+    [],
+    'main',
+    '',
+    CoworkSessionMode.Work,
+    undefined,
+    workspace.id,
+    [],
+    CoworkSessionSource.Scheduled,
+  );
+  db.prepare('UPDATE cowork_sessions SET updated_at = ? WHERE id = ?').run(1, scheduled.id);
+  for (let index = 0; index < 8; index += 1) {
+    const manual = store.createSession(`manual-${index}`, workspace.path);
+    db.prepare('UPDATE cowork_sessions SET updated_at = ? WHERE id = ?').run(index + 2, manual.id);
+  }
+
+  const scheduledSources = [CoworkSessionSource.Scheduled];
+  const regularSources = [CoworkSessionSource.Manual, CoworkSessionSource.Im];
+
+  expect(
+    store
+      .listSessions(6, 0, undefined, workspace.id, CoworkSessionMode.Work, scheduledSources)
+      .map(session => session.id),
+  ).toEqual([scheduled.id]);
+  expect(
+    store.countSessions(undefined, workspace.id, CoworkSessionMode.Work, scheduledSources),
+  ).toBe(1);
+  expect(store.countSessions(undefined, workspace.id, CoworkSessionMode.Work, regularSources)).toBe(
+    8,
+  );
 });
 
 test('workspace order changes only when the workspace is explicitly touched', () => {
@@ -548,11 +590,7 @@ test('updateSession can patch model override without refreshing the session upda
   insertSession(sid);
   db.prepare('UPDATE cowork_sessions SET updated_at = ? WHERE id = ?').run(1000, sid);
 
-  store.updateSession(
-    sid,
-    { modelOverride: 'deepseek/qwen3.6-plus' },
-    { touchUpdatedAt: false },
-  );
+  store.updateSession(sid, { modelOverride: 'deepseek/qwen3.6-plus' }, { touchUpdatedAt: false });
 
   const session = store.getSession(sid);
   expect(session?.modelOverride).toBe('deepseek/qwen3.6-plus');

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -436,6 +436,8 @@ export interface CoworkConversationReplacementEntry {
   timestamp?: number;
 }
 
+export type CoworkSessionSource = 'manual' | 'scheduled' | 'im';
+
 export interface CoworkSession {
   id: string;
   title: string;
@@ -451,6 +453,8 @@ export interface CoworkSession {
   activeSkillIds: string[];
   workspaceId: string;
   agentId: string;
+  /** Origin of the session: user-created, scheduled task, or IM channel. */
+  source: CoworkSessionSource;
   experts: CoworkSessionExpertSnapshot[];
   messages: CoworkMessage[];
   /** Offset of the first loaded message in the full message history. */
@@ -472,6 +476,7 @@ export interface CoworkSessionSummary {
   pinOrder?: number | null;
   workspaceId: string;
   agentId: string;
+  source: CoworkSessionSource;
   createdAt: number;
   updatedAt: number;
 }
@@ -773,6 +778,7 @@ export class CoworkStore {
     id?: string,
     workspaceId?: string,
     expertSnapshots: CoworkSessionExpertInput[] = [],
+    source: CoworkSessionSource = 'manual',
   ): CoworkSession {
     const sessionId = id || uuidv4();
     const now = Date.now();
@@ -785,8 +791,8 @@ export class CoworkStore {
     if (!workspace) throw new Error('Workspace not found');
 
     const insertSession = this.db.prepare(`
-      INSERT INTO cowork_sessions (id, title, claude_session_id, status, mode, cwd, system_prompt, model_override, execution_mode, active_skill_ids, workspace_id, agent_id, pinned, created_at, updated_at)
-      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+      INSERT INTO cowork_sessions (id, title, claude_session_id, status, mode, cwd, system_prompt, model_override, execution_mode, active_skill_ids, workspace_id, agent_id, pinned, source, created_at, updated_at)
+      VALUES (?, ?, NULL, 'idle', ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
     `);
     const insertExpert = this.db.prepare(`
       INSERT INTO cowork_session_experts
@@ -805,6 +811,7 @@ export class CoworkStore {
         JSON.stringify(activeSkillIds),
         workspace.id,
         agentId,
+        source,
         now,
         now,
       );
@@ -840,6 +847,7 @@ export class CoworkStore {
       activeSkillIds,
       workspaceId: workspace.id,
       agentId,
+      source,
       experts: expertSnapshots.map(expert => ({
         ...expert,
         capabilityPolicy: expert.capabilityPolicy ?? {},
@@ -873,13 +881,14 @@ export class CoworkStore {
       active_skill_ids?: string | null;
       workspace_id?: string | null;
       agent_id?: string | null;
+      source?: string | null;
       created_at: number;
       updated_at: number;
     }
 
     const row = this.getOne<SessionRow>(
       `
-      SELECT id, title, claude_session_id, status, mode, pinned, pin_order, cwd, system_prompt, model_override, execution_mode, active_skill_ids, workspace_id, agent_id, created_at, updated_at
+      SELECT id, title, claude_session_id, status, mode, pinned, pin_order, cwd, system_prompt, model_override, execution_mode, active_skill_ids, workspace_id, agent_id, source, created_at, updated_at
       FROM cowork_sessions
       WHERE id = ?
     `,
@@ -982,6 +991,7 @@ export class CoworkStore {
       activeSkillIds,
       workspaceId: row.workspace_id || this.ensureWorkspace(row.cwd).id,
       agentId: row.agent_id || 'main',
+      source: (row.source as CoworkSessionSource) || 'manual',
       experts,
       messages,
       messagesOffset: messageOffset,
@@ -1196,6 +1206,7 @@ export class CoworkStore {
       cwd: string;
       workspace_id: string | null;
       agent_id: string | null;
+      source: string | null;
       created_at: number;
       updated_at: number;
     }
@@ -1217,7 +1228,7 @@ export class CoworkStore {
     const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
     const rows = this.getAll<SessionSummaryRow>(
       `
-        SELECT id, title, status, mode, pinned, pin_order, cwd, workspace_id, agent_id, created_at, updated_at
+        SELECT id, title, status, mode, pinned, pin_order, cwd, workspace_id, agent_id, source, created_at, updated_at
         FROM cowork_sessions
         ${whereClause}
         ORDER BY pinned DESC,
@@ -1238,6 +1249,7 @@ export class CoworkStore {
       pinOrder: row.pin_order ?? null,
       workspaceId: row.workspace_id || this.ensureWorkspace(row.cwd).id,
       agentId: row.agent_id || 'main',
+      source: (row.source as CoworkSessionSource) || 'manual',
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }));

--- a/src/main/coworkStore.ts
+++ b/src/main/coworkStore.ts
@@ -11,6 +11,7 @@ import {
   COWORK_SESSION_PAGE_SIZE,
   CoworkPermissionMode,
   CoworkSessionMode,
+  CoworkSessionSource,
   type CoworkPermissionMode as CoworkPermissionModeType,
   type CoworkSessionMode as CoworkSessionModeType,
 } from '../shared/cowork/constants';
@@ -436,8 +437,6 @@ export interface CoworkConversationReplacementEntry {
   timestamp?: number;
 }
 
-export type CoworkSessionSource = 'manual' | 'scheduled' | 'im';
-
 export interface CoworkSession {
   id: string;
   title: string;
@@ -778,7 +777,7 @@ export class CoworkStore {
     id?: string,
     workspaceId?: string,
     expertSnapshots: CoworkSessionExpertInput[] = [],
-    source: CoworkSessionSource = 'manual',
+    source: CoworkSessionSource = CoworkSessionSource.Manual,
   ): CoworkSession {
     const sessionId = id || uuidv4();
     const now = Date.now();
@@ -991,7 +990,7 @@ export class CoworkStore {
       activeSkillIds,
       workspaceId: row.workspace_id || this.ensureWorkspace(row.cwd).id,
       agentId: row.agent_id || 'main',
-      source: (row.source as CoworkSessionSource) || 'manual',
+      source: (row.source as CoworkSessionSource) || CoworkSessionSource.Manual,
       experts,
       messages,
       messagesOffset: messageOffset,
@@ -1167,7 +1166,12 @@ export class CoworkStore {
     return pinOrder;
   }
 
-  countSessions(agentId?: string, workspaceId?: string, mode?: CoworkSessionModeType): number {
+  countSessions(
+    agentId?: string,
+    workspaceId?: string,
+    mode?: CoworkSessionModeType,
+    sources?: readonly CoworkSessionSource[],
+  ): number {
     const filters: string[] = [];
     const params: string[] = [];
     if (workspaceId) {
@@ -1180,6 +1184,10 @@ export class CoworkStore {
     if (mode) {
       filters.push('mode = ?');
       params.push(mode);
+    }
+    if (sources?.length) {
+      filters.push(`source IN (${sources.map(() => '?').join(', ')})`);
+      params.push(...sources);
     }
 
     const whereClause = filters.length > 0 ? ` WHERE ${filters.join(' AND ')}` : '';
@@ -1195,6 +1203,7 @@ export class CoworkStore {
     agentId?: string,
     workspaceId?: string,
     mode?: CoworkSessionModeType,
+    sources?: readonly CoworkSessionSource[],
   ): CoworkSessionSummary[] {
     interface SessionSummaryRow {
       id: string;
@@ -1224,6 +1233,10 @@ export class CoworkStore {
       filters.push('mode = ?');
       params.push(mode);
     }
+    if (sources?.length) {
+      filters.push(`source IN (${sources.map(() => '?').join(', ')})`);
+      params.push(...sources);
+    }
 
     const whereClause = filters.length > 0 ? `WHERE ${filters.join(' AND ')}` : '';
     const rows = this.getAll<SessionSummaryRow>(
@@ -1249,7 +1262,7 @@ export class CoworkStore {
       pinOrder: row.pin_order ?? null,
       workspaceId: row.workspace_id || this.ensureWorkspace(row.cwd).id,
       agentId: row.agent_id || 'main',
-      source: (row.source as CoworkSessionSource) || 'manual',
+      source: (row.source as CoworkSessionSource) || CoworkSessionSource.Manual,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }));

--- a/src/main/im/imCoworkHandler.test.ts
+++ b/src/main/im/imCoworkHandler.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { CoworkErrorKind } from '../../common/coworkError';
 import { ActivityStatus } from '../../shared/activity/constants';
+import { CoworkSessionSource } from '../../shared/cowork/constants';
 import { IMCoworkHandler } from './imCoworkHandler';
 
 const electronMocks = vi.hoisted(() => ({
@@ -39,7 +40,9 @@ class FakeRuntime extends EventEmitter {
     this.continueCalls.push({ sessionId, prompt, options });
   }
 
-  stopSession(sessionId: string) { this.stopCalls.push(sessionId); }
+  stopSession(sessionId: string) {
+    this.stopCalls.push(sessionId);
+  }
   stopAllSessions() {}
   respondToPermission() {}
   isSessionActive() {
@@ -88,6 +91,8 @@ class FakeCoworkStore {
     mode: 'work' | 'chat' = 'work',
     _id?: string,
     workspaceId = 'workspace-1',
+    _expertSnapshots: unknown[] = [],
+    source = CoworkSessionSource.Manual,
   ) {
     const id = `session-${++this.sessionCounter}`;
     const session = {
@@ -101,6 +106,7 @@ class FakeCoworkStore {
       modelOverride,
       mode,
       workspaceId,
+      source,
       claudeSessionId: null,
       status: 'idle',
       messages: [] as Array<Record<string, unknown>>,
@@ -469,6 +475,7 @@ test('IM turns use workspace session configuration without disabling Pi tools', 
     activeSkillIds: [],
     modelOverride: '',
     mode: 'work',
+    source: CoworkSessionSource.Im,
   });
   expect(runtime.startCalls[0].options).toMatchObject({
     skillIds: [],
@@ -575,7 +582,9 @@ test('emits a matching terminal run event when a session fails while waiting for
     coworkRuntime: runtime,
     coworkStore,
     imStore,
-    activityService: { upsertBestEffort: (run: Record<string, unknown>) => activityUpdates.push(run) } as any,
+    activityService: {
+      upsertBestEffort: (run: Record<string, unknown>) => activityUpdates.push(run),
+    } as any,
   });
 
   const response = handler.processMessage(
@@ -622,7 +631,9 @@ test('closes a started run when existing-session setup fails before runtime exec
       if (failSkillsPrompt) throw new Error('skill prompt unavailable');
       return null;
     },
-    activityService: { upsertBestEffort: (run: Record<string, unknown>) => activityUpdates.push(run) } as any,
+    activityService: {
+      upsertBestEffort: (run: Record<string, unknown>) => activityUpdates.push(run),
+    } as any,
   });
 
   const firstResponse = handler.processMessage(

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -418,6 +418,8 @@ export class IMCoworkHandler extends EventEmitter {
       'work',
       undefined,
       workspace.id,
+      undefined,
+      'im',
     );
 
     // Save mapping

--- a/src/main/im/imCoworkHandler.ts
+++ b/src/main/im/imCoworkHandler.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'events';
 
 import { type CoworkError, CoworkErrorKind } from '../../common/coworkError';
 import { buildScheduledTaskEnginePrompt } from '../../scheduledTask/enginePrompt';
+import { CoworkSessionSource } from '../../shared/cowork/constants';
 import { ActivitySource, ActivityStatus } from '../../shared/activity/constants';
 import type { CoworkMessage, CoworkStore } from '../coworkStore';
 import type { ActivityService } from '../activity/activityService';
@@ -419,7 +420,7 @@ export class IMCoworkHandler extends EventEmitter {
       undefined,
       workspace.id,
       undefined,
-      'im',
+      CoworkSessionSource.Im,
     );
 
     // Save mapping

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -52,6 +52,7 @@ import {
   COWORK_SESSION_PAGE_SIZE,
   CoworkPermissionMode,
   CoworkSessionMode,
+  type CoworkSessionSource,
 } from '../shared/cowork/constants';
 import {
   type CoworkSessionExpertInput,
@@ -985,7 +986,8 @@ const startCcConnectBridge = async (): Promise<void> => {
     coworkStore: getCoworkStore(),
     imStore: new IMStore(getStore().getDatabase()),
     turnCoordinator: new ChannelTurnCoordinator(new ChannelInboxStore(getStore().getDatabase())),
-    activityService: activityService ?? (activityService = new ActivityService(getStore().getDatabase())),
+    activityService:
+      activityService ?? (activityService = new ActivityService(getStore().getDatabase())),
     getSkillsPrompt: async () => getSkillManager().buildAutoRoutingPrompt(),
     detectScheduledTaskRequest: createIMScheduledTaskRequestDetector({
       getLLMConfig: getScheduledTaskDetectorConfig,
@@ -3996,6 +3998,7 @@ if (!gotTheLock) {
         agentId?: string;
         workspaceId?: string;
         mode?: CoworkSessionMode;
+        sources?: CoworkSessionSource[];
       },
     ) => {
       try {
@@ -4004,9 +4007,10 @@ if (!gotTheLock) {
         const agentId = options?.agentId;
         const workspaceId = options?.workspaceId;
         const mode = options?.mode;
+        const sources = options?.sources;
         const store = getCoworkStore();
         const sessions = store
-          .listSessions(limit, offset, agentId, workspaceId, mode)
+          .listSessions(limit, offset, agentId, workspaceId, mode, sources)
           .map(session => {
             const reconciledSession = reconcileWorkSessionRuntimeState(
               session,
@@ -4017,7 +4021,7 @@ if (!gotTheLock) {
             }
             return reconciledSession;
           });
-        const total = store.countSessions(agentId, workspaceId, mode);
+        const total = store.countSessions(agentId, workspaceId, mode, sources);
         return { success: true, sessions, hasMore: offset + sessions.length < total };
       } catch (error) {
         return {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -39,7 +39,11 @@ import {
   WindowIpc,
   WeixinInstallIpc,
 } from '../shared/ipc/channels';
-import type { CoworkPermissionMode, CoworkSessionMode } from '../shared/cowork/constants';
+import type {
+  CoworkPermissionMode,
+  CoworkSessionMode,
+  CoworkSessionSource,
+} from '../shared/cowork/constants';
 import type { CoworkToolActivityEvent } from '../shared/cowork/toolActivity';
 import type { CoworkPendingMessage } from '../shared/cowork/pendingMessageQueue';
 import { LlamaCppIpcChannel } from '../shared/llamacpp/constants';
@@ -472,6 +476,7 @@ contextBridge.exposeInMainWorld('electron', {
       agentId?: string;
       workspaceId?: string;
       mode?: CoworkSessionMode;
+      sources?: CoworkSessionSource[];
     }) => ipcRenderer.invoke(CoworkSessionIpc.List, options),
     getSessionMessages: (options: { sessionId: string; limit?: number; offset?: number }) =>
       ipcRenderer.invoke(CoworkSessionIpc.GetMessages, options),

--- a/src/main/sqliteStore.test.ts
+++ b/src/main/sqliteStore.test.ts
@@ -10,6 +10,7 @@ import {
   DefaultAgentProfile,
   encodeAgentAvatarIcon,
 } from '../shared/agent';
+import { CoworkSessionSource } from '../shared/cowork/constants';
 
 vi.mock('electron', () => ({
   app: {
@@ -199,6 +200,67 @@ test('adds agent pin columns during migration', async () => {
   ]);
 
   store.close();
+});
+
+test('backfills legacy scheduled sessions only when adding the source column', async () => {
+  const userDataPath = createTempUserDataPath();
+  createLegacyDatabase(userDataPath);
+  const legacyDb = new Database(path.join(userDataPath, DB_FILENAME));
+  const now = Date.now();
+  legacyDb.exec(`
+    CREATE TABLE cowork_sessions (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      claude_session_id TEXT,
+      status TEXT NOT NULL DEFAULT 'idle',
+      mode TEXT NOT NULL DEFAULT 'work',
+      cwd TEXT NOT NULL,
+      system_prompt TEXT NOT NULL DEFAULT '',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  const insertLegacySession = legacyDb.prepare(`
+    INSERT INTO cowork_sessions
+      (id, title, status, mode, cwd, system_prompt, created_at, updated_at)
+    VALUES (?, ?, 'idle', 'work', '/repo', '', ?, ?)
+  `);
+  insertLegacySession.run('scheduled-cn', ' [定时]日报', now, now);
+  insertLegacySession.run('scheduled-en', '[Cron] report', now, now);
+  insertLegacySession.run('scheduled-executor', 'Scheduled: report', now, now);
+  insertLegacySession.run('manual', 'ordinary conversation', now, now);
+  legacyDb.close();
+
+  const store = await SqliteStore.create(userDataPath);
+  const migratedRows = store
+    .getDatabase()
+    .prepare('SELECT id, source FROM cowork_sessions ORDER BY id')
+    .all() as Array<{ id: string; source: string }>;
+
+  expect(migratedRows).toEqual([
+    { id: 'manual', source: CoworkSessionSource.Manual },
+    { id: 'scheduled-cn', source: CoworkSessionSource.Scheduled },
+    { id: 'scheduled-en', source: CoworkSessionSource.Scheduled },
+    { id: 'scheduled-executor', source: CoworkSessionSource.Scheduled },
+  ]);
+
+  store
+    .getDatabase()
+    .prepare(
+      `INSERT INTO cowork_sessions
+        (id, title, status, mode, pinned, cwd, system_prompt, source, created_at, updated_at)
+       VALUES (?, ?, 'idle', 'work', 0, '/repo', '', ?, ?, ?)`,
+    )
+    .run('manual-prefixed', '[Cron] user-authored title', CoworkSessionSource.Manual, now, now);
+  store.close();
+
+  const reopenedStore = await SqliteStore.create(userDataPath);
+  const reopenedRow = reopenedStore
+    .getDatabase()
+    .prepare('SELECT source FROM cowork_sessions WHERE id = ?')
+    .get('manual-prefixed') as { source: string };
+  expect(reopenedRow.source).toBe(CoworkSessionSource.Manual);
+  reopenedStore.close();
 });
 
 test('creates the artifact index after adding sequence to legacy messages', async () => {

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -13,6 +13,7 @@ import {
   LegacyAgentName,
   normalizeAgentAvatarIcon,
 } from '../shared/agent';
+import { CoworkScheduledSessionTitlePrefix, CoworkSessionSource } from '../shared/cowork/constants';
 import { DB_FILENAME } from './appConstants';
 import { initializeCoworkArtifactIndexSchema } from './coworkArtifactIndex';
 import {
@@ -99,26 +100,33 @@ export class SqliteStore {
         model_override TEXT NOT NULL DEFAULT '',
         execution_mode TEXT,
         workspace_id TEXT,
+        source TEXT NOT NULL DEFAULT '${CoworkSessionSource.Manual}',
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL
       );
     `);
 
-    // Session source classification (manual | scheduled | im). Existing rows
-    // created before this column existed are backfilled from their title
-    // prefix (the previous convention: [定时]/[Cron]/Scheduled:).
-    try {
-      this.db.exec(`
-        ALTER TABLE cowork_sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';
-      `);
-    } catch {
-      // Column already exists on upgraded databases; ignore.
+    const sessionColumns = this.db.pragma('table_info(cowork_sessions)') as Array<{
+      name: string;
+    }>;
+    if (!sessionColumns.some(column => column.name === 'source')) {
+      this.db.transaction(() => {
+        this.db.exec(`
+          ALTER TABLE cowork_sessions
+          ADD COLUMN source TEXT NOT NULL DEFAULT '${CoworkSessionSource.Manual}';
+        `);
+        const prefixes = Object.values(CoworkScheduledSessionTitlePrefix);
+        this.db
+          .prepare(
+            `
+              UPDATE cowork_sessions
+              SET source = ?
+              WHERE ${prefixes.map(() => 'TRIM(title) LIKE ?').join(' OR ')}
+            `,
+          )
+          .run(CoworkSessionSource.Scheduled, ...prefixes.map(prefix => `${prefix}%`));
+      })();
     }
-    this.db.exec(`
-      UPDATE cowork_sessions
-      SET source = 'scheduled'
-      WHERE title LIKE '[定时]%' OR title LIKE '[Cron]%' OR title LIKE 'Scheduled: %';
-    `);
 
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS workspaces (

--- a/src/main/sqliteStore.ts
+++ b/src/main/sqliteStore.ts
@@ -104,6 +104,22 @@ export class SqliteStore {
       );
     `);
 
+    // Session source classification (manual | scheduled | im). Existing rows
+    // created before this column existed are backfilled from their title
+    // prefix (the previous convention: [定时]/[Cron]/Scheduled:).
+    try {
+      this.db.exec(`
+        ALTER TABLE cowork_sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';
+      `);
+    } catch {
+      // Column already exists on upgraded databases; ignore.
+    }
+    this.db.exec(`
+      UPDATE cowork_sessions
+      SET source = 'scheduled'
+      WHERE title LIKE '[定时]%' OR title LIKE '[Cron]%' OR title LIKE 'Scheduled: %';
+    `);
+
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS workspaces (
         id TEXT PRIMARY KEY,

--- a/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
+++ b/src/renderer/components/agentSidebar/MyAgentSidebarTree.tsx
@@ -62,6 +62,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
     patchTaskPreview,
     removeTaskPreview,
     retryLoadTasks,
+    retryLoadScheduledTasks,
     loadMoreTasks,
     loadMoreScheduledTasks,
     collapseTasks,
@@ -123,8 +124,9 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
   const prefersReducedMotion = useReducedMotion();
   const [workspacePendingRemoval, setWorkspacePendingRemoval] =
     useState<WorkspaceSidebarNode | null>(null);
-  const [workspacePendingRename, setWorkspacePendingRename] =
-    useState<WorkspaceSidebarNode | null>(null);
+  const [workspacePendingRename, setWorkspacePendingRename] = useState<WorkspaceSidebarNode | null>(
+    null,
+  );
   const [workspaceRenameValue, setWorkspaceRenameValue] = useState('');
 
   const handleConfirmRemoveWorkspace = async () => {
@@ -325,7 +327,7 @@ const MyAgentSidebarTree: React.FC<MyAgentSidebarTreeProps> = ({
                   onRemoveWorkspace={selectedWorkspace =>
                     setWorkspacePendingRemoval(selectedWorkspace)
                   }
-                  onRetryLoadTasks={workspaceId => void retryLoadTasks(workspaceId)}
+                  onRetryLoadTasks={workspaceId => void retryLoadScheduledTasks(workspaceId)}
                   onLoadMoreTasks={workspaceId => void loadMoreScheduledTasks(workspaceId)}
                   onCollapseTasks={collapseScheduledTasks}
                   onSelectTask={task => void handleSelectTask(task)}

--- a/src/renderer/components/agentSidebar/constants.test.ts
+++ b/src/renderer/components/agentSidebar/constants.test.ts
@@ -8,6 +8,10 @@ describe('isScheduledSessionTitle', () => {
     expect(isScheduledSessionTitle('[Cron] daily report')).toBe(true);
   });
 
+  test('recognizes the legacy executor prefix for backfill parity', () => {
+    expect(isScheduledSessionTitle('Scheduled: daily report')).toBe(true);
+  });
+
   test('does not classify ordinary sessions by a later title fragment', () => {
     expect(isScheduledSessionTitle('计算题 [定时]')).toBe(false);
     expect(isScheduledSessionTitle('普通会话')).toBe(false);

--- a/src/renderer/components/agentSidebar/constants.ts
+++ b/src/renderer/components/agentSidebar/constants.ts
@@ -16,9 +16,16 @@ export const AgentSidebarPageSize = {
   AllBatch: 100,
 } as const;
 
+/**
+ * Legacy title-prefix convention for scheduled sessions. New sessions carry
+ * an explicit `source` column instead; this predicate is retained only for
+ * backfilling pre-source databases (see the cowork_sessions migration) and
+ * must stay in sync with that SQL.
+ */
 export const ScheduledSessionTitlePrefix = {
   Chinese: '[定时]',
   English: '[Cron]',
+  Legacy: 'Scheduled: ',
 } as const;
 
 export const isScheduledSessionTitle = (title: string): boolean => {

--- a/src/renderer/components/agentSidebar/constants.ts
+++ b/src/renderer/components/agentSidebar/constants.ts
@@ -22,11 +22,7 @@ export const AgentSidebarPageSize = {
  * backfilling pre-source databases (see the cowork_sessions migration) and
  * must stay in sync with that SQL.
  */
-export const ScheduledSessionTitlePrefix = {
-  Chinese: '[定时]',
-  English: '[Cron]',
-  Legacy: 'Scheduled: ',
-} as const;
+export const ScheduledSessionTitlePrefix = CoworkScheduledSessionTitlePrefix;
 
 export const isScheduledSessionTitle = (title: string): boolean => {
   const normalizedTitle = title.trim();
@@ -34,3 +30,4 @@ export const isScheduledSessionTitle = (title: string): boolean => {
     normalizedTitle.startsWith(prefix),
   );
 };
+import { CoworkScheduledSessionTitlePrefix } from '../../../shared/cowork/constants';

--- a/src/renderer/components/agentSidebar/useAgentSidebarState.test.ts
+++ b/src/renderer/components/agentSidebar/useAgentSidebarState.test.ts
@@ -1,14 +1,12 @@
 import { expect, test } from 'vitest';
 
+import { CoworkSessionSource } from '../../../shared/cowork/constants';
 import {
   type CoworkSessionStatus,
   CoworkSessionStatusValue,
   type CoworkSessionSummary,
 } from '../../types/cowork';
-import {
-  deriveAgentSidebarIndicator,
-  sortAgentSidebarTasks,
-} from './useAgentSidebarState';
+import { deriveAgentSidebarIndicator, sortAgentSidebarTasks } from './useAgentSidebarState';
 import { AgentSidebarIndicator } from './constants';
 
 const makeSession = (
@@ -25,6 +23,7 @@ const makeSession = (
   pinned,
   pinOrder,
   agentId: 'main',
+  source: CoworkSessionSource.Manual,
   createdAt,
   updatedAt,
 });

--- a/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
@@ -16,7 +16,7 @@ import { WorkMode, type WorkMode as WorkModeType } from '../../store/workMode/co
 import type { CoworkSessionSummary } from '../../types/cowork';
 import { CoworkSessionStatusValue } from '../../types/cowork';
 import { isScratchWorkspacePath } from '../../utils/path';
-import { AgentSidebarIndicator, AgentSidebarPageSize, isScheduledSessionTitle } from './constants';
+import { AgentSidebarIndicator, AgentSidebarPageSize } from './constants';
 import type {
   AgentSidebarTaskNode,
   WorkspaceSidebarNode,
@@ -286,7 +286,7 @@ export const useWorkspaceSidebarState = (
             session =>
               isSessionOwnedByWorkspace(session, workspace.id) &&
               modeMatches(session, workMode) &&
-              isScheduledSessionTitle(session.title) === scheduled,
+              (session.source === 'scheduled') === scheduled,
           ),
         );
         const expanded = expandedWorkspaceIds.includes(workspace.id);
@@ -362,7 +362,7 @@ export const useWorkspaceSidebarState = (
         const tasks = sortTasks(
           (searchSource[node.id] ?? []).filter(
             session =>
-              isScheduledSessionTitle(session.title) === scheduled &&
+              (session.source === 'scheduled') === scheduled &&
               session.title.toLowerCase().includes(query),
           ),
         );

--- a/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
+++ b/src/renderer/components/agentSidebar/useWorkspaceSidebarState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { CoworkSessionMode } from '../../../shared/cowork/constants';
+import { CoworkSessionMode, CoworkSessionSource } from '../../../shared/cowork/constants';
 import { coworkService } from '../../services/cowork';
 import { i18nService } from '../../services/i18n';
 import { localStore } from '../../services/store';
@@ -34,6 +34,17 @@ const modeMatches = (session: CoworkSessionSummary, workMode: WorkModeType) =>
   workMode === WorkMode.Chat
     ? session.mode === CoworkSessionMode.Chat
     : session.mode !== CoworkSessionMode.Chat;
+
+const isScheduledSession = (session: CoworkSessionSummary): boolean =>
+  session.source === CoworkSessionSource.Scheduled;
+
+const sourcesForGroup = (scheduled: boolean) =>
+  scheduled
+    ? [CoworkSessionSource.Scheduled]
+    : [CoworkSessionSource.Manual, CoworkSessionSource.Im];
+
+const workspaceGroupKey = (workspaceId: string, scheduled: boolean): string =>
+  `${workspaceId}:${scheduled ? CoworkSessionSource.Scheduled : CoworkSessionSource.Manual}`;
 
 const toTaskNode = (
   session: CoworkSessionSummary,
@@ -81,10 +92,7 @@ export const useWorkspaceSidebarState = (
   const streamingSessionIds = useSelector(selectStreamingSessionIds);
   const unreadSessionIds = useDeferredValue(useSelector(selectUnreadSessionIds));
   const unreadSet = useMemo(() => new Set(unreadSessionIds), [unreadSessionIds]);
-  const streamingSessionIdSet = useMemo(
-    () => new Set(streamingSessionIds),
-    [streamingSessionIds],
-  );
+  const streamingSessionIdSet = useMemo(() => new Set(streamingSessionIds), [streamingSessionIds]);
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
   const [expandedTaskIds, setExpandedTaskIds] = useState<string[]>([]);
   const [scheduledExpandedIds, setScheduledExpandedIds] = useState<string[]>([]);
@@ -92,18 +100,19 @@ export const useWorkspaceSidebarState = (
   const [preferencesHydrated, setPreferencesHydrated] = useState(false);
   const [previews, setPreviews] = useState<Record<string, CoworkSessionSummary[]>>({});
   const [hasMore, setHasMore] = useState<Record<string, boolean>>({});
-  const [loadingIds, setLoadingIds] = useState<string[]>([]);
-  const [failedIds, setFailedIds] = useState<string[]>([]);
+  const [loadingKeys, setLoadingKeys] = useState<string[]>([]);
+  const [failedKeys, setFailedKeys] = useState<string[]>([]);
   const loadingKeysRef = useRef(new Set<string>());
+  const loadedGroupsRef = useRef(new Set<string>());
   const hasStoredPreferenceRef = useRef(false);
 
-  const setLoading = useCallback((id: string, loading: boolean) => {
-    setLoadingIds(current =>
+  const setLoading = useCallback((key: string, loading: boolean) => {
+    setLoadingKeys(current =>
       loading
-        ? current.includes(id)
+        ? current.includes(key)
           ? current
-          : [...current, id]
-        : current.filter(value => value !== id),
+          : [...current, key]
+        : current.filter(value => value !== key),
     );
   }, []);
 
@@ -163,34 +172,39 @@ export const useWorkspaceSidebarState = (
   ]);
 
   const loadWorkspaceTasks = useCallback(
-    async (workspaceId: string, offset = 0, replace = offset === 0) => {
-      const key = `${workspaceId}:${offset}`;
-      if (loadingKeysRef.current.has(key)) return;
-      loadingKeysRef.current.add(key);
-      setLoading(workspaceId, true);
-      setFailedIds(current => current.filter(id => id !== workspaceId));
+    async (workspaceId: string, scheduled: boolean, offset = 0, replace = offset === 0) => {
+      const groupKey = workspaceGroupKey(workspaceId, scheduled);
+      const requestKey = `${groupKey}:${offset}`;
+      if (loadingKeysRef.current.has(requestKey)) return;
+      loadingKeysRef.current.add(requestKey);
+      setLoading(groupKey, true);
+      setFailedKeys(current => current.filter(key => key !== groupKey));
       try {
         const result = await coworkService.listSessionsForWorkspacePreview(
           workspaceId,
           AgentSidebarPageSize.Preview,
           offset,
+          sourcesForGroup(scheduled),
         );
         if (!result.success) {
-          setFailedIds(current =>
-            current.includes(workspaceId) ? current : [...current, workspaceId],
-          );
+          setFailedKeys(current => (current.includes(groupKey) ? current : [...current, groupKey]));
           return;
         }
         setPreviews(current => ({
           ...current,
           [workspaceId]: replace
-            ? (result.sessions ?? [])
+            ? [
+                ...(current[workspaceId] ?? []).filter(
+                  session => isScheduledSession(session) !== scheduled,
+                ),
+                ...(result.sessions ?? []),
+              ]
             : mergeSessionSummaries(current[workspaceId] ?? [], result.sessions ?? []),
         }));
-        setHasMore(current => ({ ...current, [workspaceId]: result.hasMore ?? false }));
+        setHasMore(current => ({ ...current, [groupKey]: result.hasMore ?? false }));
       } finally {
-        loadingKeysRef.current.delete(key);
-        setLoading(workspaceId, false);
+        loadingKeysRef.current.delete(requestKey);
+        setLoading(groupKey, false);
       }
     },
     [setLoading],
@@ -198,9 +212,14 @@ export const useWorkspaceSidebarState = (
 
   useEffect(() => {
     workspaces.forEach(workspace => {
-      if (!previews[workspace.id]) void loadWorkspaceTasks(workspace.id);
+      for (const scheduled of [false, true]) {
+        const groupKey = workspaceGroupKey(workspace.id, scheduled);
+        if (loadedGroupsRef.current.has(groupKey)) continue;
+        loadedGroupsRef.current.add(groupKey);
+        void loadWorkspaceTasks(workspace.id, scheduled);
+      }
     });
-  }, [loadWorkspaceTasks, previews, workspaces]);
+  }, [loadWorkspaceTasks, workspaces]);
 
   useEffect(() => {
     setPreviews(current =>
@@ -228,9 +247,12 @@ export const useWorkspaceSidebarState = (
       setExpandedTaskIds(current =>
         current.includes(workspaceId) ? current : [...current, workspaceId],
       );
-      const current = previews[workspaceId] ?? [];
-      if (!hasMore[workspaceId]) return;
-      await loadWorkspaceTasks(workspaceId, current.length, false);
+      const groupKey = workspaceGroupKey(workspaceId, false);
+      const offset = (previews[workspaceId] ?? []).filter(
+        session => !isScheduledSession(session),
+      ).length;
+      if (!hasMore[groupKey]) return;
+      await loadWorkspaceTasks(workspaceId, false, offset, false);
     },
     [hasMore, loadWorkspaceTasks, previews],
   );
@@ -239,14 +261,19 @@ export const useWorkspaceSidebarState = (
       setScheduledExpandedTaskIds(current =>
         current.includes(workspaceId) ? current : [...current, workspaceId],
       );
-      const current = previews[workspaceId] ?? [];
-      if (!hasMore[workspaceId]) return;
-      await loadWorkspaceTasks(workspaceId, current.length, false);
+      const groupKey = workspaceGroupKey(workspaceId, true);
+      const offset = (previews[workspaceId] ?? []).filter(isScheduledSession).length;
+      if (!hasMore[groupKey]) return;
+      await loadWorkspaceTasks(workspaceId, true, offset, false);
     },
     [hasMore, loadWorkspaceTasks, previews],
   );
   const retryLoadTasks = useCallback(
-    (workspaceId: string) => loadWorkspaceTasks(workspaceId, 0, true),
+    (workspaceId: string) => loadWorkspaceTasks(workspaceId, false, 0, true),
+    [loadWorkspaceTasks],
+  );
+  const retryLoadScheduledTasks = useCallback(
+    (workspaceId: string) => loadWorkspaceTasks(workspaceId, true, 0, true),
     [loadWorkspaceTasks],
   );
   const patchTaskPreview = useCallback(
@@ -280,45 +307,48 @@ export const useWorkspaceSidebarState = (
 
   const buildWorkspaceNodes = useCallback(
     (scheduled: boolean, expandedWorkspaceIds: string[], expandedTaskListIds: string[]) =>
-      workspaces.filter(workspace => !workspace.isHidden).map(workspace => {
-        const filtered = sortTasks(
-          (previews[workspace.id] ?? []).filter(
-            session =>
-              isSessionOwnedByWorkspace(session, workspace.id) &&
-              modeMatches(session, workMode) &&
-              (session.source === 'scheduled') === scheduled,
-          ),
-        );
-        const expanded = expandedWorkspaceIds.includes(workspace.id);
-        const taskExpanded = expandedTaskListIds.includes(workspace.id);
-        const visible = taskExpanded ? filtered : filtered.slice(0, AgentSidebarPageSize.Preview);
-        return {
-          id: workspace.id,
-          // The scratch workspace (「不使用文件夹」) displays as 默认对话 instead
-          // of its folder basename.
-          name: isScratchWorkspacePath(workspace.path)
-            ? i18nService.t('defaultConversation')
-            : workspace.name,
-          path: workspace.path,
-          pinned: workspace.pinned,
-          isExpanded: expanded,
-          isTaskListExpanded: taskExpanded,
-          canExpandTasks:
-            !taskExpanded &&
-            ((hasMore[workspace.id] ?? false) || filtered.length > AgentSidebarPageSize.Preview),
-          canCollapseTasks: taskExpanded && filtered.length > AgentSidebarPageSize.Preview,
-          isLoadingTasks: loadingIds.includes(workspace.id),
-          hasLoadError: failedIds.includes(workspace.id),
-          tasks: visible.map(session =>
-            toTaskNode(session, currentSessionId, unreadSet, streamingSessionIdSet),
-          ),
-        } satisfies WorkspaceSidebarNode;
-      }),
+      workspaces
+        .filter(workspace => !workspace.isHidden)
+        .map(workspace => {
+          const groupKey = workspaceGroupKey(workspace.id, scheduled);
+          const filtered = sortTasks(
+            (previews[workspace.id] ?? []).filter(
+              session =>
+                isSessionOwnedByWorkspace(session, workspace.id) &&
+                modeMatches(session, workMode) &&
+                isScheduledSession(session) === scheduled,
+            ),
+          );
+          const expanded = expandedWorkspaceIds.includes(workspace.id);
+          const taskExpanded = expandedTaskListIds.includes(workspace.id);
+          const visible = taskExpanded ? filtered : filtered.slice(0, AgentSidebarPageSize.Preview);
+          return {
+            id: workspace.id,
+            // The scratch workspace (「不使用文件夹」) displays as 默认对话 instead
+            // of its folder basename.
+            name: isScratchWorkspacePath(workspace.path)
+              ? i18nService.t('defaultConversation')
+              : workspace.name,
+            path: workspace.path,
+            pinned: workspace.pinned,
+            isExpanded: expanded,
+            isTaskListExpanded: taskExpanded,
+            canExpandTasks:
+              !taskExpanded &&
+              ((hasMore[groupKey] ?? false) || filtered.length > AgentSidebarPageSize.Preview),
+            canCollapseTasks: taskExpanded && filtered.length > AgentSidebarPageSize.Preview,
+            isLoadingTasks: loadingKeys.includes(groupKey),
+            hasLoadError: failedKeys.includes(groupKey),
+            tasks: visible.map(session =>
+              toTaskNode(session, currentSessionId, unreadSet, streamingSessionIdSet),
+            ),
+          } satisfies WorkspaceSidebarNode;
+        }),
     [
       currentSessionId,
-      failedIds,
+      failedKeys,
       hasMore,
-      loadingIds,
+      loadingKeys,
       previews,
       streamingSessionIdSet,
       unreadSet,
@@ -362,7 +392,7 @@ export const useWorkspaceSidebarState = (
         const tasks = sortTasks(
           (searchSource[node.id] ?? []).filter(
             session =>
-              (session.source === 'scheduled') === scheduled &&
+              isScheduledSession(session) === scheduled &&
               session.title.toLowerCase().includes(query),
           ),
         );
@@ -412,6 +442,7 @@ export const useWorkspaceSidebarState = (
     patchTaskPreview,
     removeTaskPreview,
     retryLoadTasks,
+    retryLoadScheduledTasks,
     loadMoreTasks,
     loadMoreScheduledTasks,
     collapseTasks,

--- a/src/renderer/components/agentSidebar/workspaceSessionPreviews.test.ts
+++ b/src/renderer/components/agentSidebar/workspaceSessionPreviews.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { CoworkSessionMode } from '../../../shared/cowork/constants';
+import { CoworkSessionMode, CoworkSessionSource } from '../../../shared/cowork/constants';
 import { CoworkSessionStatusValue, type CoworkSessionSummary } from '../../types/cowork';
 import {
   isSessionOwnedByWorkspace,
@@ -14,6 +14,7 @@ const makeSession = (id: string, workspaceId: string): CoworkSessionSummary => (
   status: CoworkSessionStatusValue.Completed,
   mode: CoworkSessionMode.Work,
   pinned: false,
+  source: CoworkSessionSource.Manual,
   createdAt: 1,
   updatedAt: 1,
 });

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -5,7 +5,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { buildSessionTitleFromInput } from '../../../common/sessionTitle';
-import { CoworkPermissionMode, CoworkSessionMode } from '../../../shared/cowork/constants';
+import {
+  CoworkPermissionMode,
+  CoworkSessionMode,
+  CoworkSessionSource,
+} from '../../../shared/cowork/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { agentService } from '../../services/agent';
@@ -147,12 +151,15 @@ const isDirectChatSessionMetrics = (value: unknown): value is DirectChatSessionM
   const start = data.requestStartedAt;
   const first = data.firstVisibleTextAt;
   const end = data.completedAt;
-  return typeof start === 'number'
-    && typeof end === 'number'
-    && Number.isFinite(start)
-    && Number.isFinite(end)
-    && end >= start
-    && (first === undefined || (typeof first === 'number' && Number.isFinite(first) && first >= start && first <= end));
+  return (
+    typeof start === 'number' &&
+    typeof end === 'number' &&
+    Number.isFinite(start) &&
+    Number.isFinite(end) &&
+    end >= start &&
+    (first === undefined ||
+      (typeof first === 'number' && Number.isFinite(first) && first >= start && first <= end))
+  );
 };
 
 const CoworkView: React.FC<CoworkViewProps> = ({
@@ -419,13 +426,12 @@ const CoworkView: React.FC<CoworkViewProps> = ({
         updatedAt: now,
         cwd: currentWorkspacePath,
         systemPrompt: '',
-        modelOverride: currentAgentSelectedModel
-          ? toAgentModelRef(currentAgentSelectedModel)
-          : '',
+        modelOverride: currentAgentSelectedModel ? toAgentModelRef(currentAgentSelectedModel) : '',
         executionMode: config.executionMode || 'local',
         activeSkillIds: sessionSkillIds,
         workspaceId: currentWorkspaceId || '',
         agentId: currentAgentId,
+        source: CoworkSessionSource.Manual,
         messages: [
           {
             id: `msg-${now}`,

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -10,6 +10,7 @@ import {
   COWORK_SESSION_PAGE_SIZE,
   CoworkPermissionOrigin,
   CoworkSessionMode,
+  type CoworkSessionSource,
 } from '../../shared/cowork/constants';
 import { store } from '../store';
 import { setCurrentAgentId } from '../store/slices/agentSlice';
@@ -336,12 +337,14 @@ class CoworkService {
     workspaceId: string,
     limit: number,
     offset: number,
+    sources: CoworkSessionSource[],
   ): Promise<CoworkSessionListResult> {
     const result = await window.electron?.cowork?.listSessions({
       limit,
       offset,
       workspaceId: workspaceService.isWorkspaceApiAvailable() ? workspaceId : undefined,
       mode: CoworkSessionMode.Work,
+      sources,
     });
     return result ?? { success: false, error: 'Cowork IPC is unavailable' };
   }
@@ -657,7 +660,8 @@ class CoworkService {
     const requestId = ++this.latestLoadSessionRequestId;
 
     const result = await cowork.getSession(sessionId);
-    if (result.success && result.session) {      // Keep only the latest session load result to avoid stale async overwrites.
+    if (result.success && result.session) {
+      // Keep only the latest session load result to avoid stale async overwrites.
       if (requestId !== this.latestLoadSessionRequestId) {
         return result.session;
       }

--- a/src/renderer/store/slices/coworkSlice.test.ts
+++ b/src/renderer/store/slices/coworkSlice.test.ts
@@ -1,6 +1,10 @@
 import { expect, test } from 'vitest';
 
-import { CoworkPermissionMode, CoworkPermissionOrigin } from '../../../shared/cowork/constants';
+import {
+  CoworkPermissionMode,
+  CoworkPermissionOrigin,
+  CoworkSessionSource,
+} from '../../../shared/cowork/constants';
 import {
   CoworkToolActivityEventType,
   CoworkToolActivityPhase,
@@ -39,6 +43,7 @@ const makeSession = (overrides: Partial<Parameters<typeof addSession>[0]> = {}) 
   activeSkillIds: [],
   workspaceId: 'workspace-test',
   agentId: 'main',
+  source: CoworkSessionSource.Manual,
   messages: [],
   messagesOffset: 0,
   totalMessages: 0,
@@ -178,6 +183,15 @@ test('addSession preserves the agent id in session summaries', () => {
   expect(state.sessions[0].agentId).toBe('agent-2');
 });
 
+test('addSession preserves the source in session summaries', () => {
+  const state = coworkReducer(
+    undefined,
+    addSession(makeSession({ source: CoworkSessionSource.Scheduled })),
+  );
+
+  expect(state.sessions[0].source).toBe(CoworkSessionSource.Scheduled);
+});
+
 test('chat sessions use the chat cache without invalidating work sessions', () => {
   const chatState = coworkReducer(
     undefined,
@@ -267,6 +281,7 @@ test('updateSessionStatus marks completed inactive sessions unread', () => {
         status: CoworkSessionStatusValue.Running,
         pinned: false,
         agentId: 'main',
+        source: CoworkSessionSource.Manual,
         createdAt: 1,
         updatedAt: 1,
       },
@@ -295,6 +310,7 @@ test('updateSessionStatus does not mark the active completed session unread', ()
           status: CoworkSessionStatusValue.Running,
           pinned: false,
           agentId: 'main',
+          source: CoworkSessionSource.Manual,
           createdAt: 1,
           updatedAt: 1,
         },

--- a/src/renderer/store/slices/coworkSlice.ts
+++ b/src/renderer/store/slices/coworkSlice.ts
@@ -159,6 +159,7 @@ const toSessionSummary = (session: CoworkSession): CoworkSessionSummary => ({
   pinOrder: session.pinOrder ?? null,
   workspaceId: session.workspaceId,
   agentId: session.agentId,
+  source: session.source,
   createdAt: session.createdAt,
   updatedAt: session.updatedAt,
 });

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -234,6 +234,8 @@ export interface CoworkSessionSummary {
   pinOrder?: number | null;
   workspaceId?: string;
   agentId?: string;
+  /** Origin of the session: user-created, scheduled task, or IM channel. */
+  source?: 'manual' | 'scheduled' | 'im';
   createdAt: number;
   updatedAt: number;
 }

--- a/src/renderer/types/cowork.ts
+++ b/src/renderer/types/cowork.ts
@@ -3,6 +3,7 @@ import type {
   CoworkPermissionMode,
   CoworkPermissionOrigin,
   CoworkSessionMode,
+  CoworkSessionSource,
 } from '../../shared/cowork/constants';
 import type { CoworkPersistedArtifact } from '../../shared/cowork/artifacts';
 import type {
@@ -118,6 +119,7 @@ export interface CoworkSession {
   activeSkillIds: string[];
   workspaceId: string;
   agentId: string;
+  source: CoworkSessionSource;
   experts?: CoworkSessionExpertSnapshot[];
   messages: CoworkMessage[];
   /** Offset of the first loaded message in the full message history. 0 means loaded from the beginning. */
@@ -234,8 +236,7 @@ export interface CoworkSessionSummary {
   pinOrder?: number | null;
   workspaceId?: string;
   agentId?: string;
-  /** Origin of the session: user-created, scheduled task, or IM channel. */
-  source?: 'manual' | 'scheduled' | 'im';
+  source: CoworkSessionSource;
   createdAt: number;
   updatedAt: number;
 }

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -6,6 +6,7 @@ import type {
   CoworkPermissionMode,
   CoworkPermissionOrigin,
   CoworkSessionMode,
+  CoworkSessionSource,
 } from '../../shared/cowork/constants';
 import type { CoworkPendingMessage } from '../../shared/cowork/pendingMessageQueue';
 import type { CoworkToolActivityEvent } from '../../shared/cowork/toolActivity';
@@ -99,6 +100,7 @@ interface CoworkSession {
   activeSkillIds: string[];
   workspaceId: string;
   agentId: string;
+  source: CoworkSessionSource;
   messages: CoworkMessage[];
   messagesOffset: number;
   totalMessages: number;
@@ -122,6 +124,7 @@ interface CoworkSessionSummary {
   pinOrder?: number | null;
   workspaceId?: string;
   agentId?: string;
+  source: CoworkSessionSource;
   createdAt: number;
   updatedAt: number;
 }
@@ -791,6 +794,7 @@ interface IElectronAPI {
       agentId?: string;
       workspaceId?: string;
       mode?: CoworkSessionMode;
+      sources?: CoworkSessionSource[];
     }) => Promise<{
       success: boolean;
       sessions?: CoworkSessionSummary[];

--- a/src/scheduledTask/piScheduledTaskExecutor.test.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.test.ts
@@ -115,6 +115,8 @@ test('runs a canonical task in its workspace and waits for complete', async () =
     'work',
     undefined,
     task.workspaceId,
+    [],
+    'scheduled',
   );
   expect(startSession).toHaveBeenCalledWith(
     session.id,

--- a/src/scheduledTask/piScheduledTaskExecutor.test.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'node:events';
 import { expect, test, vi } from 'vitest';
 
+import { CoworkSessionSource } from '../shared/cowork/constants';
+
 import {
   DeliveryMode,
   PayloadKind,
@@ -116,7 +118,7 @@ test('runs a canonical task in its workspace and waits for complete', async () =
     undefined,
     task.workspaceId,
     [],
-    'scheduled',
+    CoworkSessionSource.Scheduled,
   );
   expect(startSession).toHaveBeenCalledWith(
     session.id,

--- a/src/scheduledTask/piScheduledTaskExecutor.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.ts
@@ -3,6 +3,7 @@ import type { CoworkError } from '../common/coworkError';
 import type { PiRuntime } from '../main/libs/agentEngine/piRuntimeTypes';
 import { getDefaultConversationWorkspacePath } from '../main/defaultConversationWorkspace';
 import { parseManagedSessionKey } from '../main/libs/channelSessionKey';
+import { CoworkSessionSource } from '../shared/cowork/constants';
 
 import { PayloadKind, SessionTarget } from './constants';
 import type { ScheduledTask, ScheduledTaskRun } from './types';
@@ -70,7 +71,7 @@ export class PiScheduledTaskExecutor {
       undefined,
       workspace?.id,
       [],
-      'scheduled',
+      CoworkSessionSource.Scheduled,
     );
   }
 

--- a/src/scheduledTask/piScheduledTaskExecutor.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.ts
@@ -69,6 +69,8 @@ export class PiScheduledTaskExecutor {
       'work',
       undefined,
       workspace?.id,
+      [],
+      'scheduled',
     );
   }
 

--- a/src/shared/cowork/constants.ts
+++ b/src/shared/cowork/constants.ts
@@ -14,6 +14,20 @@ export const CoworkSessionMode = {
 
 export type CoworkSessionMode = (typeof CoworkSessionMode)[keyof typeof CoworkSessionMode];
 
+export const CoworkSessionSource = {
+  Manual: 'manual',
+  Scheduled: 'scheduled',
+  Im: 'im',
+} as const;
+
+export type CoworkSessionSource = (typeof CoworkSessionSource)[keyof typeof CoworkSessionSource];
+
+export const CoworkScheduledSessionTitlePrefix = {
+  Chinese: '[定时]',
+  English: '[Cron]',
+  Legacy: 'Scheduled: ',
+} as const;
+
 /**
  * Desktop permission mode for cowork sessions.
  * Ask: the agent requests authorization before acting (current behavior).


### PR DESCRIPTION
## 背景

侧边栏“自动化”区域原先按会话标题前缀（`[定时]` / `[Cron]`）识别定时任务，但执行器实际使用 `Scheduled: <任务名>`。这会同时造成定时会话漏显，以及用户可编辑标题带来的误分类。

## 方案

引入会话来源字段 `source`（`manual` | `scheduled` | `im`），将分类依据从可编辑标题改为系统写入的来源标记。

- **可靠迁移**：新数据库直接创建带 `source` 的表；旧数据库通过 `PRAGMA table_info` 检测缺列，并在同一个事务中执行 `ALTER TABLE` 与三种旧标题前缀的历史回填。迁移完成后不再按标题重复改写，避免后续用户手动标题被误分类。
- **统一契约**：在共享常量中集中定义会话来源及旧标题前缀，主进程、渲染进程、定时任务和 IM 创建端共用同一类型与常量。
- **创建端标记**：手动、定时任务、IM 会话分别写入 `manual`、`scheduled`、`im`。
- **服务端筛选**：`listSessions` 和 `countSessions` 支持 `sources` 条件，并通过 IPC、preload 和 renderer service 全链路传递。
- **独立分页**：普通会话（`manual` + `im`）和自动化会话（`scheduled`）分别维护加载、失败、offset 和 hasMore 状态，避免一类数据占满分页窗口导致另一类会话不可见。
- **状态传播**：完整会话、摘要、Electron 声明和 Redux summary 均保留 `source`，确保实时创建与重新加载后的分类一致。

## 迁移覆盖

- **生产端旧数据库**：当前线上 schema 不含 `source`，升级后会走一次性事务迁移并回填历史定时会话。
- **开发者旧数据库**：未运行过本分支的数据库走同一路径；运行过 PR 早期版本的数据库已经由旧逻辑加列并回填，新版本会识别已有列且不重复改写。
- **全新安装**：直接使用包含 `source` 的最终 schema，无需额外迁移。

## 验证

- Electron ABI 下 SQLite / Cowork Store：28 / 28 通过
- 侧边栏、Redux、IM、定时执行器等聚焦测试：46 / 46 通过，1 个既有 skip
- Renderer TypeScript：通过
- Electron TypeScript：通过
- `npm run lint`：通过
- `npm run build`：通过（仅既有非阻断 Vite / Rolldown 警告）
- `git diff --check`：通过

## 关联

- 修复定时任务会话不显示在侧边栏“自动化”区域
- 修复混合来源数据分页时的漏显问题
