### PR TITLE
ci: sign Windows releases with Certum

### DIFF
--- a/.github/actions/setup-certum-signing/action.yml
+++ b/.github/actions/setup-certum-signing/action.yml
@@ -1,0 +1,76 @@
+name: Set up Certum cloud signing
+description: Authenticate an ephemeral Windows runner with Certum SimplySign.
+
+inputs:
+  user-id:
+    description: Certum SimplySign account identifier.
+    required: true
+  otp-uri:
+    description: Complete Certum SimplySign TOTP URI.
+    required: true
+  certificate-thumbprint:
+    description: Expected code-signing certificate SHA-1 thumbprint.
+    required: true
+
+outputs:
+  thumbprint:
+    description: Normalized SHA-1 thumbprint of the authenticated certificate.
+    value: ${{ steps.validate.outputs.thumbprint }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate protected Certum configuration
+      id: validate
+      shell: pwsh
+      env:
+        CERTUM_USER_ID: ${{ inputs.user-id }}
+        CERTUM_OTP_URI: ${{ inputs.otp-uri }}
+        CERTUM_CERT_THUMBPRINT: ${{ inputs.certificate-thumbprint }}
+      run: |
+        if ([string]::IsNullOrWhiteSpace($env:CERTUM_USER_ID)) {
+          throw 'CERTUM_USER_ID is not configured.'
+        }
+        if ($env:CERTUM_OTP_URI -notmatch '^otpauth://totp/') {
+          throw 'CERTUM_OTP_URI must contain the complete SimplySign TOTP URI.'
+        }
+
+        $thumbprint = (
+          $env:CERTUM_CERT_THUMBPRINT -replace '[^0-9A-Fa-f]', ''
+        ).ToUpperInvariant()
+        if ($thumbprint -notmatch '^[0-9A-F]{40}$') {
+          throw 'CERTUM_CERT_THUMBPRINT must contain a SHA-1 certificate thumbprint.'
+        }
+
+        Write-Output "::add-mask::$thumbprint"
+        "thumbprint=$thumbprint" |
+          Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Download and verify SimplySign Desktop
+      shell: pwsh
+      env:
+        SIMPLYSIGN_URL: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.3.90/SimplySignDesktop-9.4.3.90-64-bit-en.msi
+      run: |
+        Invoke-WebRequest -Uri $env:SIMPLYSIGN_URL -OutFile SimplySignDesktop.msi
+        $signature = Get-AuthenticodeSignature -FilePath SimplySignDesktop.msi
+        if ($signature.Status -ne 'Valid') {
+          throw "SimplySign Desktop installer signature is $($signature.Status), expected Valid."
+        }
+        if ($signature.SignerCertificate.Subject -notmatch 'Asseco Data Systems') {
+          throw 'SimplySign Desktop installer is not signed by Asseco Data Systems.'
+        }
+
+    # This action receives the long-lived TOTP credential, so it is pinned to
+    # the exact revision reviewed for this repository.
+    - name: Connect Certum SimplySign
+      uses: dismine/windows-app-signing-setup-action@89ae3b032d4bc7a5b98d1a42a34e61ecb6faad64
+      with:
+        certum-username: ${{ inputs.user-id }}
+        certum-otp-uri: ${{ inputs.otp-uri }}
+        certum-key-id: ${{ steps.validate.outputs.thumbprint }}
+        simplysign-url: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.3.90/SimplySignDesktop-9.4.3.90-64-bit-en.msi
+        capture-diagnostics: false
+
+    - name: Remove SimplySign installer
+      shell: pwsh
+      run: Remove-Item -LiteralPath SimplySignDesktop.msi -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/certum-signing-smoke.yml
+++ b/.github/workflows/certum-signing-smoke.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  SIMPLYSIGN_URL: https://files.certum.eu/software/SimplySignDesktop/Windows/9.4.3.90/SimplySignDesktop-9.4.3.90-64-bit-en.msi
 
 jobs:
   sign-smoke:
@@ -22,54 +21,14 @@ jobs:
     timeout-minutes: 25
     environment: release
     steps:
-      - name: Require protected Certum configuration
-        id: certum
-        shell: pwsh
-        env:
-          CERTUM_USER_ID: ${{ secrets.CERTUM_USER_ID }}
-          CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
-          CERTUM_CERT_THUMBPRINT: ${{ secrets.CERTUM_CERT_THUMBPRINT }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:CERTUM_USER_ID)) {
-            throw 'CERTUM_USER_ID is not configured.'
-          }
-          if ($env:CERTUM_OTP_URI -notmatch '^otpauth://totp/') {
-            throw 'CERTUM_OTP_URI must contain the complete SimplySign TOTP URI.'
-          }
-
-          $thumbprint = (
-            $env:CERTUM_CERT_THUMBPRINT -replace '[^0-9A-Fa-f]', ''
-          ).ToUpperInvariant()
-          if ($thumbprint -notmatch '^[0-9A-F]{40}$') {
-            throw 'CERTUM_CERT_THUMBPRINT must contain a SHA-1 certificate thumbprint.'
-          }
-
-          Write-Output "::add-mask::$thumbprint"
-          "thumbprint=$thumbprint" |
-            Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-      - name: Download and verify SimplySign Desktop
-        shell: pwsh
-        run: |
-          Invoke-WebRequest -Uri $env:SIMPLYSIGN_URL -OutFile SimplySignDesktop.msi
-          $signature = Get-AuthenticodeSignature -FilePath SimplySignDesktop.msi
-          if ($signature.Status -ne 'Valid') {
-            throw "SimplySign Desktop installer signature is $($signature.Status), expected Valid."
-          }
-          if ($signature.SignerCertificate.Subject -notmatch 'Asseco Data Systems') {
-            throw 'SimplySign Desktop installer is not signed by Asseco Data Systems.'
-          }
-
-      # This third-party action receives the long-lived TOTP credential, so it
-      # is pinned to the exact revision reviewed for this workflow.
+      - uses: actions/checkout@v6
       - name: Connect Certum SimplySign
