### PR TITLE
feat(enterprise): add versioned session bridge

### DIFF
--- a/docs/enterprise-extension.md
+++ b/docs/enterprise-extension.md
@@ -23,3 +23,9 @@ An extension that is present but invalid or incompatible fails closed and preven
 The private repository owns the extension bundle, enterprise tests, release manifest, signing inputs, and Electron Builder overlay. It must pin an exact Zhiyuan tag and commit. It must not copy files over `src/`, patch the public application during packaging, or depend on an unversioned branch.
 
 API v1 is deliberately limited to lifecycle and non-secret host context. Authentication IPC, managed model projection, Skill reconciliation, and control-event operations must be added as explicit versioned capabilities rather than importing renderer state or private application internals.
+
+### Session capability v1
+
+The API v1 context exposes an optional, independently versioned `capabilities.session` object. An enterprise extension may register one password-session provider and must unregister it during disposal. Community builds expose the same fixed renderer surface but return `UNAVAILABLE` when no provider is registered.
+
+The preload bridge permits only `snapshot`, `login`, `changePassword`, and `logout`. Main-process validation copies bounded input fields, normalizes identity snapshots, never returns tokens, and replaces provider exceptions with a generic error before crossing into the renderer. The bridge does not expose arbitrary extension methods or IPC channel names.

