### PR TITLE
feat(workbench): add workflow-independent artifact ledger

### DIFF
--- a/src/main/declareArtifact/tool.test.ts
+++ b/src/main/declareArtifact/tool.test.ts
@@ -1,0 +1,46 @@
+import { expect, test, vi } from 'vitest';
+
+import { buildDeclareArtifactTool, type DeclaredArtifactInput } from './tool';
+
+type DeclareArtifactTool = {
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+  ) => Promise<{
+    content: Array<{ type: 'text'; text: string }>;
+    details: Record<string, unknown>;
+  }>;
+};
+
+test('forwards structured declarations to the artifact ledger', async () => {
+  const onDeclare = vi.fn<(artifact: DeclaredArtifactInput) => void>();
+  const tool = buildDeclareArtifactTool({ onDeclare }) as unknown as DeclareArtifactTool;
+
+  const result = await tool.execute('call-1', {
+    filePath: 'D:/workspace/report.md',
+    title: 'Final report',
+    kind: 'markdown',
+    role: 'deliverable',
+  });
+
+  expect(onDeclare).toHaveBeenCalledWith({
+    filePath: 'D:/workspace/report.md',
+    title: 'Final report',
+    kind: 'markdown',
+    role: 'deliverable',
+  });
+  expect(result.details).toMatchObject({ filePath: 'D:/workspace/report.md' });
+});
+
+test('reports ledger rejection instead of claiming the artifact was declared', async () => {
+  const tool = buildDeclareArtifactTool({
+    onDeclare: () => {
+      throw new Error('path is outside the workspace');
+    },
+  }) as unknown as DeclareArtifactTool;
+
+  const result = await tool.execute('call-1', { filePath: 'D:/outside/report.md' });
+
+  expect(result.content[0].text).toContain('Artifact declaration failed');
+  expect(result.details.error).toBe('path is outside the workspace');
+});

--- a/src/main/declareArtifact/tool.ts
+++ b/src/main/declareArtifact/tool.ts
@@ -13,9 +13,22 @@ type DeclareArtifactToolResult = {
   details: Record<string, unknown>;
 };
 
+export interface DeclaredArtifactInput {
+  filePath: string;
+  title?: string;
+  kind?: string;
+  role: 'intermediate' | 'deliverable';
+}
+
+export interface DeclareArtifactToolOptions {
+  onDeclare?: (artifact: DeclaredArtifactInput) => void | Promise<void>;
+}
+
 const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
