### PR TITLE
fix(workbench): preserve declared delivery artifacts

### DIFF
--- a/src/main/workbenchTask/artifactCollector.test.ts
+++ b/src/main/workbenchTask/artifactCollector.test.ts
@@ -10,16 +10,24 @@ import {
 } from '../../shared/workbenchTask';
 import { collectWorkbenchArtifacts, resolveWorkspaceFile } from './artifactCollector';
 
-test('accepts relative and absolute workspace files and rejects traversing references', () => {
+test('accepts workspace files while rejecting absolute and relative escapes', () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-artifact-'));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-artifact-outside-'));
   const filePath = path.join(workspace, 'result.md');
+  const dotFilePath = path.join(workspace, '..draft.md');
+  const outsidePath = path.join(outside, 'outside.md');
   fs.writeFileSync(filePath, '# result');
+  fs.writeFileSync(dotFilePath, '# draft');
+  fs.writeFileSync(outsidePath, '# outside');
   try {
     expect(resolveWorkspaceFile(workspace, 'result.md')).toBe(fs.realpathSync(filePath));
     expect(resolveWorkspaceFile(workspace, filePath)).toBe(fs.realpathSync(filePath));
+    expect(resolveWorkspaceFile(workspace, '..draft.md')).toBe(fs.realpathSync(dotFilePath));
+    expect(resolveWorkspaceFile(workspace, outsidePath)).toBeNull();
     expect(resolveWorkspaceFile(workspace, '../outside.md')).toBeNull();
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
+    fs.rmSync(outside, { recursive: true, force: true });
   }
 });
 
@@ -89,4 +97,16 @@ test('marks declared files as pending until a workflow verifies them', () => {
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
+});
+
+test('uses the final message id in message-block references', () => {
+  const [artifact] = collectWorkbenchArtifacts({
+    taskId: 'task',
+    runId: 'run',
+    workspaceRoot: process.cwd(),
+    finalAnswer: '```artifact:html title="Preview"\n<h1>Hello</h1>\n```',
+    finalMessageId: 'assistant-1',
+  });
+
+  expect(artifact.reference).toBe('message:assistant-1:block:0');
 });

--- a/src/main/workbenchTask/artifactCollector.ts
+++ b/src/main/workbenchTask/artifactCollector.ts
@@ -35,23 +35,23 @@ const mimeForPath = (filePath: string): string => {
   return mapping[extension] || 'application/octet-stream';
 };
 
