### PR TITLE
chore(logging): record application quit origins

### DIFF
--- a/src/main/appQuitOrigin.test.ts
+++ b/src/main/appQuitOrigin.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import {
+  AppQuitOrigin,
+  getAppQuitOrigin,
+  recordAppQuitOrigin,
+  resetAppQuitOriginForTesting,
+} from './appQuitOrigin';
+
+describe('app quit origin', () => {
+  beforeEach(() => resetAppQuitOriginForTesting());
+
+  test('uses the Electron before-quit fallback when no source was recorded', () => {
+    expect(getAppQuitOrigin()).toBe(AppQuitOrigin.ElectronBeforeQuit);
+  });
+
+  test('keeps the first recorded source', () => {
+    recordAppQuitOrigin(AppQuitOrigin.UpdateInstall);
+    recordAppQuitOrigin(AppQuitOrigin.WindowAllClosed);
+
+    expect(getAppQuitOrigin()).toBe(AppQuitOrigin.UpdateInstall);
+  });
+});

--- a/src/main/appQuitOrigin.ts
+++ b/src/main/appQuitOrigin.ts
@@ -1,0 +1,27 @@
+export const AppQuitOrigin = {
+  ElectronBeforeQuit: 'electron-before-quit',
+  OperatingSystemSessionEnd: 'operating-system-session-end',
+  RendererRelaunch: 'renderer-relaunch',
+  SignalInterrupt: 'signal-interrupt',
+  SignalTerminate: 'signal-terminate',
+  TrayMenu: 'tray-menu',
+  UpdateInstall: 'update-install',
+  WindowAllClosed: 'window-all-closed',
+} as const;
+
+export type AppQuitOrigin = (typeof AppQuitOrigin)[keyof typeof AppQuitOrigin];
+
+let recordedOrigin: AppQuitOrigin | null = null;
+
+export function recordAppQuitOrigin(origin: AppQuitOrigin): AppQuitOrigin {
+  recordedOrigin ??= origin;
+  return recordedOrigin;
+}
+
+export function getAppQuitOrigin(): AppQuitOrigin {
+  return recordedOrigin ?? AppQuitOrigin.ElectronBeforeQuit;
+}
+
+export function resetAppQuitOriginForTesting(): void {
+  recordedOrigin = null;
+}

--- a/src/main/libs/appUpdateCoordinator.ts
+++ b/src/main/libs/appUpdateCoordinator.ts
@@ -19,6 +19,7 @@ import {
   AppUpdateStatus,
 } from '../../shared/appUpdate/constants';
 import { APP_UPDATE_TRUSTED_KEYS } from '../../shared/appUpdate/trustedKeys';
+import { AppQuitOrigin, recordAppQuitOrigin } from '../appQuitOrigin';
 import type { SqliteStore } from '../sqliteStore';
 import { installWindowsNsis } from './appUpdateInstaller';
 
