### PR TITLE
fix(im): 所属项目选单显示 workspace 名称而非 id

### DIFF
--- a/src/renderer/components/im/ChannelWorkspaceField.test.tsx
+++ b/src/renderer/components/im/ChannelWorkspaceField.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Workspace } from '@shared/workspace';
+
+import { ChannelWorkspaceField } from './ChannelWorkspaceField';
+
+const workspaces: Workspace[] = [
+  {
+    id: 'ws-main',
+    name: '主工作区',
+    path: 'C:/main',
+    isHidden: false,
+    pinned: false,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: 'ws-sandbox',
+    name: '沙盒',
+    path: 'C:/sandbox',
+    isHidden: true,
+    pinned: false,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: 'ws-proj',
+    name: '项目 A',
+    path: 'C:/proj',
+    isHidden: false,
+    pinned: false,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+];
+
+function renderField(workspaceId: string, onChange = vi.fn()) {
+  render(
+    <ChannelWorkspaceField
+      accountId="acc-1"
+      workspaceId={workspaceId}
+      workspaces={workspaces}
+      onChange={onChange}
+    />,
+  );
+  return onChange;
+}
+
+describe('ChannelWorkspaceField', () => {
+  test('shows the workspace name for a preconfigured selection instead of the id', () => {
+    renderField('ws-proj');
+    expect(screen.getByRole('combobox')).toHaveTextContent('项目 A');
+    expect(screen.getByRole('combobox')).not.toHaveTextContent('ws-proj');
+  });
+
+  test('shows the name of the workspace picked from the popup', async () => {
+    const user = userEvent.setup();
+    // Mirror the real flow: the parent (redux) updates the controlled value.
+    function ControlledField() {
+      const [currentId, setCurrentId] = React.useState('ws-main');
+      return (
+        <ChannelWorkspaceField
+          accountId="acc-1"
+          workspaceId={currentId}
+          workspaces={workspaces}
+          onChange={setCurrentId}
+        />
+      );
+    }
+    render(<ControlledField />);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('项目 A'));
+    expect(screen.getByRole('combobox')).toHaveTextContent('项目 A');
+    expect(screen.getByRole('combobox')).not.toHaveTextContent('ws-proj');
+  });
+
+  test('shows the name of a hidden workspace that is already selected', () => {
+    renderField('ws-sandbox');
+    expect(screen.getByRole('combobox')).toHaveTextContent('沙盒');
+    expect(screen.getByRole('combobox')).not.toHaveTextContent('ws-sandbox');
+  });
+
+  test('does not offer hidden workspaces in the popup', async () => {
+    const user = userEvent.setup();
+    renderField('ws-main');
+    await user.click(screen.getByRole('combobox'));
+    expect(await screen.findByText('项目 A')).toBeInTheDocument();
+    expect(screen.queryByText('沙盒')).toBeNull();
+  });
+});

--- a/src/renderer/components/im/ChannelWorkspaceField.tsx
+++ b/src/renderer/components/im/ChannelWorkspaceField.tsx
@@ -1,8 +1,4 @@
-import {
-  Field,
-  FieldDescription,
-  FieldLabel,
-} from '@shared/components/ui/field';
+import { Field, FieldDescription, FieldLabel } from '@shared/components/ui/field';
 import {
   Select,
   SelectContent,
@@ -31,11 +27,22 @@ export const ChannelWorkspaceField: React.FC<ChannelWorkspaceFieldProps> = ({
 }) => {
   const inputId = `channel-workspace-${accountId}`;
   const visibleWorkspaces = workspaces.filter(workspace => !workspace.isHidden);
+  // Base UI resolves the trigger's selected label from the root `items` map, not
+  // from the popup items — without it the trigger shows the raw workspace id.
+  // Include hidden workspaces so an existing selection still shows its name;
+  // only visible workspaces are offered in the popup below.
+  const workspaceLabels = Object.fromEntries(
+    workspaces.map(workspace => [workspace.id, workspace.name]),
+  );
 
   return (
     <Field data-invalid={!workspaceId || undefined}>
       <FieldLabel htmlFor={inputId}>{i18nService.t('imChannelWorkspace')}</FieldLabel>
-      <Select value={workspaceId} onValueChange={value => onChange(value ?? '')}>
+      <Select
+        items={workspaceLabels}
+        value={workspaceId}
+        onValueChange={value => onChange(value ?? '')}
+      >
         <SelectTrigger id={inputId} className="w-full" aria-invalid={!workspaceId}>
           <SelectValue placeholder={i18nService.t('imChannelWorkspacePlaceholder')} />
         </SelectTrigger>


### PR DESCRIPTION
## 问题

设置 → IM 机器人页的「所属项目」选单，触发表单在任何情况下都显示**原始 workspace id**（例如 `ws-sandbox`），而不是项目名称 —— 未选择时显示 id、选中后也显示 id，`placeholder` 同样不生效。

## 根因

`ChannelWorkspaceField`（今日新引入的组件）的 `<SelectValue placeholder="..." />` **没有传 children，也没有给 `Select` 传 `items`**。当前 Base UI 1.6.0 的 `Select.Value` 不再从弹层里的 `SelectItem` 推导选中标签，而是通过根组件 `Select.Root` 的 `items` 属性（value → label 映射）解析；两者都缺失时，`resolveSelectedLabel` 走 `stringifyAsLabel(value)` 兜底，直接渲染原始值。用 jsdom + testing-library 复现确认：`默认值` 与 `选中后` 的 trigger 文本都是原始 id（如 `ws-1▼`）。

对比：项目里其它 Select（`ModelSelector`、`TaskForm`、`IMFormControls` 等）要么给 `SelectValue` 传了渲染函数/子元素，要么传了 `items` —— 只有这个新组件是裸 `SelectValue`。

## 改动

- `ChannelWorkspaceField`：把 `workspaces` 构建成 `{ id: name }` 映射，传给 `Select` 的 `items` 属性。
  - **包含隐藏 workspace**：已配置为沙盒等隐藏项目的实例，触发器中仍显示名称（隐藏项仅从弹层可选项中排除，不进入下拉）。
  - 弹层列表行为不变：仍然只展示非隐藏 workspace。
- 新增 `ChannelWorkspaceField.test.tsx`（4 个用例）：预置选中显示名称、选项后显示名称、已选隐藏项显示名称、隐藏项不出现在弹层。

验证：`tsc --noEmit` ✅ / `oxlint` ✅ / `oxfmt` ✅ / `vitest` 4/4 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