--- a/docs/enterprise-extension.zh-CN.md
+++ b/docs/enterprise-extension.zh-CN.md
@@ -23,3 +23,9 @@ Bundle 导出 `createZhiyuanEnterpriseExtension`。返回对象声明 `apiVersio
 私有仓库负责扩展 bundle、企业测试、发布清单、签名输入和 Electron Builder 覆盖配置，并必须锁定准确的 Zhiyuan tag 与 commit。企业构建不能覆盖 `src/` 文件、不能在打包时修改公开应用源码，也不能依赖未版本化分支。
 
 API v1 有意只开放生命周期和非敏感宿主上下文。认证 IPC、托管模型投影、Skill 收敛和管控事件操作必须作为明确的版本化能力逐步加入，不能直接导入 Renderer 状态或应用私有内部模块。
+
+### 会话能力 v1
+
+API v1 上下文提供可选、独立版本化的 `capabilities.session` 对象。企业扩展可以注册一个密码会话 provider，并必须在退出时注销。社区构建保留相同的固定 Renderer 接口，但未注册 provider 时只返回 `UNAVAILABLE`。
+
+Preload 桥只允许 `snapshot`、`login`、`changePassword` 和 `logout`。主进程会复制并校验有长度边界的输入字段、规范化身份快照、禁止返回任何 token，并在进入 Renderer 前将 provider 异常替换为通用错误。该桥不开放任意扩展方法或任意 IPC channel 名称。

--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -1,4 +1,23 @@
+import type {
+  EnterprisePasswordChangeInput,
+  EnterprisePasswordLoginInput,
+  EnterpriseSessionSnapshot,
+} from '../../shared/enterpriseSession';
+
 export const ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION = 1 as const;
+export const ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION = 1 as const;
+
+export interface ZhiyuanEnterpriseSessionProvider {
+  snapshot(): EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>;
+  login(input: EnterprisePasswordLoginInput): Promise<EnterpriseSessionSnapshot>;
+  changePassword(input: EnterprisePasswordChangeInput): Promise<EnterpriseSessionSnapshot>;
+  logout(): Promise<EnterpriseSessionSnapshot>;
+}
+
+export interface ZhiyuanEnterpriseSessionHostCapability {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION;
+  registerProvider(provider: ZhiyuanEnterpriseSessionProvider): () => void;
+}
 
 export const ZhiyuanEnterpriseExtensionStatus = {
   Idle: 'idle',
@@ -19,6 +38,9 @@ export interface ZhiyuanEnterpriseHostContext {
   readonly paths: {
     readonly resources: string;
     readonly userData: string;
+  };
+  readonly capabilities: {
+    readonly session: ZhiyuanEnterpriseSessionHostCapability | null;
   };
 }
 

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
   ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
+  ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION,
   ZhiyuanEnterpriseExtensionStatus,
   type ZhiyuanEnterpriseHostContext,
 } from './contract';
@@ -64,6 +65,8 @@ describe('Zhiyuan enterprise extension host', () => {
     });
     expect(Object.isFrozen(receivedContext)).toBe(true);
     expect(Object.isFrozen(receivedContext!.paths)).toBe(true);
+    expect(Object.isFrozen(receivedContext!.capabilities)).toBe(true);
+    expect(receivedContext!.capabilities.session).toBeNull();
 
     await host.dispose();
     await host.dispose();
@@ -83,6 +86,32 @@ describe('Zhiyuan enterprise extension host', () => {
     const packagedHost = new ZhiyuanEnterpriseExtensionHost(importModule);
     await packagedHost.initialize(options(root, true, developmentModule));
     expect(importModule).toHaveBeenCalledTimes(1);
+  });
+
+  test('passes the versioned session capability to the extension', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const registerProvider = vi.fn();
+    const sessionCapability = {
+      apiVersion: ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION,
+      registerProvider,
+    };
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+          receivedContext = context;
+        },
+      }),
+    }));
+
+    await host.initialize({ ...options(root, true), sessionCapability });
+
+    expect(receivedContext!.capabilities.session).toBe(sessionCapability);
+    expect(receivedContext!.capabilities.session?.apiVersion).toBe(1);
   });
 
   test('imports a real CommonJS development bundle', async () => {

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -9,6 +9,7 @@ import {
   type ZhiyuanEnterpriseExtensionSnapshot,
   ZhiyuanEnterpriseExtensionStatus,
   type ZhiyuanEnterpriseHostContext,
+  type ZhiyuanEnterpriseSessionHostCapability,
 } from './contract';
 
 const ENTERPRISE_RESOURCE_DIRECTORY = 'zhiyuan-enterprise';
@@ -22,6 +23,7 @@ export interface ZhiyuanEnterpriseExtensionHostOptions {
   readonly resourcesPath: string;
   readonly userDataPath: string;
   readonly developmentExtensionPath?: string;
+  readonly sessionCapability?: ZhiyuanEnterpriseSessionHostCapability;
 }
 
 type ExtensionModuleImporter = (modulePath: string) => Promise<unknown>;
@@ -173,12 +175,16 @@ function createHostContext(
     resources: path.resolve(options.resourcesPath),
     userData: path.resolve(options.userDataPath),
   });
+  const capabilities = Object.freeze({
+    session: options.sessionCapability ?? null,
+  });
   return Object.freeze({
     apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
     appVersion: options.appVersion,
     isPackaged: options.isPackaged,
     platform: options.platform,
     paths,
+    capabilities,
   });
 }
 

--- a/src/main/enterpriseExtension/sessionBridge.test.ts
+++ b/src/main/enterpriseExtension/sessionBridge.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { EnterpriseSessionSnapshot } from '../../shared/enterpriseSession';
+import type { ZhiyuanEnterpriseSessionProvider } from './contract';
+import { ZhiyuanEnterpriseSessionBridge } from './sessionBridge';
+
+describe('Zhiyuan enterprise session bridge', () => {
+  test('returns unavailable without exposing a generic extension channel', async () => {
+    const bridge = new ZhiyuanEnterpriseSessionBridge(vi.fn());
+
+    await expect(bridge.snapshot()).resolves.toEqual({
+      ok: false,
+      error: {
+        code: 'UNAVAILABLE',
+        message: 'Zhiyuan enterprise session is unavailable.',
+      },
+    });
+  });
+
+  test('registers one provider and releases it idempotently', async () => {
+    const bridge = new ZhiyuanEnterpriseSessionBridge(vi.fn());
+    const provider = fixtureProvider();
+    const unregister = bridge.registerProvider(provider);
+
+    expect(() => bridge.registerProvider(fixtureProvider())).toThrow('already registered');
+    await expect(bridge.snapshot()).resolves.toMatchObject({
+      ok: true,
+      snapshot: { status: 'signed-out' },
+    });
+
+    unregister();
+    unregister();
+    await expect(bridge.snapshot()).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'UNAVAILABLE' },
+    });
+  });
+
+  test('validates and copies password inputs before invoking the provider', async () => {
+    const login = vi.fn(async () => authenticatedSnapshot());
+    const changePassword = vi.fn(async () => authenticatedSnapshot());
+    const bridge = new ZhiyuanEnterpriseSessionBridge(vi.fn());
+    bridge.registerProvider(fixtureProvider({ login, changePassword }));
+
+    await expect(
+      bridge.login({ enterpriseId: '  enterprise-1 ', username: ' admin ', password: ' secret ' }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(login).toHaveBeenCalledWith({
+      enterpriseId: 'enterprise-1',
+      username: 'admin',
+      password: ' secret ',
+    });
+
+    await expect(
+      bridge.login({ enterpriseId: ' ', username: 'admin', password: 'secret' }),
+    ).resolves.toMatchObject({ ok: false, error: { code: 'INVALID_INPUT' } });
+    await expect(
+      bridge.changePassword({ currentPassword: '', newPassword: 'new' }),
+    ).resolves.toMatchObject({ ok: false, error: { code: 'INVALID_INPUT' } });
+    expect(changePassword).not.toHaveBeenCalled();
+  });
+
+  test('normalizes identities and does not return provider-owned mutable values', async () => {
+    const providerSnapshot = authenticatedSnapshot();
+    const bridge = new ZhiyuanEnterpriseSessionBridge(vi.fn());
+    bridge.registerProvider(fixtureProvider({ snapshot: vi.fn(async () => providerSnapshot) }));
+
+    const result = await bridge.snapshot();
+    expect(result).toMatchObject({
+      ok: true,
+      snapshot: {
+        status: 'authenticated',
+        identity: { user: { displayName: 'Administrator' }, roles: ['admin'] },
+      },
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    if (result.ok && result.snapshot.status === 'authenticated') {
+      expect(result.snapshot.identity).not.toBe(providerSnapshot.identity);
+      expect(Object.isFrozen(result.snapshot.identity.roles)).toBe(true);
+    }
+  });
+
+  test('logs provider failures and returns a generic renderer error', async () => {
+    const logError = vi.fn();
+    const bridge = new ZhiyuanEnterpriseSessionBridge(logError);
+    bridge.registerProvider(
+      fixtureProvider({
+        login: vi.fn(async () => {
+          throw new Error('backend included a sensitive detail');
+        }),
+      }),
+    );
+
+    const result = await bridge.login({
+      enterpriseId: 'enterprise-1',
+      username: 'admin',
+      password: 'secret',
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'OPERATION_FAILED',
+        message: 'Zhiyuan enterprise session operation failed.',
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('sensitive detail');
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+});
+
+function fixtureProvider(
+  overrides: Partial<ZhiyuanEnterpriseSessionProvider> = {},
+): ZhiyuanEnterpriseSessionProvider {
+  return {
+    snapshot: vi.fn(async () => ({ status: 'signed-out' })),
+    login: vi.fn(async () => authenticatedSnapshot()),
+    changePassword: vi.fn(async () => authenticatedSnapshot()),
+    logout: vi.fn(async () => ({ status: 'signed-out' })),
+    ...overrides,
+  };
+}
+
+function authenticatedSnapshot(): Extract<EnterpriseSessionSnapshot, { status: 'authenticated' }> {
+  return {
+    status: 'authenticated',
+    identity: {
+      user: { id: 'user-1', displayName: 'Administrator' },
+      enterprise: { id: 'enterprise-1', name: 'Zhiyuan' },
+      roles: ['admin'],
+      sessionExpiresAt: '2026-08-24T11:00:00Z',
+      passwordChangeRequired: false,
+    },
+  };
+}

--- a/src/main/enterpriseExtension/sessionBridge.ts
+++ b/src/main/enterpriseExtension/sessionBridge.ts
@@ -1,0 +1,196 @@
+import {
+  type EnterprisePasswordChangeInput,
+  type EnterprisePasswordLoginInput,
+  type EnterpriseSessionIdentity,
+  type EnterpriseSessionResult,
+  type EnterpriseSessionSnapshot,
+} from '../../shared/enterpriseSession';
+import {
+  ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION,
+  type ZhiyuanEnterpriseSessionHostCapability,
+  type ZhiyuanEnterpriseSessionProvider,
+} from './contract';
+
+const MAX_ENTERPRISE_ID_LENGTH = 256;
+const MAX_USERNAME_LENGTH = 320;
+const MAX_PASSWORD_LENGTH = 4096;
+
+type ErrorLogger = (message: string, error: unknown) => void;
+
+export class ZhiyuanEnterpriseSessionBridge implements ZhiyuanEnterpriseSessionHostCapability {
+  readonly apiVersion = ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION;
+  readonly #logError: ErrorLogger;
+  #provider: ZhiyuanEnterpriseSessionProvider | null = null;
+
+  constructor(
+    logError: ErrorLogger = (message, error) => {
+      console.error(message, error);
+    },
+  ) {
+    this.#logError = logError;
+  }
+
+  registerProvider(provider: ZhiyuanEnterpriseSessionProvider): () => void {
+    validateProvider(provider);
+    if (this.#provider) {
+      throw new Error('A Zhiyuan enterprise session provider is already registered.');
+    }
+    this.#provider = provider;
+    let registered = true;
+    return () => {
+      if (!registered) return;
+      registered = false;
+      if (this.#provider === provider) this.#provider = null;
+    };
+  }
+
+  snapshot(): Promise<EnterpriseSessionResult> {
+    return this.#execute(provider => provider.snapshot());
+  }
+
+  login(input: unknown): Promise<EnterpriseSessionResult> {
+    const parsed = parseLoginInput(input);
+    if (!parsed) return Promise.resolve(invalidInput());
+    return this.#execute(provider => provider.login(parsed));
+  }
+
+  changePassword(input: unknown): Promise<EnterpriseSessionResult> {
+    const parsed = parsePasswordChangeInput(input);
+    if (!parsed) return Promise.resolve(invalidInput());
+    return this.#execute(provider => provider.changePassword(parsed));
+  }
+
+  logout(): Promise<EnterpriseSessionResult> {
+    return this.#execute(provider => provider.logout());
+  }
+
+  async #execute(
+    operation: (
+      provider: ZhiyuanEnterpriseSessionProvider,
+    ) => EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>,
+  ): Promise<EnterpriseSessionResult> {
+    const provider = this.#provider;
+    if (!provider) {
+      return failure('UNAVAILABLE', 'Zhiyuan enterprise session is unavailable.');
+    }
+    try {
+      return Object.freeze({
+        ok: true,
+        snapshot: normalizeSnapshot(await operation(provider)),
+      });
+    } catch (error) {
+      this.#logError('[EnterpriseSession] Session operation failed:', error);
+      return failure('OPERATION_FAILED', 'Zhiyuan enterprise session operation failed.');
+    }
+  }
+}
+
+export const zhiyuanEnterpriseSessionBridge = new ZhiyuanEnterpriseSessionBridge();
+
+function parseLoginInput(value: unknown): EnterprisePasswordLoginInput | null {
+  const input = asRecord(value);
+  const enterpriseId = normalizedIdentifier(input?.enterpriseId, MAX_ENTERPRISE_ID_LENGTH);
+  const username = normalizedIdentifier(input?.username, MAX_USERNAME_LENGTH);
+  const password = boundedString(input?.password, MAX_PASSWORD_LENGTH);
+  return enterpriseId && username && password ? { enterpriseId, username, password } : null;
+}
+
+function parsePasswordChangeInput(value: unknown): EnterprisePasswordChangeInput | null {
+  const input = asRecord(value);
+  const currentPassword = boundedString(input?.currentPassword, MAX_PASSWORD_LENGTH);
+  const newPassword = boundedString(input?.newPassword, MAX_PASSWORD_LENGTH);
+  return currentPassword && newPassword ? { currentPassword, newPassword } : null;
+}
+
+function boundedString(value: unknown, maxLength: number): string | null {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength ? value : null;
+}
+
+function normalizedIdentifier(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= maxLength ? normalized : null;
+}
+
+function normalizeSnapshot(value: unknown): EnterpriseSessionSnapshot {
+  const snapshot = asRecord(value);
+  if (
+    snapshot?.status === 'unavailable' ||
+    snapshot?.status === 'signed-out' ||
+    snapshot?.status === 'recoverable'
+  ) {
+    return Object.freeze({ status: snapshot.status });
+  }
+  if (snapshot?.status !== 'authenticated') {
+    throw new Error('Zhiyuan enterprise session provider returned an invalid snapshot.');
+  }
+  return Object.freeze({
+    status: 'authenticated',
+    identity: normalizeIdentity(snapshot.identity),
+  });
+}
+
+function normalizeIdentity(value: unknown): EnterpriseSessionIdentity {
+  const identity = asRecord(value);
+  const user = asRecord(identity?.user);
+  const enterprise = asRecord(identity?.enterprise);
+  const roles = identity?.roles;
+  if (
+    !normalizedIdentifier(user?.id, 256) ||
+    !normalizedIdentifier(user?.displayName, 512) ||
+    !normalizedIdentifier(enterprise?.id, 256) ||
+    !normalizedIdentifier(enterprise?.name, 512) ||
+    !Array.isArray(roles) ||
+    !roles.every(role => normalizedIdentifier(role, 128)) ||
+    !boundedString(identity?.sessionExpiresAt, 128) ||
+    typeof identity?.passwordChangeRequired !== 'boolean' ||
+    !isOptionalEmail(user?.email)
+  ) {
+    throw new Error('Zhiyuan enterprise session provider returned an invalid identity.');
+  }
+  return Object.freeze({
+    user: Object.freeze({
+      id: user.id as string,
+      displayName: user.displayName as string,
+      ...(user.email === undefined ? {} : { email: user.email as string | null }),
+    }),
+    enterprise: Object.freeze({
+      id: enterprise.id as string,
+      name: enterprise.name as string,
+    }),
+    roles: Object.freeze([...roles]) as readonly string[],
+    sessionExpiresAt: identity.sessionExpiresAt as string,
+    passwordChangeRequired: identity.passwordChangeRequired,
+  });
+}
+
+function validateProvider(provider: ZhiyuanEnterpriseSessionProvider): void {
+  const candidate = asRecord(provider);
+  if (
+    typeof candidate?.snapshot !== 'function' ||
+    typeof candidate.login !== 'function' ||
+    typeof candidate.changePassword !== 'function' ||
+    typeof candidate.logout !== 'function'
+  ) {
+    throw new Error('Zhiyuan enterprise session provider is incomplete.');
+  }
+}
+
+function invalidInput(): EnterpriseSessionResult {
+  return failure('INVALID_INPUT', 'Zhiyuan enterprise session input is invalid.');
+}
+
+function failure(
+  code: 'UNAVAILABLE' | 'INVALID_INPUT' | 'OPERATION_FAILED',
+  message: string,
+): EnterpriseSessionResult {
+  return Object.freeze({ ok: false, error: Object.freeze({ code, message }) });
+}
+
+function isOptionalEmail(value: unknown): boolean {
+  return value === undefined || value === null || boundedString(value, 512) !== null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -75,6 +75,7 @@ import {
   SkillsIpc,
   WeixinInstallIpc,
 } from '../shared/ipc/channels';
+import { EnterpriseSessionIpc } from '../shared/enterpriseSession';
 import {
   CoworkQueueEnqueueSchema,
   CoworkQueueItemSchema,
@@ -193,6 +194,7 @@ import {
   disposeZhiyuanEnterpriseExtension,
   initializeZhiyuanEnterpriseExtension,
 } from './enterpriseExtension/host';
+import { zhiyuanEnterpriseSessionBridge } from './enterpriseExtension/sessionBridge';
 import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
 import { serializeCcConnectSidecarConfig } from './libs/ccConnectSidecarConfig';
@@ -2447,6 +2449,14 @@ if (!gotTheLock) {
       return null;
     }
   });
+  ipcMain.handle(EnterpriseSessionIpc.Snapshot, () => zhiyuanEnterpriseSessionBridge.snapshot());
+  ipcMain.handle(EnterpriseSessionIpc.Login, (_event, input: unknown) =>
+    zhiyuanEnterpriseSessionBridge.login(input),
+  );
+  ipcMain.handle(EnterpriseSessionIpc.ChangePassword, (_event, input: unknown) =>
+    zhiyuanEnterpriseSessionBridge.changePassword(input),
+  );
+  ipcMain.handle(EnterpriseSessionIpc.Logout, () => zhiyuanEnterpriseSessionBridge.logout());
 
   ipcMain.handle('hardware:nvidia-smi', async () => getNvidiaSmiSnapshot());
   ipcMain.handle(HardwareIpc.SystemMemory, async () => getSystemMemorySnapshot());
@@ -6632,6 +6642,7 @@ if (!gotTheLock) {
       resourcesPath: process.resourcesPath,
       userDataPath: app.getPath('userData'),
       developmentExtensionPath: process.env.ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH,
+      sessionCapability: zhiyuanEnterpriseSessionBridge,
     });
     if (enterpriseExtension.extensionId) {
       console.log(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -50,6 +50,7 @@ import { MarketplaceIpcChannel } from '../shared/marketplace/constants';
 import type { MarketplaceSearchRequest } from '../shared/marketplace/types';
 import { OllamaIpcChannel } from '../shared/ollama/constants';
 import type { Platform } from '../shared/platform';
+import { EnterpriseSessionIpc } from '../shared/enterpriseSession';
 import type {
   ProviderModelDiscoveryRequest,
   ProviderModelDiscoveryResult,
@@ -271,6 +272,13 @@ contextBridge.exposeInMainWorld('electron', {
 
   enterprise: {
     getConfig: () => ipcRenderer.invoke(EnterpriseIpc.GetConfig),
+    session: {
+      snapshot: () => ipcRenderer.invoke(EnterpriseSessionIpc.Snapshot),
+      login: (input: unknown) => ipcRenderer.invoke(EnterpriseSessionIpc.Login, input),
+      changePassword: (input: unknown) =>
+        ipcRenderer.invoke(EnterpriseSessionIpc.ChangePassword, input),
+      logout: () => ipcRenderer.invoke(EnterpriseSessionIpc.Logout),
+    },
   },
 
   api: {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -303,6 +303,11 @@ interface McpConnectionTestResult {
 }
 
 import type { Platform } from '@shared/platform';
+import type {
+  EnterprisePasswordChangeInput,
+  EnterprisePasswordLoginInput,
+  EnterpriseSessionResult,
+} from '../../shared/enterpriseSession';
 
 import type { Agent } from './agent';
 
@@ -1197,6 +1202,12 @@ interface IElectronAPI {
       version: string;
       name: string;
     } | null>;
+    session: {
+      snapshot: () => Promise<EnterpriseSessionResult>;
+      login: (input: EnterprisePasswordLoginInput) => Promise<EnterpriseSessionResult>;
+      changePassword: (input: EnterprisePasswordChangeInput) => Promise<EnterpriseSessionResult>;
+      logout: () => Promise<EnterpriseSessionResult>;
+    };
   };
   networkStatus: {
     send: (status: 'online' | 'offline') => void;

--- a/src/shared/enterpriseSession.ts
+++ b/src/shared/enterpriseSession.ts
@@ -1,0 +1,50 @@
+export const EnterpriseSessionIpc = {
+  Snapshot: 'enterprise:session:snapshot',
+  Login: 'enterprise:session:login',
+  ChangePassword: 'enterprise:session:change-password',
+  Logout: 'enterprise:session:logout',
+} as const;
+
+export type EnterpriseSessionIdentity = {
+  readonly user: {
+    readonly id: string;
+    readonly displayName: string;
+    readonly email?: string | null;
+  };
+  readonly enterprise: {
+    readonly id: string;
+    readonly name: string;
+  };
+  readonly roles: readonly string[];
+  readonly sessionExpiresAt: string;
+  readonly passwordChangeRequired: boolean;
+};
+
+export type EnterpriseSessionSnapshot =
+  | { readonly status: 'unavailable' }
+  | { readonly status: 'signed-out' }
+  | { readonly status: 'recoverable' }
+  | { readonly status: 'authenticated'; readonly identity: EnterpriseSessionIdentity };
+
+export type EnterpriseSessionErrorCode = 'UNAVAILABLE' | 'INVALID_INPUT' | 'OPERATION_FAILED';
+
+export type EnterpriseSessionResult =
+  | { readonly ok: true; readonly snapshot: EnterpriseSessionSnapshot }
+  | {
+      readonly ok: false;
+      readonly error: {
+        readonly code: EnterpriseSessionErrorCode;
+        readonly message: string;
+      };
+    };
+
+export interface EnterprisePasswordLoginInput {
+  readonly enterpriseId: string;
+  readonly username: string;
+  readonly password: string;
+}
+
+export interface EnterprisePasswordChangeInput {
+  readonly currentPassword: string;
+  readonly newPassword: string;
+}


### PR DESCRIPTION
Summary: add a fixed, versioned password-session capability to the Zhiyuan enterprise extension host; expose only snapshot, login, password change, and logout through preload; validate bounded inputs, normalize identity output, prevent tokens from crossing IPC, and replace provider exceptions with generic renderer errors; document the bilingual public/private contract. Verification: 13 focused tests pass; Electron typecheck and oxlint pass; renderer and Electron compilation complete and generated output contains the new main/preload bridge. The final local runtime-dependency check reports the existing dist-electron source-map baseline and is not changed by this PR. No UI changes.