### PR TITLE
fix(cowork): align conversation and floating composer

### DIFF
--- a/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
@@ -8,24 +8,20 @@ const source = readFileSync(
   'utf8',
 );
 
-test('overlays inline permission approval on the prompt input', () => {
-  const overlay = source.indexOf('className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4"');
-  const permissionContainer = source.indexOf(
-    'className="w-full max-w-5xl min-w-[320px] mx-auto pl-4"',
-    overlay,
-  );
-  const permission = source.indexOf('<CoworkPermissionModal', overlay);
+test('lets the conversation fill the pane behind the floating composer', () => {
   const inputArea = source.indexOf('{/* Input Area */}');
-  const promptContainer = source.indexOf(
-    'className="max-w-5xl min-w-[320px] mx-auto pl-4"',
-    inputArea,
-  );
+  const overlay = source.indexOf('ref={composerOverlayRef}', inputArea);
   const promptInput = source.indexOf('<CoworkPromptInput', inputArea);
+  const permission = source.indexOf('<CoworkPermissionModal', promptInput);
 
-  expect(overlay).toBeGreaterThanOrEqual(0);
-  expect(permissionContainer).toBeGreaterThan(overlay);
-  expect(permission).toBeGreaterThan(permissionContainer);
-  expect(inputArea).toBeGreaterThan(permission);
-  expect(promptContainer).toBeGreaterThan(inputArea);
-  expect(promptInput).toBeGreaterThan(promptContainer);
+  expect(source).toContain('const composerOverlayRef = useCoworkComposerInset(detailRootRef);');
+  expect(source).toContain('style={{ height: `calc(${COWORK_COMPOSER_INSET_VALUE} + 1rem)` }}');
+  expect(source).toContain('style={{ bottom: `calc(${COWORK_COMPOSER_INSET_VALUE} + 1rem)` }}');
+  expect(inputArea).toBeGreaterThanOrEqual(0);
+  expect(overlay).toBeGreaterThan(inputArea);
+  expect(source.slice(overlay, promptInput)).toContain(
+    'className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4 pb-4"',
+  );
+  expect(promptInput).toBeGreaterThan(overlay);
+  expect(permission).toBeGreaterThan(promptInput);
 });

--- a/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
@@ -7,6 +7,14 @@ const source = readFileSync(
   fileURLToPath(new URL('./CoworkSessionDetail.tsx', import.meta.url)),
   'utf8',
 );
+const turnBlockSource = readFileSync(
+  fileURLToPath(new URL('./components/TurnBlock.tsx', import.meta.url)),
+  'utf8',
+);
+const userBubbleSource = readFileSync(
+  fileURLToPath(new URL('./components/UserBubble.tsx', import.meta.url)),
+  'utf8',
+);
 
 test('lets the conversation fill the pane behind the floating composer', () => {
   const inputArea = source.indexOf('{/* Input Area */}');
@@ -20,8 +28,17 @@ test('lets the conversation fill the pane behind the floating composer', () => {
   expect(inputArea).toBeGreaterThanOrEqual(0);
   expect(overlay).toBeGreaterThan(inputArea);
   expect(source.slice(overlay, promptInput)).toContain(
-    'className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4 pb-4"',
+    'className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4"',
   );
+  expect(source.slice(overlay, promptInput)).toContain(
+    'className="pointer-events-auto relative col-start-1 row-start-1 self-end rounded-t-3xl bg-background pb-4"',
+  );
+  expect(turnBlockSource).toContain('className="mx-auto w-full max-w-5xl min-w-[320px] pl-4"');
+  expect(turnBlockSource).toContain('className="flex min-w-0 flex-1 flex-col gap-3 py-3"');
+  expect(userBubbleSource).toContain(
+    'className="mx-auto flex w-full max-w-5xl min-w-[320px] flex-col items-end pl-4"',
+  );
+  expect(source).toMatch(/<ConversationContent\r?\n\s+className="pt-3"/);
   expect(promptInput).toBeGreaterThan(overlay);
   expect(permission).toBeGreaterThan(promptInput);
 });

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -93,6 +93,10 @@ import {
 import { useSessionHistoryPagination } from './hooks/useSessionHistoryPagination';
 import { useRecoverableWorkbenchTaskId } from './hooks/useRecoverableWorkbenchTaskId';
 import { useConversationRailScrollSync } from './hooks/useConversationRailScrollSync';
+import {
+  COWORK_COMPOSER_INSET_VALUE,
+  useCoworkComposerInset,
+} from './hooks/useCoworkComposerInset';
 import { useTodoQueueLifecycle } from './hooks/useTodoQueueLifecycle';
 import { TodoQueue } from './TodoQueue';
 import AskUserQuestionCard from './AskUserQuestionCard';
@@ -214,6 +218,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
   const detailRootRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const promptInputRef = useRef<CoworkPromptInputRef>(null);
+  const composerOverlayRef = useCoworkComposerInset(detailRootRef);
 
   const sessionId = currentSession?.id;
   const recoverableTaskId = useRecoverableWorkbenchTaskId(sessionId);
@@ -1227,11 +1232,14 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                         <WorkbenchTaskAcceptanceCard sessionId={sessionId} />
                       </div>
                     )}
-                    <div className="h-20" />
+                    <div
+                      aria-hidden="true"
+                      style={{ height: `calc(${COWORK_COMPOSER_INSET_VALUE} + 1rem)` }}
+                    />
                   </div>
                 </ConversationContent>
                 <ConversationScrollButton
-                  className={todoQueue.todos.length > 0 ? 'bottom-14' : undefined}
+                  style={{ bottom: `calc(${COWORK_COMPOSER_INSET_VALUE} + 1rem)` }}
                 />
               </Conversation>
             )}
@@ -1478,74 +1486,76 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
               )}
           </div>
 
