### PR TITLE
fix(memory): 原子记忆提取 importance 提示词补范围并加 clamp 兜底

### DIFF
--- a/src/main/memory/atomicMemoryExtractor.test.ts
+++ b/src/main/memory/atomicMemoryExtractor.test.ts
@@ -125,3 +125,80 @@ test('returns no memory for non-durable evidence', async () => {
     }),
   ).resolves.toBeNull();
 });
+
+test('clamps out-of-range importance and confidence instead of failing', () => {
+  const parsed = parseAtomicMemoryResponse(
+    JSON.stringify({
+      shouldSave: true,
+      memories: [
+        {
+          title: 'Urgent decision',
+          content: 'Roll out the migration this week.',
+          kind: MemoryKind.Decision,
+          importance: 2,
+          confidence: 1.5,
+          sensitivity: MemorySensitivity.Normal,
+          evidenceSourceIds: ['message-1'],
+        },
+        {
+          title: 'Low priority',
+          content: 'Revisit the dashboard layout later.',
+          kind: MemoryKind.Preference,
+          importance: -0.5,
+          confidence: 3,
+          sensitivity: MemorySensitivity.Normal,
+          evidenceSourceIds: ['message-1'],
+        },
+      ],
+    }),
+    new Set(['message-1']),
+  );
+
+  expect(parsed).toHaveLength(2);
+  expect(parsed[0]).toMatchObject({ importance: 1, confidence: 1 });
+  expect(parsed[1]).toMatchObject({ importance: 0, confidence: 1 });
+});
+
+test('genuine schema errors still fail after clamp repair', () => {
+  expect(() =>
+    parseAtomicMemoryResponse(
+      JSON.stringify({
+        shouldSave: true,
+        memories: [
+          {
+            title: 'Bad kind',
+            content: 'This memory has an invalid kind.',
+            kind: 'not-a-kind',
+            importance: 2,
+            confidence: 0.5,
+            sensitivity: MemorySensitivity.Normal,
+            evidenceSourceIds: ['message-1'],
+          },
+        ],
+      }),
+      new Set(['message-1']),
+    ),
+  ).toThrow(/failed validation/);
+});
+
+test('non-numeric scores are not silently repaired', () => {
+  expect(() =>
+    parseAtomicMemoryResponse(
+      JSON.stringify({
+        shouldSave: true,
+        memories: [
+          {
+            title: 'String score',
+            content: 'importance as a string cannot be clamped.',
+            kind: MemoryKind.Decision,
+            importance: 'high',
+            confidence: 0.5,
+            sensitivity: MemorySensitivity.Normal,
+            evidenceSourceIds: ['message-1'],
+          },
+        ],
+      }),
+      new Set(['message-1']),
+    ),
+  ).toThrow(/failed validation/);
+});

--- a/src/main/memory/atomicMemoryExtractor.ts
+++ b/src/main/memory/atomicMemoryExtractor.ts
@@ -79,8 +79,8 @@ Schema:
     "title": string,
     "content": string,
     "kind": "decision" | "preference",
-    "importance": number,
-    "confidence": number,
+    "importance": number (0 to 1 inclusive, e.g. 0.5; 1 = most important),
+    "confidence": number (0 to 1 inclusive, e.g. 0.5; 1 = most confident),
     "sensitivity": "normal" | "sensitive",
     "evidenceSourceIds": string[]
   }]
