### PR TITLE
fix(cowork): show task summaries in history selector

### DIFF
--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.test.ts
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { render, screen, within } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import {
+  WorkbenchContractKind,
+  WorkbenchTaskStatus,
+  type WorkbenchTask,
+  type WorkbenchTaskDetail,
+} from '../../../../shared/workbenchTask';
+import { i18nService } from '../../../services/i18n';
+import { WorkbenchTaskAuditView } from './WorkbenchTaskAuditView';
+import { formatTimestamp, statusLabel } from './utils';
+
+const createTask = (
+  id: string,
+  goal: string,
+  status: WorkbenchTask['status'],
+  createdAt: number,
+): WorkbenchTask => ({
+  id,
+  sessionId: 'session-1',
+  goal,
+  status,
+  contract: {
+    kind: WorkbenchContractKind.GenericWork,
+    requiresUserAcceptance: false,
+  },
+  activeRunId: null,
+  createdAt,
+  updatedAt: createdAt,
+  completedAt: status === WorkbenchTaskStatus.Completed ? createdAt : null,
+});
+
+beforeEach(() => {
+  i18nService.setLanguage('zh', { persist: false });
+});
+
+test('renders the selected task summary instead of its id in the history trigger', () => {
+  const currentTask = createTask(
+    'task-current-id',
+    'Generate a product analysis report',
+    WorkbenchTaskStatus.Completed,
+    Date.UTC(2026, 7, 19, 11, 18, 1),
+  );
+  const previousTask = createTask(
+    'task-previous-id',
+    'Organize historical data',
+    WorkbenchTaskStatus.Cancelled,
+    Date.UTC(2026, 7, 19, 10, 17, 35),
+  );
+  const detail: WorkbenchTaskDetail = {
+    task: currentTask,
+    runs: [],
+    events: [],
+    artifacts: [],
+    approvals: [],
+  };
+
+  render(
+    createElement(WorkbenchTaskAuditView, {
+      detail,
+      tasks: [currentTask, previousTask],
+      busy: false,
+      loading: false,
+      onSelectTask: vi.fn(),
+      onRespondToApproval: vi.fn(),
+    }),
+  );
+
+  const historyTrigger = screen.getByRole('combobox');
+  expect(within(historyTrigger).getByText(statusLabel(currentTask.status))).toBeTruthy();
+  expect(within(historyTrigger).getByText(currentTask.goal)).toBeTruthy();
+  expect(within(historyTrigger).getByText(formatTimestamp(currentTask.createdAt))).toBeTruthy();
+  expect(historyTrigger).not.toHaveTextContent(currentTask.id);
+});

--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
@@ -127,21 +127,15 @@ export function WorkbenchTaskAuditView({
               </span>
               <Select value={task.id} onValueChange={value => value && onSelectTask(value)}>
                 <SelectTrigger className="w-full" disabled={loading}>
-                  <SelectValue />
+                  <SelectValue>
+                    <TaskHistorySummary task={task} />
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent align="start">
                   <SelectGroup>
                     {tasks.map(historyTask => (
                       <SelectItem key={historyTask.id} value={historyTask.id}>
-                        <span className="flex min-w-0 items-center gap-2">
-                          <Badge variant={statusBadgeVariant(historyTask.status)}>
-                            {statusLabel(historyTask.status)}
-                          </Badge>
-                          <span className="max-w-96 truncate">{historyTask.goal}</span>
-                          <span className="text-xs text-muted-foreground">
-                            {formatTimestamp(historyTask.createdAt)}
-                          </span>
-                        </span>
+                        <TaskHistorySummary task={historyTask} />
                       </SelectItem>
                     ))}
                   </SelectGroup>
@@ -284,5 +278,16 @@ function TaskMetadata({ label, value }: { label: string; value: string }) {
       <dt className="text-muted-foreground">{label}</dt>
       <dd className="break-words text-foreground">{value}</dd>
     </div>
+  );
+}
+function TaskHistorySummary({ task }: { task: WorkbenchTask }) {
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-2">
+      <Badge variant={statusBadgeVariant(task.status)}>{statusLabel(task.status)}</Badge>
+      <span className="min-w-0 flex-1 truncate">{task.goal}</span>
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {formatTimestamp(task.createdAt)}
+      </span>
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- Replace the raw task ID in the collapsed history selector with a status badge, task name, and creation time.
- Reuse the same task summary component for the selected value and every menu option.
- Keep the task ID available in the existing task metadata section.

## Implementation

- Extract a shared TaskHistorySummary renderer from the existing history option markup.
- Allow long task names to truncate while the status badge and timestamp remain stable.
- Add a DOM regression test covering the collapsed selector content.

## Validation

- npm test -- WorkbenchTaskAuditView
- npx oxlint on the changed files
- npx oxfmt --check on the changed files
- npm run build:tsc
- The local preview is running at http://127.0.0.1:5182/

## Electron Impact

No IPC, storage, main-process, or windowing behavior changes.

## Screenshots

The reporter-provided screenshots document the before state. An automated after screenshot is not included because the local browser inspection connection was blocked by a Windows ACL error; the DOM regression test verifies that the trigger contains status, name, and time and excludes the task ID.
