### PR TITLE
feat(llama): 新增临时方案--在访问本地服务时，不需要使用api-key等认证操作；对话在访问本地服务时，会在新建对话时获取l…

### DIFF
--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -1,4 +1,5 @@
 import {
+  ApiFormat,
   isProviderEnabled,
   type ModelCapabilities,
   ModelCapabilityStatus,
@@ -60,6 +61,7 @@ class ApiService {
     string,
     Promise<Partial<ModelCapabilities>>
   >();
+  private readonly localInferenceConfigByConversation = new Map<string, ApiConfig>();
   private runtimeCapabilityGeneration = 0;
 
   setConfig(config: ApiConfig) {
@@ -418,8 +420,41 @@ class ApiService {
   }
 
   // 获取指定 provider 的配置
-  private getProviderConfig(provider: string): ApiConfig | null {
+  private async getProviderConfig(
+    provider: string,
+    conversationId?: string,
+  ): Promise<ApiConfig | null> {
     const appConfig = configService.getConfig();
+    if (provider === ProviderName.LlamaCpp) {
+      const cachedConfig = conversationId
+        ? this.localInferenceConfigByConversation.get(conversationId)
+        : undefined;
+      if (cachedConfig) return cachedConfig;
+
+      const providerConfig = appConfig?.providers?.[ProviderName.LlamaCpp];
+      const providerDefinition = ProviderRegistry.get(ProviderName.LlamaCpp);
+      let baseUrl = providerConfig?.baseUrl?.trim() || providerDefinition?.defaultBaseUrl || '';
+      try {
+        const serviceConfig = await window.electron.llamacpp.getServiceConfig();
+        const host = serviceConfig.host?.trim() || '127.0.0.1';
+        const port = serviceConfig.port?.trim();
+        if (port) {
+          baseUrl = `http://${host}:${port}/v1`;
+        }
+      } catch {
+        // Keep the stored endpoint available when the local service IPC is unavailable.
+      }
+      const localConfig: ApiConfig = {
+        apiKey: '',
+        baseUrl,
+        provider,
+        apiFormat: ApiFormat.OpenAI,
+      };
+      if (conversationId) {
+        this.localInferenceConfigByConversation.set(conversationId, localConfig);
+      }
+      return localConfig;
+    }
 
     if (appConfig?.providers?.[provider]) {
       const providerConfig = appConfig.providers[provider];
@@ -462,8 +497,6 @@ class ApiService {
     reasoning?: string;
     usage?: TokenUsage;
   }> {
-    const configuredApi = this.getConfiguredApi();
-
     const modelState = store.getState().model;
     const requestedModelId = options.modelId?.trim();
     const requestedProviderKey = options.modelProviderKey?.trim();
@@ -484,12 +517,8 @@ class ApiService {
         ? { content: message }
         : { content: message.content || '', images: message.images };
 
-    // 尝试获取模型对应 provider 的配置
-    let effectiveConfig = configuredApi;
-    const providerConfig = this.getProviderConfig(provider);
-    if (providerConfig) {
-      effectiveConfig = providerConfig;
-    }
+    const providerConfig = await this.getProviderConfig(provider, options.conversationId);
+    const effectiveConfig = providerConfig ?? this.getConfiguredApi();
 
     if (this.providerRequiresApiKey(provider) && !effectiveConfig.apiKey) {
       throw new ApiError(
@@ -632,7 +661,6 @@ class ApiService {
     reasoning?: string;
     usage?: TokenUsage;
   }> {
-    const configuredApi = this.getConfiguredApi();
     const modelState = store.getState().model;
     const requestedModelId = options.modelId?.trim();
     const requestedProviderKey = options.modelProviderKey?.trim();
@@ -648,7 +676,8 @@ class ApiService {
       selectedModel.id,
       selectedModel.providerKey ?? selectedModel.provider,
     );
-    const config = this.getProviderConfig(provider) ?? configuredApi;
+    const config =
+      (await this.getProviderConfig(provider, options.conversationId)) ?? this.getConfiguredApi();
     if (this.providerRequiresApiKey(provider) && !config.apiKey) {
       throw new ApiError(
         'API key is not configured. Please set your API key in the settings menu.',

--- a/src/renderer/services/api.webSearch.test.ts
+++ b/src/renderer/services/api.webSearch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test, vi } from 'vitest';
 
-import { ModelCapabilityStatus, ProviderName } from '../../shared/providers';
+import { ApiFormat, ModelCapabilityStatus, ProviderName } from '../../shared/providers';
 import { store } from '../store';
 import { setAvailableModels, setDefaultSelectedModel } from '../store/slices/modelSlice';
 import { apiService } from './api';
@@ -34,6 +34,75 @@ test('restores the legacy API config when app bootstrap has not synced it yet', 
   await expect(apiService.chatWithWebSearch('latest news')).resolves.toEqual({
     content: 'plain answer',
   });
+});
+
+test('uses the local inference endpoint without falling back to the global API configuration', async () => {
+  const model = {
+    id: 'qwen-local',
+    name: 'Qwen Local',
+    providerKey: ProviderName.LlamaCpp,
+    supportsImage: false,
+  };
+  store.dispatch(setAvailableModels([model]));
+  store.dispatch(setDefaultSelectedModel(model));
+  const appConfig = configService.getConfig();
+  vi.spyOn(configService, 'getConfig').mockReturnValue({
+    ...appConfig,
+    api: { key: 'global-api-key', baseUrl: 'https://example.test/v1' },
+    providers: {
+      ...appConfig.providers,
+      [ProviderName.LlamaCpp]: {
+        ...(appConfig.providers?.[ProviderName.LlamaCpp] ?? {}),
+        enabled: false,
+        userEnabled: false,
+        apiKey: '',
+        baseUrl: 'http://127.0.0.1:8080/v1',
+        apiFormat: ApiFormat.OpenAI,
+        models: [],
+      },
+    },
+  });
+  apiService.setConfig({
+    apiKey: 'global-api-key',
+    baseUrl: 'https://example.test/v1',
+    apiFormat: ApiFormat.OpenAI,
+  });
+  const getServiceConfig = vi
+    .fn()
+    .mockResolvedValueOnce({ host: '127.0.0.1', port: '9090' })
+    .mockResolvedValueOnce({ host: '127.0.0.1', port: '9191' });
+  vi.stubGlobal('window', {
+    electron: {
+      llamacpp: {
+        getServiceConfig,
+      },
+    },
+  });
+  const regularChat = vi
+    .spyOn(apiService as any, 'chatWithOpenAICompatible')
+    .mockResolvedValue({ content: 'local answer' });
+
+  const options = { conversationId: 'local-inference-chat' };
+  await expect(apiService.chat('hello', undefined, [], options)).resolves.toEqual({
+    content: 'local answer',
+  });
+  await expect(apiService.chat('again', undefined, [], options)).resolves.toEqual({
+    content: 'local answer',
+  });
+
+  expect(getServiceConfig).toHaveBeenCalledOnce();
+  expect(regularChat.mock.calls.map(call => call[4])).toEqual([
+    expect.objectContaining({
+      apiKey: '',
+      baseUrl: 'http://127.0.0.1:9090/v1',
+      apiFormat: ApiFormat.OpenAI,
+    }),
+    expect.objectContaining({
+      apiKey: '',
+      baseUrl: 'http://127.0.0.1:9090/v1',
+      apiFormat: ApiFormat.OpenAI,
+    }),
+  ]);
 });
 
 test('unknown tool capability falls back to regular chat without a tool payload', async () => {

--- a/src/renderer/services/chatChatTransport.test.ts
+++ b/src/renderer/services/chatChatTransport.test.ts
@@ -259,6 +259,7 @@ test('passes the request id and abort signal through the native tool loop', asyn
   const requestId = call[4];
   expect(typeof requestId).toBe('string');
   expect(call[5]).toBe(abortController.signal);
+  expect(call[3]).toMatchObject({ conversationId: 'chat-1' });
 
   abortController.abort();
   await collectChunks(stream);

--- a/src/renderer/services/chatChatTransport.ts
+++ b/src/renderer/services/chatChatTransport.ts
@@ -64,6 +64,7 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
   // -- ChatTransport impl --------------------------------------------
 
   async sendMessages({
+    chatId,
     messages,
     abortSignal,
   }: {
@@ -73,7 +74,10 @@ export class ChatChatTransport implements ChatTransport<UIMessage> {
     messages: UIMessage[];
     abortSignal: AbortSignal | undefined;
   } & ChatRequestOptions): Promise<ReadableStream<UIMessageChunk>> {
-    const directChatOptions = this.options;
+    const directChatOptions: DirectChatRequestOptions = {
+      ...this.options,
+      conversationId: chatId,
+    };
     const lastUser = [...messages].reverse().find(m => m.role === 'user');
     const prompt = lastUser ? extractText(lastUser) : '';
     if (!prompt.trim()) throw new Error('No prompt to send.');

--- a/src/renderer/services/localThinkingRequest.ts
+++ b/src/renderer/services/localThinkingRequest.ts
@@ -1,6 +1,7 @@
 import { ProviderName } from '../../shared/providers';
 
 export type DirectChatRequestOptions = {
+  conversationId?: string;
   modelId?: string;
   modelProviderKey?: string;
   localThinkingEnabled?: boolean;


### PR DESCRIPTION
## 概述

  修复本地推理模型的无 API Key 对话路由与动态端口访问问题，并使同一对话稳定复用首次绑定的本地服务端点。

  ## 关联问题

  暂无关联 Issue。

  ## 修改内容

  - 本地模型对话不再回退至全局 API Key 或远程 API 地址。
  - 本地模型首条消息读取当前服务的 host、port 并构造本地端点。
  - 以对话 ID 缓存本地端点，同一对话后续消息复用首次绑定的地址。
  - 补充 本地无密钥访问、动态端口与会话端点复用测试。

  ## 变更类型

  - [x] 缺陷修复（不破坏现有功能的修复）
  - [x] 新功能（不破坏现有功能的新功能）
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他：

  ## 测试

  - [x] 已在本地测试
  - [x] 已新增测试用例
  - [x] 已更新已有测试
  - [ ] 已执行手动测试

  执行：

  npx vitest run src/main/libs/llamacppModelGpuPlacement.test.ts src/main/libs/llamacppModelLoadPipeline.test.ts src/renderer/services/api.webSearch.test.ts src/renderer/services/chatChatTransport.test.ts

  结果：4 个测试文件、38 个测试全部通过。

  npm run build:tsc

  结果：通过。

  完整 npm test 已执行，333 个测试文件通过；其余 7 项失败与本次修改无关，受当前 Windows 环境缺少 python3、符号链接权限和发布脚本盘符路径处理影响。

  ## 截图

  不适用，本次不涉及 UI 变更。

  ## 检查清单

  - [x] 代码遵循项目样式规范
  - [x] 已完成自查
  - [x] 已为端点缓存的容错逻辑添加必要注释
  - [ ] 已更新相关文档
  - [x] 本次修改未产生新的测试警告
  - [x] 已添加验证修复效果的测试用例
  - [x] 与本次修改相关的新旧单元测试均已通过

  ## Electron 特定变更

  - [ ] 主进程变更（src/main/）
  - [ ] 预加载脚本变更（src/main/preload.ts）
  - [ ] IPC 通信变更
  - [ ] 窗口管理变更
  - [x] 无

  ## 补充说明

  本地端点绑定仅保存在当前应用运行期。应用重启后，继续历史对话时会在下一条消息重新读取并绑定当前本地服务地址。