### PR TITLE
ci: validate Certum cloud signing on ephemeral Windows runner

### DIFF
--- a/.github/workflows/certum-signing-smoke.yml
+++ b/.github/workflows/certum-signing-smoke.yml
@@ -1,0 +1,146 @@
+name: Validate Certum cloud signing
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: certum-signing-smoke
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  SIMPLYSIGN_URL: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.3.90/SimplySignDesktop-9.4.3.90-64-bit-en.msi
+
+jobs:
+  sign-smoke:
+    name: Authenticate, sign, and verify
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: windows-latest
+    timeout-minutes: 25
+    environment: release
+    steps:
+      - name: Require protected Certum configuration
+        id: certum
+        shell: pwsh
+        env:
+          CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
+          CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+          CERTUM_CERT_THUMBPRINT: ${{ secrets.CERTUM_CERT_THUMBPRINT }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:CERTUM_USER_ID)) {
+            throw 'CERTUM_USER_ID is not configured.'
+          }
+          if ($env:CERTUM_OTP_URI -notmatch '^otpauth://totp/') {
+            throw 'CERTUM_OTP_URI must contain the complete SimplySign TOTP URI.'
+          }
+
+          $thumbprint = (
+            $env:CERTUM_CERT_THUMBPRINT -replace '[^0-9A-Fa-f]', ''
+          ).ToUpperInvariant()
+          if ($thumbprint -notmatch '^[0-9A-F]{40}$') {
+            throw 'CERTUM_CERT_THUMBPRINT must contain a SHA-1 certificate thumbprint.'
+          }
+
+          Write-Output "::add-mask::$thumbprint"
+          "thumbprint=$thumbprint" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Download and verify SimplySign Desktop
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri $env:SIMPLYSIGN_URL -OutFile SimplySignDesktop.msi
+          $signature = Get-AuthenticodeSignature -FilePath SimplySignDesktop.msi
+          if ($signature.Status -ne 'Valid') {
+            throw "SimplySign Desktop installer signature is $($signature.Status), expected Valid."
+          }
+          if ($signature.SignerCertificate.Subject -notmatch 'Asseco Data Systems') {
+            throw 'SimplySign Desktop installer is not signed by Asseco Data Systems.'
+          }
+
+      # This third-party action receives the long-lived TOTP credential, so it
+      # is pinned to the exact revision reviewed for this workflow.
+      - name: Connect Certum SimplySign
+        uses: dismine/windows-app-signing-setup-action@89ae3b032d4bc7a5b98d1a42a34e61ecb6faad64
+        with:
+          certum-username: ${{ secrets.CERTUM_USER_ID }}
+          certum-otp-uri: ${{ secrets.CERTUM_OTP_URI }}
+          certum-key-id: ${{ steps.certum.outputs.thumbprint }}
+          simplysign-url: ${{ env.SIMPLYSIGN_URL }}
+          capture-diagnostics: false
+
+      - name: Sign and verify an ephemeral executable
+        shell: pwsh
+        env:
+          CERTUM_CERT_THUMBPRINT: ${{ steps.certum.outputs.thumbprint }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $thumbprint = $env:CERTUM_CERT_THUMBPRINT
+          $certificate = @(
+            Get-ChildItem Cert:\CurrentUser\My |
+              Where-Object {
+                ($_.Thumbprint -replace '[^0-9A-Fa-f]', '').ToUpperInvariant() -eq
+                  $thumbprint
+              }
+          )
+          if ($certificate.Count -ne 1) {
+            throw "Expected exactly one certificate for the configured thumbprint; found $($certificate.Count)."
+          }
+          if (-not $certificate[0].HasPrivateKey) {
+            throw 'The Certum certificate is visible but its cloud private key is unavailable.'
+          }
+          if ($certificate[0].NotAfter -le [DateTime]::UtcNow) {
+            throw 'The Certum certificate has expired.'
+          }
+
+          $hasCodeSigningEku = @(
+            $certificate[0].Extensions |
+              Where-Object { $_.Oid.Value -eq '2.5.29.37' } |
+              ForEach-Object { $_.EnhancedKeyUsages } |
+              Where-Object { $_.Value -eq '1.3.6.1.5.5.7.3.3' }
+          ).Count -gt 0
+          if (-not $hasCodeSigningEku) {
+            throw 'The configured certificate does not permit code signing.'
+          }
+
+          $signTool = Get-ChildItem -Path `
+            "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName |
+            Select-Object -Last 1 -ExpandProperty FullName
+          if (-not $signTool) {
+            throw 'Microsoft SignTool was not found on the Windows runner.'
+          }
+
+          $smokeExecutable = Join-Path $env:RUNNER_TEMP 'certum-signing-smoke.exe'
+          Copy-Item -LiteralPath "$env:WINDIR\System32\where.exe" -Destination $smokeExecutable
+          try {
+            & $signTool sign /v /fd sha256 /sha1 $thumbprint `
+              /tr http://time.certum.pl /td sha256 $smokeExecutable
+            if ($LASTEXITCODE -ne 0) {
+              throw "SignTool failed with exit code $LASTEXITCODE."
+            }
+
+            & $signTool verify /pa /v $smokeExecutable
+            if ($LASTEXITCODE -ne 0) {
+              throw "SignTool verification failed with exit code $LASTEXITCODE."
+            }
+
+            $signature = Get-AuthenticodeSignature -FilePath $smokeExecutable
+            if ($signature.Status -ne 'Valid') {
+              throw "Authenticode status is $($signature.Status), expected Valid."
+            }
+            if ($signature.SignerCertificate.Thumbprint -ne $thumbprint) {
+              throw 'The Authenticode signer does not match the configured Certum certificate.'
+            }
+            if ($null -eq $signature.TimeStamperCertificate) {
+              throw 'The Authenticode signature does not contain a trusted timestamp.'
+            }
+
+            Write-Output 'Certum cloud signing smoke test passed.'
+          }
+          finally {
+            Remove-Item -LiteralPath $smokeExecutable -Force -ErrorAction SilentlyContinue
+            Set-Clipboard -Value ' '
+          }


### PR DESCRIPTION
## Summary

- add a manual-only Certum SimplySign smoke workflow on `windows-latest`
- require the protected `release` Environment before exposing Certum credentials
- verify the official SimplySign installer publisher before installation
- pin the third-party setup action to a reviewed commit
- sign and verify only an ephemeral test executable, including certificate thumbprint and timestamp checks

## Security boundary

The workflow is dispatch-only, refuses non-`main` refs, has read-only repository permissions, disables diagnostic screenshots, and does not upload or publish the smoke artifact. The long-lived TOTP URI is stored only in the protected `release` Environment.

## Validation

- YAML parse
- `git diff --check`
- secret names and release-environment gating checked without exposing values