### PR TITLE
feat(production-loop): lightweight review mode for low-risk generic work

### DIFF
--- a/src/main/evaluation/zhiyuanEvaluationPolicy.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.ts
@@ -92,6 +92,9 @@ export function createZhiyuanEvaluationPolicy(
     workflowKind: WorkbenchContractKind.GenericWork,
     goal: context.prompt,
     prototypeRequired: false,
+    // Evaluation measures the full harness gate, including the independent
+    // reviewer; never run evaluation runs in lightweight mode.
+    reviewMode: 'standard',
   });
   const productionTool = buildProductionLoopTool(controller) as ZhiyuanEvaluationTool;
   const executeProductionTool = productionTool.execute.bind(productionTool);

--- a/src/main/evaluation/zhiyuanEvaluationPolicy.ts
+++ b/src/main/evaluation/zhiyuanEvaluationPolicy.ts
@@ -94,7 +94,7 @@ export function createZhiyuanEvaluationPolicy(
     prototypeRequired: false,
     // Evaluation measures the full harness gate, including the independent
     // reviewer; never run evaluation runs in lightweight mode.
-    reviewMode: 'standard',
+    forceStandardReview: true,
   });
   const productionTool = buildProductionLoopTool(controller) as ZhiyuanEvaluationTool;
   const executeProductionTool = productionTool.execute.bind(productionTool);

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -2533,14 +2533,20 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 : null,
             domain: domainWorkflowSnapshot,
           });