-        uses: dismine/windows-app-signing-setup-action@89ae3b032d4bc7a5b98d1a42a34e61ecb6faad64
+        id: certum
+        uses: ./.github/actions/setup-certum-signing
         with:
-          certum-username: ${{ secrets.CERTUM_USER_ID }}
-          certum-otp-uri: ${{ secrets.CERTUM_OTP_URI }}
-          certum-key-id: ${{ steps.certum.outputs.thumbprint }}
-          simplysign-url: ${{ env.SIMPLYSIGN_URL }}
-          capture-diagnostics: false
+          user-id: ${{ secrets.CERTUM_USER_ID }}
+          otp-uri: ${{ secrets.CERTUM_OTP_URI }}
+          certificate-thumbprint: ${{ secrets.CERTUM_CERT_THUMBPRINT }}
 
       - name: Sign and verify an ephemeral executable
         shell: pwsh

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -177,11 +177,20 @@ jobs:
         run: |
           bun run setup:posix-uv-runtime
           bun run setup:posix-python-runtime
+      - name: Connect Certum SimplySign
+        if: ${{ matrix.platform == 'windows' }}
+        id: certum-signing
+        uses: ./.github/actions/setup-certum-signing
+        with:
+          user-id: ${{ secrets.CERTUM_USER_ID }}
+          otp-uri: ${{ secrets.CERTUM_OTP_URI }}
+          certificate-thumbprint: ${{ secrets.CERTUM_CERT_THUMBPRINT }}
       - name: Build Windows package
         if: ${{ matrix.platform == 'windows' }}
-        run: bun run dist:win:lite
+        run: bun run dist:win:signed
         env:
           APP_BUILD_VERSION: ${{ needs.prepare-release.outputs.version }}
