### PR TITLE
fix(production-loop): project reviewed delivery artifacts

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -79,6 +79,7 @@ import type {
   WorkbenchApprovalRequestedEvent,
   WorkbenchTaskService,
 } from '../../workbenchTask/taskService';
+import { composeWorkbenchWorkflowSnapshot } from '../../workbenchTask/workflowSnapshot';
 import { ProductionLoopController } from '../../productionLoop/controller';
 import { shouldEnableProductionWorkflow } from '../../productionLoop/entryPolicy';
 import { buildProductionLoopTool } from '../../productionLoop/tool';
@@ -2508,15 +2509,27 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           }
         }
         if (active.workbenchRunId && this.workbenchTaskService) {
-          const workflowSnapshot = active.productionWorkflowEnabled
-            ? active.productionLoop
-              ? active.productionLoop.getSnapshot()
-              : active.researchRun
-                ? active.researchRun.getSnapshot()
-                : active.shortcutWorkflow
-                  ? active.shortcutWorkflow.getSnapshot()
-                  : active.workExecution?.getSnapshot() || null
-            : null;
+          const domainWorkflowSnapshot = active.researchRun
+            ? active.researchRun.getSnapshot()
+            : active.shortcutWorkflow
+              ? active.shortcutWorkflow.getSnapshot()
+              : active.workExecution?.getSnapshot() || null;
+          const workflowSnapshot = composeWorkbenchWorkflowSnapshot({
+            production:
+              active.productionWorkflowEnabled && active.productionLoop
+                ? active.productionLoop.getSnapshot()
+                : null,
+            domain: domainWorkflowSnapshot,
+          });
+          const artifactCandidates = active.productionLoop
+            ?.getReviewedArtifacts()
+            .map(artifact => ({
+              path: artifact.reference,
+              kind: artifact.kind,
+              role: artifact.kind,
+              source: WorkbenchArtifactCandidateSource.ProductionInspection,
+              verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+            }));
           this.workbenchTaskService.completeRun({
             sessionId,
             runId: active.workbenchRunId,
@@ -2529,6 +2542,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 ? undefined
                 : active.agentLoop.getState().done,
             workflowSnapshot,
+            artifactCandidates,
           });
         }
         void this.runPostTurnMemoryMaintenance(

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -149,9 +149,7 @@ test('exposes record_prototype as the first action for deferred prototype workfl
     prototypeRequired: true,
     availableActions: ['record_prototype', 'skip_workflow'],
   });
-  expect(controller.buildInitialPrompt()).toContain(
-    'start with production_loop record_prototype',
-  );
+  expect(controller.buildInitialPrompt()).toContain('start with production_loop record_prototype');
 });
 
 test('starts deferred production state when the model commits a plan', () => {
@@ -476,4 +474,38 @@ test('getSnapshot exposes the skip flag for the verification chain', () => {
     phase: ProductionLoopPhase.Plan,
     status: ProductionLoopStatus.Completed,
   });
+});
+
+test('exposes artifacts only after the latest inspection passes critique', () => {
+  const { controller, service } = createController();
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Report passes'],
+    expectedArtifacts: [{ kind: 'report', description: 'Final report', required: true }],
+    expectedVerifiers: [{ name: 'report_check', deterministic: true }],
+  });
+  controller.updatePlanItem(planned.planItems[0].id, 'completed');
+  controller.recordToolResult('report-check', 'bash', 'Report check passed.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  controller.startInspection({
+    artifacts: [{ kind: 'report', reference: 'output/report.md' }],
+    verifiers: [{ name: 'report_check', evidenceRef }],
+  });
+  controller.requestCritique();
+
+  expect(controller.getReviewedArtifacts()).toEqual([]);
+
+  const runId = controller.getState().runId;
+  service.recordCriticStart(runId, 'critic-call');
+  service.recordCriticResult(
+    runId,
+    'critic-call',
+    JSON.stringify({ verdict: 'pass', findings: [] }),
+    false,
+  );
+
+  expect(controller.getReviewedArtifacts()).toEqual([
+    { kind: 'report', reference: 'output/report.md' },
+  ]);
 });

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -2,6 +2,7 @@ import {
   ProductionLoopPhase,
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
+  type ProductionArtifactEvidence,
   type ProductionLoopState,
 } from '../../shared/productionLoop';
 import type { WorkbenchContractKind, WorkbenchJsonObject } from '../../shared/workbenchTask';
@@ -415,6 +416,19 @@ export class ProductionLoopController {
       inspections: this.state.inspections.length,
       revisions: this.state.revisions.length,
     };
+  }
+
+  getReviewedArtifacts(): ProductionArtifactEvidence[] {
+    this.refreshIfStarted();
+    if (
+      !this.state ||
+      this.state.phase !== ProductionLoopPhase.Deliver ||
+      !this.state.critic.passed
+    ) {
+      return [];
+    }
+    const latestInspection = this.state.inspections[this.state.inspections.length - 1];
+    return latestInspection ? structuredClone(latestInspection.artifacts) : [];
   }
 
   private activate(): ProductionLoopState {

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -10,6 +10,7 @@ import {
   WorkbenchApprovalEffectStatus,
   WorkbenchApprovalRiskLevel,
   WorkbenchArtifactCandidateSource,
+  WorkbenchArtifactProvenance,
   WorkbenchArtifactVerificationStatus,
   WorkbenchContractKind,
   WorkbenchRunEventType,
@@ -183,6 +184,60 @@ test('registers a declared artifact before production workflow completion', () =
         expect.objectContaining({ type: WorkbenchRunEventType.ArtifactRegistered }),
       ]),
     );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});
