### PR TITLE
fix(ui): isolate content scrolling in feature views

### DIFF
--- a/src/renderer/components/activity/ActivityView.tsx
+++ b/src/renderer/components/activity/ActivityView.tsx
@@ -95,7 +95,7 @@ const ActivityView: React.FC<ActivityViewProps> = ({
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       {/* Header chrome — same shell as the other feature views. */}
-      <div className="flex items-center justify-between pl-4">
+      <div className="flex shrink-0 items-center justify-between pl-4">
         <div className="flex items-center gap-3 h-8">
           {isSidebarCollapsed && (
             <div className={`non-draggable flex items-center gap-1 ${isMac ? 'pl-[68px]' : ''}`}>
@@ -112,94 +112,96 @@ const ActivityView: React.FC<ActivityViewProps> = ({
         <WindowTitleBar inline />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-2xl px-8 pb-10">
-          {/* Hero */}
-          <section className="animate-fade-in-up pt-8 pb-6">
-            <div className="flex items-center gap-4">
-              <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary-muted">
-                <Activity className="size-6 text-primary" />
-              </div>
-              <div className="min-w-0">
-                <h1 className="text-xxl font-semibold text-foreground">
-                  {i18nService.t('activityTitle')}
-                </h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {i18nService.t('activityHeroDesc')}
-                </p>
-              </div>
+      <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col px-8">
+        {/* Hero */}
+        <section className="animate-fade-in-up shrink-0 pt-8 pb-6">
+          <div className="flex items-center gap-4">
+            <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary-muted">
+              <Activity className="size-6 text-primary" />
             </div>
-          </section>
-
-          {/* Filters: trigger on the left, status toggles on the right. */}
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pb-4">
-            <ButtonGroup>
-              {triggerOptions.map(option => (
-                <Button
-                  key={option.value}
-                  variant="outline"
-                  size="sm"
-                  className={
-                    triggerFilter === option.value
-                      ? 'bg-secondary text-foreground'
-                      : 'bg-card text-muted-foreground'
-                  }
-                  aria-pressed={triggerFilter === option.value}
-                  onClick={() => setTriggerFilter(option.value)}
-                >
-                  {i18nService.t(option.labelKey)}
-                </Button>
-              ))}
-            </ButtonGroup>
-            <ButtonGroup>
-              {statusOptions.map(option => (
-                <Button
-                  key={option.value}
-                  variant="outline"
-                  size="sm"
-                  className={
-                    statusFilter === option.value
-                      ? 'bg-secondary text-foreground'
-                      : 'bg-card text-muted-foreground'
-                  }
-                  aria-pressed={statusFilter === option.value}
-                  onClick={() =>
-                    setStatusFilter(current =>
-                      current === option.value ? ActivityStatusFilter.All : option.value,
-                    )
-                  }
-                >
-                  {i18nService.t(option.labelKey)}
-                </Button>
-              ))}
-            </ButtonGroup>
-          </div>
-
-          {/* Feed */}
-          {!hasAnyRun || dayGroups.length === 0 ? (
-            <div className="flex items-center justify-center py-16">
-              <p className="text-sm text-muted-foreground">
-                {i18nService.t(hasAnyRun ? 'activityFilterEmpty' : 'activityEmpty')}
+            <div className="min-w-0">
+              <h1 className="text-xxl font-semibold text-foreground">
+                {i18nService.t('activityTitle')}
+              </h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {i18nService.t('activityHeroDesc')}
               </p>
             </div>
-          ) : (
-            dayGroups.map(group => (
-              <section key={group.label} className="pb-4">
-                <h2 className="px-3 pb-1 text-xs font-medium text-muted-foreground">
-                  {group.label}
-                </h2>
-                <div className="flex flex-col">
-                  {group.runs.map(run => (
-                    <ActivityRunRow
-                      key={run.id}
-                      run={run}
-                      animateEntrance={run.updatedAt > openedAtRef.current}
-                    />
-                  ))}
-                </div>
-              </section>
-            ))
-          )}
+          </div>
+        </section>
+
+        {/* Filters: trigger on the left, status toggles on the right. */}
+        <div className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 pb-4">
+          <ButtonGroup>
+            {triggerOptions.map(option => (
+              <Button
+                key={option.value}
+                variant="outline"
+                size="sm"
+                className={
+                  triggerFilter === option.value
+                    ? 'bg-secondary text-foreground'
+                    : 'bg-card text-muted-foreground'
+                }
+                aria-pressed={triggerFilter === option.value}
+                onClick={() => setTriggerFilter(option.value)}
+              >
+                {i18nService.t(option.labelKey)}
+              </Button>
+            ))}
+          </ButtonGroup>
+          <ButtonGroup>
+            {statusOptions.map(option => (
+              <Button
+                key={option.value}
+                variant="outline"
+                size="sm"
+                className={
+                  statusFilter === option.value
+                    ? 'bg-secondary text-foreground'
+                    : 'bg-card text-muted-foreground'
+                }
+                aria-pressed={statusFilter === option.value}
+                onClick={() =>
+                  setStatusFilter(current =>
+                    current === option.value ? ActivityStatusFilter.All : option.value,
+                  )
+                }
+              >
+                {i18nService.t(option.labelKey)}
+              </Button>
+            ))}
+          </ButtonGroup>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable">
+          <div className="pb-10">
+            {/* Feed */}
+            {!hasAnyRun || dayGroups.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <p className="text-sm text-muted-foreground">
+                  {i18nService.t(hasAnyRun ? 'activityFilterEmpty' : 'activityEmpty')}
+                </p>
+              </div>
+            ) : (
+              dayGroups.map(group => (
+                <section key={group.label} className="pb-4">
+                  <h2 className="px-3 pb-1 text-xs font-medium text-muted-foreground">
+                    {group.label}
+                  </h2>
+                  <div className="flex flex-col">
+                    {group.runs.map(run => (
+                      <ActivityRunRow
+                        key={run.id}
+                        run={run}
+                        animateEntrance={run.updatedAt > openedAtRef.current}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -237,79 +237,77 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
         <WindowTitleBar inline />
       </div>
 
-      {/* Scrollable content */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-2xl px-8 pb-10">
-          {/* ── Hero ── */}
-          <section className="animate-fade-in-up pt-8 pb-6">
-            <div className="flex items-center gap-4">
-              <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary-muted">
-                <CalendarClock className="size-6 text-primary" />
-              </div>
-              <div className="min-w-0">
-                <h1 className="text-xxl font-semibold text-foreground">
-                  {i18nService.t('scheduledTasksTitle')}
-                </h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {i18nService.t('scheduledTasksHeroDesc')}
-                </p>
-              </div>
+      <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col px-8">
+        {/* ── Hero ── */}
+        <section className="animate-fade-in-up shrink-0 pt-8 pb-6">
+          <div className="flex items-center gap-4">
+            <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-primary-muted">
+              <CalendarClock className="size-6 text-primary" />
             </div>
-          </section>
-
-          {/* ── Tab list on the divider line, with a sliding underline ── */}
-          <div className="relative border-b border-border">
-            <div ref={tabRowRef} role="tablist" className="flex items-center gap-6">
-              {(
-                [
-                  { value: AUTO_TAB.Tasks, label: i18nService.t('scheduledTasksTabTasks') },
-                  { value: AUTO_TAB.Create, label: i18nService.t('scheduledTasksNewTab') },
-                  { value: AUTO_TAB.History, label: i18nService.t('scheduledTasksTabHistory') },
-                ] as const
-              ).map(tab => {
-                const active = activeTab === tab.value;
-                return (
-                  <Button
-                    key={tab.value}
-                    variant="ghost"
-                    ref={el => {
-                      tabRefs.current[tab.value] = el;
-                    }}
-                    type="button"
-                    role="tab"
-                    aria-selected={active}
-                    tabIndex={active ? 0 : -1}
-                    onClick={() => setActiveTab(tab.value)}
-                    onKeyDown={e => handleTabKeyDown(e, tab.value)}
-                    className={cn(
-                      'relative -mb-px h-auto gap-2 rounded-none border-b-2 border-transparent px-0 pb-2.5 hover:bg-transparent focus-visible:text-foreground active:translate-y-0 dark:hover:bg-transparent',
-                      active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-                    )}
-                  >
-                    {tab.label}
-                    {tab.value === AUTO_TAB.Tasks && tasks.length > 0 && (
-                      <Badge variant="secondary">{tasks.length}</Badge>
-                    )}
-                  </Button>
-                );
-              })}
+            <div className="min-w-0">
+              <h1 className="text-xxl font-semibold text-foreground">
+                {i18nService.t('scheduledTasksTitle')}
+              </h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {i18nService.t('scheduledTasksHeroDesc')}
+              </p>
             </div>
-            <span
-              aria-hidden
-              className="absolute bottom-0 h-0.5 rounded-full bg-primary transition-[left,width] duration-300 ease-smooth"
-              style={{
-                left: indicator?.left ?? 0,
-                width: indicator?.width ?? 0,
-                opacity: indicator ? 1 : 0,
-              }}
-            />
           </div>
+        </section>
 
-          {/* ── Active pane (directional slide) ── */}
+        {/* ── Tab list on the divider line, with a sliding underline ── */}
+        <div className="relative shrink-0 border-b border-border">
+          <div ref={tabRowRef} role="tablist" className="flex items-center gap-6">
+            {(
+              [
+                { value: AUTO_TAB.Tasks, label: i18nService.t('scheduledTasksTabTasks') },
+                { value: AUTO_TAB.Create, label: i18nService.t('scheduledTasksNewTab') },
+                { value: AUTO_TAB.History, label: i18nService.t('scheduledTasksTabHistory') },
+              ] as const
+            ).map(tab => {
+              const active = activeTab === tab.value;
+              return (
+                <Button
+                  key={tab.value}
+                  variant="ghost"
+                  ref={el => {
+                    tabRefs.current[tab.value] = el;
+                  }}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  tabIndex={active ? 0 : -1}
+                  onClick={() => setActiveTab(tab.value)}
+                  onKeyDown={e => handleTabKeyDown(e, tab.value)}
+                  className={cn(
+                    'relative -mb-px h-auto gap-2 rounded-none border-b-2 border-transparent px-0 pb-2.5 hover:bg-transparent focus-visible:text-foreground active:translate-y-0 dark:hover:bg-transparent',
+                    active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {tab.label}
+                  {tab.value === AUTO_TAB.Tasks && tasks.length > 0 && (
+                    <Badge variant="secondary">{tasks.length}</Badge>
+                  )}
+                </Button>
+              );
+            })}
+          </div>
+          <span
+            aria-hidden
+            className="absolute bottom-0 h-0.5 rounded-full bg-primary transition-[left,width] duration-300 ease-smooth"
+            style={{
+              left: indicator?.left ?? 0,
+              width: indicator?.width ?? 0,
+              opacity: indicator ? 1 : 0,
+            }}
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable">
           <div
             key={`${activeTab}-${tabDir ?? 'init'}`}
             className={cn(
-              'pt-6',
+              'min-h-full pt-6 pb-10',
               tabDir === 'right'
                 ? 'animate-slide-in-right'
                 : tabDir === 'left'

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -81,6 +81,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
   // (e.g. the count badge appearing/disappearing).
   const tabRefs = useRef<Record<string, HTMLElement | null>>({});
   const tabRowRef = useRef<HTMLDivElement>(null);
+  const activePaneScrollRef = useRef<HTMLDivElement>(null);
   const [indicator, setIndicator] = useState<{ left: number; width: number } | null>(null);
   useLayoutEffect(() => {
     let raf = 0;
@@ -111,6 +112,10 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
       window.removeEventListener('resize', measure);
     };
   }, [activeTab, tasks.length]);
+
+  useLayoutEffect(() => {
+    activePaneScrollRef.current?.scrollTo({ top: 0 });
+  }, [activeTab, initialDataLoaded]);
 
   // Create-task modal (template-prefilled or blank custom)
   const [createOpen, setCreateOpen] = useState(false);
@@ -237,7 +242,7 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
         <WindowTitleBar inline />
       </div>
 
-      <div className="mx-auto flex min-h-0 w-full max-w-2xl flex-1 flex-col px-8">
+      <div className="mx-auto w-full max-w-2xl shrink-0 px-8">
         {/* ── Hero ── */}
         <section className="animate-fade-in-up shrink-0 pt-8 pb-6">
           <div className="flex items-center gap-4">
@@ -302,8 +307,10 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
             }}
           />
         </div>
+      </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable">
+      <div ref={activePaneScrollRef} className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+        <div className="mx-auto w-full max-w-2xl px-8">
           <div
             key={`${activeTab}-${tabDir ?? 'init'}`}
             className={cn(

--- a/src/renderer/components/scheduledTasks/TaskTemplateGallery.tsx
+++ b/src/renderer/components/scheduledTasks/TaskTemplateGallery.tsx
@@ -93,7 +93,7 @@ const TaskTemplateGallery: React.FC<TaskTemplateGalleryProps> = ({
   onCustom,
 }) => {
   return (
-    <div className="flex flex-col gap-6 max-w-2xl mx-auto py-6">
+    <div className="flex w-full flex-col gap-6 py-6">
       <div>
         <h2 className="text-base font-semibold text-foreground mb-1">
           {i18nService.t('taskTemplateSectionTitle')}
@@ -102,7 +102,7 @@ const TaskTemplateGallery: React.FC<TaskTemplateGalleryProps> = ({
       </div>
 
       {/* Template Cards Grid */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
         {TEMPLATES.map(tpl => (
           <Card
             key={tpl.id}

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -94,6 +94,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
 
   const importInputRef = useRef<HTMLInputElement>(null);
   const marketplaceLoadedRef = useRef(false);
+  const installedGridScrollRef = useRef<HTMLDivElement>(null);
 
   const refreshMarketplace = useCallback(async (forceRefresh = false) => {
     setIsLoadingMarketplace(true);
@@ -261,6 +262,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
     setInstalledPageNumber(current => Math.min(current, installedPageCount));
   }, [installedPageCount]);
 
+  useEffect(() => {
+    installedGridScrollRef.current?.scrollTo({ top: 0 });
+  }, [installedPageNumber]);
+
   const selectedVisibleIds = useMemo(() => {
     const visibleIds = new Set(filteredInstalledSkills.map(skill => skill.id));
     return new Set([...selectedInstalledIds].filter(id => visibleIds.has(id)));
@@ -303,18 +308,12 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
       dispatch(setSkills(updatedSkills));
       setSkillActionError('');
       showToast(
-        enabled
-          ? i18nService.t('skillEnableSuccess')
-          : i18nService.t('skillDisableSuccess'),
+        enabled ? i18nService.t('skillEnableSuccess') : i18nService.t('skillDisableSuccess'),
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : i18nService.t('skillUpdateFailed');
       setSkillActionError(message);
-      showToast(
-        enabled
-          ? i18nService.t('skillEnableFailed')
-          : i18nService.t('skillDisableFailed'),
-      );
+      showToast(enabled ? i18nService.t('skillEnableFailed') : i18nService.t('skillDisableFailed'));
     } finally {
       setIsBatchUpdating(false);
     }
@@ -775,7 +774,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
         </div>
         <div className="min-h-0 flex-1 overflow-hidden">
           {activeTab === SkillTab.Installed && (
-            <div className="flex h-full min-h-0 flex-col overflow-y-auto">
+            <div className="flex h-full min-h-0 flex-col overflow-hidden">
               <div
                 className={cn(
                   'mb-4 flex w-full min-h-9 flex-wrap items-center gap-3 px-1 text-sm text-muted-foreground',
@@ -873,7 +872,10 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
                   </>
                 )}
               </div>
-              <div className="flex-1">
+              <div
+                ref={installedGridScrollRef}
+                className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable"
+              >
                 <InstalledSkillGrid
                   skills={paginatedInstalledSkills}
                   readOnly={readOnly}
@@ -889,7 +891,7 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
               <ListPagination
                 page={installedPageNumber}
                 totalPages={installedPageCount}
-                className="py-4"
+                className="shrink-0 py-4"
                 onPageChange={setInstalledPageNumber}
               />
             </div>
@@ -901,28 +903,30 @@ const SkillsManager: React.FC<SkillsManagerProps> = ({
                 {i18nService.t('loading')}
               </div>
             ) : (
-              <div className="h-full overflow-y-auto pr-2">
-                <MarketplaceSkillGrid
-                  skills={filteredMarketplaceSkills}
-                  installedSkillIds={installedSkillIds}
-                  installedSkillNames={installedSkillNames}
-                  isInstallingSkillId={installingSkillId}
-                  readOnly={readOnly}
-                  onSelect={handleSelectMarketplaceSkill}
-                  onInstall={handleInstallMarketplaceSkill}
-                  installProgress={installProgress}
-                  isDetailOpen={Boolean(selectedMarketplaceSkill)}
-                />
-                {isLoadingMoreMarketplace && (
-                  <div className="py-4 text-center text-sm text-muted-foreground">
-                    {i18nService.t('loading')}
-                  </div>
-                )}
+              <div className="flex h-full min-h-0 flex-col overflow-hidden">
+                <div className="min-h-0 flex-1 overflow-y-auto pr-2 scrollbar-gutter-stable">
+                  <MarketplaceSkillGrid
+                    skills={filteredMarketplaceSkills}
+                    installedSkillIds={installedSkillIds}
+                    installedSkillNames={installedSkillNames}
+                    isInstallingSkillId={installingSkillId}
+                    readOnly={readOnly}
+                    onSelect={handleSelectMarketplaceSkill}
+                    onInstall={handleInstallMarketplaceSkill}
+                    installProgress={installProgress}
+                    isDetailOpen={Boolean(selectedMarketplaceSkill)}
+                  />
+                  {isLoadingMoreMarketplace && (
+                    <div className="py-4 text-center text-sm text-muted-foreground">
+                      {i18nService.t('loading')}
+                    </div>
+                  )}
+                </div>
                 <ListPagination
                   page={marketplacePageNumber}
                   hasNext={marketplaceHasMore}
                   disabled={isLoadingMoreMarketplace}
-                  className="py-4"
+                  className="shrink-0 py-4"
                   onPageChange={page => void loadMarketplacePage(page)}
                 />
               </div>

--- a/src/renderer/components/skills/SkillsView.tsx
+++ b/src/renderer/components/skills/SkillsView.tsx
@@ -60,11 +60,8 @@ const SkillsView: React.FC<SkillsViewProps> = ({
         <WindowTitleBar inline />
       </div>
 
-      <div
-        ref={detailContainerRef}
-        className="relative flex-1 overflow-y-auto min-h-0 scrollbar-gutter-stable"
-      >
-        <div className="mx-auto w-full max-w-4xl px-4 py-4 sm:px-6">
+      <div ref={detailContainerRef} className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="mx-auto flex h-full w-full max-w-4xl flex-col px-4 py-4 sm:px-6">
           <SkillsManager
             readOnly={readOnly}
             onCreateByChat={onCreateSkillByChat}


### PR DESCRIPTION
## Summary

修复活动记录、定时任务和技能页面的内容滚动布局，避免页面头部、筛选栏或分页控件随内容滚动。

## Related Issue

无。

## Changes Made

- 固定活动记录和定时任务页面的头部与控制区域，仅让内容列表滚动。
- 为滚动区域保留稳定的滚动条槽位，减少布局跳动。
- 技能已安装列表和市场列表独立滚动，分页控件固定在底部。
- 切换已安装技能分页时自动回到列表顶部。

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed
- 已执行针对性 oxlint；命中相关文件已有的 React Compiler 规则告警，包括 ref render 访问、Date.now 和 effect 内同步 setState。
- `git diff --check` 通过。

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

commit: `a1d7408a`。已 rebase 到最新 `origin/main`，无冲突。