+          CERTUM_CERT_THUMBPRINT: ${{ steps.certum-signing.outputs.thumbprint }}
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
@@ -275,6 +284,14 @@ jobs:
       - name: Verify packaged app version
         shell: bash
         run: node scripts/ci/verify-packaged-app-version.mjs '${{ needs.prepare-release.outputs.version }}'
+      - name: Verify Windows Authenticode signatures
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/verify-windows-authenticode.ps1
+          -ProjectRoot ${{ github.workspace }}
+          -ExpectedThumbprint '${{ steps.certum-signing.outputs.thumbprint }}'
       - name: Verify Windows package runtimes with a clean PATH
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -183,11 +183,20 @@ jobs:
         run: |
           bun run setup:posix-uv-runtime
           bun run setup:posix-python-runtime
+      - name: Connect Certum SimplySign
+        if: ${{ matrix.platform == 'windows' }}
+        id: certum-signing
+        uses: ./.github/actions/setup-certum-signing
+        with:
+          user-id: ${{ secrets.CERTUM_USER_ID }}
+          otp-uri: ${{ secrets.CERTUM_OTP_URI }}
+          certificate-thumbprint: ${{ secrets.CERTUM_CERT_THUMBPRINT }}
       - name: Build Windows candidate
         if: ${{ matrix.platform == 'windows' }}
-        run: bun run dist:win:lite
+        run: bun run dist:win:signed
         env:
           APP_BUILD_VERSION: ${{ needs.prepare-candidate.outputs.version }}
+          CERTUM_CERT_THUMBPRINT: ${{ steps.certum-signing.outputs.thumbprint }}
           UPDATE_MANIFEST_KEY_ID: ${{ secrets.UPDATE_MANIFEST_KEY_ID }}
           UPDATE_MANIFEST_PUBLIC_KEY_BASE64: ${{ secrets.UPDATE_MANIFEST_PUBLIC_KEY_BASE64 }}
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
@@ -256,6 +265,14 @@ jobs:
       - name: Verify packaged candidate version
         shell: bash
         run: node scripts/ci/verify-packaged-app-version.mjs '${{ needs.prepare-candidate.outputs.version }}'
