### PR TITLE
perf(electron): speed up development startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prepare:modelscope-tokens": "node scripts/write-modelscope-token-resource.cjs",
     "prepare:update-release": "node scripts/prepare-update-release.cjs",
     "start:electron": "cross-env NODE_ENV=development ELECTRON_START_URL=http://localhost:5175 electron .",
-    "electron:dev": "bun run channel:runtime:download && bun run engram:runtime:host && rimraf dist-electron && bun run compile:electron && concurrently \"vite --port 5175\" \"wait-on -l -t 120000 -d 20000 -i 1000 -s 1 http://localhost:5175 && wait-on -l -t 120000 -i 1000 dist-electron/.electron-ready && bun run start:electron\"",
+    "electron:dev": "bun run channel:runtime:download && bun run engram:runtime:host && rimraf dist-electron && concurrently \"vite --port 5175\" \"wait-on -l -t 120000 -i 1000 -s 1 http://localhost:5175 && wait-on -l -t 120000 -i 1000 dist-electron/.electron-ready && bun run start:electron\"",
     "postinstall": "patch-package && electron-builder install-app-deps",
     "pack": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run channel:runtime:download && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder --dir",
     "dist": "npm run setup:uv-runtime && npm run setup:python-runtime && npm run setup:posix-uv-runtime && npm run setup:posix-python-runtime && npm run build && npm run compile:electron && npm run build:skills && npm run channel:runtime:download && npm run engram:runtime:host && npm run prepare:modelscope-tokens && electron-builder",

--- a/tests/electronDevelopmentStartupConfig.test.ts
+++ b/tests/electronDevelopmentStartupConfig.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { test } from 'vitest';
+
+const root = path.resolve(__dirname, '..');
+
+test('development startup externalizes package subpaths without redundant delays or compilation', () => {
+  const viteConfig = readFileSync(path.join(root, 'vite.config.ts'), 'utf8');
+  const packageJson = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  const developmentScript = packageJson.scripts?.['electron:dev'] || '';
+
+  assert.match(viteConfig, /extractExternalDeps\(packageJson, true\)/);
+  assert.match(viteConfig, /electronDevelopmentExternalRoots\.has\(packageRoot\(id\)\)/);
+  assert.match(viteConfig, /command === ['"]serve['"][\s\S]*isElectronDevelopmentExternal/);
+  assert.doesNotMatch(developmentScript, /-d 20000/);
+  assert.doesNotMatch(developmentScript, /compile:electron/);
+  assert.match(developmentScript, /dist-electron\/\.electron-ready/);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
 import electron from 'vite-plugin-electron';
+import { extractExternalDeps } from 'vite-plugin-electron/plugin';
 import renderer from 'vite-plugin-electron-renderer';
 
 import { ELECTRON_MAIN_EXTERNALS } from './scripts/electron-runtime-dependencies.mjs';
@@ -10,6 +11,21 @@ import { ELECTRON_MAIN_EXTERNALS } from './scripts/electron-runtime-dependencies
 // https://vitejs.dev/config/
 const devPort = Number(process.env.VITE_DEV_PORT ?? 5175);
 const katexVersion = process.env.npm_package_dependencies_katex?.replace(/^[~^]/, '') || '0.16.0';
+const packageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8'),
+) as Record<string, unknown>;
+const electronDevelopmentExternalRoots = new Set(extractExternalDeps(packageJson, true));
+const electronReadyPath = path.resolve(__dirname, 'dist-electron/.electron-ready');
+
+function packageRoot(specifier: string): string {
+  return specifier.startsWith('@')
+    ? specifier.split('/').slice(0, 2).join('/')
+    : specifier.split('/')[0];
+}
+
+function isElectronDevelopmentExternal(id: string): boolean {
+  return electronDevelopmentExternalRoots.has(packageRoot(id));
+}
 
 const copyPhotonWasmPlugin = () => ({
   name: 'copy-photon-wasm',
@@ -72,7 +88,10 @@ export default defineConfig(async ({ command }) => {
                     outDir: 'dist-electron',
                     minify: false,
                     rollupOptions: {
-                      external: id => ELECTRON_MAIN_EXTERNALS.includes(id),
+                      external:
+                        command === 'serve'
+                          ? isElectronDevelopmentExternal
+                          : id => ELECTRON_MAIN_EXTERNALS.includes(id),
                       output: {
                         // Keep CJS format (default), but load via ESM loader.mjs
                         inlineDynamicImports: true,
@@ -82,7 +101,7 @@ export default defineConfig(async ({ command }) => {
                 },
                 onstart() {
                   // Signal that the main process bundle is ready for electron to load
-                  fs.writeFileSync('dist-electron/.electron-ready', '');
+                  fs.writeFileSync(electronReadyPath, '');
 
                   // Copy photon-node WASM artifact into dist-electron so pi-coding-agent can load it
                   const wasmSource = path.resolve(


### PR DESCRIPTION
Externalizes declared package dependencies and their subpath imports from the Electron main-process development bundle while preserving the production external allowlist. Removes the fixed 20-second wait and redundant compile:electron lifecycle from electron:dev, which also avoids rebuilding better-sqlite3 on every preview start. Adds focused configuration regression coverage. Tests: focused Vitest, TypeScript check, oxlint, and git diff --check.