@@ -353,6 +354,7 @@ export class AppUpdateCoordinator {
       if (process.platform === 'win32') {
         await installWindowsNsis(readyFilePath);
       } else {
+        recordAppQuitOrigin(AppQuitOrigin.UpdateInstall);
         this.updater.quitAndInstall(false, true);
       }
       return { success: true, state: this.getState() };

--- a/src/main/libs/appUpdateInstaller.ts
+++ b/src/main/libs/appUpdateInstaller.ts
@@ -3,6 +3,8 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import { AppQuitOrigin, recordAppQuitOrigin } from '../appQuitOrigin';
+
 /**
  * Preserve the assisted, visible NSIS handoff. electron-updater owns the
  * verified download, but its default quitAndInstall handoff cannot guarantee
@@ -56,5 +58,6 @@ export async function installWindowsNsis(exePath: string): Promise<void> {
   const launcher = spawn('wscript.exe', [vbsPath], { detached: true, stdio: 'ignore' });
   launcher.unref();
   console.log(`[AppUpdate] Launcher PID: ${launcher.pid}, calling app.quit()`);
+  recordAppQuitOrigin(AppQuitOrigin.UpdateInstall);
   app.quit();
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -113,6 +113,7 @@ import {
   resolveAnySearchGatewayUrl,
 } from './libs/anysearchGatewayCredentials';
 import { APP_DATA_DIR_NAME, APP_NAME, DB_FILENAME } from './appConstants';
+import { AppQuitOrigin, getAppQuitOrigin, recordAppQuitOrigin } from './appQuitOrigin';
 import { getAutoLaunchEnabled, isAutoLaunched, setAutoLaunchEnabled } from './autoLaunchManager';
 import { getChangedSessionPermissionModes } from './coworkPermissionModeChanges';
 import type { CoworkPromptLanguage } from './coworkLanguagePrompt';
@@ -2576,6 +2577,7 @@ if (!gotTheLock) {
 
   ipcMain.handle('app:relaunch', () => {
     console.log('[Main] app:relaunch requested, scheduling restart...');
+    recordAppQuitOrigin(AppQuitOrigin.RendererRelaunch);
     app.relaunch();
     app.quit();
   });
@@ -6419,6 +6421,10 @@ if (!gotTheLock) {
     mainWindow.on('leave-full-screen', forwardAndPersistWindowState);
     mainWindow.on('focus', forwardWindowState);
     mainWindow.on('blur', forwardWindowState);
+    mainWindow.on('session-end', () => {
+      recordAppQuitOrigin(AppQuitOrigin.OperatingSystemSessionEnd);
+      logAppQuitContextOnce();
+    });
 
     // 等待内容加载完成后再显示窗口
     mainWindow.once('ready-to-show', () => {
@@ -6465,9 +6471,23 @@ if (!gotTheLock) {
 
   let isCleanupFinished = false;
   let isCleanupInProgress = false;
+  let hasLoggedAppQuitContext = false;
+
+  const logAppQuitContextOnce = (): void => {
+    if (hasLoggedAppQuitContext) return;
+    hasLoggedAppQuitContext = true;
+
+    const origin = getAppQuitOrigin();
+    const windowCount = BrowserWindow.getAllWindows().length;
+    const appImageContext = process.env.APPIMAGE ? ` from AppImage ${process.env.APPIMAGE}` : '';
+    console.log(
+      `[AppLifecycle] Quit requested by ${origin} on ${process.platform} with ${windowCount} open window(s) ` +
+        `(pid ${process.pid}, executable ${process.execPath}${appImageContext}).`,
+    );
+  };
 
   const runAppCleanup = async (): Promise<void> => {
-    console.log('[Main] App is quitting, starting cleanup...');
+    console.log('[AppLifecycle] App cleanup started.');
     destroyTray();
     skillManager?.stopWatching();
 
@@ -6540,6 +6560,7 @@ if (!gotTheLock) {
       return;
     }
 
+    logAppQuitContextOnce();
     isCleanupInProgress = true;
     isQuitting = true;
 
@@ -6554,11 +6575,13 @@ if (!gotTheLock) {
       });
   });
 
-  const handleTerminationSignal = (signal: NodeJS.Signals) => {
+  const handleTerminationSignal = (signal: NodeJS.Signals, origin: AppQuitOrigin) => {
     if (isCleanupFinished || isCleanupInProgress) {
       return;
     }
-    console.log(`[Main] Received ${signal}, running cleanup before exit...`);
+    recordAppQuitOrigin(origin);
+    logAppQuitContextOnce();
+    console.log(`[AppLifecycle] Received ${signal}; running cleanup before exit.`);
     isCleanupInProgress = true;
     isQuitting = true;
     void runAppCleanup()
@@ -6572,8 +6595,8 @@ if (!gotTheLock) {
       });
   };
 
-  process.once('SIGINT', () => handleTerminationSignal('SIGINT'));
-  process.once('SIGTERM', () => handleTerminationSignal('SIGTERM'));
+  process.once('SIGINT', () => handleTerminationSignal('SIGINT', AppQuitOrigin.SignalInterrupt));
+  process.once('SIGTERM', () => handleTerminationSignal('SIGTERM', AppQuitOrigin.SignalTerminate));
 
   // 初始化应用
   const initApp = async () => {
@@ -7073,6 +7096,7 @@ if (!gotTheLock) {
   // 当所有窗口关闭时退出应用
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {
+      recordAppQuitOrigin(AppQuitOrigin.WindowAllClosed);
       app.quit();
     }
   });

--- a/src/main/trayManager.ts
+++ b/src/main/trayManager.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Menu, nativeImage, Tray } from 'electron';
 import path from 'path';
 
 import { APP_NAME } from './appConstants';
+import { AppQuitOrigin, recordAppQuitOrigin } from './appQuitOrigin';
 import { t } from './i18n';
 
 let tray: Tray | null = null;
@@ -79,6 +80,7 @@ function buildContextMenu(getWindow: () => BrowserWindow | null): Menu {
     {
       label: labels.quit,
       click: () => {
+        recordAppQuitOrigin(AppQuitOrigin.TrayMenu);
         app.quit();
       },
     },


### PR DESCRIPTION
## Summary

- Track the first application quit origin in one shared main-process module.
- Cover window exhaustion, renderer-requested relaunch, tray quit, update installation, Windows session end, SIGINT, and SIGTERM.
- Log the origin once with the platform, process ID, executable path, AppImage source path, and remaining window count.
- Preserve `electron-before-quit` as the fallback for native or otherwise untracked exits.

## Context

Linux logs showed the application entering `before-quit` without identifying the initiating path. They also showed an AppImage process receiving a second-instance launch from `/opt/知远/知远`. The additional executable and AppImage context makes distribution conflicts visible while the origin distinguishes internal window closure from updates, relaunches, tray actions, and signals.

This is a diagnostic follow-up to #570 and does not change shutdown policy.

## Verification

- `npm test -- appQuitOrigin appUpdateCoordinator appUpdateInstaller` (22 tests)
- `npm run compile:electron`
- `npm run lint`
