### PR TITLE
fix(cowork): prevent trace audit layout overflow

### DIFF
--- a/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.test.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, expect, test } from 'vitest';
+
+import {
+  WorkbenchArtifactKind,
+  WorkbenchArtifactProvenance,
+  WorkbenchArtifactVerificationStatus,
+  type WorkbenchArtifact,
+} from '../../../../shared/workbenchTask';
+import { i18nService } from '../../../services/i18n';
+import { ArtifactAuditTab } from './ArtifactAuditTab';
+
+beforeEach(() => {
+  i18nService.setLanguage('zh', { persist: false });
+});
+
+test('contains long artifact values without overlapping fixed action columns', () => {
+  const reference = 'furmark_analysis/reports/very-long-performance-analysis-result.json';
+  const contentHash = 'a249783279ab3e496449534bc5f47a274a3ffe67da7ed46b85f1e052fc2b755d';
+  const artifact: WorkbenchArtifact = {
+    id: 'artifact-1',
+    taskId: 'task-1',
+    runId: 'run-1',
+    kind: WorkbenchArtifactKind.File,
+    mimeType: 'application/json',
+    reference,
+    contentHash,
+    provenance: WorkbenchArtifactProvenance.Workspace,
+    verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+    metadata: {},
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  render(<ArtifactAuditTab artifacts={[artifact]} runs={[]} />);
+
+  const table = screen.getByRole('table');
+  const referenceValue = screen.getByText(reference);
+  const hashValue = screen.getByText(contentHash);
+  const copyButton = screen.getByRole('button', {
+    name: i18nService.t('workbenchTaskCopyHash'),
+  });
+  const actionCell = copyButton.closest('[data-slot="table-cell"]');
+
+  expect(table).toHaveClass('min-w-max');
+  expect(referenceValue).toHaveClass('block', 'w-56', 'truncate');
+  expect(hashValue).toHaveClass('block', 'w-56', 'truncate');
+  expect(actionCell).toHaveClass('w-28');
+  expect(copyButton.parentElement).toHaveClass('shrink-0');
+  expect(table.parentElement).toHaveClass('overflow-x-auto');
+});

--- a/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.tsx
@@ -84,16 +84,18 @@ export function ArtifactAuditTab({ artifacts, runs }: ArtifactAuditTabProps) {
 
   return (
     <TooltipProvider>
-      <Table>
+      <Table className="min-w-max">
         <TableHeader>
           <TableRow>
-            <TableHead>{i18nService.t('workbenchTaskAttempt')}</TableHead>
-            <TableHead>{i18nService.t('workbenchTaskReference')}</TableHead>
-            <TableHead>{i18nService.t('workbenchTaskType')}</TableHead>
-            <TableHead>{i18nService.t('workbenchTaskSource')}</TableHead>
-            <TableHead>{i18nService.t('workbenchTaskHash')}</TableHead>
-            <TableHead>{i18nService.t('workbenchTaskVerification')}</TableHead>
-            <TableHead className="text-right">{i18nService.t('workbenchTaskActions')}</TableHead>
+            <TableHead className="w-12">{i18nService.t('workbenchTaskAttempt')}</TableHead>
+            <TableHead className="w-56">{i18nService.t('workbenchTaskReference')}</TableHead>
+            <TableHead className="w-20">{i18nService.t('workbenchTaskType')}</TableHead>
+            <TableHead className="w-24">{i18nService.t('workbenchTaskSource')}</TableHead>
+            <TableHead className="w-56">{i18nService.t('workbenchTaskHash')}</TableHead>
+            <TableHead className="w-24">{i18nService.t('workbenchTaskVerification')}</TableHead>
+            <TableHead className="w-28 text-right">
+              {i18nService.t('workbenchTaskActions')}
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -101,16 +103,24 @@ export function ArtifactAuditTab({ artifacts, runs }: ArtifactAuditTabProps) {
             const filePath = resolveArtifactFilePath(artifact, runs);
             return (
               <TableRow key={artifact.id}>
-                <TableCell>{getRunAttempt(runs, artifact.runId) ?? '-'}</TableCell>
-                <TableCell className="max-w-[320px] break-all">{artifact.reference}</TableCell>
-                <TableCell>{artifactKindLabel(artifact.kind)}</TableCell>
-                <TableCell>{artifactProvenanceLabel(artifact.provenance)}</TableCell>
-                <TableCell className="max-w-64 break-all font-mono text-xs">
-                  {artifact.contentHash}
+                <TableCell className="w-12">{getRunAttempt(runs, artifact.runId) ?? '-'}</TableCell>
+                <TableCell className="w-56">
+                  <span className="block w-56 truncate">{artifact.reference}</span>
                 </TableCell>
-                <TableCell>{artifactVerificationLabel(artifact.verificationStatus)}</TableCell>
-                <TableCell>
-                  <div className="flex justify-end gap-1">
+                <TableCell className="w-20">{artifactKindLabel(artifact.kind)}</TableCell>
+                <TableCell className="w-24">
+                  {artifactProvenanceLabel(artifact.provenance)}
+                </TableCell>
+                <TableCell className="w-56">
+                  <code className="block w-56 truncate font-mono text-xs">
+                    {artifact.contentHash}
+                  </code>
+                </TableCell>
+                <TableCell className="w-24">
+                  {artifactVerificationLabel(artifact.verificationStatus)}
+                </TableCell>
+                <TableCell className="w-28">
+                  <div className="flex shrink-0 justify-end gap-1">
                     {filePath && (
                       <>
                         <ArtifactAction

--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.test.ts
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.test.ts
@@ -76,3 +76,50 @@ test('renders the selected task summary instead of its id in the history trigger
   expect(within(historyTrigger).getByText(formatTimestamp(currentTask.createdAt))).toBeTruthy();
   expect(historyTrigger).not.toHaveTextContent(currentTask.id);
 });
+
+test('stacks audit sections in independent desktop columns', () => {
+  const task = createTask(
+    'task-layout-id',
+    'Inspect the audit layout',
+    WorkbenchTaskStatus.Completed,
+    Date.UTC(2026, 7, 20, 8, 30, 0),
+  );
+  const detail: WorkbenchTaskDetail = {
+    task,
+    runs: [],
+    events: [],
+    artifacts: [],
+    approvals: [],
+  };
+
+  render(
+    createElement(WorkbenchTaskAuditView, {
+      detail,
+      tasks: [task],
+      busy: false,
+      loading: false,
+      onSelectTask: vi.fn(),
+      onRespondToApproval: vi.fn(),
+    }),
+  );
+
+  const runsSection = screen.getByRole('region', {
+    name: `${i18nService.t('workbenchTaskRuns')} (0)`,
+  });
+  const eventsSection = screen.getByRole('region', {
+    name: `${i18nService.t('workbenchTaskEvents')} (0)`,
+  });
+  const artifactsSection = screen.getByRole('region', {
+    name: `${i18nService.t('workbenchTaskArtifacts')} (0)`,
+  });
+  const approvalsSection = screen.getByRole('region', {
+    name: `${i18nService.t('workbenchTaskApprovals')} (0)`,
+  });
+
+  expect(runsSection.parentElement).toBe(artifactsSection.parentElement);
+  expect(eventsSection.parentElement).toBe(approvalsSection.parentElement);
+  expect(runsSection.parentElement).not.toBe(eventsSection.parentElement);
+  expect(runsSection.parentElement).toHaveClass('flex', 'flex-col', 'gap-4');
+  expect(eventsSection.parentElement).toHaveClass('flex', 'flex-col', 'gap-4');
+  expect(runsSection.parentElement?.parentElement).toHaveClass('grid', 'md:grid-cols-2');
+});

--- a/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.tsx
@@ -211,35 +211,39 @@ export function WorkbenchTaskAuditView({
         )}
 
         <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
-          <WorkbenchTaskAuditSection
-            title={i18nService.t('workbenchTaskRuns')}
-            count={filteredDetail.runs.length}
-          >
-            <RunAuditTab runs={filteredDetail.runs} activeRunId={task.activeRunId} />
-          </WorkbenchTaskAuditSection>
-          <WorkbenchTaskAuditSection
-            title={i18nService.t('workbenchTaskEvents')}
-            count={filteredDetail.events.length}
-          >
-            <EventAuditTab events={filteredDetail.events} runs={detail.runs} />
-          </WorkbenchTaskAuditSection>
-          <WorkbenchTaskAuditSection
-            title={i18nService.t('workbenchTaskArtifacts')}
-            count={filteredDetail.artifacts.length}
-          >
-            <ArtifactAuditTab artifacts={filteredDetail.artifacts} runs={detail.runs} />
-          </WorkbenchTaskAuditSection>
-          <WorkbenchTaskAuditSection
-            title={i18nService.t('workbenchTaskApprovals')}
-            count={filteredDetail.approvals.length}
-          >
-            <ApprovalAuditTab
-              approvals={filteredDetail.approvals}
-              runs={detail.runs}
-              busy={busy}
-              onRespond={onRespondToApproval}
-            />
-          </WorkbenchTaskAuditSection>
+          <div className="flex min-w-0 flex-col gap-4">
+            <WorkbenchTaskAuditSection
+              title={i18nService.t('workbenchTaskRuns')}
+              count={filteredDetail.runs.length}
+            >
+              <RunAuditTab runs={filteredDetail.runs} activeRunId={task.activeRunId} />
+            </WorkbenchTaskAuditSection>
+            <WorkbenchTaskAuditSection
+              title={i18nService.t('workbenchTaskArtifacts')}
+              count={filteredDetail.artifacts.length}
+            >
+              <ArtifactAuditTab artifacts={filteredDetail.artifacts} runs={detail.runs} />
+            </WorkbenchTaskAuditSection>
+          </div>
+          <div className="flex min-w-0 flex-col gap-4">
+            <WorkbenchTaskAuditSection
+              title={i18nService.t('workbenchTaskEvents')}
+              count={filteredDetail.events.length}
+            >
+              <EventAuditTab events={filteredDetail.events} runs={detail.runs} />
+            </WorkbenchTaskAuditSection>
+            <WorkbenchTaskAuditSection
+              title={i18nService.t('workbenchTaskApprovals')}
+              count={filteredDetail.approvals.length}
+            >
+              <ApprovalAuditTab
+                approvals={filteredDetail.approvals}
+                runs={detail.runs}
+                busy={busy}
+                onRespond={onRespondToApproval}
+              />
+            </WorkbenchTaskAuditSection>
+          </div>
         </div>
       </div>
     </ScrollArea>


### PR DESCRIPTION
## Summary

- arrange trace audit modules in two independent columns so a tall event list no longer leaves a large gap below the run section
- constrain artifact reference, hash, verification, and action columns while preserving horizontal scrolling in narrow containers
- add regression coverage for independent column grouping and long artifact values

## Problem

The trace page used a row-based two-column grid. A tall event section determined the height of the entire first row, leaving an empty area between the run and artifact sections. The artifact table also inherited `whitespace-nowrap` from the shared table cell, so long hashes painted over the verification and action columns.

## Verification

- `npx vitest run src/renderer/components/cowork/workbenchTaskAudit/WorkbenchTaskAuditView.test.ts src/renderer/components/cowork/workbenchTaskAudit/ArtifactAuditTab.test.tsx`
- `npx tsc --noEmit`
- `npm run lint`
- `npx oxfmt --check` on the four changed files
- `npm run build`

## Electron Notes

- renderer-only layout change
- no IPC, storage, main-process, or window lifecycle changes
