### PR TITLE
fix(memory): repair background completion handling

### DIFF
--- a/src/main/libs/agentEngine/piBackgroundCompletion.test.ts
+++ b/src/main/libs/agentEngine/piBackgroundCompletion.test.ts
@@ -1,0 +1,92 @@
+import { createModels } from '@earendil-works/pi-ai';
+import {
+  fauxAssistantMessage,
+  fauxProvider,
+  fauxThinking,
+} from '@earendil-works/pi-ai/providers/faux';
+import { expect, test } from 'vitest';
+
+import { SessionMemoryCompletionRole } from '../../memory/sessionMemoryExtractor';
+import {
+  buildPiBackgroundCompletionContext,
+  extractPiBackgroundCompletionText,
+} from './piBackgroundCompletion';
+
+test('builds a Pi context with system instructions outside conversation messages', () => {
+  const context = buildPiBackgroundCompletionContext(
+    [
+      { role: SessionMemoryCompletionRole.System, content: 'Return JSON only.' },
+      { role: SessionMemoryCompletionRole.System, content: 'Use supplied evidence.' },
+      { role: SessionMemoryCompletionRole.User, content: '{"conversation":[]}' },
+    ],
+    () => 42,
+  );
+
+  expect(context).toEqual({
+    systemPrompt: 'Return JSON only.\n\nUse supplied evidence.',
+    messages: [
+      {
+        role: SessionMemoryCompletionRole.User,
+        content: '{"conversation":[]}',
+        timestamp: 42,
+      },
+    ],
+  });
+});
+
+test('uses a context accepted by the real Pi faux provider', async () => {
+  const faux = fauxProvider();
+  const models = createModels();
+  models.setProvider(faux.provider);
+  faux.setResponses([
+    context => {
+      expect(context.systemPrompt).toBe('Extract semantic memory.');
+      expect(context.messages).toEqual([
+        {
+          role: SessionMemoryCompletionRole.User,
+          content: 'Conversation evidence',
+          timestamp: 7,
+        },
+      ]);
+      return fauxAssistantMessage('{"shouldSave":false}');
+    },
+  ]);
+
+  const result = await models.completeSimple(
+    faux.getModel(),
+    buildPiBackgroundCompletionContext(
+      [
+        { role: SessionMemoryCompletionRole.System, content: 'Extract semantic memory.' },
+        { role: SessionMemoryCompletionRole.User, content: 'Conversation evidence' },
+      ],
+      () => 7,
+    ),
+  );
+
+  expect(extractPiBackgroundCompletionText(result)).toBe('{"shouldSave":false}');
+});
+
+test('surfaces Pi provider errors instead of reporting an empty extraction', () => {
+  expect(() =>
+    extractPiBackgroundCompletionText(
+      fauxAssistantMessage([], {
+        stopReason: 'error',
+        errorMessage: 'Provider rejected the request.',
+      }),
+    ),
+  ).toThrow('Provider rejected the request.');
+});
+
+test('rejects reasoning-only responses without treating them as empty provider errors', () => {
+  expect(() =>
+    extractPiBackgroundCompletionText(fauxAssistantMessage(fauxThinking('Internal reasoning'))),
+  ).toThrow('Pi background completion returned reasoning without final text.');
+});
+
+test('rejects completion requests without a user message', () => {
+  expect(() =>
+    buildPiBackgroundCompletionContext([
+      { role: SessionMemoryCompletionRole.System, content: 'Extract semantic memory.' },
+    ]),
+  ).toThrow('Background completion requires at least one user message.');
+});