-          {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
-            <div className="absolute inset-x-0 bottom-0 z-20 px-4 pb-4">
-              <div className="w-full max-w-5xl min-w-[320px] mx-auto pl-4">
-                <CoworkPermissionModal
-                  permission={inlinePermission}
-                  onRespond={onRespondToInlinePermission}
-                  inline
-                />
-              </div>
-            </div>
-          )}
-
           {/* Input Area */}
-          <div className="px-4 pb-4 shrink-0">
-            <div className="max-w-5xl min-w-[320px] mx-auto pl-4">
-              <CoworkPromptInput
-                ref={promptInputRef}
-                topAccessory={
-                  isSessionSwitching ? null : (
-                    <>
-                      {workMode === CoworkSessionMode.Work &&
-                        !isDirectChat &&
-                        currentSession?.id && (
-                          <PendingMessageQueue
-                            sessionId={currentSession.id}
-                            isStreaming={isStreaming}
-                          />
-                        )}
-                      <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
-                    </>
-                  )
-                }
-                onSubmit={onContinue}
-                onStop={onStop}
-                isStreaming={isSessionSwitching ? false : isStreaming}
-                placeholder={i18nService.t(
-                  !isSessionSwitching && remoteManaged
-                    ? 'coworkRemoteManagedPlaceholder'
-                    : workMode === 'chat'
-                      ? 'chatPlaceholder'
-                      : 'coworkContinuePlaceholder',
-                )}
-                disabled={
-                  !isSessionSwitching &&
-                  (remoteManaged || isAwaitingInlineQuestion || Boolean(inlinePermission))
-                }
-                sessionContextPending={isSessionSwitching}
-                size="large"
-                remoteManaged={!isSessionSwitching && remoteManaged}
-                onManageSkills={!isSessionSwitching && remoteManaged ? undefined : onManageSkills}
-                onManageConnectors={
-                  !isSessionSwitching && remoteManaged ? undefined : onManageConnectors
-                }
-                showPermissionModeSelector={workMode === 'work'}
-                permissionMode={permissionMode}
-                onPermissionModeChange={onPermissionModeChange}
-                showModelSelector={true}
-                isDirectChat={isDirectChat}
-                showLocalThinkingToggle={isDirectChat}
-                localThinkingEnabled={localThinkingEnabled}
-                onLocalThinkingEnabledChange={onLocalThinkingEnabledChange}
-                resumeTaskActive={Boolean(resumeTaskId)}
-                onCancelTaskResume={onCancelTaskResume}
-                sessionId={displayedSessionId ?? currentSession?.id}
-              />
-              <p className="text-center text-[11px] text-muted opacity-85 mt-2 mb-[-8px] select-none">
-                {i18nService.t('aiGeneratedDisclaimer')}
-              </p>
+          <div
+            ref={composerOverlayRef}
+            className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4 pb-4"
+          >
+            <div className="mx-auto grid w-full max-w-5xl min-w-[320px] pl-4">
+              <div className="pointer-events-auto col-start-1 row-start-1 self-end">
+                <CoworkPromptInput
+                  ref={promptInputRef}
+                  topAccessory={
+                    isSessionSwitching ? null : (
+                      <>
+                        {workMode === CoworkSessionMode.Work &&
+                          !isDirectChat &&
+                          currentSession?.id && (
+                            <PendingMessageQueue
+                              sessionId={currentSession.id}
+                              isStreaming={isStreaming}
+                            />
+                          )}
+                        <TodoQueue todos={todoQueue.todos} isDismissing={todoQueue.isDismissing} />
+                      </>
+                    )
+                  }
+                  onSubmit={onContinue}
+                  onStop={onStop}
+                  isStreaming={isSessionSwitching ? false : isStreaming}
+                  placeholder={i18nService.t(
+                    !isSessionSwitching && remoteManaged
+                      ? 'coworkRemoteManagedPlaceholder'
+                      : workMode === 'chat'
+                        ? 'chatPlaceholder'
+                        : 'coworkContinuePlaceholder',
+                  )}
+                  disabled={
+                    !isSessionSwitching &&
+                    (remoteManaged || isAwaitingInlineQuestion || Boolean(inlinePermission))
+                  }
+                  sessionContextPending={isSessionSwitching}
+                  size="large"
+                  remoteManaged={!isSessionSwitching && remoteManaged}
+                  onManageSkills={!isSessionSwitching && remoteManaged ? undefined : onManageSkills}
+                  onManageConnectors={
+                    !isSessionSwitching && remoteManaged ? undefined : onManageConnectors
+                  }
+                  showPermissionModeSelector={workMode === 'work'}
+                  permissionMode={permissionMode}
+                  onPermissionModeChange={onPermissionModeChange}
+                  showModelSelector={true}
+                  isDirectChat={isDirectChat}
+                  showLocalThinkingToggle={isDirectChat}
+                  localThinkingEnabled={localThinkingEnabled}
+                  onLocalThinkingEnabledChange={onLocalThinkingEnabledChange}
+                  resumeTaskActive={Boolean(resumeTaskId)}
+                  onCancelTaskResume={onCancelTaskResume}
+                  sessionId={displayedSessionId ?? currentSession?.id}
+                />
+                <p className="text-center text-[11px] text-muted opacity-85 mt-2 mb-[-8px] select-none">
+                  {i18nService.t('aiGeneratedDisclaimer')}
+                </p>
+              </div>
+              {!isSessionSwitching && inlinePermission && onRespondToInlinePermission && (
+                <div className="pointer-events-auto relative z-10 col-start-1 row-start-1 self-end">
+                  <CoworkPermissionModal
+                    permission={inlinePermission}
+                    onRespond={onRespondToInlinePermission}
+                    inline
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1212,7 +1212,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
                 resize={isStreaming ? 'smooth' : 'instant'}
               >
                 <ConversationContent
-                  className={`pt-3 ${turns.length > 1 ? 'pr-8' : 'pr-3'}`}
+                  className="pt-3"
                   observeContentResize={false}
                   reverse={false}
                   scrollClassName="cowork-conversation-scroll"
@@ -1489,10 +1489,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
           {/* Input Area */}
           <div
             ref={composerOverlayRef}
-            className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4 pb-4"
+            className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4"
           >
             <div className="mx-auto grid w-full max-w-5xl min-w-[320px] pl-4">
-              <div className="pointer-events-auto col-start-1 row-start-1 self-end">
+              <div className="pointer-events-auto relative col-start-1 row-start-1 self-end rounded-t-3xl bg-background pb-4">
                 <CoworkPromptInput
                   ref={promptInputRef}
                   topAccessory={

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -422,10 +422,10 @@ const TurnBlockComponent: React.FC<{
     );
   };
   return (
-    <div className="px-4 py-2">
-      <div className="max-w-5xl min-w-[320px] mx-auto">
+    <div className="py-2">
+      <div className="mx-auto w-full max-w-5xl min-w-[320px] pl-4">
         <div className="flex items-start gap-3">
-          <div className="flex min-w-0 flex-1 flex-col gap-3 px-4 py-3">
+          <div className="flex min-w-0 flex-1 flex-col gap-3 py-3">
             <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
               {primaryExpert ? (
                 <>

--- a/src/renderer/components/cowork/components/UserBubble.tsx
+++ b/src/renderer/components/cowork/components/UserBubble.tsx
@@ -142,13 +142,13 @@ export const UserBubble: React.FC<{
 
   return (
     <div
-      className="w-full py-2 px-4 focus:outline-none"
+      className="w-full py-2 focus:outline-none"
       tabIndex={0}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={handleMouseLeave}
       onBlur={handleBlur}
     >
-      <div className="mx-auto flex w-full max-w-5xl min-w-[320px] flex-col items-end">
+      <div className="mx-auto flex w-full max-w-5xl min-w-[320px] flex-col items-end pl-4">
         {inlineAttachments.length > 0 && (
           <CoworkInlineAttachments
             attachments={inlineAttachments}

--- a/src/renderer/components/cowork/hooks/useCoworkComposerInset.test.ts
+++ b/src/renderer/components/cowork/hooks/useCoworkComposerInset.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import React, { useRef } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { useCoworkComposerInset } from './useCoworkComposerInset';
+
+class TestResizeObserver implements ResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  disconnect(): void {}
+
+  observe(): void {
+    this.callback([], this);
+  }
+
+  takeRecords(): ResizeObserverEntry[] {
+    return [];
+  }
+
+  unobserve(): void {}
+}
+
+function Fixture() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const composerRef = useCoworkComposerInset(rootRef);
+
+  return React.createElement(
+    'div',
+    { ref: rootRef, 'data-testid': 'root' },
+    React.createElement('div', { ref: composerRef, 'data-testid': 'composer' }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('keeps the conversation inset synchronized with the composer height', async () => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver);
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+    function (this: HTMLElement) {
+      const height = this.dataset.testid === 'composer' ? 128.4 : 0;
+      return {
+        bottom: height,
+        height,
+        left: 0,
+        right: 0,
+        top: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      };
+    },
+  );
+
+  const view = render(React.createElement(Fixture));
+  const root = view.getByTestId('root');
+
+  await waitFor(() => {
+    expect(root.style.getPropertyValue('--cowork-composer-inset')).toBe('129px');
+  });
+
+  view.unmount();
+  expect(root.style.getPropertyValue('--cowork-composer-inset')).toBe('');
+});

--- a/src/renderer/components/cowork/hooks/useCoworkComposerInset.ts
+++ b/src/renderer/components/cowork/hooks/useCoworkComposerInset.ts
@@ -1,0 +1,35 @@
+import { type RefObject, useEffect, useRef } from 'react';
+
+const COWORK_COMPOSER_INSET_PROPERTY = '--cowork-composer-inset';
+
+export const COWORK_COMPOSER_INSET_VALUE = `var(${COWORK_COMPOSER_INSET_PROPERTY}, 8rem)`;
+
+export function useCoworkComposerInset(
+  rootRef: RefObject<HTMLElement | null>,
+): RefObject<HTMLDivElement | null> {
+  const composerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const composer = composerRef.current;
+    if (!root || !composer) return undefined;
+
+    const updateInset = () => {
+      const height = Math.ceil(composer.getBoundingClientRect().height);
+      root.style.setProperty(COWORK_COMPOSER_INSET_PROPERTY, `${height}px`);
+    };
+
+    updateInset();
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateInset);
+    resizeObserver?.observe(composer);
+
+    return () => {
+      resizeObserver?.disconnect();
+      root.style.removeProperty(COWORK_COMPOSER_INSET_PROPERTY);
+    };
+  }, [rootRef]);
+
+  return composerRef;
+}


### PR DESCRIPTION
## Summary

- Extend the AI Elements conversation viewport and scrollbar to the bottom of the main pane while keeping the composer floating above messages.
- Align assistant and user message containers with the composer by sharing the same `max-w-5xl` boundary and removing nested horizontal padding.
- Keep the composer top corners transparent so underlying content remains visible through the rounded cutouts, while the input footer, stats, disclaimer, and bottom inset use an opaque `bg-background` surface.
- Preserve the measured composer inset so expanding attachments, task controls, and inline permissions do not cover the final message or jump-to-latest button.

## Visual behavior

- Message content and composer use the same left and right layout boundary.
- Conversation content may pass behind the floating input, but cannot show through below the input surface.
- The conversation scrollbar still reaches the main-pane bottom edge.

## Testing

- `npx vitest run src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts src/renderer/components/cowork/hooks/useCoworkComposerInset.test.ts`
- `npm run lint`
- `npm run build`
- Manual Electron QA on the development instance at `http://localhost:5176/`

## Electron impact

Renderer-only layout changes. No IPC, storage, window lifecycle, preload, or main-process behavior changes.