### PR TITLE
fix(sidebar): 登录选单宽度与侧边栏对齐

### DIFF
--- a/src/renderer/components/LoginButton.tsx
+++ b/src/renderer/components/LoginButton.tsx
@@ -83,7 +83,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({ onShowSettings }) => {
       {showMenu ? (
         <div
           role="menu"
-          className="absolute bottom-full left-0 z-50 mb-2 w-60 overflow-hidden rounded-xl border border-border bg-surface p-1.5 shadow-popover"
+          className="absolute bottom-full left-0 right-0 z-50 mb-2 overflow-hidden rounded-xl border border-border bg-surface p-1.5 shadow-popover"
         >
           {user ? (
             <>


### PR DESCRIPTION
## 问题

侧边栏左下角"登录"按钮的展开选单使用固定宽度 `w-60`（240px）。侧边栏宽度是可拖拽调整的（`sidebarWidth` state），当侧边栏较窄时，选单右边缘会超出侧边栏边界。

## 修复

[LoginButton.tsx:86](src/renderer/components/LoginButton.tsx#L86)：`w-60` → `left-0 right-0`。选单是 `absolute` 定位、容器是 `relative`（宽度 = 按钮宽度 = 侧边栏内容区宽度），左右同时锚定后选单与侧边栏在任何宽度下左右对齐。

## 验证

- `npx tsc --project electron-tsconfig.json` ✅
- `npx oxlint src/renderer/components/LoginButton.tsx` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
