### PR TITLE
fix(cowork): align permission approval with prompt

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -66,6 +66,7 @@ test('keeps the session permission selector available during an active run', () 
 
 test('keeps streaming controls gated without obscuring the prompt', () => {
   expect(source).not.toContain('bg-input/50 dark:bg-input/80');
+  expect(source).not.toContain("className={isStreaming ? 'relative z-20' : undefined}");
   expect(source).toContain('disabled={disabled || isStreaming || isAddingFile}');
   expect(source.match(/disabled=\{disabled \|\| isStreaming\}/g)).toHaveLength(2);
   expect(source).toContain("status={isStreaming ? 'streaming' : 'ready'}");

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1287,7 +1287,6 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               </div>
             )}
             <PromptInputSubmit
-              className={isStreaming ? 'relative z-20' : undefined}
               disabled={sessionContextPending}
               status={isStreaming ? 'streaming' : 'ready'}
               onStop={isStreaming ? onStop : undefined}

--- a/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./CoworkSessionDetail.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('anchors inline permission approval directly above the prompt input', () => {
+  const inputArea = source.indexOf('{/* Input Area */}');
+  const permission = source.indexOf('<CoworkPermissionModal', inputArea);
+  const promptInput = source.indexOf('<CoworkPromptInput', inputArea);
+
+  expect(inputArea).toBeGreaterThanOrEqual(0);
+  expect(permission).toBeGreaterThan(inputArea);
+  expect(promptInput).toBeGreaterThan(permission);
+  expect(source.slice(inputArea, permission)).toContain('className="mb-2"');
+  expect(source).not.toContain('absolute inset-x-0 bottom-0 z-20 px-4 pb-4');
+});

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1478,21 +1478,18 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               )}
           </div>
 
-          {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
-            <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4">
-              <div className="w-full max-w-5xl mx-auto">
-                <CoworkPermissionModal
-                  permission={inlinePermission}
-                  onRespond={onRespondToInlinePermission}
-                  inline
-                />
-              </div>
-            </div>
-          )}
-
           {/* Input Area */}
           <div className="px-4 pb-4 shrink-0">
             <div className="max-w-5xl min-w-[320px] mx-auto pl-4">
+              {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
+                <div className="mb-2">
+                  <CoworkPermissionModal
+                    permission={inlinePermission}
+                    onRespond={onRespondToInlinePermission}
+                    inline
+                  />
+                </div>
+              )}
               <CoworkPromptInput
                 ref={promptInputRef}
                 topAccessory={


### PR DESCRIPTION
## Summary

- anchor inline permission approval in the same layout container as the prompt input
- place the approval surface directly above the prompt instead of absolutely overlaying it
- remove the streaming Stop button's manual stacking level so it cannot paint over approval UI
- add structure guards for both layout regressions

## Root cause

The approval surface used `absolute bottom-0 z-20`, while the prompt remained in normal flow below it. The streaming Stop button also used `relative z-20` and appeared later in the DOM, so it could render above the approval surface. The approval wrapper additionally did not share the prompt container's left inset.

## Behavior

- approval and prompt now share the same `max-w-5xl` container and left inset
- approval occupies layout space immediately above the prompt with the standard 8 px gap
- Stop remains available and keeps the existing callback behavior, without a custom z-index
- permission response handling, disabled input state, IPC, and streaming behavior are unchanged

## Validation

- `npm.cmd test -- CoworkSessionDetail.structure CoworkPromptInput.structure` (`2` files, `9` tests passed)
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

## Screenshots

Not attached. The repository does not provide a renderer fixture that can inject a live permission request; the affected flow should receive one desktop smoke check during PR review.

## Electron impact

Renderer-only layout change. No IPC, persistence, preload, or main-process behavior changes.
