### PR TITLE
fix(workbench): 交付物验证统一走人工验收,验收后转已验证并触发记忆提升

### DIFF
--- a/src/main/workbenchTask/repository.test.ts
+++ b/src/main/workbenchTask/repository.test.ts
@@ -200,6 +200,78 @@ test('promotes an existing pending artifact when verified evidence arrives', () 
   }
 });
 
+test('marks only pending artifacts of a run as verified', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const run = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    const pending = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'pending.txt',
+      contentHash: 'pending-hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: { role: 'deliverable' },
+    });
+    const failed = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'failed.txt',
+      contentHash: 'failed-hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Failed,
+      metadata: {},
+    });
+    const verified = repository.addArtifact({
+      taskId: task.id,
+      runId: run.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'verified.txt',
+      contentHash: 'verified-hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+      metadata: {},
+    });
+    const otherRun = repository.createRun(task.id, WorkbenchRunTrigger.Retry);
+    const otherPending = repository.addArtifact({
+      taskId: task.id,
+      runId: otherRun.id,
+      kind: WorkbenchArtifactKind.File,
+      mimeType: 'text/plain',
+      reference: 'other.txt',
+      contentHash: 'other-hash',
+      provenance: WorkbenchArtifactProvenance.Workspace,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+      metadata: {},
+    });
+
+    const changes = repository.markArtifactsVerified(run.id);
+
+    expect(changes).toBe(1);
+    const artifacts = repository.getDetail(task.id)?.artifacts ?? [];
+    expect(artifacts.find(artifact => artifact.id === pending.id)?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+    expect(artifacts.find(artifact => artifact.id === failed.id)?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Failed,
+    );
+    expect(artifacts.find(artifact => artifact.id === verified.id)?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+    expect(artifacts.find(artifact => artifact.id === otherPending.id)?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Pending,
+    );
+  } finally {
+    db.close();
+  }
+});
+
 test('preserves declared identity when pending tool evidence is deduplicated', () => {
   const { db, repository } = createRepository();
   try {

--- a/src/main/workbenchTask/repository.test.ts
+++ b/src/main/workbenchTask/repository.test.ts
@@ -200,6 +200,22 @@ test('promotes an existing pending artifact when verified evidence arrives', () 
   }
 });
 
+test('persists and restores the run final answer', () => {
+  const { db, repository } = createRepository();
+  try {
+    const task = repository.createTask('session', 'goal', contract);
+    const run = repository.createRun(task.id, WorkbenchRunTrigger.Message);
+    expect(repository.getRunFinalAnswer(run.id)).toBe('');
+    expect(repository.getRunFinalAnswer('missing-run')).toBe('');
+
+    repository.updateFinalAnswer(run.id, 'final answer text');
+
+    expect(repository.getRunFinalAnswer(run.id)).toBe('final answer text');
+  } finally {
+    db.close();
+  }
+});
+
 test('marks only pending artifacts of a run as verified', () => {
   const { db, repository } = createRepository();
   try {

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -420,6 +420,28 @@ export class WorkbenchTaskRepository {
     );
   }
 
+  /**
+   * Promote every pending artifact of a run to verified. Invoked when the
+   * run's own verification gate succeeds — deterministic verification pass
+   * or explicit user acceptance — because pending workspace artifacts have
+   * no other verifier. Verified and failed artifacts are left untouched.
+   */
+  markArtifactsVerified(runId: string): number {
+    const result = this.db
+      .prepare(
+        `UPDATE workbench_artifacts
+         SET verification_status = ?, updated_at = ?
+         WHERE run_id = ? AND verification_status = ?`,
+      )
+      .run(
+        WorkbenchArtifactVerificationStatus.Verified,
+        Date.now(),
+        runId,
+        WorkbenchArtifactVerificationStatus.Pending,
+      );
+    return result.changes;
+  }
+
   createApproval(
     input: Pick<
       WorkbenchApproval,

--- a/src/main/workbenchTask/repository.ts
+++ b/src/main/workbenchTask/repository.ts
@@ -281,6 +281,32 @@ export class WorkbenchTaskRepository {
     return this.requireRun(runId);
   }
 
+  /**
+   * Persist the run's final answer so later steps (e.g. user acceptance)
+   * can still dispatch the verified-run memory promotion, which consumes
+   * the answer text as extraction evidence.
+   */
+  updateFinalAnswer(runId: string, finalAnswer: string): WorkbenchRun {
+    this.requireRun(runId);
+    this.db
+      .prepare('UPDATE workbench_runs SET final_answer_json = ?, updated_at = ? WHERE id = ?')
+      .run(JSON.stringify(finalAnswer), Date.now(), runId);
+    return this.requireRun(runId);
+  }
+
+  getRunFinalAnswer(runId: string): string {
+    const row = this.db
+      .prepare('SELECT final_answer_json FROM workbench_runs WHERE id = ?')
+      .get(runId) as { final_answer_json: string | null } | undefined;
+    if (!row || !row.final_answer_json) return '';
+    try {
+      const parsed = JSON.parse(row.final_answer_json);
+      return typeof parsed === 'string' ? parsed : '';
+    } catch {
+      return '';
+    }
+  }
+
   updateRunStatus(
     runId: string,
     status: WorkbenchRunStatusType,
@@ -440,6 +466,16 @@ export class WorkbenchTaskRepository {
         WorkbenchArtifactVerificationStatus.Pending,
       );
     return result.changes;
+  }
+
+  countPendingArtifacts(runId: string): number {
+    const row = this.db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM workbench_artifacts
+         WHERE run_id = ? AND verification_status = ?`,
+      )
+      .get(runId, WorkbenchArtifactVerificationStatus.Pending) as { n: number };
+    return row.n;
   }
 
   createApproval(

--- a/src/main/workbenchTask/schema.ts
+++ b/src/main/workbenchTask/schema.ts
@@ -108,4 +108,7 @@ export function initializeWorkbenchTaskSchema(db: Database.Database): void {
   if (!runColumns.some(column => column.name === 'context_json')) {
     db.exec('ALTER TABLE workbench_runs ADD COLUMN context_json TEXT');
   }
+  if (!runColumns.some(column => column.name === 'final_answer_json')) {
+    db.exec('ALTER TABLE workbench_runs ADD COLUMN final_answer_json TEXT');
+  }
 }

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -374,7 +374,7 @@ test('user acceptance promotes pending workspace artifacts to verified', () => {
   }
 });
 
-test('baseline pass without the production workflow verifies pending artifacts', () => {
+test('baseline pass without the production workflow requires acceptance when artifacts exist', () => {
   const { db, service } = createService();
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-baseline-artifact-'));
   const filePath = path.join(workspace, 'report.md');
@@ -384,7 +384,7 @@ test('baseline pass without the production workflow verifies pending artifacts',
       kind: WorkbenchContractKind.GenericWork,
       requiresUserAcceptance: false,
     };
-    const { run } = service.beginRun({
+    const { task, run } = service.beginRun({
       sessionId: 'session',
       goal: 'produce a quick report',
       contract,
@@ -407,14 +407,126 @@ test('baseline pass without the production workflow verifies pending artifacts',
       finalAnswer: 'done',
     });
 
-    expect(detail.task.status).toBe(WorkbenchTaskStatus.Completed);
+    // A passed baseline only attests a non-empty final response and a clean
+    // stream — it says nothing about artifact content. Pending artifacts must
+    // therefore go through explicit user acceptance instead of being
+    // auto-promoted to verified.
+    expect(detail.task.status).toBe(WorkbenchTaskStatus.NeedsReview);
+    expect(detail.runs[0].verificationResult?.outcome).toBe(
+      WorkbenchVerificationOutcome.AcceptanceRequired,
+    );
+    expect(detail.runs[0].verificationResult?.checks).toContainEqual(
+      expect.objectContaining({ name: 'artifact_verification', status: 'skipped' }),
+    );
     expect(detail.artifacts[0]?.verificationStatus).toBe(
-      WorkbenchArtifactVerificationStatus.Verified,
+      WorkbenchArtifactVerificationStatus.Pending,
     );
     expect(detail.events).toContainEqual(
       expect.objectContaining({
         type: WorkbenchRunEventType.VerificationFinished,
-        payload: expect.objectContaining({ verifiedArtifacts: 1, outcome: 'passed' }),
+        payload: expect.objectContaining({ outcome: 'acceptance_required' }),
+      }),
+    );
+
+    const accepted = service.acceptTask(task.id);
+    expect(accepted.task.status).toBe(WorkbenchTaskStatus.Completed);
+    expect(accepted.artifacts[0]?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});
+
+test('baseline pass without artifacts completes without acceptance', () => {
+  const { db, service } = createService();
+  try {
+    const contract = {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: false,
+    };
+    const { run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'answer a simple question',
+      contract,
+    });
+
+    const detail = service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: process.cwd(),
+      finalAnswer: 'done',
+    });
+
+    expect(detail.task.status).toBe(WorkbenchTaskStatus.Completed);
+    expect(detail.runs[0].verificationResult?.outcome).toBe(
+      WorkbenchVerificationOutcome.Passed,
+    );
+  } finally {
+    db.close();
+  }
+});
+
+test('user acceptance dispatches the verified-run memory promotion', () => {
+  const onVerifiedRun = vi.fn();
+  const { db, service } = createService({ onVerifiedRun });
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-accept-promotion-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const contract = {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: true,
+    };
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'complete generic work',
+      contract,
+    });
+    service.updateRunContext(run.id, {
+      model: 'test-model',
+      provider: 'test-provider',
+      reasoningProfile: 'default',
+      workspaceRoot: workspace,
+      skillIds: [],
+    });
+    prepareProductionDelivery(service, task.id, run.id, WorkbenchContractKind.GenericWork);
+    service.registerArtifact({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+    service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+    });
+    expect(onVerifiedRun).not.toHaveBeenCalled();
+
+    service.acceptTask(task.id);
+
+    expect(onVerifiedRun).toHaveBeenCalledOnce();
+    expect(onVerifiedRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({ id: task.id }),
+        run: expect.objectContaining({ id: run.id, status: WorkbenchRunStatus.Succeeded }),
+        verificationResult: expect.objectContaining({
+          outcome: WorkbenchVerificationOutcome.Passed,
+        }),
+        workspaceRoot: workspace,
+        finalAnswer: 'done',
+        artifacts: expect.arrayContaining([
+          expect.objectContaining({
+            verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+          }),
+        ]),
       }),
     );
   } finally {

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -321,6 +321,108 @@ test('keeps acceptance-required production work ready until explicit user accept
   }
 });
 
+test('user acceptance promotes pending workspace artifacts to verified', () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-accept-artifact-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const contract = {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: true,
+    };
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'complete generic work',
+      contract,
+    });
+    prepareProductionDelivery(service, task.id, run.id, WorkbenchContractKind.GenericWork);
+    service.registerArtifact({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+
+    const pending = service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+    });
+    expect(pending.artifacts[0]?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Pending,
+    );
+
+    const accepted = service.acceptTask(task.id);
+    expect(accepted.artifacts[0]?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+    expect(accepted.events).toContainEqual(
+      expect.objectContaining({
+        type: WorkbenchRunEventType.VerificationFinished,
+        payload: expect.objectContaining({ verifiedArtifacts: 1, acceptedByUser: true }),
+      }),
+    );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});
+
+test('baseline pass without the production workflow verifies pending artifacts', () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-baseline-artifact-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const contract = {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: false,
+    };
+    const { run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'produce a quick report',
+      contract,
+    });
+    service.registerArtifact({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      candidate: {
+        path: filePath,
+        role: 'deliverable',
+        source: WorkbenchArtifactCandidateSource.Declaration,
+      },
+    });
+
+    const detail = service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+    });
+
+    expect(detail.task.status).toBe(WorkbenchTaskStatus.Completed);
+    expect(detail.artifacts[0]?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+    expect(detail.events).toContainEqual(
+      expect.objectContaining({
+        type: WorkbenchRunEventType.VerificationFinished,
+        payload: expect.objectContaining({ verifiedArtifacts: 1, outcome: 'passed' }),
+      }),
+    );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});
+
 test('creates a new task for each ordinary user message', () => {
   const { db, service } = createService();
   try {

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -332,9 +332,18 @@ export class WorkbenchTaskService extends EventEmitter {
         });
         this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
       }
+      // A passed verification is the only verifier pending workspace artifacts
+      // have when the production workflow is absent (or was skipped): promote
+      // them along with the run. Acceptance-required runs are promoted in
+      // acceptTask instead.
+      const verifiedArtifacts =
+        result.outcome === WorkbenchVerificationOutcome.Passed
+          ? this.repository.markArtifactsVerified(run.id)
+          : 0;
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationFinished, {
         outcome: result.outcome,
         summary: result.summary,
+        verifiedArtifacts,
       });
       this.measurement.recordVerification(run.id, {
         passed: result.outcome === WorkbenchVerificationOutcome.Passed,
@@ -395,9 +404,13 @@ export class WorkbenchTaskService extends EventEmitter {
         verificationResult: acceptedResult,
       });
       this.repository.updateTaskStatus(taskId, WorkbenchTaskStatus.Completed, null);
+      // User acceptance is the final verifier: promote every pending artifact
+      // (workspace declarations and tool effects) alongside the accepted run.
+      const verifiedArtifacts = this.repository.markArtifactsVerified(run.id);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationFinished, {
         outcome: acceptedResult.outcome,
         acceptedByUser: true,
+        verifiedArtifacts,
       });
       this.productionLoop.recordVerificationResult(
         run.id,

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -307,6 +307,7 @@ export class WorkbenchTaskService extends EventEmitter {
           : [];
       });
     const artifactCandidates = [...toolArtifactCandidates, ...(input.artifactCandidates ?? [])];
+    let finalResult = result;
     this.repository.transaction(() => {
       this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Verifying);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationStarted);
@@ -321,40 +322,58 @@ export class WorkbenchTaskService extends EventEmitter {
       })) {
         this.repository.addArtifact(artifact);
       }
+      // A passed baseline only attests a non-empty final response and a
+      // cleanly closed stream; it says nothing about artifact content. Pending
+      // artifacts therefore have no verifier on the baseline-only path and
+      // must go through explicit user acceptance instead. Pending artifacts
+      // are promoted to verified exclusively by acceptTask.
       if (result.outcome === WorkbenchVerificationOutcome.Passed) {
+        const pendingCount = this.repository.countPendingArtifacts(run.id);
+        if (pendingCount > 0) {
+          finalResult = {
+            outcome: WorkbenchVerificationOutcome.AcceptanceRequired,
+            checks: [
+              {
+                name: 'artifact_verification',
+                status: WorkbenchVerificationCheckStatus.Skipped,
+                detail: `${pendingCount} artifact(s) require explicit user acceptance.`,
+              },
+              ...result.checks,
+            ],
+            evidence: result.evidence,
+            summary: `The work result produced ${pendingCount} artifact(s) that require explicit user acceptance.`,
+          };
+        }
+      }
+      if (finalResult.outcome === WorkbenchVerificationOutcome.Passed) {
         this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Succeeded, {
-          verificationResult: result,
+          verificationResult: finalResult,
         });
         this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.Completed, null);
       } else {
         this.repository.updateRunStatus(run.id, WorkbenchRunStatus.NeedsReview, {
-          verificationResult: result,
+          verificationResult: finalResult,
         });
         this.repository.updateTaskStatus(task.id, WorkbenchTaskStatus.NeedsReview, run.id);
       }
-      // A passed verification is the only verifier pending workspace artifacts
-      // have when the production workflow is absent (or was skipped): promote
-      // them along with the run. Acceptance-required runs are promoted in
-      // acceptTask instead.
-      const verifiedArtifacts =
-        result.outcome === WorkbenchVerificationOutcome.Passed
-          ? this.repository.markArtifactsVerified(run.id)
-          : 0;
+      // Keep the completion context so user acceptance can still dispatch the
+      // verified-run memory promotion with the same evidence the automatic
+      // path uses.
+      this.repository.updateFinalAnswer(run.id, input.finalAnswer);
       this.repository.appendRunEvent(run.id, WorkbenchRunEventType.VerificationFinished, {
-        outcome: result.outcome,
-        summary: result.summary,
-        verifiedArtifacts,
+        outcome: finalResult.outcome,
+        summary: finalResult.summary,
       });
       this.measurement.recordVerification(run.id, {
-        passed: result.outcome === WorkbenchVerificationOutcome.Passed,
-        outcome: result.outcome,
-        checks: result.checks.map(check => ({ name: check.name, status: check.status })),
+        passed: finalResult.outcome === WorkbenchVerificationOutcome.Passed,
+        outcome: finalResult.outcome,
+        checks: finalResult.checks.map(check => ({ name: check.name, status: check.status })),
       });
-      this.productionLoop.recordVerificationResult(run.id, result.outcome, result.summary);
+      this.productionLoop.recordVerificationResult(run.id, finalResult.outcome, finalResult.summary);
     });
     const detail = this.repository.getDetail(task.id);
     if (!detail) throw new Error('Workbench task detail disappeared after verification.');
-    if (result.outcome === WorkbenchVerificationOutcome.Passed) {
+    if (finalResult.outcome === WorkbenchVerificationOutcome.Passed) {
       const verifiedRun = detail.runs.find(candidate => candidate.id === run.id);
       if (verifiedRun) {
         try {
@@ -399,6 +418,10 @@ export class WorkbenchTaskService extends EventEmitter {
       ],
       summary: 'The user accepted the work result.',
     };
+    // Recover the completion context persisted at completeRun so acceptance
+    // can dispatch the same verified-run promotion the automatic path uses.
+    const workspaceRoot = run.context?.workspaceRoot ?? '';
+    const finalAnswer = this.repository.getRunFinalAnswer(run.id);
     this.repository.transaction(() => {
       this.repository.updateRunStatus(run.id, WorkbenchRunStatus.Succeeded, {
         verificationResult: acceptedResult,
@@ -420,6 +443,22 @@ export class WorkbenchTaskService extends EventEmitter {
     });
     const accepted = this.repository.getDetail(taskId);
     if (!accepted) throw new Error('Workbench task not found after acceptance.');
+    const acceptedRun = accepted.runs.find(candidate => candidate.id === run.id);
+    if (acceptedRun) {
+      try {
+        this.options.onVerifiedRun?.({
+          task: accepted.task,
+          run: acceptedRun,
+          artifacts: accepted.artifacts.filter(artifact => artifact.runId === run.id),
+          approvals: accepted.approvals.filter(approval => approval.runId === run.id),
+          verificationResult: acceptedResult,
+          workspaceRoot,
+          finalAnswer,
+        });
+      } catch (error) {
+        console.warn('[WorkbenchTask] Failed to propose accepted run memory:', error);
+      }
+    }
     this.emitChanged(accepted.task);
     return accepted;
   }


### PR DESCRIPTION
## 问题

工作区交付物(declare_artifact 声明、审批通过的工具写文件)落库时
`verification_status` 固定为 `pending`,但存在**两条没有验证通道的路径**:

1. **无生产循环的任务**(或模型 skip_workflow):
   `requiresUserAcceptance = false` → baseline 通过即 `passed` →
   任务直接 completed,**不触发人工验收** → pending 永远 pending
2. **生产循环任务(requiresUserAcceptance = true)**:
   走人工验收 `acceptTask`,但验收逻辑只更新 run/task 状态,
   **从不更新交付物状态** → 验收通过后工作区交付物仍是 pending

附带两个缺陷:

- **验证语义污染**:baseline 只检查"最终回复非空 + 流干净关闭",
  与工件内容无关;若把未检查的工件自动标为 verified,审计状态
  与任务记忆都会把未经验证的内容当作可信证据
- **记忆提升缺失**:自动验证路径派发 `onVerifiedRun`
  (→ taskMemoryPromotion),而 acceptTask 不派发 → 人工验收后
  经确认的工件内容永远无法进入任务记忆

## 修复

**语义原则:pending 工件只能通过人工验收转 verified。**
baseline 通过不作为工件验证依据。

1. **completeRun 降级判定**([taskService.ts](src/main/workbenchTask/taskService.ts)):
   确定性验证 passed 但该 run 存在 pending 工件时,结果降级为
   `acceptance_required`(新增 `artifact_verification` check,
   status=skipped + "N artifact(s) require explicit user acceptance"),
   任务进入 needs_review——不再自动提升未经检查的工件;
   无工件任务仍直接 completed,不增加验收负担
2. **acceptTask 提升 + 记忆回调**:
   人工验收通过后,该 run 的 pending 工件全部转 verified
   ([repository.ts](src/main/workbenchTask/repository.ts)
   `markArtifactsVerified`,只提升 pending,不碰 failed/verified/其它 run);
   并以与自动路径相同的结构派发 `onVerifiedRun`,触发任务记忆提升
3. **完成上下文持久化**([schema.ts](src/main/workbenchTask/schema.ts)):
   `workbench_runs` 新增 `final_answer_json` 列(沿用既有
   ALTER TABLE 迁移模式),completeRun 保存最终回答;acceptTask
   从 run context 恢复 workspaceRoot、从 final_answer_json 恢复
   finalAnswer,保证验收后的记忆提取拿到与自动路径相同的证据
4. **审计**:acceptTask 的 VerificationFinished 事件 payload 记录
   `verifiedArtifacts` 提升数量

## 测试

- 服务层:有 pending 工件时 baseline pass → needs_review +
  acceptance_required + artifact_verification check(不再直接
  verified);无工件时仍直接 completed;人工验收后 pending→verified
  且事件带提升计数;验收派发 onVerifiedRun(带 workspaceRoot、
  finalAnswer、verified 工件列表),验收前不派发
- 仓库层:markArtifactsVerified 只提升本 run 的 pending,
  不碰 failed/verified/其它 run;final_answer_json 写入/恢复/缺失回退
- workbenchTask 全目录 8 文件 65 用例通过;相关 memory/
  declareArtifact/piRuntimeAdapter 100 用例通过;
  tsc(electron-tsconfig)+ oxlint 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)