### PR TITLE
fix(ci): normalize Certum signer thumbprint

### DIFF
--- a/.github/workflows/certum-signing-smoke.yml
+++ b/.github/workflows/certum-signing-smoke.yml
@@ -131,7 +131,10 @@ jobs:
             if ($signature.Status -ne 'Valid') {
               throw "Authenticode status is $($signature.Status), expected Valid."
             }
-            if ($signature.SignerCertificate.Thumbprint -ne $thumbprint) {
+            $actualSignerThumbprint = (
+              $signature.SignerCertificate.Thumbprint -replace '[^0-9A-Fa-f]', ''
+            ).ToUpperInvariant()
+            if ($actualSignerThumbprint -ne $thumbprint) {
               throw 'The Authenticode signer does not match the configured Certum certificate.'
             }
             if ($null -eq $signature.TimeStamperCertificate) {


### PR DESCRIPTION
Normalize the thumbprint returned by `Get-AuthenticodeSignature` before comparing it with the configured Certum SHA-1 value. The first smoke run successfully signed and verified the executable and timestamp; only this stricter PowerShell comparison misreported the result.

Evidence: https://github.com/rongxinzy/RongxinAI/actions/runs/32715776749