--- a/src/main/libs/agentEngine/piBackgroundCompletion.ts
+++ b/src/main/libs/agentEngine/piBackgroundCompletion.ts
@@ -1,0 +1,94 @@
+import type { AssistantMessage, Context, TextContent } from '@earendil-works/pi-ai';
+
+import {
+  SessionMemoryCompletionRole,
+  type SessionMemoryCompletionMessage,
+} from '../../memory/sessionMemoryExtractor';
+
+const PiBackgroundCompletionStopReason = {
+  Aborted: 'aborted',
+  Error: 'error',
+  Length: 'length',
+} as const;
+
+const PiBackgroundCompletionContentType = {
+  Text: 'text',
+  Thinking: 'thinking',
+} as const;
+
+export type PiBackgroundCompletionResult = Pick<AssistantMessage, 'content'> &
+  Partial<Pick<AssistantMessage, 'errorMessage' | 'stopReason'>>;
+
+export function buildPiBackgroundCompletionContext(
+  messages: readonly SessionMemoryCompletionMessage[],
+  now: () => number = Date.now,
+): Context {
+  const systemPrompts: string[] = [];
+  const userMessages: Context['messages'] = [];
+
+  for (const message of messages) {
+    if (message.role === SessionMemoryCompletionRole.System) {
+      if (message.content.trim()) systemPrompts.push(message.content);
+      continue;
+    }
+    userMessages.push({
+      role: SessionMemoryCompletionRole.User,
+      content: message.content,
+      timestamp: now(),
+    });
+  }
+
+  if (userMessages.length === 0) {
+    throw new Error('Background completion requires at least one user message.');
+  }
+
+  const systemPrompt = systemPrompts.join('\n\n');
+  return {
+    ...(systemPrompt ? { systemPrompt } : {}),
+    messages: userMessages,
+  };
+}
+
+export function extractPiBackgroundCompletionText(result: PiBackgroundCompletionResult): string {
+  if (
+    result.stopReason === PiBackgroundCompletionStopReason.Error ||
+    result.stopReason === PiBackgroundCompletionStopReason.Aborted
+  ) {
+    throw new Error(
+      result.errorMessage || `Pi background completion stopped with ${result.stopReason}.`,
+    );
+  }
+  if (result.stopReason === PiBackgroundCompletionStopReason.Length) {
+    throw new Error('Pi background completion reached its output token limit.');
+  }
+
+  const text = result.content
+    .filter(isTextContent)
+    .map(block => block.text)
+    .join('');
+  if (text.trim()) return text;
+
+  const hasThinking = result.content.some(
+    block =>
+      typeof block === 'object' &&
+      block !== null &&
+      'type' in block &&
+      block.type === PiBackgroundCompletionContentType.Thinking,
+  );
+  throw new Error(
+    hasThinking
+      ? 'Pi background completion returned reasoning without final text.'
+      : result.errorMessage || 'Pi background completion returned no text content.',
+  );
+}
+
+function isTextContent(content: unknown): content is TextContent {
+  return (
+    typeof content === 'object' &&
+    content !== null &&
+    'type' in content &&
+    content.type === PiBackgroundCompletionContentType.Text &&
+    'text' in content &&
+    typeof content.text === 'string'
+  );
+}

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -51,7 +51,10 @@ const hoisted = vi.hoisted(() => {
     applyOverrides: vi.fn(),
     getShellPath: vi.fn(),
   }));
-  const mockCompleteSimple = vi.fn().mockResolvedValue({ content: [{ text: 'Hello from Pi' }] });
+  const mockCompleteSimple = vi.fn().mockResolvedValue({
+    content: [{ type: 'text', text: 'Hello from Pi' }],
+    stopReason: 'stop',
+  });
 
   return {
     mockSession,
@@ -305,9 +308,13 @@ describe('PiRuntimeAdapter', () => {
       expect(hoisted.mockCompleteSimple).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'gpt-5', provider: 'openai' }),
         {
+          systemPrompt: 'Extract memory.',
           messages: [
-            { role: 'system', content: 'Extract memory.' },
-            { role: 'user', content: 'Conversation payload.' },
+            expect.objectContaining({
+              role: SessionMemoryCompletionRole.User,
+              content: 'Conversation payload.',
+              timestamp: expect.any(Number),
+            }),
           ],
         },
       );
@@ -319,14 +326,24 @@ describe('PiRuntimeAdapter', () => {
         .mockImplementationOnce(
           () =>
             new Promise(resolve => {
-              releaseFirst = () => resolve({ content: [{ text: 'First memory' }] });
+              releaseFirst = () =>
+                resolve({
+                  content: [{ type: 'text', text: 'First memory' }],
+                  stopReason: 'stop',
+                });
             }),
         )
-        .mockResolvedValueOnce({ content: [{ text: 'Second memory' }] });
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'Second memory' }],
+          stopReason: 'stop',
+        });
       await adapter.startSession('memory-queue', 'Remember this');
       const complete = adapter.getSessionMemoryCompletion('memory-queue');
       expect(complete).not.toBeNull();
-      const messages = [{ role: SessionMemoryCompletionRole.System, content: 'Extract memory.' }];
+      const messages = [
+        { role: SessionMemoryCompletionRole.System, content: 'Extract memory.' },
+        { role: SessionMemoryCompletionRole.User, content: 'Conversation payload.' },
+      ];
 
       const first = complete!(messages);
       const second = complete!(messages);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -74,6 +74,7 @@ import type {
   SessionMemoryCompletion,
   SessionMemoryCompletionMessage,
 } from '../../memory/sessionMemoryExtractor';
