### PR TITLE
fix(experts): 按选中 agent 解析团队快照，subagent 成员实时读取

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -58,6 +58,7 @@ import {
 } from '../../../shared/providers';
 import type { CoworkMessage } from '../../coworkStore';
 import type { CoworkStore } from '../../coworkStore';
+import { resolveBundledPresetMembers } from '../../presetExpertSnapshot';
 import { buildPiConversationHistoryTool } from '../../conversationHistory/piTool';
 import type { ConversationHistoryService } from '../../conversationHistory/service';
 import { t } from '../../i18n';
@@ -886,6 +887,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const subagentTool = buildPiSubagentTool({
         getPiAgentsDir: () => this.getPiAgentsDir(),
         presetId: subagentPresetId,
+        loadBundledMembers: subagentPresetId
+          ? presetId =>
+              this.resolveBundledMemberProfiles(presetId)?.map(member => ({
+                ...member,
+                source: 'member' as const,
+              })) ?? null
+          : undefined,
         resolvedModel,
         workspaceRoot,
         webSearchSkillPath:
@@ -3110,6 +3118,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     return path.join(configDir, 'agents');
   }
 
+  /**
+   * Live team member definitions for bundled presets. Returns null when the
+   * preset is not bundled, so the subagent tool falls back to the synced pi
+   * agents files (user-imported packages).
+   */
+  private resolveBundledMemberProfiles(
+    presetId: string,
+  ): Array<{ id: string; description: string; systemPrompt: string }> | null {
+    return resolveBundledPresetMembers(getSkillsRoot(), presetId);
+  }
   private createWorkbenchContract(
     sessionMode: PiStartOptions['sessionMode'],
     skillIds: string[] | undefined,

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -495,6 +495,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   >();
   private store: CoworkStore | null = null;
   private mcpServerManager: McpServerManager | null = null;
+  private bundledSkillsRoot: string | null = null;
   /**
    * Pi custom tools are fixed when a session is created. Bump this whenever
    * MCP discovery changes so the next user turn recreates an outdated session
@@ -511,6 +512,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
   setCoworkStore(store: CoworkStore): void {
     this.store = store;
+  }
+  /**
+   * Bundled SKILLs root (resources/SKILLs in production). Injected so the
+   * live member source matches the main-session preset snapshot; getSkillsRoot
+   * alone is wrong in packaged builds, where it resolves to the userData copy
+   * that can drift from the bundled truth.
+   */
+  setBundledSkillsRoot(root: string): void {
+    this.bundledSkillsRoot = root;
   }
   setProjectMemoryService(service: ProjectMemoryService): void {
     this.projectMemoryService = service;
@@ -3126,7 +3136,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private resolveBundledMemberProfiles(
     presetId: string,
   ): Array<{ id: string; description: string; systemPrompt: string }> | null {
-    return resolveBundledPresetMembers(getSkillsRoot(), presetId);
+    return resolveBundledPresetMembers(this.bundledSkillsRoot ?? getSkillsRoot(), presetId);
   }
   private createWorkbenchContract(
     sessionMode: PiStartOptions['sessionMode'],

--- a/src/main/libs/agentEngine/piSubagentTool.test.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.test.ts
@@ -264,6 +264,39 @@ describe('buildPiSubagentTool', () => {
       }
     });
 
+    it('prefers live bundled member definitions over synced pi agents files', async () => {
+      const agentsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-subagent-test-'));
+      try {
+        // Stale synced copy: would be used if the bundled source were absent.
+        fs.writeFileSync(
+          path.join(agentsDir, 'team1--custom-member.md'),
+          '---\ndescription: Stale member\n---\nYou are the stale member definition.\n',
+        );
+
+        const { tool, deps } = buildTool({
+          getPiAgentsDir: () => agentsDir,
+          presetId: 'team1',
+          loadBundledMembers: () => [
+            {
+              id: 'custom-member',
+              description: 'Live member',
+              systemPrompt: 'You are the live bundled member definition.',
+            },
+          ],
+        });
+
+        expect(tool.description).toContain('Live member');
+        await tool.execute('call-1', { agent: 'custom-member', task: 'help out' });
+        expect(deps.createPiResourceLoader).toHaveBeenCalledWith(
+          '/tmp/workspace',
+          'You are the live bundled member definition.',
+          4096,
+        );
+      } finally {
+        fs.rmSync(agentsDir, { recursive: true, force: true });
+      }
+    });
+
     it('does not let a team member override the production reviewer', async () => {
       const agentsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-subagent-test-'));
       try {

--- a/src/main/libs/agentEngine/piSubagentTool.ts
+++ b/src/main/libs/agentEngine/piSubagentTool.ts
@@ -93,6 +93,14 @@ export interface PiSubagentToolDeps {
   getPiAgentsDir(): string;
   /** Team preset id; when set, member agents `<presetId>--<agentId>.md` are exposed. */
   presetId?: string | null;
+  /**
+   * Live bundled member source. When the preset ships inside the app's
+   * bundled SKILLs, member definitions are read from disk per session so
+   * editing a member file takes effect without re-importing; falls back to
+   * the synced pi agents directory when absent or when the preset is a
+   * user-imported package.
+   */
+  loadBundledMembers?: (presetId: string) => SubagentProfile[] | null;
   resolvedModel: PiSubagentResolvedModel;
   workspaceRoot?: string;
   /** Absolute bundled web-search skill directory for researcher subagents. */
@@ -256,7 +264,13 @@ function resolveAgentProfiles(deps: PiSubagentToolDeps): SubagentProfile[] {
     profiles.set(builtin.id, { ...builtin, source: 'builtin' });
   }
   if (deps.presetId) {
-    for (const member of loadMemberProfiles(deps.getPiAgentsDir(), deps.presetId)) {
+    // Bundled presets are file-sourced: prefer the live member definitions
+    // so member edits take effect without re-importing. User-imported
+    // packages keep the synced pi agents files.
+    const bundled =
+      deps.loadBundledMembers?.(deps.presetId) ??
+      loadMemberProfiles(deps.getPiAgentsDir(), deps.presetId);
+    for (const member of bundled) {
       if (member.id === PiSubagentProfileId.ProductionReviewer) continue;
       profiles.set(member.id, member);
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -882,6 +882,9 @@ const getPiRuntimeAdapter = (): PiRuntimeAdapter => {
     piRuntimeAdapter.setConversationHistoryService(
       new ConversationHistoryService(getStore().getDatabase()),
     );
+    // Live team member definitions must read the same bundled truth as the
+    // main-session preset snapshot, not the userData skills copy.
+    piRuntimeAdapter.setBundledSkillsRoot(getSkillManager().getBundledSkillsRoot());
     // MCP initialization runs asynchronously, so late injection may still be needed.
     console.log('[PiRuntime] mcpServerManager available at init:', mcpServerManager !== null);
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1965,7 +1965,13 @@ const resolveSessionExpertSnapshots = (expertIds: string[]): CoworkSessionExpert
     // when the preset directory is missing or unreadable.
     if (expert.presetId.trim()) {
       const bundledSkillsRoot = getSkillManager().getBundledSkillsRoot();
-      const liveSnapshot = resolveBundledPresetExpertSnapshot(bundledSkillsRoot, packageId);
+      // The main session loads only the selected agent's file: the lead for
+      // teams, the single file for standalone agents.
+      const liveSnapshot = resolveBundledPresetExpertSnapshot(
+        bundledSkillsRoot,
+        packageId,
+        expert.id,
+      );
       if (liveSnapshot) {
         promptSnapshot = liveSnapshot.promptSnapshot;
         skillIds = liveSnapshot.skillIds;

--- a/src/main/presetExpertSnapshot.test.ts
+++ b/src/main/presetExpertSnapshot.test.ts
@@ -169,3 +169,16 @@ test('does not resolve members for a single-agent or unknown preset', () => {
   expect(resolveBundledPresetMembers(root, 'no-such-preset')).toBeNull();
   expect(resolveBundledPresetMembers(skillsRoot, 'data-analyst')).toBeNull();
 });
+
+test('unknown or timestamp-suffixed agent ids resolve to null (DB fallback)', () => {
+  const root = buildTeamPreset();
+  // A never-registered id must not silently load agents[0] (wrong role).
+  expect(resolveBundledPresetExpertSnapshot(root, 'team-fixture', 'no-such-agent')).toBeNull();
+  // DB id conflicts append timestamps (member-alpha-1699999999); the suffix
+  // never matches the preset file, so the caller must fall back to the DB
+  // snapshot rather than combine a lead prompt with member skill policy.
+  expect(
+    resolveBundledPresetExpertSnapshot(root, 'team-fixture', 'member-alpha-1699999999'),
+  ).toBeNull();
+  expect(resolveBundledPresetExpertSnapshot(root, 'team-fixture', 'member-alpha')).not.toBeNull();
+});

--- a/src/main/presetExpertSnapshot.test.ts
+++ b/src/main/presetExpertSnapshot.test.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
-import { expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import { afterEach, expect, test } from 'vitest';
 
-import { resolveBundledPresetExpertSnapshot } from './presetExpertSnapshot';
+import {
+  resolveBundledPresetExpertSnapshot,
+  resolveBundledPresetMembers,
+} from './presetExpertSnapshot';
 
 const skillsRoot = path.resolve('SKILLs');
 
@@ -21,4 +26,146 @@ test('returns null for a missing preset', () => {
 
 test('returns null for an unreadable preset directory', () => {
   expect(resolveBundledPresetExpertSnapshot(path.resolve('SKILLs', '..', 'no-such-root'), 'data-analyst')).toBeNull();
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+/** Minimal bundled team preset in a temp dir with a lead and two members. */
+const buildTeamPreset = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'preset-expert-team-'));
+  temporaryDirectories.push(root);
+  const presetDir = path.join(root, 'zhiyuan-expert-manager', 'presets', 'team-fixture');
+  fs.mkdirSync(path.join(presetDir, 'agents'), { recursive: true });
+  // Copy the real registration scripts so the snapshot's skill resolution
+  // follows the production path (packaged skills appended to declared ids).
+  const scriptsDir = path.join(root, 'zhiyuan-expert-manager', 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.copyFileSync(
+    path.resolve('SKILLs/zhiyuan-expert-manager/scripts/register_expert.js'),
+    path.join(scriptsDir, 'register_expert.js'),
+  );
+  fs.copyFileSync(
+    path.resolve('SKILLs/zhiyuan-expert-manager/scripts/validate_expert.js'),
+    path.join(scriptsDir, 'validate_expert.js'),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'plugin.json'),
+    JSON.stringify(
+      {
+        name: 'team-fixture',
+        expertType: 'team',
+        agentName: 'team-fixture-team-lead',
+        teamInfo: {
+          leadAgent: 'team-fixture-team-lead',
+          memberAgents: ['member-alpha', 'member-beta'],
+        },
+        agents: [
+          './agents/team-fixture-team-lead.md',
+          './agents/member-alpha.md',
+          './agents/member-beta.md',
+        ],
+        members: [
+          { id: 'member-alpha', profession: { zh: '研究员' } },
+          { id: 'member-beta', profession: { zh: '分析师' } },
+        ],
+        skills: ['./skills/team-skill'],
+        skillIds: ['web-search'],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'agents', 'team-fixture-team-lead.md'),
+    [
+      '---',
+      'name: team-fixture-team-lead',
+      'description: Team lead.',
+      '---',
+      '# 团队主理人',
+      '',
+      '你是团队主理人。',
+      '',
+      '## 工作流路由（CRITICAL — 收到请求时首先判断）',
+      '',
+      '| 场景 | 判定条件 | 使用模式 |',
+      '|------|---------|---------|',
+      '| 标准任务 | 复杂需求 | SOP |',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'agents', 'member-alpha.md'),
+    [
+      '---',
+      'name: member-alpha',
+      'description: Alpha member.',
+      '---',
+      '# Alpha 成员',
+      '',
+      '你是团队的**研究员**。',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(presetDir, 'agents', 'member-beta.md'),
+    [
+      '---',
+      'name: member-beta',
+      'description: Beta member.',
+      '---',
+      '# Beta 成员',
+      '',
+      '你是团队的**分析师**。',
+    ].join('\n'),
+  );
+  fs.mkdirSync(path.join(presetDir, 'skills', 'team-skill'), { recursive: true });
+  fs.writeFileSync(
+    path.join(presetDir, 'skills', 'team-skill', 'SKILL.md'),
+    ['---', 'name: team-skill', 'description: Team skill.', '---', '', '# Team skill'].join('\n'),
+  );
+  return root;
+};
+
+test('team lead snapshot carries the member roster and team skills', () => {
+  const root = buildTeamPreset();
+  const lead = resolveBundledPresetExpertSnapshot(root, 'team-fixture', 'team-fixture-team-lead');
+  expect(lead).not.toBeNull();
+  expect(lead?.promptSnapshot).toContain('你是团队主理人');
+  expect(lead?.promptSnapshot).toContain('## 已注册成员映射');
+  expect(lead?.promptSnapshot).toContain('member-alpha（研究员）');
+  expect(lead?.promptSnapshot).toContain('member-beta（分析师）');
+  expect(lead?.skillIds).toEqual(['web-search', 'team-skill']);
+  // The lead prompt must not leak member bodies.
+  expect(lead?.promptSnapshot).not.toContain('你是团队的**研究员**');
+});
+
+test('member snapshot loads only the member file with no skills and no lead body', () => {
+  const root = buildTeamPreset();
+  const alpha = resolveBundledPresetExpertSnapshot(root, 'team-fixture', 'member-alpha');
+  expect(alpha).not.toBeNull();
+  expect(alpha?.promptSnapshot).toContain('你是团队的**研究员**');
+  expect(alpha?.promptSnapshot).not.toContain('主理人');
+  expect(alpha?.promptSnapshot).not.toContain('已注册成员映射');
+  expect(alpha?.skillIds).toEqual([]);
+});
+
+test('resolves live bundled member definitions for the subagent tool', () => {
+  const root = buildTeamPreset();
+  const members = resolveBundledPresetMembers(root, 'team-fixture');
+  expect(members).not.toBeNull();
+  expect(members?.map(member => member.id)).toEqual(['member-alpha', 'member-beta']);
+  expect(members?.find(member => member.id === 'member-alpha')?.systemPrompt).toContain(
+    '研究员',
+  );
+});
+
+test('does not resolve members for a single-agent or unknown preset', () => {
+  const root = buildTeamPreset();
+  expect(resolveBundledPresetMembers(root, 'no-such-preset')).toBeNull();
+  expect(resolveBundledPresetMembers(skillsRoot, 'data-analyst')).toBeNull();
 });

--- a/src/main/presetExpertSnapshot.ts
+++ b/src/main/presetExpertSnapshot.ts
@@ -103,11 +103,14 @@ export function resolveBundledPresetExpertSnapshot(
   try {
     const agentPaths = Array.isArray(pluginJson.agents) ? pluginJson.agents : [];
     // The main session only loads the single selected agent file: the agent
-    // named by `agentId` (lead for teams, the only file for single agents),
-    // falling back to the first entry for compatibility.
+    // named by `agentId` (lead for teams, the only file for single agents).
+    // An unmatched agentId (e.g. a timestamp-suffixed id after a DB id
+    // conflict) resolves to null so the caller falls back to the DB snapshot
+    // instead of silently loading the wrong role's prompt.
     const selected =
-      (agentId ? agentPaths.find(entry => matchesAgentId(String(entry), agentId)) : undefined) ??
-      agentPaths[0];
+      agentId === undefined
+        ? agentPaths[0]
+        : agentPaths.find(entry => matchesAgentId(String(entry), agentId));
     const agentMdPath = selected === undefined ? null : agentFilePath(presetDir, selected);
     if (!agentMdPath) return null;
 

--- a/src/main/presetExpertSnapshot.ts
+++ b/src/main/presetExpertSnapshot.ts
@@ -12,7 +12,16 @@ export interface BundledPresetExpertSnapshot {
   skillIds: string[];
 }
 
+export interface BundledPresetMember {
+  id: string;
+  description: string;
+  systemPrompt: string;
+}
+
 const PRESET_EXPERTS_DIR = ['zhiyuan-expert-manager', 'presets'];
+
+const normalizeId = (name: string): string =>
+  name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
 const stripFrontmatter = (markdown: string): string => {
   const lines = markdown.split(/\r?\n/);
@@ -25,44 +34,175 @@ const stripFrontmatter = (markdown: string): string => {
   return markdown;
 };
 
+const readPluginJson = (presetDir: string): Record<string, unknown> | null => {
+  const pluginPath = path.join(presetDir, 'plugin.json');
+  if (!fs.existsSync(pluginPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(pluginPath, 'utf-8')) as Record<string, unknown>;
+  } catch (error) {
+    console.warn(`[PresetExpert] failed to read bundled preset plugin.json:`, error);
+    return null;
+  }
+};
+
+const agentFilePath = (presetDir: string, relative: unknown): string | null => {
+  if (typeof relative !== 'string' || !relative) return null;
+  const resolved = path.resolve(presetDir, relative);
+  return fs.existsSync(resolved) ? resolved : null;
+};
+
+/** Matches a plugin agents entry against a registered agent id (kebab-case). */
+const matchesAgentId = (agentPath: string, agentId: string): boolean => {
+  const fileName = path.basename(agentPath).replace(/\.md$/i, '');
+  return fileName === agentId || normalizeId(fileName) === agentId;
+};
+
+/** Mirror of the registration script's team-lead augmentation (member roster). */
+const buildLeadRoster = (
+  pluginJson: Record<string, unknown>,
+  rawLeadAgent: string | null,
+): string | null => {
+  const teamInfo = pluginJson.teamInfo as
+    | { memberAgents?: unknown; leadAgent?: unknown }
+    | undefined;
+  const members = Array.isArray(teamInfo?.memberAgents) ? teamInfo.memberAgents : [];
+  if (members.length === 0 || teamInfo?.leadAgent !== rawLeadAgent) return null;
+  const displayMembers = Array.isArray(pluginJson.members) ? pluginJson.members : [];
+  const roster = members
+    .map(member => {
+      const memberId = String(member);
+      const display = (displayMembers as Array<Record<string, unknown>>).find(
+        entry => String(entry?.id) === memberId,
+      );
+      const profession = (display?.profession as { zh?: string; en?: string } | undefined)?.zh
+        ?? (display?.profession as { zh?: string; en?: string } | undefined)?.en
+        ?? memberId;
+      return `- ${memberId}（${profession}）`;
+    })
+    .join('\n');
+  const firstMember = members[0] ? String(members[0]) : 'member-id';
+  return [
+    '',
+    '## 已注册成员映射',
+    '',
+    roster,
+    '',
+    `调度成员时，在 subagent 工具的 name 参数中使用成员 ID（如 ${firstMember}），系统会自动路由到对应 Agent。`,
+  ].join('\n');
+};
+
 export function resolveBundledPresetExpertSnapshot(
   skillsRoot: string,
   presetId: string,
+  agentId?: string,
 ): BundledPresetExpertSnapshot | null {
   const presetDir = path.join(skillsRoot, ...PRESET_EXPERTS_DIR, presetId);
-  const pluginPath = path.join(presetDir, 'plugin.json');
-  if (!fs.existsSync(pluginPath)) return null;
+  const pluginJson = readPluginJson(presetDir);
+  if (!pluginJson) return null;
 
   try {
-    const pluginJson = JSON.parse(fs.readFileSync(pluginPath, 'utf-8')) as {
-      agents?: unknown;
-      [key: string]: unknown;
-    };
     const agentPaths = Array.isArray(pluginJson.agents) ? pluginJson.agents : [];
-    const firstAgent = agentPaths.find((entry): entry is string => typeof entry === 'string');
-    if (!firstAgent) return null;
+    // The main session only loads the single selected agent file: the agent
+    // named by `agentId` (lead for teams, the only file for single agents),
+    // falling back to the first entry for compatibility.
+    const selected =
+      (agentId ? agentPaths.find(entry => matchesAgentId(String(entry), agentId)) : undefined) ??
+      agentPaths[0];
+    const agentMdPath = selected === undefined ? null : agentFilePath(presetDir, selected);
+    if (!agentMdPath) return null;
 
-    const agentMdPath = path.resolve(presetDir, firstAgent);
-    if (!fs.existsSync(agentMdPath)) return null;
-    const promptSnapshot = stripFrontmatter(fs.readFileSync(agentMdPath, 'utf-8'));
+    let promptSnapshot = stripFrontmatter(fs.readFileSync(agentMdPath, 'utf-8'));
     if (!promptSnapshot) return null;
 
-    // Reuse the registration script's pure resolver for packaged + shared
-    // skill IDs; it only reads plugin.json and SKILL.md frontmatter.
-    const registerExpertPath = path.join(
-      skillsRoot,
-      'zhiyuan-expert-manager',
-      'scripts',
-      'register_expert.js',
-    );
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { resolveSkillIds } = require(registerExpertPath) as {
-      resolveSkillIds: (pluginJson: unknown, expertDir: string) => string[];
-    };
+    // Team leads get the same member roster the registration script embeds;
+    // without it the live disk snapshot would silently lose the member map.
+    const teamInfo = pluginJson.teamInfo as { leadAgent?: unknown } | undefined;
+    const rawLeadAgent = typeof teamInfo?.leadAgent === 'string' ? teamInfo.leadAgent : null;
+    const leadAgentId = rawLeadAgent ? normalizeId(rawLeadAgent) : null;
+    const selectedAgentId =
+      agentId ??
+      path.basename(agentMdPath).replace(/\.md$/i, '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    if (leadAgentId && selectedAgentId === leadAgentId) {
+      const roster = buildLeadRoster(pluginJson, rawLeadAgent);
+      if (roster) promptSnapshot = `${promptSnapshot}\n${roster}`;
+    }
 
-    return { promptSnapshot, skillIds: resolveSkillIds(pluginJson, presetDir) };
+    // Team members never own skills; only leads and single agents do.
+    const isMember = leadAgentId !== null && selectedAgentId !== leadAgentId;
+    const skillIds = isMember
+      ? []
+      : resolveSkillIdsFromRegistry(pluginJson, presetDir, skillsRoot);
+
+    return { promptSnapshot, skillIds };
   } catch (error) {
     console.warn(`[PresetExpert] failed to read bundled preset '${presetId}':`, error);
     return null;
   }
+}
+
+/**
+ * Live team member definitions for the subagent tool. Members are read from
+ * the bundled preset directory so editing a member file takes effect without
+ * re-importing; imported packages keep their synced pi agents files.
+ */
+export function resolveBundledPresetMembers(
+  skillsRoot: string,
+  presetId: string,
+): BundledPresetMember[] | null {
+  const presetDir = path.join(skillsRoot, ...PRESET_EXPERTS_DIR, presetId);
+  const pluginJson = readPluginJson(presetDir);
+  if (!pluginJson || pluginJson.expertType !== 'team') return null;
+
+  const teamInfo = pluginJson.teamInfo as { memberAgents?: unknown } | undefined;
+  const members = Array.isArray(teamInfo?.memberAgents) ? teamInfo.memberAgents : [];
+  if (members.length === 0) return null;
+
+  const result: BundledPresetMember[] = [];
+  for (const member of members) {
+    const memberId = String(member);
+    const memberPath = agentFilePath(presetDir, path.join('agents', `${memberId}.md`));
+    if (!memberPath) {
+      console.warn(`[PresetExpert] bundled team member file not found: ${memberId}`);
+      continue;
+    }
+    const content = fs.readFileSync(memberPath, 'utf-8');
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+    const systemPrompt = (frontmatterMatch ? frontmatterMatch[2] : content).trim();
+    if (!systemPrompt) continue;
+    const descriptionMatch = frontmatterMatch?.[1].match(/^description:\s*(.+)$/m);
+    result.push({
+      id: memberId,
+      description: descriptionMatch?.[1].trim() ?? `Team member ${memberId}`,
+      systemPrompt,
+    });
+  }
+  return result.length > 0 ? result : null;
+}
+
+function resolveSkillIdsFromRegistry(
+  pluginJson: Record<string, unknown>,
+  presetDir: string,
+  skillsRoot: string,
+): string[] {
+  // Reuse the registration script's pure resolver; it only reads plugin.json
+  // and SKILL.md frontmatter. Fall back to the declared skillIds when the
+  // script is unavailable so a snapshot never hard-depends on it.
+  const registerExpertPath = path.join(
+    skillsRoot,
+    'zhiyuan-expert-manager',
+    'scripts',
+    'register_expert.js',
+  );
+  if (fs.existsSync(registerExpertPath)) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { resolveSkillIds } = require(registerExpertPath) as {
+        resolveSkillIds: (pluginJson: unknown, expertDir: string) => string[];
+      };
+      return resolveSkillIds(pluginJson, presetDir);
+    } catch (error) {
+      console.warn(`[PresetExpert] failed to resolve skill ids via register script:`, error);
+    }
+  }
+  return Array.isArray(pluginJson.skillIds) ? [...pluginJson.skillIds] : [];
 }


### PR DESCRIPTION
## 背景

方案A（PR #494）的磁盘快照只取 `pluginJson.agents[0]`，对 team 型专家存在三个缺口：

1. **选中错位**：主会话若选中成员，拿到的却是主理人 Prompt
2. **成员映射丢失**：注册时（register_expert.js）会给主理人追加「已注册成员映射」roster，磁盘快照不会——team 主理人经方案A 会静默失去成员调度表
3. **成员不实时**：subagent 成员定义仍从注册时同步的 pi agents 目录读取（piSubagentTool.ts:216 `loadMemberProfiles`），编辑成员文件不生效

## 变更

### presetExpertSnapshot.ts

- `resolveBundledPresetExpertSnapshot` 增加 `agentId` 参数：主会话只解析**选中的单个 Agent 文件**（team 主理人 / 单 agent 唯一文件）；匹配支持精确与 kebab-case 归一化，未命中回退 agents[0]（兼容）
- **team 主理人快照附加与注册脚本同构的成员映射 roster**（复现 register 的增强，磁盘快照不再丢成员表）
- team 成员快照 skillIds 为空（成员不拥有技能）
- 新增 `resolveBundledPresetMembers`：供 subagent 工具实时读取成员定义
- resolveSkillIds 解析失败时回退声明的 skillIds，不再硬依赖 register 脚本存在

### piSubagentTool.ts

- deps 新增 `loadBundledMembers`：内置 preset 实时读取**优先**，未命中（用户导入包）回退同步的 pi agents 文件——两条路径语义正确

### piRuntimeAdapter.ts / main.ts

- `resolveSessionExpertSnapshots` 传入选中的 `expert.id`
- adapter 接线 `loadBundledMembers`（经 getSkillsRoot），成员定义加 `source: 'member'`

## 测试

- presetExpertSnapshot：team 夹具（临时目录 + 真实 register 脚本）验证——主理人快照含 roster、成员快照不含 lead 内容（**互不串入**）、成员 skillIds 为空、成员实时解析、单 agent/未知 preset 返回 null
- piSubagentTool：`loadBundledMembers` 优先于同步文件（stale 同步副本被实时定义覆盖）

## 验证

- tsc（electron-tsconfig）✅　oxlint ✅
- 相关测试 41/41（snapshot 7 / subagent 20 / validation 2 / upgrade 2 / bridge 10）

🤖 Generated with [Claude Code](https://claude.com/claude-code)