+
+test('promotes a declared artifact when reviewed evidence is projected at completion', () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-reviewed-artifact-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'create a reviewed report',
+      contract: chatContract,
+    });
+    service.registerArtifact({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+
+    const detail = service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'Done',
+      artifactCandidates: [
+        {
+          path: filePath,
+          kind: 'report',
+          role: 'report',
+          source: WorkbenchArtifactCandidateSource.ProductionInspection,
+          verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+        },
+      ],
+    });
+
+    expect(detail.artifacts).toHaveLength(1);
+    expect(detail.artifacts[0]).toMatchObject({
+      taskId: task.id,
+      provenance: WorkbenchArtifactProvenance.Controller,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      metadata: {
+        source: WorkbenchArtifactCandidateSource.ProductionInspection,
+        declaredKind: 'report',
+      },
+    });
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
     db.close();

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -263,6 +263,7 @@ export class WorkbenchTaskService extends EventEmitter {
     finalMessageId?: string | null;
     workflowCompleted?: boolean;
     workflowSnapshot?: Record<string, unknown> | null;
+    artifactCandidates?: WorkbenchArtifactCandidate[];
     streamClosedCleanly?: boolean;
   }): WorkbenchTaskDetail {
     const run = this.requireRun(input.runId);
@@ -280,7 +281,7 @@ export class WorkbenchTaskService extends EventEmitter {
       workflowSnapshot: input.workflowSnapshot,
     };
     const result = verifyWorkbenchRun(verificationContext);
-    const artifactCandidates: WorkbenchArtifactCandidate[] = this.repository
+    const toolArtifactCandidates: WorkbenchArtifactCandidate[] = this.repository
       .listApprovalsForRun(run.id)
       .filter(approval => approval.effectStatus === WorkbenchApprovalEffectStatus.Succeeded)
       .flatMap(approval => {
@@ -296,6 +297,7 @@ export class WorkbenchTaskService extends EventEmitter {
             ]
           : [];
       });
+    const artifactCandidates = [...toolArtifactCandidates, ...(input.artifactCandidates ?? [])];
     this.repository.transaction(() => {
       this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Verifying);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationStarted);

--- a/src/main/workbenchTask/workflowSnapshot.test.ts
+++ b/src/main/workbenchTask/workflowSnapshot.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest';
+
+import { composeWorkbenchWorkflowSnapshot } from './workflowSnapshot';
+
+test('keeps domain completion failures and files under the production controller', () => {
+  const domain = {
+    phase: 'domain-complete',
+    completionFailures: ['Preview is missing'],
+    files: [{ path: 'output/report.md' }],
+    artifacts: [{ path: 'output/validation.json' }],
+  };
+  const production = { phase: 'deliver', status: 'ready_to_deliver', skipped: false };
+
+  expect(composeWorkbenchWorkflowSnapshot({ production, domain })).toEqual({
+    ...production,
+    domainWorkflow: domain,
+    completionFailures: ['Preview is missing'],
+    files: [{ path: 'output/report.md' }],
+    artifacts: [{ path: 'output/validation.json' }],
+  });
+});
+
+test('returns the available snapshot without introducing a wrapper', () => {
+  const production = { phase: 'deliver' };
+  const domain = { completionFailures: [] };
+
+  expect(composeWorkbenchWorkflowSnapshot({ production })).toBe(production);
+  expect(composeWorkbenchWorkflowSnapshot({ domain })).toBe(domain);
+  expect(composeWorkbenchWorkflowSnapshot({})).toBeNull();
+});

--- a/src/main/workbenchTask/workflowSnapshot.ts
+++ b/src/main/workbenchTask/workflowSnapshot.ts
@@ -1,0 +1,25 @@
+const array = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+
+const stringArray = (value: unknown): string[] =>
+  array(value).filter((entry): entry is string => typeof entry === 'string');
+
+export function composeWorkbenchWorkflowSnapshot(input: {
+  production?: Record<string, unknown> | null;
+  domain?: Record<string, unknown> | null;
+}): Record<string, unknown> | null {
+  const production = input.production ?? null;
+  const domain = input.domain ?? null;
+  if (!production) return domain;
+  if (!domain) return production;
+
+  return {
+    ...production,
+    domainWorkflow: domain,
+    completionFailures: [
+      ...stringArray(domain.completionFailures),
+      ...stringArray(production.completionFailures),
+    ],
+    files: [...array(domain.files), ...array(production.files)],
+    artifacts: [...array(domain.artifacts), ...array(production.artifacts)],
+  };
+}


### PR DESCRIPTION
## Summary

- project artifacts from the latest critic-approved production inspection into the Workbench ledger
- compose the outer production snapshot with the downstream domain snapshot so completion failures and domain files are not shadowed
- promote an existing pending declaration to verified evidence instead of creating a duplicate trajectory entry
- keep production review responsible for verification while artifact discovery remains workflow-independent

## Dependency

Stacked on #547. Merge #547 first, then retarget this PR to `main` if GitHub does not update the base automatically.

## Validation

- `npx vitest run src/main/declareArtifact/tool.test.ts src/main/productionLoop/controller.test.ts src/main/workbenchTask/artifactCollector.test.ts src/main/workbenchTask/repository.test.ts src/main/workbenchTask/riskClassifier.test.ts src/main/workbenchTask/taskService.test.ts src/main/workbenchTask/verification.test.ts src/main/workbenchTask/workflowSnapshot.test.ts` (68 tests)
- `npm run lint`
- `npm run build`

## Electron behavior

No IPC, storage-schema, or windowing changes. Run completion now persists reviewed production artifacts and retains downstream workflow evidence in the existing audit model.
