### PR TITLE
build: upgrade bun to 1.4.0

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Restore packaging caches
         uses: actions/cache@v5
         with:
@@ -90,9 +90,9 @@ jobs:
             ~/AppData/Local/electron-builder/Cache
             vendor/engram-runtime
             vendor/channel-runtime
-          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
           restore-keys: |
-            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
+            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-
       - name: Install Electron system dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Restore Bun package cache
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          key: bun-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            bun-${{ runner.os }}-1.3.14-
+            bun-${{ runner.os }}-1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Validate bundled Skill frontmatter
         run: bun run validate:skills
@@ -52,7 +52,7 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Restore Bun and Electron caches
         uses: actions/cache@v5
         with:
@@ -60,9 +60,9 @@ jobs:
             ~/.bun/install/cache
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: test-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          key: test-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            test-${{ runner.os }}-1.3.14-
+            test-${{ runner.os }}-1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Compile Electron sources used by integration tests
         run: bun run compile:electron
@@ -82,14 +82,14 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Restore Bun package cache
         uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          key: bun-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            bun-${{ runner.os }}-1.3.14-
+            bun-${{ runner.os }}-1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Build renderer bundle
         run: bun run build:vite

--- a/.github/workflows/electron-verify.yml
+++ b/.github/workflows/electron-verify.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.14'
+          bun-version: '1.4.0'
       - name: Restore build dependency caches
         uses: actions/cache@v5
         with:
@@ -24,9 +24,9 @@ jobs:
             ~/.bun/install/cache
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: electron-verify-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          key: electron-verify-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            electron-verify-${{ runner.os }}-1.3.14-
+            electron-verify-${{ runner.os }}-1.4.0-
 
       - name: Install Electron Dependencies
         run: |

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version: '24.x' }
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: '1.3.14' }
+        with: { bun-version: '1.4.0' }
       # Installs only the exact Bun lockfile graph and never runs dependency
       # lifecycle scripts. This catches a lockfile/integrity mismatch before
       # a release build begins.
@@ -126,7 +126,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version: '24.x' }
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: '1.3.14' }
+        with: { bun-version: '1.4.0' }
       # These are application-bundled runtimes, not package-manager caches.
       # GitLab's release runners retain them independently; keep the same
       # boundary here so changing an unrelated build script does not require
@@ -154,9 +154,9 @@ jobs:
             ~/AppData/Local/electron/Cache
             ~/AppData/Local/electron-builder/Cache
             vendor/channel-runtime
-          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          key: packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
           restore-keys: |
-            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
+            packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-
       - name: Install Electron and virtual desktop dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version: '24.x' }
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: '1.3.14' }
+        with: { bun-version: '1.4.0' }
       - name: Restore Bun and Electron caches
         uses: actions/cache@v5
         with:
@@ -81,9 +81,9 @@ jobs:
             ~/.bun/install/cache
             ~/.cache/electron
             ~/.cache/electron-builder
-          key: candidate-quality-${{ runner.os }}-1.3.14-${{ hashFiles('bun.lock') }}
+          key: candidate-quality-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
           restore-keys: |
-            candidate-quality-${{ runner.os }}-1.3.14-
+            candidate-quality-${{ runner.os }}-1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Verify npm package signatures
         shell: bash
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version: '24.x' }
       - uses: oven-sh/setup-bun@v2
-        with: { bun-version: '1.3.14' }
+        with: { bun-version: '1.4.0' }
       - name: Restore bundled runtime cache
         uses: actions/cache@v5
         with:
@@ -160,9 +160,9 @@ jobs:
             ~/AppData/Local/electron/Cache
             ~/AppData/Local/electron-builder/Cache
             vendor/channel-runtime
-          key: candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          key: candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
           restore-keys: |
-            candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.3.14-
+            candidate-packaging-${{ runner.os }}-${{ matrix.runtime_target }}-node24-bun1.4.0-
       - name: Install Electron system dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |

--- a/.github/workflows/windows-installer-pr.yml
+++ b/.github/workflows/windows-installer-pr.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: "24.x"
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.14"
+          bun-version: "1.4.0"
       - name: Restore packaging caches
         uses: actions/cache@v5
         with:
@@ -50,9 +50,9 @@ jobs:
             ~/AppData/Local/electron-builder/Cache
             vendor/engram-runtime
             vendor/channel-runtime
-          key: windows-installer-node24-bun1.3.14-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          key: windows-installer-node24-bun1.4.0-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
           restore-keys: |
-            windows-installer-node24-bun1.3.14-
+            windows-installer-node24-bun1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Set up offline Windows runtimes
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please read this guide and [`AGENTS.md`](AGENTS.md) before making a code change.
 
 - Git
 - Node.js `>=24 <25`
-- Bun `>=1.3`
+- Bun `>=1.4 <1.5`
 
 Windows release builds also require PortableGit. Native dependencies such as `better-sqlite3` may require Python and a supported C/C++ build toolchain when a prebuilt binary is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Scheduled tasks can be created with natural language or through the GUI. A run s
 
 - Git
 - Node.js `24.x`
-- Bun `1.3+`
+- Bun `1.4.x`
 
 On Windows, native dependency builds may also require:
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,5 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "configVersion": 1,
   "workspaces": {
     "": {
@@ -163,6 +163,11 @@
     "utf-8-validate",
     "bufferutil",
   ],
+  "overrides": {
+    "@electron/osx-sign": {
+      "isbinaryfile": "^5.0.0",
+    },
+  },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "https://registry.npmmirror.com/7zip-bin/-/7zip-bin-5.2.0.tgz", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
 
@@ -3054,8 +3059,6 @@
 
     "@electron/notarize/fs-extra": ["fs-extra@9.1.0", "https://registry.npmmirror.com/fs-extra/-/fs-extra-9.1.0.tgz", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "https://registry.npmmirror.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
-
     "@electron/osx-sign/plist": ["plist@3.1.1", "https://registry.npmmirror.com/plist/-/plist-3.1.1.tgz", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 
     "@electron/rebuild/node-abi": ["node-abi@4.33.0", "https://registry.npmmirror.com/node-abi/-/node-abi-4.33.0.tgz", { "dependencies": { "semver": "^7.6.3" } }, "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA=="],
@@ -4193,8 +4196,6 @@
     "dir-compare/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/notarize/fs-extra": ["fs-extra@9.1.0", "https://registry.npmmirror.com/fs-extra/-/fs-extra-9.1.0.tgz", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
-
-    "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "https://registry.npmmirror.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign/plist": ["plist@3.1.1", "https://registry.npmmirror.com/plist/-/plist-3.1.1.tgz", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "dev@zhiyuanagent.com"
   },
   "license": "AGPL-3.0-only",
+  "packageManager": "bun@1.4.0",
   "version": "2026.7.16",
   "llamacpp": {
     "runtimeRepo": "https://github.com/ggml-org/llama.cpp.git",


### PR DESCRIPTION
## Summary

- pin Bun 1.4.0 for contributors and all CI/release workflows
- regenerate bun.lock with lockfile v3 and materialize the existing nested override
- refresh Bun-specific cache keys without changing dependency versions

## Validation

- Bun 1.4 frozen install
- supply-chain input policy
- renderer and Electron TypeScript checks
- lint and production build