+      - name: Verify Windows Authenticode signatures
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: >-
+          powershell -NoProfile -ExecutionPolicy Bypass
+          -File scripts/ci/verify-windows-authenticode.ps1
+          -ProjectRoot '${{ github.workspace }}'
+          -ExpectedThumbprint '${{ steps.certum-signing.outputs.thumbprint }}'
       - name: Verify Windows candidate size and runtimes
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/electron-builder.windows-signed.cjs
+++ b/electron-builder.windows-signed.cjs
@@ -1,0 +1,23 @@
+const baseConfig = require('./electron-builder.json');
+
+const certificateThumbprint = (process.env.CERTUM_CERT_THUMBPRINT || '')
+  .replace(/[^0-9a-f]/gi, '')
+  .toUpperCase();
+
+if (!/^[0-9A-F]{40}$/.test(certificateThumbprint)) {
+  throw new Error(
+    'CERTUM_CERT_THUMBPRINT must contain the 40-character SHA-1 thumbprint for the release certificate.',
+  );
+}
+
+module.exports = {
+  ...baseConfig,
+  win: {
+    ...baseConfig.win,
+    signtoolOptions: {
+      certificateSha1: certificateThumbprint,
+      signingHashAlgorithms: ['sha256'],
+      rfc3161TimeStampServer: 'http://time.certum.pl',
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "dist:mac:universal": "npm run prepare:update-release && npm run build && npm run compile:electron && npm run build:skills && npm run channel:runtime:mac-universal && npm run engram:runtime:mac-arm64 && npm run prepare:modelscope-tokens && electron-builder --mac --universal",
     "dist:win": "npm run dist:win:offline",
     "dist:win:offline": "npm run channel:runtime:win-x64 && npm run engram:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_UPDATE_VARIANT=lite node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && electron-builder --win nsis --x64 --config electron-builder.json --publish never",
+    "dist:win:signed": "npm run channel:runtime:win-x64 && npm run engram:runtime:win-x64 && npm run prepare:update-release && cross-env ZHIYUAN_UPDATE_VARIANT=lite node scripts/ensure-build-version.js && npm run build && npm run build:skills && npm run prepare:modelscope-tokens && electron-builder --win nsis --x64 --config electron-builder.windows-signed.cjs --publish never",
     "dist:win:lite": "npm run dist:win:offline",
     "predist:linux": "npm run channel:runtime:linux-x64 && npm run engram:runtime:linux-x64 && node scripts/ensure-build-version.js && npm run prepare:update-release",
     "dist:linux": "npm run build && npm run compile:electron && npm run build:skills && npm run engram:runtime:linux-x64 && npm run prepare:modelscope-tokens && electron-builder --linux --publish never",

--- a/scripts/ci/verify-windows-authenticode.ps1
+++ b/scripts/ci/verify-windows-authenticode.ps1
@@ -1,0 +1,68 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ProjectRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ExpectedThumbprint
+)
+
+$ErrorActionPreference = 'Stop'
+
+$normalizedThumbprint = (
+  $ExpectedThumbprint -replace '[^0-9A-Fa-f]', ''
+).ToUpperInvariant()
+if ($normalizedThumbprint -notmatch '^[0-9A-F]{40}$') {
+  throw 'ExpectedThumbprint must contain a 40-character SHA-1 thumbprint.'
+}
+
+$expectedCertificates = @(
+  Get-ChildItem Cert:\CurrentUser\My |
+    Where-Object {
+      ($_.Thumbprint -replace '[^0-9A-Fa-f]', '').ToUpperInvariant() -eq
+        $normalizedThumbprint
+    }
+)
+if ($expectedCertificates.Count -ne 1) {
+  throw "Expected exactly one configured Certum certificate; found $($expectedCertificates.Count)."
+}
+$expectedCertificateDer = [Convert]::ToBase64String(
+  $expectedCertificates[0].RawData
+)
+
+$builderConfig = Get-Content -LiteralPath (
+  Join-Path $ProjectRoot 'electron-builder.json'
+) -Raw | ConvertFrom-Json
+$appExecutable = Join-Path $ProjectRoot (
+  "release\win-unpacked\$($builderConfig.executableName).exe"
+)
+$installers = @(
+  Get-ChildItem -LiteralPath (Join-Path $ProjectRoot 'release') `
+    -Filter '*.exe' -File
+)
+if ($installers.Count -ne 1) {
+  throw "Expected exactly one Windows installer; found $($installers.Count)."
+}
+
+$targets = @($appExecutable, $installers[0].FullName)
+foreach ($target in $targets) {
+  if (-not (Test-Path -LiteralPath $target -PathType Leaf)) {
+    throw "Signed Windows target was not found: $target"
+  }
+
+  $signature = Get-AuthenticodeSignature -FilePath $target
+  if ($signature.Status -ne 'Valid') {
+    throw "Authenticode status for $target is $($signature.Status), expected Valid."
+  }
+
+  $actualCertificateDer = [Convert]::ToBase64String(
+    $signature.SignerCertificate.RawData
+  )
+  if ($actualCertificateDer -ne $expectedCertificateDer) {
+    throw "Authenticode signer does not match the configured Certum certificate: $target"
+  }
+  if ($null -eq $signature.TimeStamperCertificate) {
+    throw "Authenticode signature does not contain a trusted timestamp: $target"
+  }
+}
+
+Write-Output 'Windows application and installer Authenticode signatures are valid.'

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -251,6 +251,81 @@ test("Windows release workflow runs the clean-path bundled runtime gate", () => 
   assert.match(packageScript, /windows-runtime-smoke\.ps1/);
 });
 
+test("protected Windows releases authenticate with Certum and require valid signatures", () => {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(root, "package.json"), "utf8"),
+  ) as { scripts: Record<string, string> };
+  assert.match(
+    packageJson.scripts["dist:win:signed"],
+    /electron-builder\.windows-signed\.cjs/,
+  );
+  assert.match(packageJson.scripts["dist:win:offline"], /electron-builder\.json/);
+
+  for (const workflowName of [
+    "online-update-release.yml",
+    "release-candidate.yml",
+  ]) {
+    const workflow = readFileSync(
+      path.join(root, ".github", "workflows", workflowName),
+      "utf8",
+    );
+    assert.match(workflow, /\.\/\.github\/actions\/setup-certum-signing/);
+    assert.match(workflow, /bun run dist:win:signed/);
+    assert.match(workflow, /CERTUM_CERT_THUMBPRINT:/);
+    assert.match(workflow, /verify-windows-authenticode\.ps1/);
+  }
+
+  const setupAction = readFileSync(
+    path.join(
+      root,
+      ".github",
+      "actions",
+      "setup-certum-signing",
+      "action.yml",
+    ),
+    "utf8",
+  );
+  assert.match(
+    setupAction,
+    /dismine\/windows-app-signing-setup-action@[0-9a-f]{40}/,
+  );
+  assert.match(setupAction, /SimplySignDesktop-9\.4\.3\.90-64-bit-en\.msi/);
+  assert.match(setupAction, /SignerCertificate\.Subject[\s\S]*Asseco Data Systems/);
+  assert.match(setupAction, /capture-diagnostics: false/);
+
+  const signedConfigPath = path.join(
+    root,
+    "electron-builder.windows-signed.cjs",
+  );
+  const signedConfig = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        "-e",
+        "const c=require(process.argv[1]); process.stdout.write(JSON.stringify(c.win.signtoolOptions));",
+        signedConfigPath,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CERTUM_CERT_THUMBPRINT: "0123456789abcdef0123456789abcdef01234567",
+        },
+      },
+    ),
+  ) as {
+    certificateSha1: string;
+    signingHashAlgorithms: string[];
+    rfc3161TimeStampServer: string;
+  };
+  assert.equal(
+    signedConfig.certificateSha1,
+    "0123456789ABCDEF0123456789ABCDEF01234567",
+  );
+  assert.deepEqual(signedConfig.signingHashAlgorithms, ["sha256"]);
+  assert.equal(signedConfig.rfc3161TimeStampServer, "http://time.certum.pl");
+});
+
 test("installer-related pull requests build and exercise the Windows installer", () => {
   const workflow = readFileSync(
     path.join(root, ".github", "workflows", "windows-installer-pr.yml"),


### PR DESCRIPTION
## Summary

- reuse the validated ephemeral-runner Certum SimplySign setup in protected release workflows
- add a dedicated signed Windows electron-builder configuration selected by certificate-store thumbprint
- sign with SHA-256 and the Certum RFC3161 timestamp service during packaging, before updater metadata is finalized
- verify the packaged app and final NSIS installer against the exact authenticated certificate before candidate assembly or R2 upload
- keep pull-request installer builds unsigned and isolated from the protected TOTP credential

## Security boundary

- Certum secrets remain in the reviewer-gated `release` Environment
- setup action is pinned to a reviewed commit
- official SimplySign MSI Authenticode publisher is checked before installation
- diagnostic screenshots are disabled
- missing, expired, mismatched, unsigned, or untimestamped artifacts fail closed

## Validation

- Certum smoke run passed: https://github.com/rongxinzy/RongxinAI/actions/runs/32717917732
- targeted runtime packaging tests: 13 passed
- source lint passed
- workflow/action YAML parse and `git diff --check` passed