### PR TITLE
feat(cowork): redesign task trajectory view

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionLayout.test.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLayout.test.tsx
@@ -2,11 +2,18 @@
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { useState } from 'react';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { i18nService } from '../../services/i18n';
 import { CoworkSessionLayout } from './CoworkSessionLayout';
+
+const taskAuditSource = readFileSync(
+  resolve('src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx'),
+  'utf8',
+);
 
 vi.mock('../icons/ArtifactPanelAnimatedToggleIcon', () => ({
   ArtifactPanelAnimatedToggleIcon: () => <span data-testid="artifact-toggle-icon" />,
@@ -75,4 +82,15 @@ test('renders the title above tabs and preserves conversation state across tab s
 
   await user.click(conversationTab);
   expect(screen.getByRole('textbox', { name: 'conversation draft' })).toHaveValue('保留草稿');
+});
+
+test('renders every task audit module in one natural-height full-width view', () => {
+  expect(taskAuditSource).not.toContain('max-w-5xl');
+  expect(taskAuditSource).not.toContain('<Tabs');
+  expect(taskAuditSource).toContain('md:grid-cols-2');
+  expect(taskAuditSource).toContain('gap-4 p-4');
+  expect(taskAuditSource).toContain('rounded-lg border border-border');
+  expect(taskAuditSource.match(/<WorkbenchTaskAuditSection/g)).toHaveLength(4);
+  expect(taskAuditSource).toContain('max-h-80');
+  expect(taskAuditSource).not.toContain('grid-rows-2');
 });

--- a/src/renderer/components/cowork/WorkbenchTaskTrajectory.tsx
+++ b/src/renderer/components/cowork/WorkbenchTaskTrajectory.tsx
@@ -297,7 +297,7 @@ export function WorkbenchTaskTrajectory({
 
 function WorkbenchTaskTrajectorySkeleton() {
   return (
-    <div className="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 p-4">
+    <div className="flex h-full w-full flex-col gap-4 overflow-y-auto p-4">
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-col gap-2">
           <Skeleton className="h-5 w-40" />
@@ -305,9 +305,17 @@ function WorkbenchTaskTrajectorySkeleton() {
         </div>
         <Skeleton className="h-8 w-24" />
       </div>
-      <Skeleton className="h-24 w-full" />
-      <Skeleton className="h-8 w-80" />
-      <Skeleton className="min-h-0 flex-1 w-full" />
+      <div className="rounded-lg border border-border bg-muted p-4">
+        <Skeleton className="h-20 w-full" />
+      </div>
+      <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
+        {[0, 1, 2, 3].map(index => (
+          <div key={index} className="rounded-lg border border-border p-3">
+            <Skeleton className="mb-3 h-5 w-24" />
+            <Skeleton className="h-48 w-full" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
@@ -9,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@shared/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@shared/components/ui/tabs';
 import { Download } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -23,7 +22,7 @@ import { i18nService } from '../../../services/i18n';
 import { ApprovalAuditTab } from './ApprovalAuditTab';
 import { ArtifactAuditTab } from './ArtifactAuditTab';
 import { AuditJsonDisclosure } from './AuditJsonDisclosure';
-import { WorkbenchTaskAuditTab, WorkbenchTaskRunFilter } from './constants';
+import { WorkbenchTaskRunFilter } from './constants';
 import { EventAuditTab } from './EventAuditTab';
 import { RunAuditTab } from './RunAuditTab';
 import {
@@ -92,7 +91,7 @@ export function WorkbenchTaskAuditView({
 
   return (
     <ScrollArea className="h-full">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 p-4">
+      <div className="flex w-full flex-col gap-4 p-4">
         <header className="flex shrink-0 flex-wrap items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <h2 className="text-base font-semibold text-foreground">
@@ -118,7 +117,7 @@ export function WorkbenchTaskAuditView({
         </header>
 
         <section
-          className="flex shrink-0 flex-col gap-3"
+          className="flex shrink-0 flex-col gap-3 rounded-lg border border-border bg-muted p-4"
           aria-label={i18nService.t('workbenchTaskSummary')}
         >
           {tasks.length > 1 && (
@@ -190,74 +189,92 @@ export function WorkbenchTaskAuditView({
           )}
         </section>
 
-        <Tabs defaultValue={WorkbenchTaskAuditTab.Runs} className="gap-0">
-          <div className="shrink-0 border-b border-border">
-            <TabsList
-              variant="line"
-              className="w-full justify-start overflow-x-auto overflow-y-hidden"
-            >
-              <TabsTrigger value={WorkbenchTaskAuditTab.Runs} className="after:bottom-[-1px]">
-                {tabLabel('workbenchTaskRuns', filteredDetail.runs.length)}
-              </TabsTrigger>
-              <TabsTrigger value={WorkbenchTaskAuditTab.Events} className="after:bottom-[-1px]">
-                {tabLabel('workbenchTaskEvents', filteredDetail.events.length)}
-              </TabsTrigger>
-              <TabsTrigger value={WorkbenchTaskAuditTab.Artifacts} className="after:bottom-[-1px]">
-                {tabLabel('workbenchTaskArtifacts', filteredDetail.artifacts.length)}
-              </TabsTrigger>
-              <TabsTrigger value={WorkbenchTaskAuditTab.Approvals} className="after:bottom-[-1px]">
-                {tabLabel('workbenchTaskApprovals', filteredDetail.approvals.length)}
-              </TabsTrigger>
-            </TabsList>
-          </div>
-
-          {detail.runs.length > 1 && (
-            <div className="flex items-center gap-2 pt-3">
-              <span className="text-xs text-muted-foreground">
-                {i18nService.t('workbenchTaskRunFilter')}
-              </span>
-              <Select value={runFilter} onValueChange={value => value && setRunFilter(value)}>
-                <SelectTrigger size="sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent align="start">
-                  <SelectGroup>
-                    <SelectItem value={WorkbenchTaskRunFilter.All}>
-                      {i18nService.t('workbenchTaskAllRuns')}
+        {detail.runs.length > 1 && (
+          <div className="flex items-center justify-end gap-2">
+            <span className="text-xs text-muted-foreground">
+              {i18nService.t('workbenchTaskRunFilter')}
+            </span>
+            <Select value={runFilter} onValueChange={value => value && setRunFilter(value)}>
+              <SelectTrigger size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectGroup>
+                  <SelectItem value={WorkbenchTaskRunFilter.All}>
+                    {i18nService.t('workbenchTaskAllRuns')}
+                  </SelectItem>
+                  {detail.runs.map(run => (
+                    <SelectItem key={run.id} value={run.id}>
+                      {i18nService
+                        .t('workbenchTaskRunAttempt')
+                        .replace('{attempt}', String(run.attempt))}
                     </SelectItem>
-                    {detail.runs.map(run => (
-                      <SelectItem key={run.id} value={run.id}>
-                        {i18nService
-                          .t('workbenchTaskRunAttempt')
-                          .replace('{attempt}', String(run.attempt))}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </div>
-          )}
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
-          <TabsContent value={WorkbenchTaskAuditTab.Runs} className="flex-none pt-3">
+        <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
+          <WorkbenchTaskAuditSection
+            title={i18nService.t('workbenchTaskRuns')}
+            count={filteredDetail.runs.length}
+          >
             <RunAuditTab runs={filteredDetail.runs} activeRunId={task.activeRunId} />
-          </TabsContent>
-          <TabsContent value={WorkbenchTaskAuditTab.Events} className="flex-none pt-3">
+          </WorkbenchTaskAuditSection>
+          <WorkbenchTaskAuditSection
+            title={i18nService.t('workbenchTaskEvents')}
+            count={filteredDetail.events.length}
+          >
             <EventAuditTab events={filteredDetail.events} runs={detail.runs} />
-          </TabsContent>
-          <TabsContent value={WorkbenchTaskAuditTab.Artifacts} className="flex-none pt-3">
+          </WorkbenchTaskAuditSection>
+          <WorkbenchTaskAuditSection
+            title={i18nService.t('workbenchTaskArtifacts')}
+            count={filteredDetail.artifacts.length}
+          >
             <ArtifactAuditTab artifacts={filteredDetail.artifacts} runs={detail.runs} />
-          </TabsContent>
-          <TabsContent value={WorkbenchTaskAuditTab.Approvals} className="flex-none pt-3">
+          </WorkbenchTaskAuditSection>
+          <WorkbenchTaskAuditSection
+            title={i18nService.t('workbenchTaskApprovals')}
+            count={filteredDetail.approvals.length}
+          >
             <ApprovalAuditTab
               approvals={filteredDetail.approvals}
               runs={detail.runs}
               busy={busy}
               onRespond={onRespondToApproval}
             />
-          </TabsContent>
-        </Tabs>
+          </WorkbenchTaskAuditSection>
+        </div>
       </div>
     </ScrollArea>
+  );
+}
+
+function WorkbenchTaskAuditSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className="min-w-0 overflow-hidden rounded-lg border border-border bg-background"
+      aria-label={`${title} (${count})`}
+    >
+      <div className="flex h-10 items-center border-b border-border bg-muted px-4">
+        <h3 className="text-sm font-semibold text-foreground">
+          {title} <span className="font-normal text-muted-foreground">({count})</span>
+        </h3>
+      </div>
+      <ScrollArea className="max-h-80 [&_[data-slot=scroll-area-viewport]]:max-h-80">
+        <div className="p-3">{children}</div>
+      </ScrollArea>
+    </section>
   );
 }
 
@@ -268,8 +285,4 @@ function TaskMetadata({ label, value }: { label: string; value: string }) {
       <dd className="break-words text-foreground">{value}</dd>
     </div>
   );
-}
-
-function tabLabel(key: string, count: number): string {
-  return `${i18nService.t(key)} (${count})`;
 }

--- a/src/renderer/components/cowork/workbenchTaskAudit/constants.ts
+++ b/src/renderer/components/cowork/workbenchTaskAudit/constants.ts
@@ -1,13 +1,3 @@
-export const WorkbenchTaskAuditTab = {
-  Runs: 'runs',
-  Events: 'events',
-  Artifacts: 'artifacts',
-  Approvals: 'approvals',
-} as const;
-
-export type WorkbenchTaskAuditTab =
-  (typeof WorkbenchTaskAuditTab)[keyof typeof WorkbenchTaskAuditTab];
-
 export const WorkbenchTaskRunFilter = {
   All: 'all',
 } as const;


### PR DESCRIPTION
Removes the internal audit tabs and presents runs, events, artifacts, and approvals together in a full-width responsive layout. Adds consistent page padding, module gaps, natural-height panels, capped internal scrolling, and matching loading skeleton coverage. Tests: focused CoworkSessionLayout Vitest, TypeScript check, and oxlint.