+import { SessionMemoryCompletionRole } from '../../memory/sessionMemoryExtractor';
 import type { SessionSummaryService } from '../../memory/sessionSummaryService';
 import type {
   WorkbenchApprovalRequestedEvent,
@@ -100,6 +101,11 @@ import {
   type PiAskUserQuestionResponse,
 } from './piAskUserQuestion';
 import { PiAgentLoopController, PiAgentLoopMode } from './piAgentLoop';
+import {
+  buildPiBackgroundCompletionContext,
+  extractPiBackgroundCompletionText,
+  type PiBackgroundCompletionResult,
+} from './piBackgroundCompletion';
 import { buildPiConversationPrompt } from './piConversationContext';
 import { prependProductionWorkflowPrompt } from './piExpertProductionPrompt';
 import { isAcademicResearchSkillSet, PiResearchRunController } from './piResearchRun';
@@ -314,9 +320,9 @@ interface PiModules {
   };
   completeSimple: (
     model: unknown,
-    context: { messages: Array<{ role: string; content: string }> },
+    context: ReturnType<typeof buildPiBackgroundCompletionContext>,
     options?: { apiKey?: string },
-  ) => Promise<{ content: Array<{ text: string }> }>;
+  ) => Promise<PiBackgroundCompletionResult>;
 }
 
 interface PiResourceLoader {
@@ -349,8 +355,8 @@ interface PiModelRuntime {
   getModel(provider: string, modelId: string): unknown;
   completeSimple?(
     model: unknown,
-    context: { messages: Array<{ role: string; content: string }> },
-  ): Promise<{ content: Array<{ text: string }> }>;
+    context: ReturnType<typeof buildPiBackgroundCompletionContext>,
+  ): Promise<PiBackgroundCompletionResult>;
 }
 
 interface PiModelRuntimeCreateOptions {
@@ -439,7 +445,7 @@ async function getPiModules(): Promise<PiModules> {
               .SettingsManager as PiModules['SettingsManager'])
           : undefined,
         getAgentDir: codingAgent.getAgentDir as PiModules['getAgentDir'],
-        ModelRuntime: codingAgent.ModelRuntime as PiModules['ModelRuntime'],
+        ModelRuntime: codingAgent.ModelRuntime as unknown as PiModules['ModelRuntime'],
         // getModel is the current API (deprecated but functional); will migrate to createModels() later
         getModel: compat.getModel as unknown as PiModules['getModel'],
         completeSimple: compat.completeSimple as unknown as PiModules['completeSimple'],
@@ -2078,16 +2084,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   async chatDirect(prompt: string, modelId?: string): Promise<string> {
     const pi = await getPiModules();
     const resolvedModel = await resolvePiModel(pi, modelId);
+    const context = buildPiBackgroundCompletionContext([
+      { role: SessionMemoryCompletionRole.User, content: prompt },
+    ]);
     const result = resolvedModel.modelRuntime?.completeSimple
-      ? await resolvedModel.modelRuntime.completeSimple(resolvedModel.model, {
-          messages: [{ role: 'user', content: prompt }],
-        })
-      : await pi.completeSimple(
-          resolvedModel.model,
-          { messages: [{ role: 'user', content: prompt }] },
-          resolvedModel.requestOptions,
-        );
-    return extractPiCompletionText(result);
+      ? await resolvedModel.modelRuntime.completeSimple(resolvedModel.model, context)
+      : await pi.completeSimple(resolvedModel.model, context, resolvedModel.requestOptions);
+    return extractPiBackgroundCompletionText(result);
   }
 
   private createSessionMemoryCompletion(active: ActivePiSession): SessionMemoryCompletion {
@@ -2147,11 +2150,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     messages: readonly SessionMemoryCompletionMessage[],
   ): Promise<string> {
     const pi = await getPiModules();
-    const context = { messages: messages.map(message => ({ ...message })) };
+    const context = buildPiBackgroundCompletionContext(messages);
     const result = modelRuntime?.completeSimple
       ? await modelRuntime.completeSimple(model, context)
       : await pi.completeSimple(model, context, modelRequestOptions);
-    return extractPiCompletionText(result);
+    return extractPiBackgroundCompletionText(result);
   }
 
   // ── Private: event mapping ──
@@ -3289,19 +3292,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       },
     };
   }
-}
-
-function extractPiCompletionText(result: { content: unknown[] }): string {
-  return result.content
-    .filter(
-      (content): content is { text: string } =>
-        typeof content === 'object' &&
-        content !== null &&
-        'text' in content &&
-        typeof content.text === 'string',
-    )
-    .map(content => content.text)
-    .join('');
 }
 
 // ── Provider resolution ──


### PR DESCRIPTION
## Summary

- build Pi background completion requests with system instructions in `context.systemPrompt`
- share the same context and response adapter between direct chat and semantic session-memory extraction
- surface provider errors, aborts, output limits, and reasoning-only responses instead of reporting them as empty summaries

## Electron behavior

- changes main-process agent runtime behavior only
- does not change IPC contracts, renderer state, or persisted data

## Verification

- `npm test -- piBackgroundCompletion` (5 tests passed)
- `npm run compile:electron`
- `npx oxlint` on the four changed files
- `git diff --check`

## Test environment note

The broader `piRuntimeAdapter` suite remains blocked locally by the existing `better-sqlite3` Node ABI mismatch (`NODE_MODULE_VERSION 143` vs `137`). The new provider-contract tests and Electron TypeScript compilation pass.
