### PR TITLE
fix(cowork): prevent horizontal conversation scrolling

### DIFF
--- a/src/shared/components/ai-elements/conversation.test.ts
+++ b/src/shared/components/ai-elements/conversation.test.ts
@@ -70,3 +70,29 @@ test('supports normal flow for virtualized conversation content', () => {
   expect(content).toHaveClass('flex-col');
   expect(content).not.toHaveClass('flex-col-reverse');
 });
+
+test('keeps horizontal overflow inside message content', () => {
+  const view = render(
+    React.createElement(
+      Conversation,
+      null,
+      React.createElement(
+        TestConversationContent,
+        {
+          observeContentResize: false,
+          scrollClassName: 'cowork-conversation-scroll',
+        },
+        'message',
+      ),
+    ),
+  );
+
+  const content = view.getByText('message');
+  expect(content).toHaveClass('min-w-0');
+  expect(content.parentElement).toHaveClass(
+    'cowork-conversation-scroll',
+    'min-w-0',
+    'overflow-x-hidden',
+    'overflow-y-auto',
+  );
+});

--- a/src/shared/components/ai-elements/conversation.tsx
+++ b/src/shared/components/ai-elements/conversation.tsx
@@ -34,8 +34,9 @@ export const ConversationContent = ({
   ...props
 }: ConversationContentProps) => {
   const context = useStickToBottomContext();
+  const resolvedScrollClassName = cn('min-w-0 overflow-x-hidden overflow-y-auto', scrollClassName);
   const contentClassName = cn(
-    'flex gap-8 p-4',
+    'flex min-w-0 gap-8 p-4',
     reverse ? 'flex-col-reverse' : 'flex-col',
     className,
   );
@@ -50,7 +51,7 @@ export const ConversationContent = ({
     return (
       <StickToBottom.Content
         className={contentClassName}
-        scrollClassName={scrollClassName}
+        scrollClassName={resolvedScrollClassName}
         {...props}
       >
         {children}
@@ -61,7 +62,7 @@ export const ConversationContent = ({
   return (
     <div
       ref={context.scrollRef}
-      className={scrollClassName}
+      className={resolvedScrollClassName}
       style={{ height: '100%', width: '100%', scrollbarGutter: 'stable both-edges' }}
     >
       <div {...props} ref={passiveContentRef} className={contentClassName}>


### PR DESCRIPTION
## Summary

- Prevent the outer conversation viewport from showing a native horizontal scrollbar.
- Keep intentional horizontal scrolling scoped to nested code blocks and tables.
- Add regression coverage for the conversation viewport overflow contract.

## Root Cause

The stick-to-bottom dependency falls back to overflow: auto when the scroll viewport does not declare an axis. That enables scrolling on both axes, so any slightly oversized message descendant creates a full-width horizontal scrollbar.

## Changes

- Apply min-width: 0, overflow-x: hidden, and overflow-y: auto to the shared conversation scroll viewport.
- Allow the conversation content flex container to shrink within split layouts.
- Verify custom scroll classes remain intact while the axis constraints are applied.

## Validation

- npm test -- conversation (9 files, 20 tests passed)
- npx oxlint on the changed files
- npx oxfmt --check on the changed files
- TypeScript and Vite production build stages passed
- The final Electron runtime dependency check remains blocked by pre-existing source maps under dist-electron

## Electron Impact

No IPC, storage, main-process, or windowing behavior changes.

## Screenshots

Not included. This change only removes the native horizontal scrollbar from the conversation viewport.