@@ -162,25 +162,63 @@ export function parseAtomicMemoryResponse(
   }
   const result = AtomicMemoryResponseSchema.safeParse(parsed);
   if (!result.success) {
-    throw new Error(`Atomic memory response failed validation: ${result.error.message}`);
-  }
-  if (!result.data.shouldSave) {
-    if (result.data.memories.length > 0) {
-      throw new Error('Atomic memory response returned memories while shouldSave is false.');
+    // Out-of-range importance/confidence is the most common model slip. The
+    // prompt now states the 0-1 range; as a fallback, clamp those numeric
+    // scores instead of dropping the whole migration. Other schema errors
+    // still surface unchanged.
+    const repaired = clampOutOfRangeScores(parsed);
+    const retried = repaired ? AtomicMemoryResponseSchema.safeParse(repaired) : null;
+    if (!retried?.success) {
+      throw new Error(`Atomic memory response failed validation: ${result.error.message}`);
     }
-    return [];
+    console.warn('[AtomicMemory] clamped out-of-range importance/confidence values.');
+    return finish(retried.data);
   }
-  if (result.data.memories.length === 0 || result.data.memories.length > maxItems) {
-    throw new Error('Atomic memory response returned an invalid number of memories.');
-  }
-  for (const memory of result.data.memories) {
-    for (const sourceId of memory.evidenceSourceIds) {
-      if (!allowedSourceIds.has(sourceId)) {
-        throw new Error(`Atomic memory referenced unknown evidence source ${sourceId}.`);
+  return finish(result.data);
+
+  function finish(data: z.infer<typeof AtomicMemoryResponseSchema>): AtomicMemoryItem[] {
+    if (!data.shouldSave) {
+      if (data.memories.length > 0) {
+        throw new Error('Atomic memory response returned memories while shouldSave is false.');
+      }
+      return [];
+    }
+    if (data.memories.length === 0 || data.memories.length > maxItems) {
+      throw new Error('Atomic memory response returned an invalid number of memories.');
+    }
+    for (const memory of data.memories) {
+      for (const sourceId of memory.evidenceSourceIds) {
+        if (!allowedSourceIds.has(sourceId)) {
+          throw new Error(`Atomic memory referenced unknown evidence source ${sourceId}.`);
+        }
       }
     }
+    return data.memories;
   }
-  return result.data.memories;
+}
+
+/**
+ * Clamp numeric importance/confidence scores into [0, 1] on a parsed model
+ * response. Returns null when the payload shape does not allow safe repair
+ * (e.g. scores are non-numeric), so genuine schema errors still fail loudly.
+ */
+function clampOutOfRangeScores(parsed: unknown): unknown {
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !Array.isArray((parsed as { memories?: unknown }).memories)
+  ) {
+    return null;
+  }
+  const repaired = structuredClone(parsed) as { memories: Array<Record<string, unknown>> };
+  for (const memory of repaired.memories) {
+    for (const key of ['importance', 'confidence'] as const) {
+      const value = memory[key];
+      if (typeof value !== 'number') continue;
+      if (value < 0 || value > 1) memory[key] = Math.min(1, Math.max(0, value));
+    }
+  }
+  return repaired;
 }
 
 export function buildAtomicMemorySources(sources: AtomicMemorySource[]): AtomicMemorySource[] {


### PR DESCRIPTION
fix(memory): 原子记忆提取 importance/confidence 提示词补范围并加 clamp 兜底

## 问题

legacy 记忆迁移(#535 引入)时,模型输出的 importance/confidence 超出
[0,1](如 importance=2),被 zod 严格校验拒绝,整个迁移失败并抛
"Atomic memory response failed validation"。

根因:EXTRACTION_SYSTEM_PROMPT 只写 `"importance": number`,未声明
取值范围;schema 却要求 `z.number().min(0).max(1)`——快模型(如
deepseek-v4-flash)容易输出超限整数。且校验失败无容错,一条记录
超限即丢弃整个迁移。

## 修复

[atomicMemoryExtractor.ts](src/main/memory/atomicMemoryExtractor.ts):

1. **提示词补范围**(治本):`"importance": number (0 to 1 inclusive, e.g. 0.5; 1 = most important)`,confidence 同样
2. **解析 clamp 兜底**:safeParse 失败时,若失败原因是数值越界
   (importance/confidence 为数值且不在 [0,1]),clamp 到 [0,1] 后
   重新校验并告警——不再丢弃整个迁移
3. **其他 schema 错误保持响亮失败**:非数值 score、非法 kind 等
   仍抛原错误,clamp 不掩盖真实问题

## 测试

新增 3 个用例(共 7/7 通过):
- 越界 importance=2 / confidence=1.5 / -0.5 / 3 → clamp 后通过
- 非法 kind(非数值问题)→ 仍失败
- 字符串 importance(不可修复)→ 仍失败

## 验证

- tsc(electron-tsconfig)✅　oxlint ✅
- atomicMemoryExtractor 7/7、legacyMemoryMigrationService、
  taskMemoryPromotion 相关 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
