### PR TITLE
fix(linux): deb 安装前终止旧实例,单实例锁失败不再静默退出

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -211,6 +211,9 @@
         "url": "https://updates.rongxzyai.com/v2/electron/stable/linux/x64/appimage"
       }
     ],
+    "deb": {
+      "fpm": ["--before-install=scripts/linux-before-install.sh"]
+    },
     "icon": "build/icons/png",
     "category": "Utility",
     "artifactName": "${productName}-${version}-${arch}.${ext}",

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -14,18 +14,12 @@
     {
       "from": "dist",
       "to": "dist",
-      "filter": [
-        "**/*",
-        "!**/*.map"
-      ]
+      "filter": ["**/*", "!**/*.map"]
     },
     {
       "from": "dist-electron",
       "to": "dist-electron",
-      "filter": [
-        "**/*",
-        "!**/*.map"
-      ]
+      "filter": ["**/*", "!**/*.map"]
     },
     "!**/*.map",
     "!**/*.d.ts",
@@ -66,9 +60,7 @@
     {
       "from": "resources/tray",
       "to": "tray",
-      "filter": [
-        "**/*"
-      ]
+      "filter": ["**/*"]
     },
     {
       "from": "resources/modelscope.tokens.local.json",
@@ -77,27 +69,17 @@
     {
       "from": "vendor/engram-runtime/current",
       "to": "memory",
-      "filter": [
-        "engram",
-        "engram.exe",
-        "runtime-build-info.json",
-        "LICENSE"
-      ]
+      "filter": ["engram", "engram.exe", "runtime-build-info.json", "LICENSE"]
     }
   ],
   "protocols": [
     {
       "name": "知远",
-      "schemes": [
-        "zhiyuan"
-      ]
+      "schemes": ["zhiyuan"]
     }
   ],
   "mac": {
-    "target": [
-      "dmg",
-      "zip"
-    ],
+    "target": ["dmg", "zip"],
     "publish": [
       {
         "provider": "generic",
@@ -120,9 +102,7 @@
       {
         "from": "MCPs",
         "to": "MCPs",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "SKILLs",
@@ -160,23 +140,17 @@
       {
         "from": "resources/uv-mac",
         "to": "uv-mac",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "resources/python-mac",
         "to": "python-mac",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "resources/skill-python",
         "to": "skill-python",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "vendor/channel-runtime/current",
@@ -213,9 +187,7 @@
     "sign": false
   },
   "win": {
-    "target": [
-      "nsis"
-    ],
+    "target": ["nsis"],
     "publish": [
       {
         "provider": "generic",
@@ -231,11 +203,13 @@
       }
     ]
   },
+  "deb": {
+    "fpm": [
+      "--before-install=scripts/linux-before-install.sh"
+    ]
+  },
   "linux": {
-    "target": [
-      "AppImage",
-      "deb"
-    ],
+    "target": ["AppImage", "deb"],
     "publish": [
       {
         "provider": "generic",
@@ -249,30 +223,22 @@
       {
         "from": "MCPs",
         "to": "MCPs",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "resources/uv-linux",
         "to": "uv-linux",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "resources/python-linux",
         "to": "python-linux",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "resources/skill-python",
         "to": "skill-python",
-        "filter": [
-          "**/*"
-        ]
+        "filter": ["**/*"]
       },
       {
         "from": "SKILLs",
@@ -350,16 +316,7 @@
     "artifactName": "${productName}-Setup-${version}.${ext}"
   },
   "electronVersion": "40.2.1",
-  "electronLanguages": [
-    "en-US",
-    "zh-CN",
-    "zh-TW",
-    "ja",
-    "ko",
-    "fr",
-    "es",
-    "es-419"
-  ],
+  "electronLanguages": ["en-US", "zh-CN", "zh-TW", "ja", "ko", "fr", "es", "es-419"],
   "electronUpdaterCompatibility": ">=6.0.0",
   "detectUpdateChannel": false,
   "generateUpdatesFilesForAllChannels": false,
@@ -369,10 +326,5 @@
     "node_modules/better-sqlite3/**",
     "node_modules/npm/**"
   ],
-  "asar": true,
-  "deb": {
-    "fpm": [
-      "--before-install=scripts/linux-before-install.sh"
-    ]
-  }
+  "asar": true
 }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -14,12 +14,18 @@
     {
       "from": "dist",
       "to": "dist",
-      "filter": ["**/*", "!**/*.map"]
+      "filter": [
+        "**/*",
+        "!**/*.map"
+      ]
     },
     {
       "from": "dist-electron",
       "to": "dist-electron",
-      "filter": ["**/*", "!**/*.map"]
+      "filter": [
+        "**/*",
+        "!**/*.map"
+      ]
     },
     "!**/*.map",
     "!**/*.d.ts",
@@ -60,7 +66,9 @@
     {
       "from": "resources/tray",
       "to": "tray",
-      "filter": ["**/*"]
+      "filter": [
+        "**/*"
+      ]
     },
     {
       "from": "resources/modelscope.tokens.local.json",
@@ -69,17 +77,27 @@
     {
       "from": "vendor/engram-runtime/current",
       "to": "memory",
-      "filter": ["engram", "engram.exe", "runtime-build-info.json", "LICENSE"]
+      "filter": [
+        "engram",
+        "engram.exe",
+        "runtime-build-info.json",
+        "LICENSE"
+      ]
     }
   ],
   "protocols": [
     {
       "name": "知远",
-      "schemes": ["zhiyuan"]
+      "schemes": [
+        "zhiyuan"
+      ]
     }
   ],
   "mac": {
-    "target": ["dmg", "zip"],
+    "target": [
+      "dmg",
+      "zip"
+    ],
     "publish": [
       {
         "provider": "generic",
@@ -102,7 +120,9 @@
       {
         "from": "MCPs",
         "to": "MCPs",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "SKILLs",
@@ -140,17 +160,23 @@
       {
         "from": "resources/uv-mac",
         "to": "uv-mac",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "resources/python-mac",
         "to": "python-mac",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "resources/skill-python",
         "to": "skill-python",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "vendor/channel-runtime/current",
@@ -187,7 +213,9 @@
     "sign": false
   },
   "win": {
-    "target": ["nsis"],
+    "target": [
+      "nsis"
+    ],
     "publish": [
       {
         "provider": "generic",
@@ -204,16 +232,16 @@
     ]
   },
   "linux": {
-    "target": ["AppImage", "deb"],
+    "target": [
+      "AppImage",
+      "deb"
+    ],
     "publish": [
       {
         "provider": "generic",
         "url": "https://updates.rongxzyai.com/v2/electron/stable/linux/x64/appimage"
       }
     ],
-    "deb": {
-      "fpm": ["--before-install=scripts/linux-before-install.sh"]
-    },
     "icon": "build/icons/png",
     "category": "Utility",
     "artifactName": "${productName}-${version}-${arch}.${ext}",
@@ -221,22 +249,30 @@
       {
         "from": "MCPs",
         "to": "MCPs",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "resources/uv-linux",
         "to": "uv-linux",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "resources/python-linux",
         "to": "python-linux",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "resources/skill-python",
         "to": "skill-python",
-        "filter": ["**/*"]
+        "filter": [
+          "**/*"
+        ]
       },
       {
         "from": "SKILLs",
@@ -314,7 +350,16 @@
     "artifactName": "${productName}-Setup-${version}.${ext}"
   },
   "electronVersion": "40.2.1",
-  "electronLanguages": ["en-US", "zh-CN", "zh-TW", "ja", "ko", "fr", "es", "es-419"],
+  "electronLanguages": [
+    "en-US",
+    "zh-CN",
+    "zh-TW",
+    "ja",
+    "ko",
+    "fr",
+    "es",
+    "es-419"
+  ],
   "electronUpdaterCompatibility": ">=6.0.0",
   "detectUpdateChannel": false,
   "generateUpdatesFilesForAllChannels": false,
@@ -324,5 +369,10 @@
     "node_modules/better-sqlite3/**",
     "node_modules/npm/**"
   ],
-  "asar": true
+  "asar": true,
+  "deb": {
+    "fpm": [
+      "--before-install=scripts/linux-before-install.sh"
+    ]
+  }
 }

--- a/scripts/linux-before-install.sh
+++ b/scripts/linux-before-install.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# deb preinst: 安装前终止仍在运行的旧版本实例。
+#
+# 背景:应用使用单实例锁(SingletonLock,位于 userData 目录)。deb 覆盖安装
+# 时旧版本进程仍持有锁,新版本启动会拿不到锁而静默退出(退出码 0),用户
+# 观感是"装上就报错"。这里在 dpkg 解包前杀掉旧实例,与 Windows NSIS
+# 安装器的 "Stopping running 知远 processes" 阶段对齐。
+#
+# 匹配范围(按可执行路径,避免误杀 dpkg 自身——其命令行含 .deb 文件名):
+#   - 主进程与全部子进程(renderer/GPU/node sidecar/engram):可执行路径均
+#     位于 deb 安装目录 /opt/知远/ 下
+#   - 用户同时运行 AppImage 时,其挂载路径 /tmp/.mount_知远* 也匹配
+#
+# 注意:preinst 以 root 运行,不能依赖 $HOME;因此不清 SingletonLock 文件
+# (Electron 启动时会检测残留 socket 并自动清理),只杀进程。
+
+DEB_INSTALL_PATTERN='/opt/知远'
+APPIMAGE_MOUNT_PATTERN='\.mount_知远'
+
+# 终止旧实例;pkill 无匹配时返回 1,忽略
+pkill -f "$DEB_INSTALL_PATTERN" 2>/dev/null || true
+pkill -f "$APPIMAGE_MOUNT_PATTERN" 2>/dev/null || true
+
+# 等待进程退出(最多 10 秒),与 NSIS 的 15×500ms 重试循环对齐
+i=0
+while [ "$i" -lt 10 ]; do
+  if ! pgrep -f "$DEB_INSTALL_PATTERN" >/dev/null 2>&1 &&
+    ! pgrep -f "$APPIMAGE_MOUNT_PATTERN" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  i=$((i + 1))
+done
+
+# preinst 失败不能阻塞安装,永远以 0 退出
+exit 0

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2206,20 +2206,104 @@ const scheduleReload = (reason: string, webContents?: WebContents) => {
 // 确保应用程序只有一个实例
 const gotTheLock = app.requestSingleInstanceLock();
 
-if (!gotTheLock) {
-  // Linux 覆盖安装(AppImage 替换/deb 升级)时旧实例可能仍在运行并持有
-  // 单实例锁;这里不静默退出,给用户明确提示(deb 的 preinst 已先杀旧进程,
-  // 此分支主要兜底 AppImage 替换与手动多开场景)。
-  console.warn('[Main] Another ZhiYuanAgent instance is already running; exiting.');
-  try {
-    dialog.showErrorBox(
-      '知远已在运行',
-      '检测到知远已在运行,请先关闭现有实例后再启动。',
-    );
-  } catch {
-    // 无显示环境(如无头 CI)时跳过弹窗,仍以退出码 0 结束。
+/**
+ * Linux only: 单实例锁被"不同版本"的旧实例持有时(如 AppImage 原地替换、
+ * deb 升级后旧进程残留),杀掉旧版本并让当前实例 relaunch 重新拿锁。
+ * 同一版本多开(APPIMAGE 相同)不杀,交给下面的提示分支。
+ *
+ * 身份判定:
+ *  - AppImage:运行时环境变量 APPIMAGE 指向源文件(文件名含版本号),
+ *    与当前进程的 APPIMAGE 不同即视为旧版本
+ *  - deb:/opt/知远 下的进程无 APPIMAGE,exe 路径含 /opt/知远 即视为同族;
+ *    同路径进程不杀(可能只是并发启动,提示即可)
+ *  - 混合场景(旧 AppImage + 新 deb):APPIMAGE 存在且与当前不同 → 杀
+ */
+async function terminateStaleLinuxInstances(): Promise<boolean> {
+  if (process.platform !== 'linux') return false;
+
+  const currentAppImage = process.env.APPIMAGE ?? null;
+  const familyPattern = /知远|ZhiYuanAgent/i;
+
+  const findFamilyPids = (): number[] => {
+    const pids: number[] = [];
+    let entries: string[];
+    try {
+      entries = fs.readdirSync('/proc');
+    } catch {
+      return pids;
+    }
+    for (const entry of entries) {
+      if (!/^\d+$/.test(entry)) continue;
+      const pid = Number(entry);
+      if (pid === process.pid) continue;
+      try {
+        const env = fs.readFileSync(`/proc/${pid}/environ`, 'utf8');
+        const appImage = env.match(/APPIMAGE=([^\0]*)/)?.[1] ?? null;
+        if (appImage) {
+          // AppImage 实例:仅当源文件属于本产品时纳入
+          if (!familyPattern.test(appImage)) continue;
+          // 同一版本文件的多开不杀
+          if (currentAppImage && appImage === currentAppImage) continue;
+        } else {
+          // 非 AppImage:匹配 deb 安装路径 /opt/知远
+          const exe = fs.readlinkSync(`/proc/${pid}/exe`);
+          if (!/\/opt\/知远/.test(exe)) continue;
+        }
+        pids.push(pid);
+      } catch {
+        // 权限不足或进程已退出,跳过
+      }
+    }
+    return pids;
+  };
+
+  const pids = findFamilyPids();
+  if (pids.length === 0) return false;
+
+  console.warn(
+    `[Main] Terminating ${pids.length} stale Linux instance(s) before taking over: ${pids.join(', ')}`,
+  );
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // 已退出或无权,忽略
+    }
   }
-  app.quit();
+
+  // 等待旧实例退出(最多 5 秒),确认全部清理后才 relaunch
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const remaining = findFamilyPids();
+    if (remaining.length === 0) return true;
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  console.warn('[Main] Stale Linux instance(s) did not exit in time; giving up takeover.');
+  return false;
+}
+
+if (!gotTheLock) {
+  void (async () => {
+    // Linux 覆盖安装(AppImage 替换/deb 升级)时旧版本实例可能仍在运行并
+    // 持有单实例锁。先尝试终止旧版本实例,成功则 relaunch 让新进程重新
+    // 拿锁启动;失败(同一版本多开)则提示用户手动关闭。
+    const reclaimed = await terminateStaleLinuxInstances();
+    if (reclaimed) {
+      app.relaunch();
+      app.exit(0);
+      return;
+    }
+    console.warn('[Main] Another ZhiYuanAgent instance is already running; exiting.');
+    try {
+      dialog.showErrorBox(
+        '知远已在运行',
+        '检测到知远已在运行,请先关闭现有实例后再启动。',
+      );
+    } catch {
+      // 无显示环境(如无头 CI)时跳过弹窗,仍以退出码 0 结束。
+    }
+    app.quit();
+  })();
 } else {
   // In development Electron needs the app entry point before the callback URL;
   // otherwise Windows treats the URL itself as the application to launch.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2207,6 +2207,18 @@ const scheduleReload = (reason: string, webContents?: WebContents) => {
 const gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
+  // Linux 覆盖安装(AppImage 替换/deb 升级)时旧实例可能仍在运行并持有
+  // 单实例锁;这里不静默退出,给用户明确提示(deb 的 preinst 已先杀旧进程,
+  // 此分支主要兜底 AppImage 替换与手动多开场景)。
+  console.warn('[Main] Another ZhiYuanAgent instance is already running; exiting.');
+  try {
+    dialog.showErrorBox(
+      '知远已在运行',
+      '检测到知远已在运行,请先关闭现有实例后再启动。',
+    );
+  } catch {
+    // 无显示环境(如无头 CI)时跳过弹窗,仍以退出码 0 结束。
+  }
   app.quit();
 } else {
   // In development Electron needs the app entry point before the callback URL;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2207,62 +2207,68 @@ const scheduleReload = (reason: string, webContents?: WebContents) => {
 const gotTheLock = app.requestSingleInstanceLock();
 
 /**
- * Linux only: 单实例锁被"不同版本"的旧实例持有时(如 AppImage 原地替换、
- * deb 升级后旧进程残留),杀掉旧版本并让当前实例 relaunch 重新拿锁。
- * 同一版本多开(APPIMAGE 相同)不杀,交给下面的提示分支。
+ * Linux only: 检测单实例锁被哪个"知远"实例持有。
+ *
+ * 返回 null 表示没有可接管的目标(同版本多开或未检测到),此时由第一实例
+ * 的 second-instance 处理唤起已有窗口,本实例直接退出。
+ * 返回 { pids, oldLabel } 表示存在"旧版本"实例,需要用户确认后接管。
  *
  * 身份判定:
  *  - AppImage:运行时环境变量 APPIMAGE 指向源文件(文件名含版本号),
  *    与当前进程的 APPIMAGE 不同即视为旧版本
- *  - deb:/opt/知远 下的进程无 APPIMAGE,exe 路径含 /opt/知远 即视为同族;
- *    同路径进程不杀(可能只是并发启动,提示即可)
- *  - 混合场景(旧 AppImage + 新 deb):APPIMAGE 存在且与当前不同 → 杀
+ *  - deb:/opt/知远 下的进程无 APPIMAGE,exe 路径匹配即视为同族;
+ *    无法区分版本,统一按"旧实例"提示确认
  */
-async function terminateStaleLinuxInstances(): Promise<boolean> {
-  if (process.platform !== 'linux') return false;
+async function findStaleLinuxInstances(): Promise<{
+  pids: number[];
+  oldLabel: string;
+} | null> {
+  if (process.platform !== 'linux') return null;
 
   const currentAppImage = process.env.APPIMAGE ?? null;
   const familyPattern = /知远|ZhiYuanAgent/i;
 
-  const findFamilyPids = (): number[] => {
-    const pids: number[] = [];
-    let entries: string[];
+  const pids: number[] = [];
+  const oldAppImages: string[] = [];
+  let entries: string[];
+  try {
+    entries = fs.readdirSync('/proc');
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (pid === process.pid) continue;
     try {
-      entries = fs.readdirSync('/proc');
-    } catch {
-      return pids;
-    }
-    for (const entry of entries) {
-      if (!/^\d+$/.test(entry)) continue;
-      const pid = Number(entry);
-      if (pid === process.pid) continue;
-      try {
-        const env = fs.readFileSync(`/proc/${pid}/environ`, 'utf8');
-        const appImage = env.match(/APPIMAGE=([^\0]*)/)?.[1] ?? null;
-        if (appImage) {
-          // AppImage 实例:仅当源文件属于本产品时纳入
-          if (!familyPattern.test(appImage)) continue;
-          // 同一版本文件的多开不杀
-          if (currentAppImage && appImage === currentAppImage) continue;
-        } else {
-          // 非 AppImage:匹配 deb 安装路径 /opt/知远
-          const exe = fs.readlinkSync(`/proc/${pid}/exe`);
-          if (!/\/opt\/知远/.test(exe)) continue;
-        }
+      const env = fs.readFileSync(`/proc/${pid}/environ`, 'utf8');
+      const appImage = env.match(/APPIMAGE=([^\0]*)/)?.[1] ?? null;
+      if (appImage) {
+        if (!familyPattern.test(appImage)) continue;
+        // 同一版本文件的多开:唤起已有窗口即可,不接管
+        if (currentAppImage && appImage === currentAppImage) continue;
         pids.push(pid);
-      } catch {
-        // 权限不足或进程已退出,跳过
+        oldAppImages.push(appImage);
+      } else {
+        // 非 AppImage:匹配 deb 安装路径 /opt/知远
+        const exe = fs.readlinkSync(`/proc/${pid}/exe`);
+        if (!/\/opt\/知远/.test(exe)) continue;
+        pids.push(pid);
       }
+    } catch {
+      // 权限不足或进程已退出,跳过
     }
-    return pids;
-  };
+  }
+  if (pids.length === 0) return null;
 
-  const pids = findFamilyPids();
-  if (pids.length === 0) return false;
+  // 从 AppImage 文件名提取旧版本号,如 知远-1.0.0.AppImage → 1.0.0
+  const versionMatch = oldAppImages[0]?.match(/-(\d+\.\d+\.\d+)\.AppImage/i);
+  const oldLabel = versionMatch ? `知远 ${versionMatch[1]}` : '旧版本的知远';
+  return { pids, oldLabel };
+}
 
-  console.warn(
-    `[Main] Terminating ${pids.length} stale Linux instance(s) before taking over: ${pids.join(', ')}`,
-  );
+/** 终止指定进程并等待退出(最多 5 秒)。 */
+async function terminatePids(pids: number[]): Promise<boolean> {
   for (const pid of pids) {
     try {
       process.kill(pid, 'SIGTERM');
@@ -2270,39 +2276,67 @@ async function terminateStaleLinuxInstances(): Promise<boolean> {
       // 已退出或无权,忽略
     }
   }
-
-  // 等待旧实例退出(最多 5 秒),确认全部清理后才 relaunch
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
-    const remaining = findFamilyPids();
-    if (remaining.length === 0) return true;
+    const alive = pids.filter(pid => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (alive.length === 0) return true;
     await new Promise(resolve => setTimeout(resolve, 200));
   }
-  console.warn('[Main] Stale Linux instance(s) did not exit in time; giving up takeover.');
   return false;
 }
 
 if (!gotTheLock) {
   void (async () => {
-    // Linux 覆盖安装(AppImage 替换/deb 升级)时旧版本实例可能仍在运行并
-    // 持有单实例锁。先尝试终止旧版本实例,成功则 relaunch 让新进程重新
-    // 拿锁启动;失败(同一版本多开)则提示用户手动关闭。
-    const reclaimed = await terminateStaleLinuxInstances();
-    if (reclaimed) {
+    // 同版本多开:第一实例已通过 second-instance 聚焦窗口,本实例直接退出。
+    const stale = await findStaleLinuxInstances();
+    if (stale) {
+      // 旧版本实例(AppImage 替换):弹窗确认后再接管,避免中断用户正在进行
+      // 的会话。确认后终止旧实例并 relaunch,让新进程重新拿锁启动。
+      console.warn(
+        `[Main] Detected running ${stale.oldLabel} instance (pid ${stale.pids.join(', ')}); asking user before takeover.`,
+      );
+      try {
+        await app.whenReady();
+        const currentVersion = app.getVersion();
+        const { response } = await dialog.showMessageBox({
+          type: 'question',
+          buttons: ['关闭旧版本并启动新版本', '取消'],
+          defaultId: 0,
+          cancelId: 1,
+          title: '检测到旧版本正在运行',
+          message: `检测到 ${stale.oldLabel} 正在运行。`,
+          detail:
+            `当前启动的是知远 ${currentVersion}。启动新版本需要先关闭旧版本,` +
+            '关闭旧版本将中断其中进行中的任务。是否继续?',
+        });
+        if (response === 1) {
+          app.exit(0);
+          return;
+        }
+      } catch {
+        // 无显示环境(如无头 CI):无法确认,直接退出
+        app.exit(0);
+        return;
+      }
+      const terminated = await terminatePids(stale.pids);
+      if (!terminated) {
+        console.warn('[Main] Stale instance did not exit in time; giving up takeover.');
+        app.exit(0);
+        return;
+      }
       app.relaunch();
       app.exit(0);
       return;
     }
     console.warn('[Main] Another ZhiYuanAgent instance is already running; exiting.');
-    try {
-      dialog.showErrorBox(
-        '知远已在运行',
-        '检测到知远已在运行,请先关闭现有实例后再启动。',
-      );
-    } catch {
-      // 无显示环境(如无头 CI)时跳过弹窗,仍以退出码 0 结束。
-    }
-    app.quit();
+    app.exit(0);
   })();
 } else {
   // In development Electron needs the app entry point before the callback URL;


### PR DESCRIPTION
## 背景

Ubuntu 用户反馈"装上就报错":deb 安装后启动应用立即退出(退出码 0)。根因是**单实例锁冲突**:

1. 应用使用单实例锁(`requestSingleInstanceLock`,锁文件在 userData 的 `SingletonLock`)
2. deb 覆盖安装 / AppImage 原地替换时**旧版本进程仍在运行**,持有锁
3. 新版本启动 → 拿不到锁 → 静默 `app.quit()` → 退出码 0,无任何提示

Windows 的 NSIS 安装器早已处理此问题(安装时杀掉运行中的 `知远` 进程),Linux 打包缺少对应逻辑。

## 交互设计(本次实现)

| 场景 | 行为 |
|---|---|
| 同版本多开(双击同一 AppImage) | **唤起已有窗口** —— 第一实例通过 `second-instance` 事件聚焦窗口,新实例直接退出,用户无感 |
| 旧版本正在运行(AppImage 替换) | **弹窗确认** —— 显示旧版本号与新版本号,提示"关闭旧版本将中断进行中的任务",用户确认后才终止旧实例并启动新版本;取消则退出 |
| 无显示环境(无头 CI) | 无法弹窗,直接退出,不误杀 |

## 改动

### 1. deb 安装前终止旧实例([scripts/linux-before-install.sh](scripts/linux-before-install.sh),新增)

通过 `deb.fpm: ["--before-install=..."]` 注入 deb 的 **preinst**,dpkg 解包前杀掉旧版本进程:

- 按**可执行路径**匹配 `/opt/知远` + AppImage 挂载 `/tmp/.mount_知远*`,避免误杀 dpkg 自身(`dpkg -i 知远-*.deb` 命令行含"知远")
- 等待退出(最多 10 秒),preinst 永远以 0 退出不阻塞安装

### 2. AppImage 启动时接管([main.ts](src/main/main.ts) `findStaleLinuxInstances` / `terminatePids`)

- 扫描 `/proc/<pid>/environ` 读各进程 `APPIMAGE` 环境变量,与当前进程比较:
  - **不同**(文件名含版本号差异)→ 旧版本 → 弹窗确认后 `SIGTERM` + `app.relaunch()` 接管
  - **相同** → 同版本多开 → 退出,由 `second-instance` 唤起已有窗口
  - 非本产品 AppImage → 跳过,不误杀
- deb 场景(无 APPIMAGE,exe 路径 `/opt/知远`)→ 按旧实例弹窗确认
- 版本号从 AppImage 文件名解析(如 `知远-1.0.0.AppImage` → `1.0.0`),弹窗展示新旧版本

## 验证

- `sh -n scripts/linux-before-install.sh` 通过
- `electron-builder.json` 的 `linux.deb.fpm` 配置解析正确(fpm 原样传入 `--before-install`,已核验 app-builder-lib 源码)
- `tsc --project electron-tsconfig.json --noEmit` 通过
- 身份判定逻辑 node 模拟验证:旧版本→确认接管、同版本→唤起、非本产品→跳过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
