### PR TITLE
feat(enterprise): add versioned extension host

### DIFF
--- a/docs/enterprise-extension.md
+++ b/docs/enterprise-extension.md
@@ -1,0 +1,25 @@
+# Zhiyuan Enterprise Extension Host
+
+[简体中文](enterprise-extension.zh-CN.md)
+
+Zhiyuan community builds and closed enterprise modules remain in separate repositories. The public application loads an optional, versioned main-process extension from a fixed packaged resource and does not contain AEP endpoints, tenant configuration, customer policy, or private implementation code.
+
+## API v1
+
+An enterprise build places a standalone CommonJS bundle at:
+
+```text
+resources/zhiyuan-enterprise/extension.cjs
+```
+
+The bundle exports `createZhiyuanEnterpriseExtension`. The returned object declares `apiVersion: 1`, a stable lowercase ID, and asynchronous `initialize` and `dispose` lifecycle methods. Initialization receives a frozen context containing the Zhiyuan version, platform, packaging state, resource path, and user-data path.
+
+Community packages omit the resource and continue startup without loading an extension. A packaged application never accepts an environment-controlled module path. Development builds may set `ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH` to an absolute bundle path.
+
+An extension that is present but invalid or incompatible fails closed and prevents the remainder of application initialization. Shutdown invokes `dispose` exactly once so private services can stop polling and release local state before the application database closes.
+
+## Build Boundary
+
+The private repository owns the extension bundle, enterprise tests, release manifest, signing inputs, and Electron Builder overlay. It must pin an exact Zhiyuan tag and commit. It must not copy files over `src/`, patch the public application during packaging, or depend on an unversioned branch.
+
+API v1 is deliberately limited to lifecycle and non-secret host context. Authentication IPC, managed model projection, Skill reconciliation, and control-event operations must be added as explicit versioned capabilities rather than importing renderer state or private application internals.

--- a/docs/enterprise-extension.zh-CN.md
+++ b/docs/enterprise-extension.zh-CN.md
@@ -1,0 +1,25 @@
+# Zhiyuan 企业扩展宿主
+
+[English](enterprise-extension.md)
+
+Zhiyuan 社区构建与闭源企业模块分别保存在独立仓库。公开应用只从固定制品位置加载可选、版本化的主进程扩展，不包含 AEP 地址、租户配置、客户策略或私有实现代码。
+
+## API v1
+
+企业构建将独立 CommonJS bundle 放置在：
+
+```text
+resources/zhiyuan-enterprise/extension.cjs
+```
+
+Bundle 导出 `createZhiyuanEnterpriseExtension`。返回对象声明 `apiVersion: 1`、稳定的小写 ID，以及异步 `initialize` 和 `dispose` 生命周期方法。初始化会收到冻结的上下文，其中只包含 Zhiyuan 版本、运行平台、是否已打包、资源目录和用户数据目录。
+
+社区安装包不包含该资源，因此会继续正常启动。已打包应用永远不接受环境变量控制的模块路径；只有开发构建可以通过 `ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH` 指定绝对 bundle 路径。
+
+如果扩展文件存在但无效或版本不兼容，应用会关闭启动门，不能带病继续初始化。退出时宿主只调用一次 `dispose`，使私有服务可以在应用数据库关闭前停止轮询并释放本地状态。
+
+## 构建边界
+
+私有仓库负责扩展 bundle、企业测试、发布清单、签名输入和 Electron Builder 覆盖配置，并必须锁定准确的 Zhiyuan tag 与 commit。企业构建不能覆盖 `src/` 文件、不能在打包时修改公开应用源码，也不能依赖未版本化分支。
+
+API v1 有意只开放生命周期和非敏感宿主上下文。认证 IPC、托管模型投影、Skill 收敛和管控事件操作必须作为明确的版本化能力逐步加入，不能直接导入 Renderer 状态或应用私有内部模块。