-export function buildDeclareArtifactTool(): Record<string, unknown> {
+export function buildDeclareArtifactTool(
+  options: DeclareArtifactToolOptions = {},
+): Record<string, unknown> {
   return {
     name: DeclareArtifactToolName,
     label: 'Declare Artifact',
@@ -69,6 +82,20 @@ export function buildDeclareArtifactTool(): Record<string, unknown> {
       const title = text(params.title);
       const kind = text(params.kind);
       const fileName = filePath.split(/[/\\]/).pop() || filePath;
+      try {
+        await options.onDeclare?.({
+          filePath,
+          role,
+          ...(title ? { title } : {}),
+          ...(kind ? { kind } : {}),
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `Artifact declaration failed: ${message}` }],
+          details: { filePath, role, error: message },
+        };
+      }
       return {
         content: [
           {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -45,6 +45,8 @@ import {
 import { MAX_STALE_PRODUCTION_ITERATIONS } from '../../../shared/productionLoop';
 import {
   WorkbenchContractKind,
+  WorkbenchArtifactCandidateSource,
+  WorkbenchArtifactVerificationStatus,
   WorkbenchRunTrigger,
   WorkbenchTaskStatus,
   type WorkbenchTaskContract,
@@ -806,7 +808,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             getMessages: () => this.store?.getSession(sessionId, 32)?.messages ?? [],
             complete: async messages => {
               const complete = this.getSessionMemoryCompletion(sessionId);
-              if (!complete) throw new Error('The session model is unavailable for memory extraction.');
+              if (!complete)
+                throw new Error('The session model is unavailable for memory extraction.');
               return await complete(messages);
             },
           }),
@@ -822,7 +825,30 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       }
       if (resourceState.fileToolsEnabled) {
         customTools.push(buildPiDocumentReaderTool({ workspaceRoot }));
-        customTools.push(buildDeclareArtifactTool());
+        customTools.push(
+          buildDeclareArtifactTool({
+            onDeclare: this.workbenchTaskService
+              ? artifact => {
+                  const runId =
+                    this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId;
+                  if (!runId) throw new Error('No active workbench run is available.');
+                  this.workbenchTaskService?.registerArtifact({
+                    sessionId,
+                    runId,
+                    workspaceRoot,
+                    candidate: {
+                      path: artifact.filePath,
+                      source: WorkbenchArtifactCandidateSource.Declaration,
+                      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+                      role: artifact.role,
+                      ...(artifact.title ? { title: artifact.title } : {}),
+                      ...(artifact.kind ? { kind: artifact.kind } : {}),
+                    },
+                  });
+                }
+              : undefined,
+          }),
+        );
       }
 
       // MCP tools: register a single proxy tool (pi-mcp-adapter pattern)
@@ -1192,9 +1218,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         ? active.requestedSkillIds
         : normalizeSkillIds(options.skillIds);
     const requestedExpertIds =
-      options.expertIds === undefined
-        ? active.requestedExpertIds
-        : explicitExpertIds;
+      options.expertIds === undefined ? active.requestedExpertIds : explicitExpertIds;
     const requestedSessionMode =
       options.sessionMode ??
       (active.workbenchContract.kind === WorkbenchContractKind.Chat
@@ -1935,10 +1959,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       noSkills: true,
       noPromptTemplates: true,
       noThemes: true,
-      additionalSkillPaths: [
-        ...this.resolveZhiyuanSkillDirs(),
-        ...resourceState.expertSkillDirs,
-      ],
+      additionalSkillPaths: [...this.resolveZhiyuanSkillDirs(), ...resourceState.expertSkillDirs],
       skillsOverride: (base: {
         skills: Array<{ name?: string; id?: string }>;
         diagnostics: unknown[];
@@ -2043,13 +2064,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const agent = this.store?.getAgent(expertId);
       const presetId = agent?.presetId?.trim();
       if (!presetId) continue;
-      const dir = path.join(
-        skillsRoot,
-        'zhiyuan-expert-manager',
-        'presets',
-        presetId,
-        'skills',
-      );
+      const dir = path.join(skillsRoot, 'zhiyuan-expert-manager', 'presets', presetId, 'skills');
       if (!dirs.includes(dir) && fs.existsSync(dir)) dirs.push(dir);
     }
     return dirs;
@@ -2083,9 +2098,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const previous = this.pendingMemoryCompletions.get(sessionId) ?? Promise.resolve('');
       const current = previous
         .catch(() => '')
-        .then(() =>
-          this.completeSessionMemory(model, modelRuntime, modelRequestOptions, messages),
-        )
+        .then(() => this.completeSessionMemory(model, modelRuntime, modelRequestOptions, messages))
         .finally(() => {
           if (this.pendingMemoryCompletions.get(sessionId) === current) {
             this.pendingMemoryCompletions.delete(sessionId);
@@ -2390,7 +2403,15 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             isStreaming: false,
             isFinal: true,
             ...(active.toolStartedAtByCallId.has(event.toolCallId)
-              ? { metrics: { toolDurationMs: Math.max(0, Date.now() - (active.toolStartedAtByCallId.get(event.toolCallId) ?? Date.now())) } }
+              ? {
+                  metrics: {
+                    toolDurationMs: Math.max(
+                      0,
+                      Date.now() -
+                        (active.toolStartedAtByCallId.get(event.toolCallId) ?? Date.now()),
+                    ),
+                  },
+                }
               : {}),
           },
         };
@@ -3247,9 +3268,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // requests) is gated by the baseline checks alone and never needs manual
       // acceptance. The production workflow owns the acceptance gate instead.
       requiresUserAcceptance:
-        sessionMode !== 'chat' &&
-        kind === WorkbenchContractKind.GenericWork &&
-        managedWorkflow,
+        sessionMode !== 'chat' && kind === WorkbenchContractKind.GenericWork && managedWorkflow,
       metadata: {
         productionWorkflowEnabled: managedWorkflow,
         ...(skillIds?.length ? { skillIds } : {}),

--- a/src/main/workbenchTask/artifactCollector.test.ts
+++ b/src/main/workbenchTask/artifactCollector.test.ts
@@ -4,18 +4,19 @@ import path from 'path';
 import { expect, test } from 'vitest';
 
 import {
+  WorkbenchArtifactCandidateSource,
   WorkbenchArtifactProvenance,
   WorkbenchArtifactVerificationStatus,
 } from '../../shared/workbenchTask';
 import { collectWorkbenchArtifacts, resolveWorkspaceFile } from './artifactCollector';
 
-test('accepts workspace files and rejects absolute or traversing references', () => {
+test('accepts relative and absolute workspace files and rejects traversing references', () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-artifact-'));
   const filePath = path.join(workspace, 'result.md');
   fs.writeFileSync(filePath, '# result');
   try {
     expect(resolveWorkspaceFile(workspace, 'result.md')).toBe(fs.realpathSync(filePath));
-    expect(resolveWorkspaceFile(workspace, filePath)).toBeNull();
+    expect(resolveWorkspaceFile(workspace, filePath)).toBe(fs.realpathSync(filePath));
     expect(resolveWorkspaceFile(workspace, '../outside.md')).toBeNull();
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
@@ -45,11 +46,46 @@ test('collects successful tool files using actual content hashes', () => {
       runId: 'run',
       workspaceRoot: workspace,
       finalAnswer: '',
-      toolArtifacts: [{ path: 'result.txt', sha256: 'incorrect' }],
+      artifactCandidates: [
+        {
+          path: 'result.txt',
+          sha256: 'incorrect',
+          source: WorkbenchArtifactCandidateSource.ToolEffect,
+        },
+      ],
     });
     expect(artifact.provenance).toBe(WorkbenchArtifactProvenance.Workspace);
     expect(artifact.contentHash).not.toBe('incorrect');
     expect(artifact.verificationStatus).toBe(WorkbenchArtifactVerificationStatus.Failed);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test('marks declared files as pending until a workflow verifies them', () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-declared-artifact-'));
+  const filePath = path.join(workspace, 'result.md');
+  fs.writeFileSync(filePath, '# result');
+  try {
+    const [artifact] = collectWorkbenchArtifacts({
+      taskId: 'task',
+      runId: 'run',
+      workspaceRoot: workspace,
+      finalAnswer: '',
+      artifactCandidates: [
+        {
+          path: filePath,
+          role: 'deliverable',
+          source: WorkbenchArtifactCandidateSource.Declaration,
+        },
+      ],
+    });
+    expect(artifact.reference).toBe('result.md');
+    expect(artifact.verificationStatus).toBe(WorkbenchArtifactVerificationStatus.Pending);
+    expect(artifact.metadata).toMatchObject({
+      role: 'deliverable',
+      source: WorkbenchArtifactCandidateSource.Declaration,
+    });
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/src/main/workbenchTask/artifactCollector.ts
+++ b/src/main/workbenchTask/artifactCollector.ts
@@ -3,11 +3,13 @@ import fs from 'fs';
 import path from 'path';
 
 import {
+  WorkbenchArtifactCandidateSource,
   WorkbenchArtifactKind,
   WorkbenchArtifactProvenance,
   WorkbenchArtifactVerificationStatus,
   discoverWorkbenchMessageArtifactBlocks,
   type WorkbenchArtifact,
+  type WorkbenchArtifactCandidate,
 } from '../../shared/workbenchTask';
 
 type ArtifactInput = Omit<WorkbenchArtifact, 'id' | 'createdAt' | 'updatedAt'>;
@@ -34,13 +36,16 @@ const mimeForPath = (filePath: string): string => {
 };
 
 const resolveWorkspaceFile = (workspaceRoot: string, reference: string): string | null => {
-  if (!reference.trim() || path.isAbsolute(reference)) return null;
-  const lexical = path.resolve(workspaceRoot, reference);
-  const relative = path.relative(workspaceRoot, lexical);
+  if (!reference.trim()) return null;
+  const root = path.resolve(workspaceRoot);
+  const lexical = path.isAbsolute(reference)
+    ? path.normalize(reference)
+    : path.resolve(root, reference);
+  const relative = path.relative(root, lexical);
   if (relative.startsWith('..') || path.isAbsolute(relative) || !fs.existsSync(lexical))
     return null;
   try {
-    const resolvedRoot = fs.realpathSync(workspaceRoot);
+    const resolvedRoot = fs.realpathSync(root);
     const resolved = fs.realpathSync(lexical);
     const realRelative = path.relative(resolvedRoot, resolved);
     const stat = fs.statSync(resolved);
@@ -59,7 +64,7 @@ export function collectWorkbenchArtifacts(input: {
   finalAnswer: string;
   finalMessageId?: string | null;
   workflowSnapshot?: Record<string, unknown> | null;
-  toolArtifacts?: Array<Record<string, unknown>>;
+  artifactCandidates?: WorkbenchArtifactCandidate[];
 }): ArtifactInput[] {
   const artifacts: ArtifactInput[] = [];
   for (const block of discoverWorkbenchMessageArtifactBlocks(input.finalAnswer)) {
@@ -78,30 +83,47 @@ export function collectWorkbenchArtifacts(input: {
     });
   }
 
-  const snapshotFiles: Array<{
-    value: unknown;
-    provenance: WorkbenchArtifactProvenance;
-  }> = [
+  const snapshotFiles: WorkbenchArtifactCandidate[] = [
     ...(Array.isArray(input.workflowSnapshot?.files) ? input.workflowSnapshot.files : []).map(
-      value => ({ value, provenance: WorkbenchArtifactProvenance.Controller }),
+      value => ({
+        ...(value && typeof value === 'object' ? (value as Record<string, unknown>) : {}),
+        path:
+          value &&
+          typeof value === 'object' &&
+          typeof (value as Record<string, unknown>).path === 'string'
+            ? String((value as Record<string, unknown>).path)
+            : '',
+        source: WorkbenchArtifactCandidateSource.DomainWorkflow,
+        verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      }),
     ),
     ...(Array.isArray(input.workflowSnapshot?.artifacts)
       ? input.workflowSnapshot.artifacts
       : []
-    ).map(value => ({ value, provenance: WorkbenchArtifactProvenance.Controller })),
-    ...(input.toolArtifacts ?? []).map(value => ({
-      value,
-      provenance: WorkbenchArtifactProvenance.Workspace,
+    ).map(value => ({
+      ...(value && typeof value === 'object' ? (value as Record<string, unknown>) : {}),
+      path:
+        value &&
+        typeof value === 'object' &&
+        typeof (value as Record<string, unknown>).path === 'string'
+          ? String((value as Record<string, unknown>).path)
+          : '',
+      source: WorkbenchArtifactCandidateSource.DomainWorkflow,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
     })),
+    ...(input.artifactCandidates ?? []),
   ];
-  for (const { value, provenance } of snapshotFiles) {
-    if (!value || typeof value !== 'object') continue;
-    const record = value as Record<string, unknown>;
-    const reference = typeof record.path === 'string' ? record.path : '';
+  for (const candidate of snapshotFiles) {
+    const reference = candidate.path;
     const resolved = resolveWorkspaceFile(input.workspaceRoot, reference);
     if (!resolved) continue;
     const contentHash = createHash('sha256').update(fs.readFileSync(resolved)).digest('hex');
-    const declaredHash = typeof record.sha256 === 'string' ? record.sha256 : null;
+    const declaredHash = candidate.sha256 ?? null;
+    const provenance =
+      candidate.source === WorkbenchArtifactCandidateSource.DomainWorkflow ||
+      candidate.source === WorkbenchArtifactCandidateSource.ProductionInspection
+        ? WorkbenchArtifactProvenance.Controller
+        : WorkbenchArtifactProvenance.Workspace;
     artifacts.push({
       taskId: input.taskId,
       runId: input.runId,
@@ -113,10 +135,12 @@ export function collectWorkbenchArtifacts(input: {
       verificationStatus:
         declaredHash && declaredHash !== contentHash
           ? WorkbenchArtifactVerificationStatus.Failed
-          : WorkbenchArtifactVerificationStatus.Verified,
+          : (candidate.verificationStatus ?? WorkbenchArtifactVerificationStatus.Pending),
       metadata: {
-        ...(typeof record.role === 'string' ? { role: record.role } : {}),
-        ...(typeof record.verifiedAt === 'string' ? { verifiedAt: record.verifiedAt } : {}),
+        source: candidate.source,
+        ...(candidate.role ? { role: candidate.role } : {}),
+        ...(candidate.title ? { title: candidate.title } : {}),
+        ...(candidate.kind ? { declaredKind: candidate.kind } : {}),
         ...(declaredHash ? { declaredHash } : {}),
       },
     });

--- a/src/main/workbenchTask/repository.test.ts
+++ b/src/main/workbenchTask/repository.test.ts
@@ -157,3 +157,44 @@ test('deduplicates identical artifact evidence within a run', () => {
     db.close();
   }
 });
+
+test('promotes an existing pending artifact when verified evidence arrives', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const run = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    const pending = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'result.txt',
+      contentHash: 'hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: { role: 'deliverable' },
+    });
+
+    const verified = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'result.txt',
+      contentHash: 'hash',
+      provenance: WorkbenchArtifactProvenance.Controller,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      metadata: { verifier: 'production_inspection' },
+    });
+
+    expect(verified).toMatchObject({
+      id: pending.id,
+      provenance: WorkbenchArtifactProvenance.Controller,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      metadata: { role: 'deliverable', verifier: 'production_inspection' },
+    });
+    expect(repository.getDetail(task.id)?.artifacts).toHaveLength(1);
+  } finally {
+    db.close();
+  }
+});

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import {
   WorkbenchApprovalDecision,
   WorkbenchApprovalEffectStatus,
+  WorkbenchArtifactVerificationStatus,
   WorkbenchContractKind,
   WorkbenchRunEventType,
   WorkbenchRunStatus,
@@ -15,7 +16,6 @@ import {
   type WorkbenchArtifact,
   type WorkbenchArtifactKind,
   type WorkbenchArtifactProvenance,
-  type WorkbenchArtifactVerificationStatus,
   type WorkbenchJsonObject,
   type WorkbenchRun,
   type WorkbenchRunContext,
@@ -349,7 +349,31 @@ export class WorkbenchTaskRepository {
          WHERE run_id = ? AND reference = ? AND content_hash = ?`,
       )
       .get(input.runId, input.reference, input.contentHash) as ArtifactRow | undefined;
-    if (existing) return this.mapArtifact(existing);
+    if (existing) {
+      const current = this.mapArtifact(existing);
+      const replaceEvidence =
+        input.verificationStatus !== WorkbenchArtifactVerificationStatus.Pending ||
+        current.verificationStatus === WorkbenchArtifactVerificationStatus.Pending;
+      const updatedAt = Date.now();
+      this.db
+        .prepare(
+          `UPDATE workbench_artifacts
+           SET provenance = ?, verification_status = ?, metadata_json = ?, updated_at = ?
+           WHERE id = ?`,
+        )
+        .run(
+          replaceEvidence ? input.provenance : current.provenance,
+          replaceEvidence ? input.verificationStatus : current.verificationStatus,
+          JSON.stringify({ ...current.metadata, ...input.metadata }),
+          updatedAt,
+          current.id,
+        );
+      return this.mapArtifact(
+        this.db
+          .prepare('SELECT * FROM workbench_artifacts WHERE id = ?')
+          .get(current.id) as ArtifactRow,
+      );
+    }
     const now = Date.now();
     const id = randomUUID();
     this.db

--- a/src/main/workbenchTask/riskClassifier.test.ts
+++ b/src/main/workbenchTask/riskClassifier.test.ts
@@ -39,6 +39,12 @@ test('all production loop control actions bypass user approval', () => {
   }
 });
 
+test('artifact declarations bypass user approval', () => {
+  expect(
+    classifyWorkbenchToolRisk('declare_artifact', { filePath: 'D:/workspace/report.md' }),
+  ).toBe(WorkbenchApprovalRiskLevel.ReadOnly);
+});
+
 test('only explicitly read-only shell commands qualify for allow-all auto approval', () => {
   expect(isSafeShellCommand('cd "C:/project" && ls -la')).toBe(true);
   expect(isSafeShellCommand("python -c \"open('out.txt', 'w').write('x')\"")).toBe(false);

--- a/src/main/workbenchTask/riskClassifier.ts
+++ b/src/main/workbenchTask/riskClassifier.ts
@@ -10,6 +10,7 @@ const internalControlTools = new Set([
   'work_acceptance',
   'workflow_state',
   'research_state',
+  'declare_artifact',
 ]);
 const reversibleTools = new Set(['write', 'edit']);
 const irreversibleShellPattern =

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { expect, test, vi } from 'vitest';
 
 import {
@@ -6,6 +9,8 @@ import {
   WorkbenchApprovalDecisionSource,
   WorkbenchApprovalEffectStatus,
   WorkbenchApprovalRiskLevel,
+  WorkbenchArtifactCandidateSource,
+  WorkbenchArtifactVerificationStatus,
   WorkbenchContractKind,
   WorkbenchRunEventType,
   WorkbenchRunTrigger,
@@ -141,6 +146,45 @@ test('emits a verified run source only after deterministic verification passes',
       }),
     );
   } finally {
+    db.close();
+  }
+});
+
+test('registers a declared artifact before production workflow completion', () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-ledger-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'create a small report',
+      contract: chatContract,
+    });
+    const artifact = service.registerArtifact({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+
+    expect(artifact).toMatchObject({
+      taskId: task.id,
+      runId: run.id,
+      reference: 'report.md',
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+    });
+    expect(service.getDetail(task.id)?.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: WorkbenchRunEventType.ArtifactRegistered }),
+      ]),
+    );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
     db.close();
   }
 });

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -6,6 +6,8 @@ import {
   WorkbenchApprovalDecisionSource,
   WorkbenchApprovalEffectStatus,
   WorkbenchApprovalRiskLevel,
+  WorkbenchArtifactCandidateSource,
+  WorkbenchArtifactVerificationStatus,
   WorkbenchRunEventType,
   WorkbenchRunStatus,
   WorkbenchRunTrigger,
@@ -13,6 +15,8 @@ import {
   WorkbenchVerificationCheckStatus,
   WorkbenchVerificationOutcome,
   type WorkbenchApproval,
+  type WorkbenchArtifact,
+  type WorkbenchArtifactCandidate,
   type WorkbenchApprovalResponseInput,
   type WorkbenchJsonObject,
   type WorkbenchRun,
@@ -102,6 +106,43 @@ export class WorkbenchTaskService extends EventEmitter {
 
   listForSession(sessionId: string): WorkbenchTask[] {
     return this.repository.listTasksForSession(sessionId);
+  }
+
+  registerArtifact(input: {
+    sessionId: string;
+    runId: string;
+    workspaceRoot: string;
+    candidate: WorkbenchArtifactCandidate;
+  }): WorkbenchArtifact {
+    const run = this.requireRun(input.runId);
+    const task = this.requireTask(run.taskId);
+    if (task.sessionId !== input.sessionId || task.activeRunId !== run.id) {
+      throw new Error('The artifact does not belong to the active task run.');
+    }
+    if (run.status !== WorkbenchRunStatus.Running) {
+      throw new Error('Artifacts can only be registered while the task run is active.');
+    }
+    const [artifact] = collectWorkbenchArtifacts({
+      taskId: task.id,
+      runId: run.id,
+      workspaceRoot: input.workspaceRoot,
+      finalAnswer: '',
+      artifactCandidates: [input.candidate],
+    });
+    if (!artifact) {
+      throw new Error('The artifact path must resolve to a file inside the workspace.');
+    }
+    const registered = this.repository.transaction(() => {
+      const stored = this.repository.addArtifact(artifact);
+      this.repository.appendRunEvent(run.id, WorkbenchRunEventType.ArtifactRegistered, {
+        artifactId: stored.id,
+        reference: stored.reference,
+        source: input.candidate.source,
+      });
+      return stored;
+    });
+    this.emitChanged(task);
+    return registered;
   }
 
   private withProductionPlan(detail: WorkbenchTaskDetail | null): WorkbenchTaskDetail | null {
@@ -239,14 +280,20 @@ export class WorkbenchTaskService extends EventEmitter {
       workflowSnapshot: input.workflowSnapshot,
     };
     const result = verifyWorkbenchRun(verificationContext);
-    const toolArtifacts = this.repository
+    const artifactCandidates: WorkbenchArtifactCandidate[] = this.repository
       .listApprovalsForRun(run.id)
       .filter(approval => approval.effectStatus === WorkbenchApprovalEffectStatus.Succeeded)
       .flatMap(approval => {
         const pathValue =
           approval.request.path ?? approval.request.file_path ?? approval.request.filePath;
         return typeof pathValue === 'string'
-          ? [{ path: pathValue, toolName: approval.toolName, toolCallId: approval.toolCallId }]
+          ? [
+              {
+                path: pathValue,
+                source: WorkbenchArtifactCandidateSource.ToolEffect,
+                verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+              },
+            ]
           : [];
       });
     this.repository.transaction(() => {
@@ -259,7 +306,7 @@ export class WorkbenchTaskService extends EventEmitter {
         finalAnswer: input.finalAnswer,
         finalMessageId: input.finalMessageId,
         workflowSnapshot: input.workflowSnapshot,
-        toolArtifacts,
+        artifactCandidates,
       })) {
         this.repository.addArtifact(artifact);
       }

--- a/src/shared/workbenchTask/constants.ts
+++ b/src/shared/workbenchTask/constants.ts
@@ -107,6 +107,15 @@ export const WorkbenchArtifactProvenance = {
 export type WorkbenchArtifactProvenance =
   (typeof WorkbenchArtifactProvenance)[keyof typeof WorkbenchArtifactProvenance];
 
+export const WorkbenchArtifactCandidateSource = {
+  Declaration: 'declaration',
+  ToolEffect: 'tool_effect',
+  DomainWorkflow: 'domain_workflow',
+  ProductionInspection: 'production_inspection',
+} as const;
+export type WorkbenchArtifactCandidateSource =
+  (typeof WorkbenchArtifactCandidateSource)[keyof typeof WorkbenchArtifactCandidateSource];
+
 export const WorkbenchArtifactVerificationStatus = {
   Pending: 'pending',
   Verified: 'verified',
@@ -133,6 +142,7 @@ export const WorkbenchRunEventType = {
   HarnessActivation: 'harness_activation',
   HarnessFailure: 'harness_failure',
   HarnessQualityMeasured: 'harness_quality_measured',
+  ArtifactRegistered: 'artifact_registered',
 } as const;
 export type WorkbenchRunEventType =
   (typeof WorkbenchRunEventType)[keyof typeof WorkbenchRunEventType];

--- a/src/shared/workbenchTask/types.ts
+++ b/src/shared/workbenchTask/types.ts
@@ -4,6 +4,7 @@ import type {
   WorkbenchApprovalEffectStatus,
   WorkbenchApprovalRiskLevel,
   WorkbenchArtifactKind,
+  WorkbenchArtifactCandidateSource,
   WorkbenchArtifactProvenance,
   WorkbenchArtifactVerificationStatus,
   WorkbenchContractKind,
@@ -94,6 +95,16 @@ export interface WorkbenchArtifact {
   metadata: WorkbenchJsonObject;
   createdAt: number;
   updatedAt: number;
+}
+
+export interface WorkbenchArtifactCandidate {
+  path: string;
+  source: WorkbenchArtifactCandidateSource;
+  title?: string;
+  kind?: string;
+  role?: string;
+  sha256?: string;
+  verificationStatus?: WorkbenchArtifactVerificationStatus;
 }
 
 export interface WorkbenchApproval {


### PR DESCRIPTION
## Summary

- persist `declare_artifact` calls directly in the Workbench artifact ledger, independent of production-loop activation
- accept absolute artifact paths only when their real path remains inside the active workspace
- keep unreviewed tool and declaration artifacts pending, deduplicate repeated evidence, and promote records when verified evidence arrives
- treat artifact declaration as a read-only control call so registration never opens an approval prompt

## Validation

- `npx vitest run src/main/declareArtifact/tool.test.ts src/main/workbenchTask/artifactCollector.test.ts src/main/workbenchTask/riskClassifier.test.ts src/main/workbenchTask/repository.test.ts src/main/workbenchTask/taskService.test.ts` (40 tests)
- `npm run lint`
- `npm run compile:electron`

## Electron behavior

No IPC, storage-schema, or windowing changes. Existing `workbench_artifacts` rows are used as the durable trajectory projection.
