### PR TITLE
fix(ui): update collapsed sidebar navigation icons

### DIFF
--- a/src/renderer/components/activity/ActivityView.tsx
+++ b/src/renderer/components/activity/ActivityView.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { ButtonGroup } from '@shared/components/ui/button-group';
-import { Activity, PanelLeft, Pencil } from 'lucide-react';
+import { Activity, PanelLeftOpen } from 'lucide-react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -8,6 +8,7 @@ import { i18nService } from '../../services/i18n';
 import type { RootState } from '../../store';
 import { selectActivityRuns } from '../../store/selectors/activitySelectors';
 import type { ActivityRun } from '../../../shared/activity/types';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
 import ActivityRunRow from './ActivityRunRow';
 import { ActivityStatusFilter, ActivityTriggerFilter } from './constants';
@@ -99,10 +100,10 @@ const ActivityView: React.FC<ActivityViewProps> = ({
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
               <Button type="button" variant="ghost" size="icon" onClick={onToggleSidebar}>
-                <PanelLeft />
+                <PanelLeftOpen />
               </Button>
               <Button type="button" variant="ghost" size="icon" onClick={onNewChat}>
-                <Pencil />
+                <SidebarAnimatedMessageCirclePlusIcon />
               </Button>
               {updateBadge}
             </div>

--- a/src/renderer/components/cowork/CoworkSessionLayout.tsx
+++ b/src/renderer/components/cowork/CoworkSessionLayout.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@shared/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@shared/components/ui/tabs';
 import { cn } from '@shared/lib/utils';
-import { PanelLeft } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
@@ -76,7 +76,7 @@ export function CoworkSessionLayout({
                   onClick={onToggleSidebar}
                   aria-label={i18nService.t('coworkShowSidebar')}
                 >
-                  <PanelLeft />
+                  <PanelLeftOpen />
                 </Button>
                 <Button
                   variant="ghost"

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { cn } from '@shared/lib/utils';
-import { PanelLeft } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -1525,7 +1525,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
               onClick={onToggleSidebar}
               className="text-muted-foreground hover:bg-surface-raised hover:text-foreground"
             >
-              <PanelLeft className="size-4" />
+              <PanelLeftOpen className="size-4" />
             </Button>
             <Button
               variant="ghost"

--- a/src/renderer/components/expert/ExpertView.tsx
+++ b/src/renderer/components/expert/ExpertView.tsx
@@ -5,10 +5,11 @@ import {
   LayeredTabsSeparatorEdge,
 } from '@shared/components/ui/layered-tabs';
 import { Tabs } from '@shared/components/ui/tabs';
-import { PanelLeft, Pencil, Users } from 'lucide-react';
+import { PanelLeftOpen, Users } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import McpManager from '../mcp/McpManager';
 import SkillsManager from '../skills/SkillsManager';
 import WindowTitleBar from '../window/WindowTitleBar';
@@ -76,10 +77,10 @@ const ExpertView: React.FC<ExpertViewProps> = ({
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
               <Button type="button" variant="ghost" size="icon" onClick={onToggleSidebar}>
-                <PanelLeft className="h-4 w-4" />
+                <PanelLeftOpen className="h-4 w-4" />
               </Button>
               <Button type="button" variant="ghost" size="icon" onClick={onNewChat}>
-                <Pencil className="h-4 w-4" />
+                <SidebarAnimatedMessageCirclePlusIcon />
               </Button>
               {updateBadge}
             </div>

--- a/src/renderer/components/localInference/LocalInferenceView.tsx
+++ b/src/renderer/components/localInference/LocalInferenceView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@shared/components/ui/dropdown-menu';
 import { LayeredTabsContent } from '@shared/components/ui/layered-tabs';
 import { Tabs } from '@shared/components/ui/tabs';
-import { PanelLeft, Pencil } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import { useReducedMotion } from 'motion/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -35,6 +35,7 @@ import { notifyLlamaCppRunningModelsChanged } from '../../services/availableMode
 import { i18nService } from '../../services/i18n';
 import { LocalInferenceAnimatedFolderDownIcon } from '../icons/LocalInferenceAnimatedFolderDownIcon';
 import { LocalInferenceAnimatedWifiPenIcon } from '../icons/LocalInferenceAnimatedWifiPenIcon';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import {
   GalleryThumbnailsIcon,
 } from '../icons/GalleryThumbnailsIcon';
@@ -1054,11 +1055,11 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                   variant="ghost"
                   size="icon"
                   onClick={onToggleSidebar}
-                  aria-label={i18nService.t('collapse')}
-                  title={i18nService.t('collapse')}
+                  aria-label={i18nService.t('expand')}
+                  title={i18nService.t('expand')}
                   className="text-foreground/70 hover:text-foreground"
                 >
-                  <PanelLeft />
+                  <PanelLeftOpen />
                 </Button>
                 <Button
                   type="button"
@@ -1069,7 +1070,7 @@ const LocalInferenceView: React.FC<LocalInferenceViewProps> = ({
                   title={i18nService.t('newChat')}
                   className="text-foreground/70 hover:text-foreground"
                 >
-                  <Pencil />
+                  <SidebarAnimatedMessageCirclePlusIcon />
                 </Button>
                 {updateBadge}
               </div>

--- a/src/renderer/components/mcp/McpView.tsx
+++ b/src/renderer/components/mcp/McpView.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@shared/components/ui/button';
-import { PanelLeft, Pencil } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import React from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
 import McpManager from './McpManager';
 import type { McpRegistryId } from './constants';
@@ -40,7 +41,7 @@ const McpView: React.FC<McpViewProps> = ({
                 onClick={onToggleSidebar}
                 className="h-8 w-8"
               >
-                <PanelLeft className="h-4 w-4" />
+                <PanelLeftOpen className="h-4 w-4" />
               </Button>
               <Button
                 type="button"
@@ -49,7 +50,7 @@ const McpView: React.FC<McpViewProps> = ({
                 onClick={onNewChat}
                 className="h-8 w-8"
               >
-                <Pencil className="h-4 w-4" />
+                <SidebarAnimatedMessageCirclePlusIcon />
               </Button>
               {updateBadge}
             </div>

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -9,11 +9,12 @@ import {
 } from '@shared/components/ui/dialog';
 import { Spinner } from '@shared/components/ui/spinner';
 import { cn } from '@shared/lib/utils';
-import { CalendarClock, PanelLeft, Pencil } from 'lucide-react';
+import { CalendarClock, PanelLeftOpen } from 'lucide-react';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { i18nService } from '../../services/i18n';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { RootState } from '../../store';
 import { selectTask, setViewMode } from '../../store/slices/scheduledTaskSlice';
@@ -224,10 +225,10 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
               <Button type="button" variant="ghost" size="icon" onClick={onToggleSidebar}>
-                <PanelLeft />
+                <PanelLeftOpen />
               </Button>
               <Button type="button" variant="ghost" size="icon" onClick={onNewChat}>
-                <Pencil />
+                <SidebarAnimatedMessageCirclePlusIcon />
               </Button>
               {updateBadge}
             </div>

--- a/src/renderer/components/skills/SkillsView.tsx
+++ b/src/renderer/components/skills/SkillsView.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@shared/components/ui/button';
-import { PanelLeft, Pencil } from 'lucide-react';
+import { PanelLeftOpen } from 'lucide-react';
 import React, { useRef } from 'react';
 
 import { i18nService } from '../../services/i18n';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
 import WindowTitleBar from '../window/WindowTitleBar';
 import SkillsManager from './SkillsManager';
 
@@ -40,7 +41,7 @@ const SkillsView: React.FC<SkillsViewProps> = ({
                 onClick={onToggleSidebar}
                 className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised"
               >
-                <PanelLeft className="h-4 w-4" />
+                <PanelLeftOpen className="h-4 w-4" />
               </Button>
               <Button
                 type="button"
@@ -49,7 +50,7 @@ const SkillsView: React.FC<SkillsViewProps> = ({
                 onClick={onNewChat}
                 className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised"
               >
-                <Pencil className="h-4 w-4" />
+                <SidebarAnimatedMessageCirclePlusIcon />
               </Button>
               {updateBadge}
             </div>


### PR DESCRIPTION
## Summary

统一更新各功能页面在侧边栏收起状态下的导航图标，提升图标语义和交互一致性。

## Related Issue

无。

## Changes Made

- 使用 `PanelLeftOpen` 表示展开侧边栏操作。
- 使用项目已有的新建会话动态图标替换铅笔图标。
- 覆盖活动记录、协作会话、专家、模型推理、MCP、定时任务和技能页面。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed
- 已运行 `npm run lint`，发现仓库现有 React 规则错误，未涉及本次改动的逻辑。
- 已运行 `npm test -- --run`：2305 passed，26 failed，11 skipped；失败主要来自沙箱网络监听/用户目录权限及既有断言。
- 已运行 `npm run build`：现有 `richMessageResponse.tsx` 的 streamdown/shiki 类型不兼容导致 TypeScript 阶段失败。

## Screenshots (if applicable)

不适用，本 PR 仅调整图标。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

commit: `fe545ab5`。已将分支 rebase 到最新 `origin/main`，无冲突。