+const isOutside = (root: string, target: string): boolean => {
+  const relative = path.relative(root, target);
+  return relative.split(path.sep)[0] === '..' || path.isAbsolute(relative);
+};
+
 const resolveWorkspaceFile = (workspaceRoot: string, reference: string): string | null => {
   if (!reference.trim()) return null;
   const root = path.resolve(workspaceRoot);
   const lexical = path.isAbsolute(reference)
     ? path.normalize(reference)
     : path.resolve(root, reference);
-  const relative = path.relative(root, lexical);
-  if (relative.startsWith('..') || path.isAbsolute(relative) || !fs.existsSync(lexical))
-    return null;
+  if (isOutside(root, lexical) || !fs.existsSync(lexical)) return null;
   try {
     const resolvedRoot = fs.realpathSync(root);
     const resolved = fs.realpathSync(lexical);
-    const realRelative = path.relative(resolvedRoot, resolved);
     const stat = fs.statSync(resolved);
-    return realRelative.startsWith('..') || path.isAbsolute(realRelative) || !stat.isFile()
-      ? null
-      : resolved;
+    return isOutside(resolvedRoot, resolved) || !stat.isFile() ? null : resolved;
   } catch {
     return null;
   }

--- a/src/main/workbenchTask/repository.test.ts
+++ b/src/main/workbenchTask/repository.test.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { expect, test } from 'vitest';
 
 import {
+  WorkbenchArtifactCandidateSource,
   WorkbenchArtifactKind,
   WorkbenchArtifactProvenance,
   WorkbenchArtifactVerificationStatus,
@@ -192,6 +193,54 @@ test('promotes an existing pending artifact when verified evidence arrives', () 
       provenance: WorkbenchArtifactProvenance.Controller,
       verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
       metadata: { role: 'deliverable', verifier: 'production_inspection' },
+    });
+    expect(repository.getDetail(task.id)?.artifacts).toHaveLength(1);
+  } finally {
+    db.close();
+  }
+});
+
+test('preserves declared identity when pending tool evidence is deduplicated', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const run = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    const declared = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/markdown',
+      reference: 'result.md',
+      contentHash: 'hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: {
+        source: WorkbenchArtifactCandidateSource.Declaration,
+        role: 'deliverable',
+        title: 'Final report',
+      },
+    });
+
+    const duplicate = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/markdown',
+      reference: 'result.md',
+      contentHash: 'hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: { source: WorkbenchArtifactCandidateSource.ToolEffect },
+    });
+
+    expect(duplicate).toMatchObject({
+      id: declared.id,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: {
+        source: WorkbenchArtifactCandidateSource.Declaration,
+        role: 'deliverable',
+        title: 'Final report',
+      },
     });
     expect(repository.getDetail(task.id)?.artifacts).toHaveLength(1);
   } finally {

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import {
   WorkbenchApprovalDecision,
   WorkbenchApprovalEffectStatus,
+  WorkbenchArtifactCandidateSource,
   WorkbenchArtifactVerificationStatus,
   WorkbenchContractKind,
   WorkbenchRunEventType,
@@ -31,6 +32,16 @@ import {
 import { assertRunTransition, assertTaskTransition } from './stateMachine';
 
 const terminalTaskStatuses = new Set<string>(WorkbenchTerminalTaskStatuses);
+
+const artifactSourcePriority: Record<string, number> = {
+  [WorkbenchArtifactCandidateSource.ToolEffect]: 1,
+  [WorkbenchArtifactCandidateSource.DomainWorkflow]: 2,
+  [WorkbenchArtifactCandidateSource.Declaration]: 3,
+  [WorkbenchArtifactCandidateSource.ProductionInspection]: 4,
+};
+
+const getArtifactSourcePriority = (source: unknown): number =>
+  typeof source === 'string' ? (artifactSourcePriority[source] ?? 0) : 0;
 
 const parseJson = <T>(value: string | null, fallback: T): T => {
   if (!value) return fallback;
@@ -351,9 +362,16 @@ export class WorkbenchTaskRepository {
       .get(input.runId, input.reference, input.contentHash) as ArtifactRow | undefined;
     if (existing) {
       const current = this.mapArtifact(existing);
+      const replaceIdentity =
+        getArtifactSourcePriority(input.metadata.source) >=
+        getArtifactSourcePriority(current.metadata.source);
       const replaceEvidence =
         input.verificationStatus !== WorkbenchArtifactVerificationStatus.Pending ||
-        current.verificationStatus === WorkbenchArtifactVerificationStatus.Pending;
+        (current.verificationStatus === WorkbenchArtifactVerificationStatus.Pending &&
+          replaceIdentity);
+      const mergedMetadata = replaceIdentity
+        ? { ...current.metadata, ...input.metadata }
+        : { ...input.metadata, ...current.metadata };
       const updatedAt = Date.now();
       this.db
         .prepare(
@@ -364,7 +382,7 @@ export class WorkbenchTaskRepository {
         .run(
           replaceEvidence ? input.provenance : current.provenance,
           replaceEvidence ? input.verificationStatus : current.verificationStatus,
-          JSON.stringify({ ...current.metadata, ...input.metadata }),
+          JSON.stringify(mergedMetadata),
           updatedAt,
           current.id,
         );

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -853,3 +853,66 @@ test('startup recovery marks a verifying run for review', () => {
     db.close();
   }
 });
+
+test('keeps declared artifact identity scoped to its run after tool-effect collection', async () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-run-artifact-'));
+  const filePath = path.join(workspace, 'result.md');
+  fs.writeFileSync(filePath, '# result');
+  try {
+    const first = service.beginRun({
+      sessionId: 'session',
+      goal: 'write a report',
+      contract: chatContract,
+    });
+    service.registerArtifact({
+      sessionId: 'session',
+      runId: first.run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        title: 'Final report',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+    await service.authorizeToolCall({
+      sessionId: 'session',
+      runId: first.run.id,
+      toolCallId: 'write-call',
+      toolName: 'write',
+      toolInput: { path: filePath, content: '# result' },
+      autoApprove: true,
+    });
+    service.recordToolResult(first.run.id, 'write-call', { path: filePath }, false);
+
+    const completed = service.completeRun({
+      sessionId: 'session',
+      runId: first.run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+    });
+    expect(completed.artifacts).toHaveLength(1);
+    expect(completed.artifacts[0].metadata).toMatchObject({
+      role: 'deliverable',
+      title: 'Final report',
+      source: WorkbenchArtifactCandidateSource.Declaration,
+    });
+
+    const second = service.beginRun({
+      sessionId: 'session',
+      goal: 'answer without a file',
+      contract: chatContract,
+    });
+    const nextCompleted = service.completeRun({
+      sessionId: 'session',
+      runId: second.run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+    });
+    expect(nextCompleted.artifacts).toHaveLength(0);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -285,8 +285,17 @@ export class WorkbenchTaskService extends EventEmitter {
       .listApprovalsForRun(run.id)
       .filter(approval => approval.effectStatus === WorkbenchApprovalEffectStatus.Succeeded)
       .flatMap(approval => {
+        const resultDetails =
+          approval.result?.details && typeof approval.result.details === 'object'
+            ? (approval.result.details as Record<string, unknown>)
+            : {};
         const pathValue =
-          approval.request.path ?? approval.request.file_path ?? approval.request.filePath;
+          approval.request.path ??
+          approval.request.file_path ??
+          approval.request.filePath ??
+          resultDetails.path ??
+          resultDetails.file_path ??
+          resultDetails.filePath;
         return typeof pathValue === 'string'
           ? [
               {


### PR DESCRIPTION
## Summary

- Preserve explicit declaration identity when the same file is later rediscovered through a successful write effect.
- Keep production inspection evidence authoritative when it upgrades an artifact to verified status.
- Accept absolute paths inside the active workspace while rejecting absolute, traversal, and symlink escapes.
- Keep artifacts scoped to the owning run so later tasks do not inherit earlier deliverables.
- Recover file paths from structured tool-result details when the request does not expose one.

## Root Cause

The artifact ledger deduplicated by run, reference, and content hash, but pending tool-effect evidence could overwrite higher-value declaration metadata during the duplicate update. Path containment also used a broad parent-prefix check that rejected valid names such as ..draft.md.

## Validation

- 56 targeted tests passed across artifact collection, task completion, and repository persistence.
- Electron TypeScript compilation passed.
- oxlint src/ passed.
- Production data confirmed the affected session workspace was C:/Users/Administrator/Desktop, so its absolute Markdown path remains inside the enforced workspace boundary.