### PR TITLE
fix(linux): stabilize AppImage startup and shutdown

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -210,6 +210,7 @@
   },
   "linux": {
     "target": ["AppImage", "deb"],
+    "syncDesktopName": true,
     "publish": [
       {
         "provider": "generic",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "zhiyuan-agent",
+  "desktopName": "zhiyuan.desktop",
   "description": "知远 - AI-assisted coding and productivity tool",
   "private": true,
   "author": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -240,6 +240,7 @@ import { ChannelInboxStore } from './im/channelInboxStore';
 import { ChannelTurnCoordinator } from './im/channelTurnCoordinator';
 import { createIMScheduledTaskRequestDetector } from './im/imScheduledTaskHandler';
 import { IMStore } from './im/imStore';
+import { shouldReloadRendererProcess } from './rendererProcessRecovery';
 import { configureRendererStartup } from './rendererStartup';
 import { SkillManager } from './skillManager';
 import { listPresetExperts } from './presetExpertCatalog';
@@ -771,14 +772,8 @@ app.on('ready', () => {
 
 // 添加错误处理
 app.on('render-process-gone', (_event, webContents, details) => {
-  console.error('Render process gone:', details);
-  const shouldReload =
-    details.reason === 'crashed' ||
-    details.reason === 'killed' ||
-    details.reason === 'oom' ||
-    details.reason === 'launch-failed' ||
-    details.reason === 'integrity-failure';
-  if (shouldReload) {
+  console.error('[RendererProcess] Render process exited:', details);
+  if (shouldReloadRendererProcess(details.reason, isQuitting)) {
     scheduleReload(`render-process-gone (${details.reason})`, webContents);
   }
 });
@@ -2194,6 +2189,10 @@ const showSystemMenu = (position?: { x?: number; y?: number }) => {
 };
 
 const scheduleReload = (reason: string, webContents?: WebContents) => {
+  if (isQuitting) {
+    console.debug(`[RendererProcess] Skipping reload during shutdown (${reason}).`);
+    return;
+  }
   const target = webContents ?? mainWindow?.webContents;
   if (!target || target.isDestroyed()) {
     return;
@@ -6345,12 +6344,6 @@ if (!gotTheLock) {
       }
     });
 
-    // 处理渲染进程崩溃或退出
-    mainWindow.webContents.on('render-process-gone', (_event, details) => {
-      console.error('Window render process gone:', details);
-      scheduleReload('webContents-crashed');
-    });
-
     if (isDev) {
       // 开发环境
       const maxRetries = 3;
@@ -6419,6 +6412,22 @@ if (!gotTheLock) {
     mainWindow.on('leave-full-screen', forwardAndPersistWindowState);
     mainWindow.on('focus', forwardWindowState);
     mainWindow.on('blur', forwardWindowState);
+
+    // Some Linux desktop/GPU combinations finish loading without emitting ready-to-show.
+    // Show the loaded window so the first launch does not remain hidden until a second click.
+    mainWindow.webContents.once('did-finish-load', () => {
+      if (
+        mainWindow &&
+        !mainWindow.isDestroyed() &&
+        !mainWindow.isVisible() &&
+        (isLinuxRendererSmoke || !isAutoLaunched())
+      ) {
+        console.warn(
+          '[MainWindow] Page loaded before ready-to-show; showing the initial window now.',
+        );
+        mainWindow.show();
+      }
+    });
 
     // 等待内容加载完成后再显示窗口
     mainWindow.once('ready-to-show', () => {

--- a/src/main/rendererProcessRecovery.test.ts
+++ b/src/main/rendererProcessRecovery.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'vitest';
+
+import { RendererProcessExitReason, shouldReloadRendererProcess } from './rendererProcessRecovery';
+
+describe('shouldReloadRendererProcess', () => {
+  test.each([
+    RendererProcessExitReason.Crashed,
+    RendererProcessExitReason.Killed,
+    RendererProcessExitReason.OutOfMemory,
+    RendererProcessExitReason.LaunchFailed,
+    RendererProcessExitReason.IntegrityFailure,
+  ])('reloads after recoverable renderer exit %s', reason => {
+    expect(shouldReloadRendererProcess(reason, false)).toBe(true);
+  });
+
+  test('does not reload a renderer that exited cleanly', () => {
+    expect(shouldReloadRendererProcess(RendererProcessExitReason.CleanExit, false)).toBe(false);
+  });
+
+  test('does not reload while the application is quitting', () => {
+    expect(shouldReloadRendererProcess(RendererProcessExitReason.Crashed, true)).toBe(false);
+  });
+});

--- a/src/main/rendererProcessRecovery.ts
+++ b/src/main/rendererProcessRecovery.ts
@@ -1,0 +1,20 @@
+export const RendererProcessExitReason = {
+  CleanExit: 'clean-exit',
+  Crashed: 'crashed',
+  Killed: 'killed',
+  OutOfMemory: 'oom',
+  LaunchFailed: 'launch-failed',
+  IntegrityFailure: 'integrity-failure',
+} as const;
+
+const RECOVERABLE_RENDERER_EXIT_REASONS = new Set<string>([
+  RendererProcessExitReason.Crashed,
+  RendererProcessExitReason.Killed,
+  RendererProcessExitReason.OutOfMemory,
+  RendererProcessExitReason.LaunchFailed,
+  RendererProcessExitReason.IntegrityFailure,
+]);
+
+export function shouldReloadRendererProcess(reason: string, isQuitting: boolean): boolean {
+  return !isQuitting && RECOVERABLE_RENDERER_EXIT_REASONS.has(reason);
+}


### PR DESCRIPTION
## Summary

- Assign an ASCII desktop name and synchronize the generated Linux desktop entry for reliable launcher/window association.
- Show the initial window after the page loads when `ready-to-show` is not emitted.
- Avoid renderer reloads during application shutdown and remove the duplicate window-level recovery listener.
- Centralize recoverable renderer exit reasons with regression tests.

## Root Cause Covered

A renderer `clean-exit` during shutdown was being reloaded unconditionally. That attempted to start renderer and GPU processes after cleanup had already begun, amplifying an internal quit into the observed Chromium GPU fatal error.

This change prevents that shutdown-time failure and addresses the hidden first-launch window. The earlier trigger that caused the programmatic quit is not proven by the available screenshot and should be diagnosed separately if it still reproduces.

## Verification

- `npm test -- rendererProcessRecovery rendererStartup`
- `npm run compile:electron`
- `npm run lint`
- electron-builder accepted the updated configuration. Full Linux packaging was not completed on Windows because the Linux channel runtime is not installed.
