### PR TITLE
fix(cowork): restore permission overlay alignment

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
@@ -8,14 +8,24 @@ const source = readFileSync(
   'utf8',
 );
 
-test('anchors inline permission approval directly above the prompt input', () => {
+test('overlays inline permission approval on the prompt input', () => {
+  const overlay = source.indexOf('className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4"');
+  const permissionContainer = source.indexOf(
+    'className="w-full max-w-5xl min-w-[320px] mx-auto pl-4"',
+    overlay,
+  );
+  const permission = source.indexOf('<CoworkPermissionModal', overlay);
   const inputArea = source.indexOf('{/* Input Area */}');
-  const permission = source.indexOf('<CoworkPermissionModal', inputArea);
+  const promptContainer = source.indexOf(
+    'className="max-w-5xl min-w-[320px] mx-auto pl-4"',
+    inputArea,
+  );
   const promptInput = source.indexOf('<CoworkPromptInput', inputArea);
 
-  expect(inputArea).toBeGreaterThanOrEqual(0);
-  expect(permission).toBeGreaterThan(inputArea);
-  expect(promptInput).toBeGreaterThan(permission);
-  expect(source.slice(inputArea, permission)).toContain('className="mb-2"');
-  expect(source).not.toContain('absolute inset-x-0 bottom-0 z-20 px-4 pb-4');
+  expect(overlay).toBeGreaterThanOrEqual(0);
+  expect(permissionContainer).toBeGreaterThan(overlay);
+  expect(permission).toBeGreaterThan(permissionContainer);
+  expect(inputArea).toBeGreaterThan(permission);
+  expect(promptContainer).toBeGreaterThan(inputArea);
+  expect(promptInput).toBeGreaterThan(promptContainer);
 });

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1478,18 +1478,21 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               )}
           </div>
 
+          {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
+            <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4">
+              <div className="w-full max-w-5xl min-w-[320px] mx-auto pl-4">
+                <CoworkPermissionModal
+                  permission={inlinePermission}
+                  onRespond={onRespondToInlinePermission}
+                  inline
+                />
+              </div>
+            </div>
+          )}
+
           {/* Input Area */}
           <div className="px-4 pb-4 shrink-0">
             <div className="max-w-5xl min-w-[320px] mx-auto pl-4">
-              {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
-                <div className="mb-2">
-                  <CoworkPermissionModal
-                    permission={inlinePermission}
-                    onRespond={onRespondToInlinePermission}
-                    inline
-                  />
-                </div>
-              )}
               <CoworkPromptInput
                 ref={promptInputRef}
                 topAccessory={


### PR DESCRIPTION
## Summary

- Restore the inline permission approval as an overlay on the conversation prompt instead of stacking it above the prompt.
- Match the prompt container width, minimum width, and left inset so the approval surface covers the same horizontal area.
- Keep permission callbacks, prompt state, and artifact preview behavior unchanged.

## Context

PR #542 moved the approval surface into normal document flow. That aligned the containers horizontally, but it also made the approval and prompt render as two separate stacked surfaces. This follow-up restores the intended overlay behavior while retaining exact horizontal alignment.

## Verification

- `git diff --check`
- `npm run lint`
- `npm run build`

## Electron Impact

Renderer-only layout change. No IPC, storage, runtime, or windowing behavior changes.