--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -1,0 +1,41 @@
+export const ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION = 1 as const;
+
+export const ZhiyuanEnterpriseExtensionStatus = {
+  Idle: 'idle',
+  Absent: 'absent',
+  Active: 'active',
+  Failed: 'failed',
+  Disposed: 'disposed',
+} as const;
+
+export type ZhiyuanEnterpriseExtensionStatus =
+  (typeof ZhiyuanEnterpriseExtensionStatus)[keyof typeof ZhiyuanEnterpriseExtensionStatus];
+
+export interface ZhiyuanEnterpriseHostContext {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION;
+  readonly appVersion: string;
+  readonly isPackaged: boolean;
+  readonly platform: NodeJS.Platform;
+  readonly paths: {
+    readonly resources: string;
+    readonly userData: string;
+  };
+}
+
+export interface ZhiyuanEnterpriseExtension {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION;
+  readonly id: string;
+  initialize(context: ZhiyuanEnterpriseHostContext): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+export interface ZhiyuanEnterpriseExtensionModule {
+  createZhiyuanEnterpriseExtension():
+    | ZhiyuanEnterpriseExtension
+    | Promise<ZhiyuanEnterpriseExtension>;
+}
+
+export interface ZhiyuanEnterpriseExtensionSnapshot {
+  readonly status: ZhiyuanEnterpriseExtensionStatus;
+  readonly extensionId: string | null;
+}

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -1,0 +1,222 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+  ZhiyuanEnterpriseExtensionStatus,
+  type ZhiyuanEnterpriseHostContext,
+} from './contract';
+import { ZhiyuanEnterpriseExtensionHost, type ZhiyuanEnterpriseExtensionHostOptions } from './host';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('Zhiyuan enterprise extension host', () => {
+  test('keeps community startup unchanged when no extension is packaged', async () => {
+    const importModule = vi.fn();
+    const host = new ZhiyuanEnterpriseExtensionHost(importModule);
+
+    await expect(host.initialize(options())).resolves.toEqual({
+      status: ZhiyuanEnterpriseExtensionStatus.Absent,
+      extensionId: null,
+    });
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
+  test('loads the fixed packaged module and passes frozen host context', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const dispose = vi.fn(async () => undefined);
+    const host = new ZhiyuanEnterpriseExtensionHost(async importedPath => {
+      expect(importedPath).toBe(modulePath);
+      return {
+        createZhiyuanEnterpriseExtension: () => ({
+          apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+          id: 'zhiyuan.aaas',
+          initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+            receivedContext = context;
+          },
+          dispose,
+        }),
+      };
+    });
+
+    await expect(host.initialize(options(root, true))).resolves.toEqual({
+      status: ZhiyuanEnterpriseExtensionStatus.Active,
+      extensionId: 'zhiyuan.aaas',
+    });
+    expect(receivedContext).toMatchObject({
+      apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+      appVersion: '2026.8.0',
+      isPackaged: true,
+      platform: process.platform,
+    });
+    expect(Object.isFrozen(receivedContext)).toBe(true);
+    expect(Object.isFrozen(receivedContext!.paths)).toBe(true);
+
+    await host.dispose();
+    await host.dispose();
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  test('allows an absolute development module without changing packaged resolution', async () => {
+    const root = createTemporaryDirectory();
+    const developmentModule = path.join(root, 'private-extension.cjs');
+    fs.writeFileSync(developmentModule, 'module placeholder');
+    const importModule = vi.fn(async () => validModule());
+    const host = new ZhiyuanEnterpriseExtensionHost(importModule);
+
+    await host.initialize(options(root, false, developmentModule));
+    expect(importModule).toHaveBeenCalledWith(developmentModule);
+
+    const packagedHost = new ZhiyuanEnterpriseExtensionHost(importModule);
+    await packagedHost.initialize(options(root, true, developmentModule));
+    expect(importModule).toHaveBeenCalledTimes(1);
+  });
+
+  test('imports a real CommonJS development bundle', async () => {
+    const root = createTemporaryDirectory();
+    const developmentModule = path.join(root, 'private-extension.cjs');
+    fs.writeFileSync(
+      developmentModule,
+      'module.exports.createZhiyuanEnterpriseExtension = () => ({\n' +
+        '  apiVersion: 1,\n' +
+        "  id: 'zhiyuan.fixture',\n" +
+        "  initialize: async context => { if (!Object.isFrozen(context)) throw new Error('context is mutable'); },\n" +
+        '  dispose: async () => undefined,\n' +
+        '});\n',
+    );
+    const host = new ZhiyuanEnterpriseExtensionHost();
+
+    await expect(host.initialize(options(root, false, developmentModule))).resolves.toEqual({
+      status: ZhiyuanEnterpriseExtensionStatus.Active,
+      extensionId: 'zhiyuan.fixture',
+    });
+    await host.dispose();
+  });
+
+  test('rejects relative development paths and incompatible extensions', async () => {
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => validModule());
+    await expect(host.initialize(options(undefined, false, 'relative.cjs'))).rejects.toThrow(
+      'must be absolute',
+    );
+
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const incompatibleHost = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        apiVersion: 2,
+      }),
+    }));
+    await expect(incompatibleHost.initialize(options(root, true))).rejects.toThrow(
+      'API version is not supported',
+    );
+    expect(incompatibleHost.snapshot().status).toBe(ZhiyuanEnterpriseExtensionStatus.Failed);
+  });
+
+  test('cleans up a partially initialized extension and preserves both failures', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async () => {
+          throw new Error('initialization failed');
+        },
+        dispose: async () => {
+          throw new Error('cleanup failed');
+        },
+      }),
+    }));
+
+    await expect(host.initialize(options(root, true))).rejects.toBeInstanceOf(AggregateError);
+    expect(host.snapshot().status).toBe(ZhiyuanEnterpriseExtensionStatus.Failed);
+  });
+
+  test('waits for in-flight initialization before disposing', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    let finishInitialization: (() => void) | null = null;
+    let signalInitializationStarted: (() => void) | null = null;
+    const initializationStarted = new Promise<void>(resolve => {
+      signalInitializationStarted = resolve;
+    });
+    const dispose = vi.fn(async () => undefined);
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: () =>
+          new Promise<void>(resolve => {
+            finishInitialization = resolve;
+            signalInitializationStarted!();
+          }),
+        dispose,
+      }),
+    }));
+
+    const initializing = host.initialize(options(root, true));
+    await initializationStarted;
+    const disposing = host.dispose();
+    finishInitialization!();
+
+    await initializing;
+    await disposing;
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(host.snapshot()).toEqual({
+      status: ZhiyuanEnterpriseExtensionStatus.Disposed,
+      extensionId: null,
+    });
+  });
+});
+
+function options(
+  root = createTemporaryDirectory(),
+  isPackaged = true,
+  developmentExtensionPath?: string,
+): ZhiyuanEnterpriseExtensionHostOptions {
+  return {
+    appVersion: '2026.8.0',
+    isPackaged,
+    platform: process.platform,
+    resourcesPath: path.join(root, 'resources'),
+    userDataPath: path.join(root, 'user-data'),
+    developmentExtensionPath,
+  };
+}
+
+function validModule() {
+  return { createZhiyuanEnterpriseExtension: () => validExtension() };
+}
+
+function validExtension() {
+  return {
+    apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+    id: 'zhiyuan.aaas',
+    initialize: async () => undefined,
+    dispose: async () => undefined,
+  };
+}
+
+function createTemporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-enterprise-host-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+  type ZhiyuanEnterpriseExtension,
+  type ZhiyuanEnterpriseExtensionModule,
+  type ZhiyuanEnterpriseExtensionSnapshot,
+  ZhiyuanEnterpriseExtensionStatus,
+  type ZhiyuanEnterpriseHostContext,
+} from './contract';
+
+const ENTERPRISE_RESOURCE_DIRECTORY = 'zhiyuan-enterprise';
+const ENTERPRISE_EXTENSION_FILENAME = 'extension.cjs';
+const ENTERPRISE_EXTENSION_ID_PATTERN = /^[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$/;
+
+export interface ZhiyuanEnterpriseExtensionHostOptions {
+  readonly appVersion: string;
+  readonly isPackaged: boolean;
+  readonly platform: NodeJS.Platform;
+  readonly resourcesPath: string;
+  readonly userDataPath: string;
+  readonly developmentExtensionPath?: string;
+}
+
+type ExtensionModuleImporter = (modulePath: string) => Promise<unknown>;
+
+export class ZhiyuanEnterpriseExtensionHost {
+  readonly #importModule: ExtensionModuleImporter;
+  #extension: ZhiyuanEnterpriseExtension | null = null;
+  #initializePromise: Promise<ZhiyuanEnterpriseExtensionSnapshot> | null = null;
+  #disposePromise: Promise<void> | null = null;
+  #status: ZhiyuanEnterpriseExtensionStatus = ZhiyuanEnterpriseExtensionStatus.Idle;
+
+  constructor(importModule: ExtensionModuleImporter = importExtensionModule) {
+    this.#importModule = importModule;
+  }
+
+  snapshot(): ZhiyuanEnterpriseExtensionSnapshot {
+    return Object.freeze({
+      status: this.#status,
+      extensionId: this.#extension?.id ?? null,
+    });
+  }
+
+  initialize(
+    options: ZhiyuanEnterpriseExtensionHostOptions,
+  ): Promise<ZhiyuanEnterpriseExtensionSnapshot> {
+    if (this.#initializePromise) return this.#initializePromise;
+    if (
+      this.#status === ZhiyuanEnterpriseExtensionStatus.Active ||
+      this.#status === ZhiyuanEnterpriseExtensionStatus.Absent
+    ) {
+      return Promise.resolve(this.snapshot());
+    }
+    if (this.#status !== ZhiyuanEnterpriseExtensionStatus.Idle) {
+      return Promise.reject(
+        new Error(`Zhiyuan enterprise extension cannot initialize from ${this.#status}.`),
+      );
+    }
+
+    this.#initializePromise = this.#initialize(options).finally(() => {
+      this.#initializePromise = null;
+    });
+    return this.#initializePromise;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.#disposePromise) return this.#disposePromise;
+    this.#disposePromise = (async () => {
+      if (this.#initializePromise) {
+        try {
+          await this.#initializePromise;
+        } catch {
+          // Initialization already records failure; shutdown still needs to finish.
+        }
+      }
+      await this.#dispose();
+    })().finally(() => {
+      this.#disposePromise = null;
+    });
+    return this.#disposePromise;
+  }
+
+  async #initialize(
+    options: ZhiyuanEnterpriseExtensionHostOptions,
+  ): Promise<ZhiyuanEnterpriseExtensionSnapshot> {
+    const modulePath = resolveExtensionModulePath(options);
+    if (!fs.existsSync(modulePath)) {
+      this.#status = ZhiyuanEnterpriseExtensionStatus.Absent;
+      return this.snapshot();
+    }
+
+    let extension: ZhiyuanEnterpriseExtension | null = null;
+    try {
+      const imported = await this.#importModule(modulePath);
+      const extensionModule = resolveExtensionModule(imported);
+      extension = await extensionModule.createZhiyuanEnterpriseExtension();
+      validateExtension(extension);
+      await extension.initialize(createHostContext(options));
+      this.#extension = extension;
+      this.#status = ZhiyuanEnterpriseExtensionStatus.Active;
+      return this.snapshot();
+    } catch (error) {
+      if (extension && typeof extension.dispose === 'function') {
+        try {
+          await extension.dispose();
+        } catch (disposeError) {
+          this.#status = ZhiyuanEnterpriseExtensionStatus.Failed;
+          throw new AggregateError(
+            [error, disposeError],
+            'Zhiyuan enterprise extension initialization and cleanup failed.',
+          );
+        }
+      }
+      this.#status = ZhiyuanEnterpriseExtensionStatus.Failed;
+      throw error;
+    }
+  }
+
+  async #dispose(): Promise<void> {
+    const extension = this.#extension;
+    this.#extension = null;
+    this.#status = ZhiyuanEnterpriseExtensionStatus.Disposed;
+    if (extension) await extension.dispose();
+  }
+}
+
+function resolveExtensionModulePath(options: ZhiyuanEnterpriseExtensionHostOptions): string {
+  if (!options.isPackaged && options.developmentExtensionPath) {
+    if (!path.isAbsolute(options.developmentExtensionPath)) {
+      throw new Error('Zhiyuan enterprise development extension path must be absolute.');
+    }
+    return path.normalize(options.developmentExtensionPath);
+  }
+  return path.join(
+    path.resolve(options.resourcesPath),
+    ENTERPRISE_RESOURCE_DIRECTORY,
+    ENTERPRISE_EXTENSION_FILENAME,
+  );
+}
+
+function resolveExtensionModule(imported: unknown): ZhiyuanEnterpriseExtensionModule {
+  const candidate = asRecord(imported);
+  const defaultCandidate = asRecord(candidate?.default);
+  const factory =
+    candidate?.createZhiyuanEnterpriseExtension ??
+    defaultCandidate?.createZhiyuanEnterpriseExtension;
+  if (typeof factory !== 'function') {
+    throw new Error('Zhiyuan enterprise extension module does not export its factory.');
+  }
+  return { createZhiyuanEnterpriseExtension: () => factory() };
+}
+
+function validateExtension(extension: unknown): asserts extension is ZhiyuanEnterpriseExtension {
+  const candidate = asRecord(extension);
+  if (candidate?.apiVersion !== ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION) {
+    throw new Error('Zhiyuan enterprise extension API version is not supported.');
+  }
+  if (typeof candidate.id !== 'string' || !ENTERPRISE_EXTENSION_ID_PATTERN.test(candidate.id)) {
+    throw new Error('Zhiyuan enterprise extension ID is invalid.');
+  }
+  if (typeof candidate.initialize !== 'function' || typeof candidate.dispose !== 'function') {
+    throw new Error('Zhiyuan enterprise extension lifecycle is incomplete.');
+  }
+}
+
+function createHostContext(
+  options: ZhiyuanEnterpriseExtensionHostOptions,
+): ZhiyuanEnterpriseHostContext {
+  const paths = Object.freeze({
+    resources: path.resolve(options.resourcesPath),
+    userData: path.resolve(options.userDataPath),
+  });
+  return Object.freeze({
+    apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+    appVersion: options.appVersion,
+    isPackaged: options.isPackaged,
+    platform: options.platform,
+    paths,
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+async function importExtensionModule(modulePath: string): Promise<unknown> {
+  return import(/* @vite-ignore */ pathToFileURL(modulePath).href);
+}
+
+const defaultEnterpriseExtensionHost = new ZhiyuanEnterpriseExtensionHost();
+
+export function initializeZhiyuanEnterpriseExtension(
+  options: ZhiyuanEnterpriseExtensionHostOptions,
+): Promise<ZhiyuanEnterpriseExtensionSnapshot> {
+  return defaultEnterpriseExtensionHost.initialize(options);
+}
+
+export function disposeZhiyuanEnterpriseExtension(): Promise<void> {
+  return defaultEnterpriseExtensionHost.dispose();
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -189,6 +189,10 @@ import {
 import { resolveBundledNpmRuntime, NpmCli } from './libs/npmRuntime';
 import { refreshEndpointsTestMode } from './libs/endpoints';
 import { resolveEnterpriseConfigPath, syncEnterpriseConfig } from './libs/enterpriseConfigSync';
+import {
+  disposeZhiyuanEnterpriseExtension,
+  initializeZhiyuanEnterpriseExtension,
+} from './enterpriseExtension/host';
 import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
 import { serializeCcConnectSidecarConfig } from './libs/ccConnectSidecarConfig';
@@ -6500,6 +6504,10 @@ if (!gotTheLock) {
     destroyTray();
     skillManager?.stopWatching();
 
+    await disposeZhiyuanEnterpriseExtension().catch(error => {
+      console.error('[EnterpriseExtension] Failed to dispose enterprise extension:', error);
+    });
+
     // Stop all active Pi sessions without blocking shutdown.
     console.log('[Main] Stopping cowork sessions...');
     if (piRuntimeAdapter) piRuntimeAdapter.stopAllSessions();
@@ -6616,6 +6624,20 @@ if (!gotTheLock) {
     await app.whenReady();
     profiler.measure('app.whenReady');
     console.log('[Main] initApp: app is ready');
+
+    const enterpriseExtension = await initializeZhiyuanEnterpriseExtension({
+      appVersion: app.getVersion(),
+      isPackaged: app.isPackaged,
+      platform: process.platform,
+      resourcesPath: process.resourcesPath,
+      userDataPath: app.getPath('userData'),
+      developmentExtensionPath: process.env.ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH,
+    });
+    if (enterpriseExtension.extensionId) {
+      console.log(
+        `[EnterpriseExtension] Initialized ${enterpriseExtension.extensionId} with API version 1.`,
+      );
+    }
 
     void getEngramManager()
       .start()


### PR DESCRIPTION
Summary: add an optional versioned main-process extension host for Zhiyuan enterprise builds; keep community startup unchanged when no extension is packaged and fail closed for invalid extensions; document the public/private build boundary in English and Simplified Chinese. Verification: target tests, Electron typecheck, oxlint, oxfmt, and full Vite build completed locally. This changes Electron main-process startup and shutdown only; it adds no UI, IPC surface, tenant configuration, or private implementation.