-          const artifactCandidates = active.productionLoop
-            ?.getReviewedArtifacts()
+          // Deliver-phase artifacts are preserved regardless of review
+          // outcome: a reviewer pass marks them Verified, a lightweight skip
+          // leaves them Pending so user acceptance can elevate them
+          // (markArtifactsVerified on accept).
+          const deliveryArtifacts = active.productionLoop
+            ?.getDeliveryArtifacts()
             .map(artifact => ({
               path: artifact.reference,
               kind: artifact.kind,
               role: artifact.kind,
               source: WorkbenchArtifactCandidateSource.ProductionInspection,
-              verificationStatus: WorkbenchArtifactVerificationStatus.Verified,
+              verificationStatus: active.productionLoop?.getReviewOutcome().skipped
+                ? WorkbenchArtifactVerificationStatus.Pending
+                : WorkbenchArtifactVerificationStatus.Verified,
             }));
           this.workbenchTaskService.completeRun({
             sessionId,
@@ -2552,7 +2558,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               ? active.agentLoop.getState().done
               : undefined,
             workflowSnapshot,
-            artifactCandidates,
+            artifactCandidates: deliveryArtifacts,
           });
         }
         void this.runPostTurnMemoryMaintenance(

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -999,16 +999,19 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 deferDecision:
                   options.goalMode !== true && options._productionWorkflowEnabled === undefined,
                 skipAllowed: options.goalMode !== true,
-                // System-side risk probe: an approved irreversible approval
-                // (classified by riskClassifier, not by the model) forces the
-                // full reviewer even in lightweight mode.
-                resolveIrreversibleRisk: probeRunId =>
+                // System-side risk probe: an approved approval whose risk was
+                // classified as irreversible OR unknown (e.g. mcp tools,
+                // unclassified shell commands) forces the full reviewer —
+                // lightweight review is fail-open only for positively
+                // read-only/reversible runs.
+                resolveElevatedRisk: probeRunId =>
                   this.workbenchTaskService?.repository
                     .listApprovalsForRun(probeRunId)
                     .some(
                       approval =>
-                        approval.riskLevel === WorkbenchApprovalRiskLevel.Irreversible &&
-                        approval.decision === WorkbenchApprovalDecision.Approved,
+                        approval.decision === WorkbenchApprovalDecision.Approved &&
+                        (approval.riskLevel === WorkbenchApprovalRiskLevel.Irreversible ||
+                          approval.riskLevel === WorkbenchApprovalRiskLevel.Unknown),
                     ) ?? false,
               },
               completionWorkflow || undefined,

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -44,6 +44,8 @@ import {
 } from '../../../shared/harness';
 import { MAX_STALE_PRODUCTION_ITERATIONS } from '../../../shared/productionLoop';
 import {
+  WorkbenchApprovalDecision,
+  WorkbenchApprovalRiskLevel,
   WorkbenchContractKind,
   WorkbenchArtifactCandidateSource,
   WorkbenchArtifactVerificationStatus,
@@ -997,6 +999,17 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 deferDecision:
                   options.goalMode !== true && options._productionWorkflowEnabled === undefined,
                 skipAllowed: options.goalMode !== true,
+                // System-side risk probe: an approved irreversible approval
+                // (classified by riskClassifier, not by the model) forces the
+                // full reviewer even in lightweight mode.
+                resolveIrreversibleRisk: probeRunId =>
+                  this.workbenchTaskService?.repository
+                    .listApprovalsForRun(probeRunId)
+                    .some(
+                      approval =>
+                        approval.riskLevel === WorkbenchApprovalRiskLevel.Irreversible &&
+                        approval.decision === WorkbenchApprovalDecision.Approved,
+                    ) ?? false,
               },
               completionWorkflow || undefined,
             )

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -85,7 +85,7 @@ const reachCritique = (controller: ProductionLoopController) => {
 };
 
 const createGenericWorkController = (
-  options: { resolveIrreversibleRisk?: (runId: string) => boolean } = {},
+  options: { resolveElevatedRisk?: (runId: string) => boolean } = {},
 ) => {
   const workbench = new WorkbenchTaskRepository(db);
   const task = workbench.createTask('session', 'Analyze GPU logs', {
@@ -120,10 +120,51 @@ const createGenericWorkController = (
   };
 };
 
-test('lightweight generic work skips the reviewer and still reaches delivery', () => {
-  // Full split coverage lives in 'irreversible-risk probe consulted at
-  // critique time' (lightweight branch, standard branch, and the probe flip).
-  const { controller } = createGenericWorkController({ resolveIrreversibleRisk: () => false });
+test('lightweight generic work skips the reviewer, reaches delivery, and exposes no reviewed artifacts', () => {
+  // Full split coverage lives in 'risk probe consulted at critique time'
+  // (lightweight branch, standard branch, and the probe flip).
+  const { controller } = createGenericWorkController({
+    resolveElevatedRisk: () => false,
+  });
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [{ kind: 'report', description: 'Final report', required: true }],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  for (const item of planned.planItems) {
+    controller.updatePlanItem(item.id, 'completed');
+  }
+  controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  controller.startInspection({
+    artifacts: [{ kind: 'report', reference: 'output/report.md' }],
+    verifiers: [{ name: 'preview', evidenceRef }],
+  });
+
+  const prompt = controller.requestCritique();
+
+  expect(prompt).toContain('skipped');
+  expect(prompt).not.toContain('subagent');
+  const state = controller.getState();
+  expect(state.phase).toBe(ProductionLoopPhase.Deliver);
+  expect(state.status).toBe(ProductionLoopStatus.ReadyToDeliver);
+  expect(state.critic.skipped).toBe(true);
+  expect(state.critic.passed).toBe(false);
+  // A skipped review is not a passed review: artifacts stay pending until
+  // user acceptance elevates them.
+  expect(controller.getReviewedArtifacts()).toEqual([]);
+  expect(controller.getSnapshot().criticSkipped).toBe(true);
+});
+
+test('approved unknown-risk approvals force the full reviewer', () => {
+  // Unknown-classified operations (mcp tools, unclassified shell commands)
+  // must not be treated as low risk: lightweight review is fail-open only
+  // for positively read-only/reversible runs.
+  const { controller } = createGenericWorkController({
+    resolveElevatedRisk: () => true, // approved Unknown approval present
+  });
   const planned = controller.commitPlan({
     items: [{ title: 'Build' }],
     constraints: [],
@@ -142,14 +183,31 @@ test('lightweight generic work skips the reviewer and still reaches delivery', (
   });
 
   const prompt = controller.requestCritique();
+  expect(prompt).toContain('production-reviewer');
+  expect(prompt).not.toContain('skipped');
+});
 
-  expect(prompt).toContain('skipped');
-  expect(prompt).not.toContain('subagent');
-  const state = controller.getState();
-  expect(state.phase).toBe(ProductionLoopPhase.Deliver);
-  expect(state.status).toBe(ProductionLoopStatus.ReadyToDeliver);
-  expect(state.critic.skipped).toBe(true);
-  expect(state.critic.passed).toBe(true);
+test('a missing risk probe fails closed into the full reviewer', () => {
+  const { controller } = createGenericWorkController();
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  for (const item of planned.planItems) {
+    controller.updatePlanItem(item.id, 'completed');
+  }
+  controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  controller.startInspection({
+    artifacts: [],
+    verifiers: [{ name: 'preview', evidenceRef }],
+  });
+
+  const prompt = controller.requestCritique();
+  expect(prompt).toContain('production-reviewer');
 });
 
 test('domain workflows always run the full reviewer', () => {
@@ -161,10 +219,10 @@ test('domain workflows always run the full reviewer', () => {
   expect(controller.getState().critic.requested).toBe(true);
 });
 
-test('irreversible-risk probe consulted at critique time revokes lightweight mode', () => {
+test('elevated-risk probe consulted at critique time revokes lightweight mode', () => {
   let risky = false;
   const { controller } = createGenericWorkController({
-    resolveIrreversibleRisk: () => risky,
+    resolveElevatedRisk: () => risky,
   });
   const planned = controller.commitPlan({
     items: [{ title: 'Build' }],
@@ -191,7 +249,7 @@ test('irreversible-risk probe consulted at critique time revokes lightweight mod
   // A risk-free run stays lightweight; a risky run is the standard branch.
   risky = true;
   const { controller: riskyController } = createGenericWorkController({
-    resolveIrreversibleRisk: () => risky,
+    resolveElevatedRisk: () => risky,
   });
   const riskyPlanned = riskyController.commitPlan({
     items: [{ title: 'Build' }],

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -84,6 +84,137 @@ const reachCritique = (controller: ProductionLoopController) => {
   controller.requestCritique();
 };
 
+const createGenericWorkController = (
+  options: { resolveIrreversibleRisk?: (runId: string) => boolean } = {},
+) => {
+  const workbench = new WorkbenchTaskRepository(db);
+  const task = workbench.createTask('session', 'Analyze GPU logs', {
+    kind: WorkbenchContractKind.GenericWork,
+    requiresUserAcceptance: true,
+  });
+  const run = workbench.createRun(task.id, WorkbenchRunTrigger.Message);
+  const service = new ProductionLoopService(
+    new ProductionLoopRepository(db),
+    new HarnessMeasurementService(workbench),
+  );
+  const downstream = {
+    goal: 'Analyzed result',
+    requestCompletion: vi.fn(() => 'downstream requested'),
+    onAgentEnd: vi.fn(() => ({ shouldFinish: true, reason: 'downstream passed' })),
+  };
+  return {
+    controller: new ProductionLoopController(
+      service,
+      {
+        taskId: task.id,
+        runId: run.id,
+        workflowKind: WorkbenchContractKind.GenericWork,
+        goal: task.goal,
+        prototypeRequired: false,
+        ...options,
+      },
+      downstream,
+    ),
+    service,
+    downstream,
+  };
+};
+
+test('lightweight generic work skips the reviewer and still reaches delivery', () => {
+  // Full split coverage lives in 'irreversible-risk probe consulted at
+  // critique time' (lightweight branch, standard branch, and the probe flip).
+  const { controller } = createGenericWorkController({ resolveIrreversibleRisk: () => false });
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  for (const item of planned.planItems) {
+    controller.updatePlanItem(item.id, 'completed');
+  }
+  controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  controller.startInspection({
+    artifacts: [],
+    verifiers: [{ name: 'preview', evidenceRef }],
+  });
+
+  const prompt = controller.requestCritique();
+
+  expect(prompt).toContain('skipped');
+  expect(prompt).not.toContain('subagent');
+  const state = controller.getState();
+  expect(state.phase).toBe(ProductionLoopPhase.Deliver);
+  expect(state.status).toBe(ProductionLoopStatus.ReadyToDeliver);
+  expect(state.critic.skipped).toBe(true);
+  expect(state.critic.passed).toBe(true);
+});
+
+test('domain workflows always run the full reviewer', () => {
+  const { controller } = createController();
+  reachCritique(controller);
+  // createController uses Shortcut: requestCritique inside reachCritique
+  // requested the reviewer, so the state is waiting for a critic.
+  expect(controller.getState().phase).toBe(ProductionLoopPhase.Critique);
+  expect(controller.getState().critic.requested).toBe(true);
+});
+
+test('irreversible-risk probe consulted at critique time revokes lightweight mode', () => {
+  let risky = false;
+  const { controller } = createGenericWorkController({
+    resolveIrreversibleRisk: () => risky,
+  });
+  const planned = controller.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  for (const item of planned.planItems) {
+    controller.updatePlanItem(item.id, 'completed');
+  }
+  controller.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const evidenceRef = controller.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  controller.startInspection({
+    artifacts: [],
+    verifiers: [{ name: 'preview', evidenceRef }],
+  });
+
+  // No risk at critique time: lightweight skip.
+  const lightweightPrompt = controller.requestCritique();
+  expect(lightweightPrompt).toContain('skipped');
+  expect(controller.getState().phase).toBe(ProductionLoopPhase.Deliver);
+
+  // A risk-free run stays lightweight; a risky run is the standard branch.
+  risky = true;
+  const { controller: riskyController } = createGenericWorkController({
+    resolveIrreversibleRisk: () => risky,
+  });
+  const riskyPlanned = riskyController.commitPlan({
+    items: [{ title: 'Build' }],
+    constraints: [],
+    acceptanceCriteria: ['Preview passes'],
+    expectedArtifacts: [],
+    expectedVerifiers: [{ name: 'preview', deterministic: true }],
+  });
+  for (const item of riskyPlanned.planItems) {
+    riskyController.updatePlanItem(item.id, 'completed');
+  }
+  riskyController.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  const riskyEvidenceRef =
+    riskyController.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
+  riskyController.startInspection({
+    artifacts: [],
+    verifiers: [{ name: 'preview', evidenceRef: riskyEvidenceRef }],
+  });
+  const fullPrompt = riskyController.requestCritique();
+  expect(fullPrompt).toContain('production-reviewer');
+  expect(fullPrompt).not.toContain('skipped');
+});
+
 test('re-submitting the same plan is idempotent and keeps item IDs stable', () => {
   const { controller } = createController();
   const plan = {

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -152,10 +152,16 @@ test('lightweight generic work skips the reviewer, reaches delivery, and exposes
   expect(state.status).toBe(ProductionLoopStatus.ReadyToDeliver);
   expect(state.critic.skipped).toBe(true);
   expect(state.critic.passed).toBe(false);
-  // A skipped review is not a passed review: artifacts stay pending until
-  // user acceptance elevates them.
+  // A skipped review is not a passed review: artifacts are not projected as
+  // verified...
   expect(controller.getReviewedArtifacts()).toEqual([]);
   expect(controller.getSnapshot().criticSkipped).toBe(true);
+  // ...but they are preserved for the completion chain, mapped to pending so
+  // user acceptance can elevate them.
+  expect(controller.getDeliveryArtifacts()).toEqual([
+    { kind: 'report', reference: 'output/report.md' },
+  ]);
+  expect(controller.getReviewOutcome()).toEqual({ passed: false, skipped: true });
 });
 
 test('approved unknown-risk approvals force the full reviewer', () => {

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -43,18 +43,19 @@ interface ProductionLoopRunInput {
   deferDecision?: boolean;
   skipAllowed?: boolean;
   /**
-   * Explicit review-mode override. 'standard' forces the full reviewer
-   * (evaluation harnesses and strictly-gated callers); without it, generic
-   * work runs lightweight unless the risk probe reports an approved
-   * irreversible approval.
+   * Force the full independent reviewer regardless of workflow kind or risk
+   * probe (evaluation harnesses measure the complete gate). There is no
+   * force-lightweight counterpart: lightweight applies by default only to
+   * generic work below the elevated-risk threshold.
    */
-  reviewMode?: 'standard' | 'lightweight';
+  forceStandardReview?: boolean;
   /**
    * System-side risk probe evaluated at critique time: true when this run has
-   * an approved irreversible approval on record. The model cannot influence
-   * it; lightweight mode is bypassed and the full reviewer runs instead.
+   * an approved elevated-risk (irreversible or unknown) approval on record.
+   * The model cannot influence it. When the probe is absent the run is
+   * treated as elevated — fail closed.
    */
-  resolveIrreversibleRisk?: (runId: string) => boolean;
+  resolveElevatedRisk?: (runId: string) => boolean;
 }
 
 const isStandaloneProductionReviewer = (args: unknown): boolean => {
@@ -353,15 +354,17 @@ export class ProductionLoopController {
   }
 
   /**
-   * Lightweight review applies to generic_work runs only, and is revoked at
-   * critique time when the run carries an approved irreversible approval.
-   * Explicit reviewMode 'standard' always runs the full reviewer (evaluation
-   * harnesses measure the full gate); domain workflows also stay standard.
+   * Lightweight review applies to generic_work runs only, and only when the
+   * risk probe positively reports no approved elevated-risk approval.
+   * forceStandardReview always runs the full reviewer (evaluation harnesses
+   * measure the full gate); domain workflows stay standard; a missing probe
+   * fails closed into standard review.
    */
   private isLightweightReview(): boolean {
-    if (this.initial.reviewMode === 'standard') return false;
+    if (this.initial.forceStandardReview) return false;
     if (this.initial.workflowKind !== WorkbenchContractKind.GenericWork) return false;
-    return !(this.initial.resolveIrreversibleRisk?.(this.initial.runId) ?? false);
+    if (!this.initial.resolveElevatedRisk) return false;
+    return !this.initial.resolveElevatedRisk(this.initial.runId);
   }
 
   recordSubagentStart(toolCallId: string, args: unknown): void {
@@ -573,6 +576,9 @@ export class ProductionLoopController {
       phase: this.state.phase,
       status: this.state.status,
       skipped: Boolean(this.state.skip),
+      // Distinguishes "reviewer passed" from "reviewer skipped (lightweight)"
+      // for the completion verification chain and audit UIs.
+      criticSkipped: this.state.critic.skipped === true,
       planItems: this.state.planItems.map(item => ({
         status: item.status,
         title: item.title,
@@ -587,6 +593,8 @@ export class ProductionLoopController {
     if (
       !this.state ||
       this.state.phase !== ProductionLoopPhase.Deliver ||
+      // A skipped review is not a passed review: lightweight artifacts stay
+      // pending until user acceptance elevates them.
       !this.state.critic.passed
     ) {
       return [];

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -593,14 +593,33 @@ export class ProductionLoopController {
     if (
       !this.state ||
       this.state.phase !== ProductionLoopPhase.Deliver ||
-      // A skipped review is not a passed review: lightweight artifacts stay
-      // pending until user acceptance elevates them.
+      // A skipped review is not a passed review: only a real reviewer pass
+      // projects artifacts as verified.
       !this.state.critic.passed
     ) {
       return [];
     }
     const latestInspection = this.state.inspections[this.state.inspections.length - 1];
     return latestInspection ? structuredClone(latestInspection.artifacts) : [];
+  }
+
+  /**
+   * Deliver-phase inspection artifacts regardless of review outcome. Lightweight
+   * runs still declare their artifacts — the caller maps them to pending so
+   * user acceptance can elevate them. Empty outside the deliver phase.
+   */
+  getDeliveryArtifacts(): ProductionArtifactEvidence[] {
+    this.refreshIfStarted();
+    if (!this.state || this.state.phase !== ProductionLoopPhase.Deliver) return [];
+    const latestInspection = this.state.inspections[this.state.inspections.length - 1];
+    return latestInspection ? structuredClone(latestInspection.artifacts) : [];
+  }
+
+  /** Review outcome for artifact status mapping (verified vs pending). */
+  getReviewOutcome(): { passed: boolean; skipped: boolean } {
+    this.refreshIfStarted();
+    if (!this.state) return { passed: false, skipped: false };
+    return { passed: this.state.critic.passed, skipped: this.state.critic.skipped === true };
   }
 
   private activate(): ProductionLoopState {

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -6,7 +6,10 @@ import {
   type ProductionArtifactEvidence,
   type ProductionLoopState,
 } from '../../shared/productionLoop';
-import type { WorkbenchContractKind, WorkbenchJsonObject } from '../../shared/workbenchTask';
+import {
+  WorkbenchContractKind,
+  type WorkbenchJsonObject,
+} from '../../shared/workbenchTask';
 import type { PiAgentLoopEndSignal } from '../libs/agentEngine/piAgentLoop';
 import {
   PiAgentLoopAction,
@@ -39,6 +42,19 @@ interface ProductionLoopRunInput {
   prototypeRequired: boolean;
   deferDecision?: boolean;
   skipAllowed?: boolean;
+  /**
+   * Explicit review-mode override. 'standard' forces the full reviewer
+   * (evaluation harnesses and strictly-gated callers); without it, generic
+   * work runs lightweight unless the risk probe reports an approved
+   * irreversible approval.
+   */
+  reviewMode?: 'standard' | 'lightweight';
+  /**
+   * System-side risk probe evaluated at critique time: true when this run has
+   * an approved irreversible approval on record. The model cannot influence
+   * it; lightweight mode is bypassed and the full reviewer runs instead.
+   */
+  resolveIrreversibleRisk?: (runId: string) => boolean;
 }
 
 const isStandaloneProductionReviewer = (args: unknown): boolean => {
@@ -61,15 +77,7 @@ const truncate = (value: string, max: number): string =>
  * get_state round-trip to learn what to do next.
  */
 export const buildNextHint = (
-  state: Pick<
-    ProductionLoopState,
-    | 'phase'
-    | 'status'
-    | 'skip'
-    | 'critic'
-    | 'planItems'
-    | 'deliveryReason'
-  >,
+  state: Pick<ProductionLoopState, 'phase' | 'status' | 'skip' | 'planItems' | 'deliveryReason'>,
 ): string => {
   if (state.skip) {
     return 'Answer directly and end the turn.';
@@ -90,9 +98,8 @@ export const buildNextHint = (
     case ProductionLoopPhase.Inspect:
       return 'Request an independent critique (request_critique) using the evidence already submitted.';
     case ProductionLoopPhase.Critique:
-      return state.critic.passed
-        ? 'Reviewer passed: call get_state, then agent_loop done to deliver.'
-        : 'Address reviewer findings with record_revision, re-run deterministic checks, and inspect again.';
+      // The reviewer has been requested but has not returned yet.
+      return 'Wait for the reviewer result; revise with record_revision if findings exist, otherwise deliver.';
     case ProductionLoopPhase.Revise:
       return 'Re-run deterministic checks, start_inspection with fresh evidence, then request_critique again.';
     case ProductionLoopPhase.Deliver:
@@ -325,8 +332,36 @@ export class ProductionLoopController {
 
   requestCritique(): string {
     const state = this.requireState();
+    if (this.isLightweightReview()) {
+      // Enter the critique phase first so the audit trail records the request,
+      // then skip the reviewer dispatch.
+      this.update(this.service.requestCritique(state.runId));
+      this.update(
+        this.service.skipCritique(
+          state.runId,
+          'Lightweight mode: the run has no approved irreversible approvals; the independent reviewer is skipped.',
+        ),
+      );
+      return (
+        'Independent review skipped (lightweight mode). ' +
+        'Deterministic verification and your acceptance remain the gates; ' +
+        'continue to delivery and end the turn.'
+      );
+    }
     this.update(this.service.requestCritique(state.runId));
     return this.requestCriticPrompt();
+  }
+
+  /**
+   * Lightweight review applies to generic_work runs only, and is revoked at
+   * critique time when the run carries an approved irreversible approval.
+   * Explicit reviewMode 'standard' always runs the full reviewer (evaluation
+   * harnesses measure the full gate); domain workflows also stay standard.
+   */
+  private isLightweightReview(): boolean {
+    if (this.initial.reviewMode === 'standard') return false;
+    if (this.initial.workflowKind !== WorkbenchContractKind.GenericWork) return false;
+    return !(this.initial.resolveIrreversibleRisk?.(this.initial.runId) ?? false);
   }
 
   recordSubagentStart(toolCallId: string, args: unknown): void {

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -118,7 +118,8 @@ test('skipCritique moves a critique-phase run to delivery without a reviewer', (
   expect(after.phase).toBe(ProductionLoopPhase.Deliver);
   expect(after.status).toBe(ProductionLoopStatus.ReadyToDeliver);
   expect(after.critic.skipped).toBe(true);
-  expect(after.critic.passed).toBe(true);
+  // A skipped review is not a passed review.
+  expect(after.critic.passed).toBe(false);
   expect(after.progressVersion).toBeGreaterThan(before.progressVersion);
 });
 

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -102,6 +102,33 @@ test('repeated skip_workflow stays a no-op without advancing progressVersion', (
   expect(second.status).toBe(ProductionLoopStatus.Completed);
 });
 
+test('skipCritique moves a critique-phase run to delivery without a reviewer', () => {
+  const { run } = begin();
+  const planned = commitPlan(run.id);
+  for (const item of planned.planItems) {
+    service.updatePlanItem(run.id, item.id, ProductionPlanItemStatus.Completed);
+  }
+  startInspection(run.id);
+  service.requestCritique(run.id);
+  const before = service.getState(run.id);
+  expect(before.phase).toBe(ProductionLoopPhase.Critique);
+
+  const after = service.skipCritique(run.id, 'Lightweight mode');
+
+  expect(after.phase).toBe(ProductionLoopPhase.Deliver);
+  expect(after.status).toBe(ProductionLoopStatus.ReadyToDeliver);
+  expect(after.critic.skipped).toBe(true);
+  expect(after.critic.passed).toBe(true);
+  expect(after.progressVersion).toBeGreaterThan(before.progressVersion);
+});
+
+test('skipCritique is rejected outside the critique phase', () => {
+  const { run } = begin();
+  commitPlan(run.id);
+  expect(() => service.skipCritique(run.id, 'nope')).toThrow(/not waiting for a critic/);
+  expect(() => service.skipCritique('missing-run', 'nope')).toThrow(/not found/);
+});
+
 const commitPlan = (runId: string) =>
   service.commitPlan(runId, {
     items: [{ title: 'Create artifact' }, { title: 'Run checks' }],

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -547,15 +547,16 @@ export class ProductionLoopService {
   /**
    * Bypass the independent reviewer in lightweight mode. The critique phase
    * still runs through the normal state machine (Critique → Deliver), but no
-   * subagent is dispatched: passed stays true so reviewed-artifact projection
-   * keeps working, and skipped records the distinction for audit.
+   * subagent is dispatched. passed stays false — a skipped review is NOT a
+   * passed review — so reviewed-artifact projection keeps working by
+   * requiring a real pass; skipped preserves the distinction for audit.
    */
   skipCritique(runId: string, reason: string): ProductionLoopState {
     return this.mutate(runId, state => {
       if (state.phase !== ProductionLoopPhase.Critique || !state.critic.requested) {
         throw new Error('The production loop is not waiting for a critic.');
       }
-      state.critic.passed = true;
+      state.critic.passed = false;
       state.critic.skipped = true;
       state.critic.outputSummary = reason.trim() || 'Independent review skipped.';
       state.progressVersion += 1;

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -544,6 +544,31 @@ export class ProductionLoopService {
     });
   }
 
+  /**
+   * Bypass the independent reviewer in lightweight mode. The critique phase
+   * still runs through the normal state machine (Critique → Deliver), but no
+   * subagent is dispatched: passed stays true so reviewed-artifact projection
+   * keeps working, and skipped records the distinction for audit.
+   */
+  skipCritique(runId: string, reason: string): ProductionLoopState {
+    return this.mutate(runId, state => {
+      if (state.phase !== ProductionLoopPhase.Critique || !state.critic.requested) {
+        throw new Error('The production loop is not waiting for a critic.');
+      }
+      state.critic.passed = true;
+      state.critic.skipped = true;
+      state.critic.outputSummary = reason.trim() || 'Independent review skipped.';
+      state.progressVersion += 1;
+      this.transition(state, ProductionLoopPhase.Deliver);
+      state.status = ProductionLoopStatus.ReadyToDeliver;
+      this.measurement.recordActivation(runId, {
+        activation: HarnessActivationType.LightweightReviewSkipped,
+        mechanism: 'production_loop_reviewer',
+        evidence: { reason: reason.trim() },
+      });
+    });
+  }
+
   recordCriticResult(
     runId: string,
     toolCallId: string,

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -535,6 +535,56 @@ test('user acceptance dispatches the verified-run memory promotion', () => {
   }
 });
 
+test('lightweight inspected artifacts enter pending and are elevated by acceptance', () => {
+  const { db, service } = createService();
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'workbench-lightweight-artifact-'));
+  const filePath = path.join(workspace, 'report.md');
+  fs.writeFileSync(filePath, '# report');
+  try {
+    const contract = {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: true,
+    };
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'analyze gpu logs',
+      contract,
+    });
+    // Lightweight production runs submit inspection artifacts that the
+    // reviewer never passed: they must land as pending (not be dropped),
+    // then be elevated by user acceptance.
+    const detail = service.completeRun({
+      sessionId: 'session',
+      runId: run.id,
+      workspaceRoot: workspace,
+      finalAnswer: 'done',
+      artifactCandidates: [
+        {
+          path: filePath,
+          kind: 'report',
+          role: 'report',
+          source: WorkbenchArtifactCandidateSource.ProductionInspection,
+          verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+        },
+      ],
+    });
+
+    expect(detail.artifacts).toHaveLength(1);
+    expect(detail.artifacts[0]).toMatchObject({
+      provenance: WorkbenchArtifactProvenance.Controller,
+      verificationStatus: WorkbenchArtifactVerificationStatus.Pending,
+    });
+
+    const accepted = service.acceptTask(task.id);
+    expect(accepted.artifacts[0]?.verificationStatus).toBe(
+      WorkbenchArtifactVerificationStatus.Verified,
+    );
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+    db.close();
+  }
+});
+
 test('creates a new task for each ordinary user message', () => {
   const { db, service } = createService();
   try {

--- a/src/shared/harness/constants.ts
+++ b/src/shared/harness/constants.ts
@@ -39,6 +39,7 @@ export const HarnessActivationType = {
   RevisionApplied: 'revision_applied',
   WorkflowSkipped: 'workflow_skipped',
   RecoveryTriggered: 'recovery_triggered',
+  LightweightReviewSkipped: 'lightweight_review_skipped',
 } as const;
 export type HarnessActivationType =
   (typeof HarnessActivationType)[keyof typeof HarnessActivationType];

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -87,6 +87,12 @@ export interface ProductionCriticState {
   findings: ProductionCriticFinding[];
   outputSummary: string | null;
   execution: ProductionCriticExecution | null;
+  /**
+   * True when the critique phase was bypassed by lightweight review mode.
+   * passed stays true so reviewed-artifact projection keeps working; the
+   * flag preserves the distinction for audit.
+   */
+  skipped?: boolean;
 }
 
 export interface ProductionRevision {


### PR DESCRIPTION
## Motivation

Generic work (analyses, reports, docs) forced every run through the independent reviewer subagent even when the run had no elevated-risk side effects. This PR introduces lightweight review for low-risk generic work — **decided by the system, never by the model**.

> #568 (protocol slimming) is merged; this branch is rebased on latest main and carries only its own 3 commits.

## Design

| Input | Review mode |
|---|---|
| `research` or `shortcut` domain workflows | standard (unchanged) |
| `generic_work`, no approved elevated-risk approval | **lightweight** |
| `generic_work` + approved elevated-risk (irreversible **or unknown**) approval at critique time | standard (auto-revoke) |
| `forceStandardReview` (evaluation harnesses) | standard |
| risk probe missing | standard (**fail closed**) |

1. **System-side risk signal.** `resolveElevatedRisk` probe evaluated at critique time, backed by `workbench_approvals` (risk levels classified by `riskClassifier` — irreversible shell patterns and unknown-classified tools like mcp proxies, not model judgment). Approved **Irreversible *or* Unknown** elevates; `Reversible`/`ReadOnly` do not.
2. **Protocol unchanged.** The model still calls `request_critique`; the tool schema and call sequence are identical. In lightweight mode the controller moves through the critique phase and skips the reviewer dispatch.
3. **Artifacts are preserved, statuses are honest.** Deliver-phase inspection artifacts always reach the completion chain: a reviewer pass maps them Verified, a lightweight skip maps them **Pending** — so user acceptance can see and elevate them (`markArtifactsVerified` on accept), and memory promotion then runs. `critic.skipped` is recorded (`passed` stays false — a skipped review is not a passed review) and exposed in the completion snapshot for audit UIs.
4. **Gates untouched.** Deterministic verification and user acceptance are unchanged — lightweight lifts the reviewer, not the gates.

## Review fixes

- **fail-open closed:** approved Unknown-classified operations (mcp tools, `curl POST`, `git clean`) force standard review; a missing risk probe fails closed.
- **skip ≠ pass:** `passed=false, skipped=true`; artifacts are not shown verified before acceptance.
- **artifacts not dropped:** lightweight inspected artifacts enter the ledger as pending (bash/python deliverables included) instead of being discarded.
- **contract honesty:** bare-string `reviewMode` replaced by `forceStandardReview: boolean` (the only real override).

## Tests

- service: `skipCritique` transition + phase guard + `skipped:true, passed:false`.
- controller: lightweight skip reaches delivery, preserves inspected artifacts (delivery + outcome assertions), review probe consulted at critique time (both branches), approved Unknown forces standard, missing probe fails closed, domain stays standard.
- taskService end-to-end: a production-inspection pending candidate lands in the ledger and acceptance elevates it to verified.
- productionLoop 77/77; 143 workbench + productionLoop/evaluation tests pass; tsc + oxlint clean within changed scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)