### PR TITLE
fix(ci): verify exact Certum signer certificate

### DIFF
--- a/.github/workflows/certum-signing-smoke.yml
+++ b/.github/workflows/certum-signing-smoke.yml
@@ -131,10 +131,11 @@ jobs:
             if ($signature.Status -ne 'Valid') {
               throw "Authenticode status is $($signature.Status), expected Valid."
             }
-            $actualSignerThumbprint = (
-              $signature.SignerCertificate.Thumbprint -replace '[^0-9A-Fa-f]', ''
-            ).ToUpperInvariant()
-            if ($actualSignerThumbprint -ne $thumbprint) {
+            $expectedCertificateDer = [Convert]::ToBase64String($certificate[0].RawData)
+            $actualCertificateDer = [Convert]::ToBase64String(
+              $signature.SignerCertificate.RawData
+            )
+            if ($actualCertificateDer -ne $expectedCertificateDer) {
               throw 'The Authenticode signer does not match the configured Certum certificate.'
             }
             if ($null -eq $signature.TimeStamperCertificate) {


### PR DESCRIPTION
Compare the DER bytes of the Authenticode leaf certificate with the exact certificate selected from the SimplySign-backed Windows store. This avoids platform-specific thumbprint string behavior while making the identity check stronger.

Both preceding smoke runs successfully signed the executable, verified the Certum chain, and verified the RFC3161 timestamp; only the redundant thumbprint-property assertion failed.