### PR TITLE
feat(enterprise): add extension settings surface

### DIFF
--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -7,6 +7,7 @@ import type {
 export const ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION = 1 as const;
+export const ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION = 1 as const;
 
 export interface ZhiyuanEnterpriseSessionProvider {
   snapshot(): EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>;
@@ -23,6 +24,19 @@ export interface ZhiyuanEnterpriseSessionHostCapability {
 export interface ZhiyuanEnterpriseRendererHostCapability {
   readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION;
   registerSessionGate(entrypoint: string): () => void;
+}
+
+export interface ZhiyuanEnterpriseSettingsPageRegistration {
+  readonly entrypoint: string;
+  readonly labels: {
+    readonly zh: string;
+    readonly en: string;
+  };
+}
+
+export interface ZhiyuanEnterpriseSettingsHostCapability {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION;
+  registerPage(page: ZhiyuanEnterpriseSettingsPageRegistration): () => void;
 }
 
 export const ZhiyuanEnterpriseExtensionStatus = {
@@ -48,6 +62,7 @@ export interface ZhiyuanEnterpriseHostContext {
   readonly capabilities: {
     readonly session: ZhiyuanEnterpriseSessionHostCapability | null;
     readonly renderer: ZhiyuanEnterpriseRendererHostCapability | null;
+    readonly settings: ZhiyuanEnterpriseSettingsHostCapability | null;
   };
 }
 

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -68,6 +68,7 @@ describe('Zhiyuan enterprise extension host', () => {
     expect(Object.isFrozen(receivedContext!.capabilities)).toBe(true);
     expect(receivedContext!.capabilities.session).toBeNull();
     expect(receivedContext!.capabilities.renderer).toBeNull();
+    expect(receivedContext!.capabilities.settings).toBeNull();
 
     await host.dispose();
     await host.dispose();
@@ -136,6 +137,29 @@ describe('Zhiyuan enterprise extension host', () => {
 
     expect(createRendererCapability).toHaveBeenCalledWith(path.dirname(modulePath));
     expect(receivedContext!.capabilities.renderer).toBe(rendererCapability);
+  });
+
+  test('scopes the settings capability to the loaded extension directory', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const settingsCapability = { apiVersion: 1 as const, registerPage: vi.fn() };
+    const createSettingsCapability = vi.fn(() => settingsCapability);
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+          receivedContext = context;
+        },
+      }),
+    }));
+
+    await host.initialize({ ...options(root, true), createSettingsCapability });
+
+    expect(createSettingsCapability).toHaveBeenCalledWith(path.dirname(modulePath));
+    expect(receivedContext!.capabilities.settings).toBe(settingsCapability);
   });
 
   test('imports a real CommonJS development bundle', async () => {

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -10,6 +10,7 @@ import {
   ZhiyuanEnterpriseExtensionStatus,
   type ZhiyuanEnterpriseHostContext,
   type ZhiyuanEnterpriseRendererHostCapability,
+  type ZhiyuanEnterpriseSettingsHostCapability,
   type ZhiyuanEnterpriseSessionHostCapability,
 } from './contract';
 
@@ -28,6 +29,9 @@ export interface ZhiyuanEnterpriseExtensionHostOptions {
   readonly createRendererCapability?: (
     extensionDirectory: string,
   ) => ZhiyuanEnterpriseRendererHostCapability;
+  readonly createSettingsCapability?: (
+    extensionDirectory: string,
+  ) => ZhiyuanEnterpriseSettingsHostCapability;
 }
 
 type ExtensionModuleImporter = (modulePath: string) => Promise<unknown>;
@@ -183,6 +187,7 @@ function createHostContext(
   const capabilities = Object.freeze({
     session: options.sessionCapability ?? null,
     renderer: options.createRendererCapability?.(extensionDirectory) ?? null,
+    settings: options.createSettingsCapability?.(extensionDirectory) ?? null,
   });
   return Object.freeze({
     apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,

--- a/src/main/enterpriseExtension/rendererBridge.test.ts
+++ b/src/main/enterpriseExtension/rendererBridge.test.ts
@@ -52,6 +52,74 @@ describe('Zhiyuan enterprise renderer bridge', () => {
     expect(bridge.resolveAsset('zhiyuan-enterprise-ui://renderer/%2e%2e/outside.html')).toBeNull();
     expect(bridge.resolveAsset('https://renderer/index.html')).toBeNull();
   });
+
+  test('registers a localized settings page with an independently scoped lifetime', () => {
+    const root = createRoot();
+    fs.mkdirSync(path.join(root, 'ui'));
+    fs.writeFileSync(path.join(root, 'ui', 'index.html'), '<!doctype html>');
+    fs.writeFileSync(path.join(root, 'ui', 'settings.html'), '<!doctype html>');
+    fs.writeFileSync(path.join(root, 'extension.cjs'), 'module.exports = {};');
+    const bridge = new ZhiyuanEnterpriseRendererBridge();
+    const rendererCapability = bridge.createScopedCapability(root);
+    const settingsCapability = bridge.createScopedSettingsCapability(root);
+
+    const unregisterGate = rendererCapability.registerSessionGate('ui/index.html');
+    const unregisterSettings = settingsCapability.registerPage({
+      entrypoint: 'ui/settings.html',
+      labels: { zh: '企业账户', en: 'Enterprise account' },
+    });
+
+    expect(bridge.settingsPage()).toEqual({
+      entrypoint: 'zhiyuan-enterprise-ui://renderer/settings/settings.html',
+      labels: { zh: '企业账户', en: 'Enterprise account' },
+    });
+    expect(bridge.resolveAsset('zhiyuan-enterprise-ui://renderer/settings/settings.html')).toBe(
+      fs.realpathSync(path.join(root, 'ui', 'settings.html')),
+    );
+    expect(bridge.resolveAsset('zhiyuan-enterprise-ui://renderer/settings/index.html')).toBe(
+      fs.realpathSync(path.join(root, 'ui', 'index.html')),
+    );
+    expect(bridge.resolveAsset('zhiyuan-enterprise-ui://renderer/extension.cjs')).toBeNull();
+
+    unregisterGate();
+    expect(bridge.settingsPage()).not.toBeNull();
+    expect(bridge.resolveAsset('zhiyuan-enterprise-ui://renderer/settings/settings.html')).toBe(
+      fs.realpathSync(path.join(root, 'ui', 'settings.html')),
+    );
+    unregisterSettings();
+    unregisterSettings();
+    expect(bridge.settingsPage()).toBeNull();
+  });
+
+  test('rejects invalid settings labels and duplicate settings pages', () => {
+    const root = createRoot();
+    fs.writeFileSync(path.join(root, 'settings.html'), '<!doctype html>');
+    const bridge = new ZhiyuanEnterpriseRendererBridge();
+    const capability = bridge.createScopedSettingsCapability(root);
+
+    expect(() =>
+      capability.registerPage({
+        entrypoint: 'settings.html',
+        labels: { zh: '', en: 'Enterprise account' },
+      }),
+    ).toThrow('label is invalid');
+    expect(() =>
+      capability.registerPage({
+        entrypoint: 'settings.html',
+        labels: { zh: '企业账户', en: 'Enterprise\u202eaccount' },
+      }),
+    ).toThrow('label is invalid');
+    capability.registerPage({
+      entrypoint: 'settings.html',
+      labels: { zh: '企业账户', en: 'Enterprise account' },
+    });
+    expect(() =>
+      capability.registerPage({
+        entrypoint: 'settings.html',
+        labels: { zh: '企业账户', en: 'Enterprise account' },
+      }),
+    ).toThrow('already registered');
+  });
 });
 
 function createRoot(): string {

--- a/src/main/enterpriseExtension/rendererBridge.ts
+++ b/src/main/enterpriseExtension/rendererBridge.ts
@@ -3,21 +3,32 @@ import path from 'node:path';
 
 import {
   ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION,
+  ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION,
   type ZhiyuanEnterpriseRendererHostCapability,
+  type ZhiyuanEnterpriseSettingsHostCapability,
+  type ZhiyuanEnterpriseSettingsPageRegistration,
 } from './contract';
+import type { EnterpriseRendererSettingsPage } from '../../shared/enterpriseRenderer';
 
 export const ZHIYUAN_ENTERPRISE_RENDERER_SCHEME = 'zhiyuan-enterprise-ui';
 export const ZHIYUAN_ENTERPRISE_RENDERER_ORIGIN = `${ZHIYUAN_ENTERPRISE_RENDERER_SCHEME}://renderer`;
 
 const MAX_ENTRYPOINT_LENGTH = 512;
+const MAX_LABEL_LENGTH = 64;
+const SETTINGS_RESOURCE_PREFIX = 'settings/';
 
-interface RegisteredSessionGate {
+interface RegisteredRendererPage {
   readonly rootDirectory: string;
   readonly entrypoint: string;
 }
 
+interface RegisteredSettingsPage extends RegisteredRendererPage {
+  readonly labels: EnterpriseRendererSettingsPage['labels'];
+}
+
 export class ZhiyuanEnterpriseRendererBridge {
-  #sessionGate: RegisteredSessionGate | null = null;
+  #sessionGate: RegisteredRendererPage | null = null;
+  #settingsPage: RegisteredSettingsPage | null = null;
 
   createScopedCapability(extensionDirectory: string): ZhiyuanEnterpriseRendererHostCapability {
     const rootDirectory = realDirectory(extensionDirectory);
@@ -28,17 +39,35 @@ export class ZhiyuanEnterpriseRendererBridge {
     });
   }
 
+  createScopedSettingsCapability(
+    extensionDirectory: string,
+  ): ZhiyuanEnterpriseSettingsHostCapability {
+    const rootDirectory = realDirectory(extensionDirectory);
+    return Object.freeze({
+      apiVersion: ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION,
+      registerPage: (page: ZhiyuanEnterpriseSettingsPageRegistration) =>
+        this.#registerSettingsPage(rootDirectory, page),
+    });
+  }
+
   sessionGateEntrypoint(): string | null {
     const registration = this.#sessionGate;
     return registration
-      ? `${ZHIYUAN_ENTERPRISE_RENDERER_ORIGIN}/${encodeURI(registration.entrypoint)}`
+      ? `${ZHIYUAN_ENTERPRISE_RENDERER_ORIGIN}/${encodeURIComponent(registration.entrypoint)}`
+      : null;
+  }
+
+  settingsPage(): EnterpriseRendererSettingsPage | null {
+    const registration = this.#settingsPage;
+    return registration
+      ? Object.freeze({
+          entrypoint: `${ZHIYUAN_ENTERPRISE_RENDERER_ORIGIN}/${SETTINGS_RESOURCE_PREFIX}${encodeURIComponent(registration.entrypoint)}`,
+          labels: registration.labels,
+        })
       : null;
   }
 
   resolveAsset(requestUrl: string): string | null {
-    const registration = this.#sessionGate;
-    if (!registration) return null;
-
     let url: URL;
     try {
       url = new URL(requestUrl);
@@ -55,7 +84,17 @@ export class ZhiyuanEnterpriseRendererBridge {
     } catch {
       return null;
     }
-    return resolveRegularFile(registration.rootDirectory, relativePath);
+    if (relativePath.startsWith(SETTINGS_RESOURCE_PREFIX)) {
+      return this.#settingsPage
+        ? resolveRegularFile(
+            this.#settingsPage.rootDirectory,
+            relativePath.slice(SETTINGS_RESOURCE_PREFIX.length),
+          )
+        : null;
+    }
+    return this.#sessionGate
+      ? resolveRegularFile(this.#sessionGate.rootDirectory, relativePath)
+      : null;
   }
 
   #registerSessionGate(rootDirectory: string, entrypoint: string): () => void {
@@ -80,13 +119,46 @@ export class ZhiyuanEnterpriseRendererBridge {
       if (this.#sessionGate === registration) this.#sessionGate = null;
     };
   }
+
+  #registerSettingsPage(
+    rootDirectory: string,
+    page: ZhiyuanEnterpriseSettingsPageRegistration,
+  ): () => void {
+    if (this.#settingsPage) {
+      throw new Error('A Zhiyuan enterprise settings page is already registered.');
+    }
+    if (!page || typeof page !== 'object') {
+      throw new Error('Zhiyuan enterprise settings page registration is invalid.');
+    }
+    const normalizedEntrypoint = normalizeRelativePath(page.entrypoint);
+    const resolvedEntrypoint = resolveRegularFile(rootDirectory, normalizedEntrypoint);
+    if (!resolvedEntrypoint) {
+      throw new Error('Zhiyuan enterprise settings page entrypoint is not a regular file.');
+    }
+    const labels = Object.freeze({
+      zh: normalizeLabel(page.labels?.zh),
+      en: normalizeLabel(page.labels?.en),
+    });
+    const registration = Object.freeze({
+      rootDirectory: path.dirname(resolvedEntrypoint),
+      entrypoint: path.basename(resolvedEntrypoint),
+      labels,
+    });
+    this.#settingsPage = registration;
+    let registered = true;
+    return () => {
+      if (!registered) return;
+      registered = false;
+      if (this.#settingsPage === registration) this.#settingsPage = null;
+    };
+  }
 }
 
 export const zhiyuanEnterpriseRendererBridge = new ZhiyuanEnterpriseRendererBridge();
 
 function normalizeRelativePath(value: unknown): string {
   if (typeof value !== 'string' || value.length === 0 || value.length > MAX_ENTRYPOINT_LENGTH) {
-    throw new Error('Zhiyuan enterprise session gate entrypoint is invalid.');
+    throw new Error('Zhiyuan enterprise renderer entrypoint is invalid.');
   }
   const normalized = value.replaceAll('\\', '/');
   if (
@@ -95,9 +167,22 @@ function normalizeRelativePath(value: unknown): string {
     normalized.includes('\0') ||
     normalized.split('/').some(segment => segment === '..' || segment.length === 0)
   ) {
-    throw new Error('Zhiyuan enterprise session gate entrypoint must be a safe relative path.');
+    throw new Error('Zhiyuan enterprise renderer entrypoint must be a safe relative path.');
   }
   return normalized;
+}
+
+function normalizeLabel(value: unknown): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_LABEL_LENGTH ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/.test(value)
+  ) {
+    throw new Error('Zhiyuan enterprise settings page label is invalid.');
+  }
+  return value;
 }
 
 function resolveRegularFile(rootDirectory: string, relativePath: string): string | null {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2472,6 +2472,9 @@ if (!gotTheLock) {
   ipcMain.handle(EnterpriseRendererIpc.SessionGateEntrypoint, () =>
     zhiyuanEnterpriseRendererBridge.sessionGateEntrypoint(),
   );
+  ipcMain.handle(EnterpriseRendererIpc.SettingsPage, () =>
+    zhiyuanEnterpriseRendererBridge.settingsPage(),
+  );
 
   ipcMain.handle('hardware:nvidia-smi', async () => getNvidiaSmiSnapshot());
   ipcMain.handle(HardwareIpc.SystemMemory, async () => getSystemMemorySnapshot());
@@ -6667,6 +6670,8 @@ if (!gotTheLock) {
       sessionCapability: zhiyuanEnterpriseSessionBridge,
       createRendererCapability: extensionDirectory =>
         zhiyuanEnterpriseRendererBridge.createScopedCapability(extensionDirectory),
+      createSettingsCapability: extensionDirectory =>
+        zhiyuanEnterpriseRendererBridge.createScopedSettingsCapability(extensionDirectory),
     });
     if (enterpriseExtension.extensionId) {
       console.log(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -278,6 +278,10 @@ contextBridge.exposeInMainWorld('electron', {
     renderer: {
       sessionGateEntrypoint: () =>
         ipcRenderer.invoke(EnterpriseRendererIpc.SessionGateEntrypoint) as Promise<string | null>,
+      settingsPage: () =>
+        ipcRenderer.invoke(EnterpriseRendererIpc.SettingsPage) as Promise<
+          import('../shared/enterpriseRenderer').EnterpriseRendererSettingsPage | null
+        >,
     },
     session: {
       snapshot: () => ipcRenderer.invoke(EnterpriseSessionIpc.Snapshot),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -121,6 +121,8 @@ import { GeneralLanguageField } from './settings/general/GeneralLanguageField';
 import { ModelCapabilitySettingsModal } from './localInference/components/ModelCapabilitySettingsModal';
 import { localInferenceCompactButtonClass } from './localInference/constants';
 import type { EmailSettingsHandle } from './settings/email/types';
+import type { EnterpriseRendererSettingsPage } from '../../shared/enterpriseRenderer';
+import { EnterpriseSettingsPage } from './enterprise/EnterpriseSettingsPage';
 
 type TabType =
   | 'general'
@@ -132,6 +134,7 @@ type TabType =
   | 'shortcuts'
   | 'im'
   | 'email'
+  | 'extension'
   | 'about';
 
 type AnimatedIconHandle = {
@@ -717,6 +720,8 @@ const Settings: React.FC<SettingsProps> = ({
 }) => {
   // 状态
   const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
+  const [enterpriseSettingsPage, setEnterpriseSettingsPage] =
+    useState<EnterpriseRendererSettingsPage | null>(null);
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
   const [language, setLanguage] = useState<LanguageType>('zh');
   const [autoLaunch, setAutoLaunchState] = useState(false);
@@ -771,6 +776,21 @@ const Settings: React.FC<SettingsProps> = ({
     shortcuts: shortcutsIconRef,
     about: aboutIconRef,
   };
+
+  useEffect(() => {
+    let active = true;
+    void window.electron.enterprise.renderer
+      .settingsPage()
+      .then(page => {
+        if (active) setEnterpriseSettingsPage(page);
+      })
+      .catch(() => {
+        if (active) setEnterpriseSettingsPage(null);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const startSettingsIconAnimation = (tab: TabType) => {
     if (!prefersReducedMotion) settingsIconRefs[tab]?.current?.startAnimation();
@@ -2874,6 +2894,13 @@ const Settings: React.FC<SettingsProps> = ({
         icon: <SettingsAnimatedCircleHelpIcon ref={aboutIconRef} />,
       },
     ];
+    if (enterpriseSettingsPage) {
+      allTabs.splice(allTabs.length - 1, 0, {
+        key: 'extension',
+        label: enterpriseSettingsPage.labels[language],
+        icon: <ShieldCheck aria-hidden="true" />,
+      });
+    }
     // Filter out tabs hidden by enterprise config
     // Filter out tabs with 'hide' action in enterprise config
     // e.g., ui: { "settings.im": "hide" } → hide the 'im' tab
@@ -3119,6 +3146,11 @@ const Settings: React.FC<SettingsProps> = ({
 
       case 'email':
         return null;
+
+      case 'extension':
+        return enterpriseSettingsPage ? (
+          <EnterpriseSettingsPage page={enterpriseSettingsPage} title={activeTabLabel} />
+        ) : null;
 
       case 'coworkMemory':
         return (
@@ -5192,7 +5224,10 @@ const Settings: React.FC<SettingsProps> = ({
             {/* Tab content */}
             <div
               ref={contentRef}
-              className="px-4 sm:px-6 py-4 flex-1 overflow-y-auto"
+              className={cn(
+                'flex-1',
+                activeTab === 'extension' ? 'overflow-hidden' : 'overflow-y-auto px-4 py-4 sm:px-6',
+              )}
               style={{ scrollbarGutter: 'stable' }}
             >
               <div className={activeTab === 'email' ? 'block' : 'hidden'}>
@@ -5202,25 +5237,27 @@ const Settings: React.FC<SettingsProps> = ({
             </div>
 
             {/* Footer buttons */}
-            <div className="flex flex-wrap items-center justify-end gap-2 border-border border-t bg-background p-4 shrink-0">
-              <Button
-                type="button"
-                variant="outline"
-                className={localInferenceCompactButtonClass}
-                onClick={onClose}
-                disabled={isSaving}
-              >
-                {i18nService.t('cancel')}
-              </Button>
-              <Button
-                type="submit"
-                variant="outline"
-                className={localInferenceCompactButtonClass}
-                disabled={isSaving}
-              >
-                {isSaving ? i18nService.t('saving') : i18nService.t('save')}
-              </Button>
-            </div>
+            {activeTab !== 'extension' && (
+              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 border-t border-border bg-background p-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className={localInferenceCompactButtonClass}
+                  onClick={onClose}
+                  disabled={isSaving}
+                >
+                  {i18nService.t('cancel')}
+                </Button>
+                <Button
+                  type="submit"
+                  variant="outline"
+                  className={localInferenceCompactButtonClass}
+                  disabled={isSaving}
+                >
+                  {isSaving ? i18nService.t('saving') : i18nService.t('save')}
+                </Button>
+              </div>
+            )}
           </form>
         </div>
 

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  EnterpriseRendererMessageSource,
+  EnterpriseRendererMessageType,
+  EnterpriseRendererSessionOperation,
+  EnterpriseRendererSurface,
+} from '../../../shared/enterpriseRenderer';
+import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
+import { EnterpriseSessionEvent } from '../../services/enterpriseSessionEvents';
+import { EnterpriseRendererFrame } from './EnterpriseRendererFrame';
+
+const snapshot = vi.fn<() => Promise<EnterpriseSessionResult>>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'electron', {
+    configurable: true,
+    value: {
+      enterprise: {
+        session: {
+          snapshot,
+          login: vi.fn(),
+          changePassword: vi.fn(),
+          logout: vi.fn(),
+        },
+      },
+    },
+  });
+});
+
+describe('EnterpriseRendererFrame', () => {
+  test('initializes the sandboxed frame for its declared surface', () => {
+    render(
+      <EnterpriseRendererFrame
+        src="zhiyuan-enterprise-ui://renderer/settings/settings.html"
+        title="Enterprise account"
+        surface={EnterpriseRendererSurface.Settings}
+        session={signedOut()}
+      />,
+    );
+
+    const frame = screen.getByTitle('Enterprise account') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          source: EnterpriseRendererMessageSource.Module,
+          apiVersion: 1,
+          type: EnterpriseRendererMessageType.Ready,
+        },
+      }),
+    );
+
+    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: EnterpriseRendererMessageSource.Host,
+        type: EnterpriseRendererMessageType.Initialize,
+        surface: EnterpriseRendererSurface.Settings,
+        session: signedOut(),
+      }),
+      '*',
+    );
+  });
+
+  test('ignores foreign windows and correlates valid session responses', async () => {
+    snapshot.mockResolvedValue(signedOut());
+    render(
+      <EnterpriseRendererFrame
+        src="zhiyuan-enterprise-ui://renderer/settings/settings.html"
+        title="Enterprise account"
+        surface={EnterpriseRendererSurface.Settings}
+        session={signedOut()}
+      />,
+    );
+
+    const frame = screen.getByTitle('Enterprise account') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    const request = {
+      source: EnterpriseRendererMessageSource.Module,
+      apiVersion: 1,
+      type: EnterpriseRendererMessageType.SessionRequest,
+      requestId: 'request-1',
+      operation: EnterpriseRendererSessionOperation.Snapshot,
+    };
+    window.dispatchEvent(new MessageEvent('message', { source: window, data: request }));
+    expect(snapshot).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new MessageEvent('message', { source: frame.contentWindow, data: request }),
+    );
+
+    await waitFor(() => expect(snapshot).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: EnterpriseRendererMessageSource.Host,
+        type: EnterpriseRendererMessageType.SessionResponse,
+        requestId: 'request-1',
+        result: signedOut(),
+      }),
+      '*',
+    );
+  });
+
+  test('returns a normalized failure without publishing a false session transition', async () => {
+    snapshot.mockRejectedValue(new Error('sensitive host failure'));
+    const sessionChanged = vi.fn();
+    window.addEventListener(EnterpriseSessionEvent.Changed, sessionChanged);
+    render(
+      <EnterpriseRendererFrame
+        src="zhiyuan-enterprise-ui://renderer/settings/settings.html"
+        title="Enterprise account"
+        surface={EnterpriseRendererSurface.Settings}
+        session={signedOut()}
+      />,
+    );
+
+    const frame = screen.getByTitle('Enterprise account') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          source: EnterpriseRendererMessageSource.Module,
+          apiVersion: 1,
+          type: EnterpriseRendererMessageType.SessionRequest,
+          requestId: 'request-failed',
+          operation: EnterpriseRendererSessionOperation.Snapshot,
+        },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: 'request-failed',
+          result: expect.objectContaining({ ok: false }),
+        }),
+        '*',
+      ),
+    );
+    expect(sessionChanged).not.toHaveBeenCalled();
+    window.removeEventListener(EnterpriseSessionEvent.Changed, sessionChanged);
+  });
+});
+
+function signedOut(): EnterpriseSessionResult {
+  return { ok: true, snapshot: { status: 'signed-out' } };
+}

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
@@ -1,0 +1,107 @@
+import { cn } from '@shared/lib/utils';
+import { useEffect, useRef } from 'react';
+
+import {
+  EnterpriseRendererMessageSource,
+  EnterpriseRendererMessageType,
+  type EnterpriseRendererInitializeMessage,
+  type EnterpriseRendererSessionResponseMessage,
+  type EnterpriseRendererSurface,
+} from '../../../shared/enterpriseRenderer';
+import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
+import {
+  executeEnterpriseSessionRequest,
+  isEnterpriseRendererReadyMessage,
+  parseEnterpriseSessionRequest,
+} from '../../services/enterpriseRenderer';
+import { publishEnterpriseSessionResult } from '../../services/enterpriseSessionEvents';
+
+interface EnterpriseRendererFrameProps {
+  readonly src: string;
+  readonly title: string;
+  readonly surface: EnterpriseRendererSurface;
+  readonly session: EnterpriseSessionResult;
+  readonly className?: string;
+}
+
+export function EnterpriseRendererFrame({
+  src,
+  title,
+  surface,
+  session,
+  className,
+}: EnterpriseRendererFrameProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  useEffect(() => {
+    const sendInitialization = () => {
+      const target = iframeRef.current?.contentWindow;
+      if (!target) return;
+      const message: EnterpriseRendererInitializeMessage = {
+        source: EnterpriseRendererMessageSource.Host,
+        apiVersion: 1,
+        type: EnterpriseRendererMessageType.Initialize,
+        surface,
+        language: resolveLanguage(),
+        theme: resolveTheme(),
+        session,
+      };
+      target.postMessage(message, '*');
+    };
+
+    const handleMessage = (event: MessageEvent<unknown>) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      if (isEnterpriseRendererReadyMessage(event.data)) {
+        sendInitialization();
+        return;
+      }
+      const request = parseEnterpriseSessionRequest(event.data);
+      if (!request) return;
+
+      void executeEnterpriseSessionRequest(request)
+        .catch((): EnterpriseSessionResult => operationFailed())
+        .then(result => {
+          const target = iframeRef.current?.contentWindow;
+          if (target) {
+            const response: EnterpriseRendererSessionResponseMessage = {
+              source: EnterpriseRendererMessageSource.Host,
+              apiVersion: 1,
+              type: EnterpriseRendererMessageType.SessionResponse,
+              requestId: request.requestId,
+              result,
+            };
+            target.postMessage(response, '*');
+          }
+          if (result.ok) publishEnterpriseSessionResult(result);
+        });
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [session, surface]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      src={src}
+      title={title}
+      sandbox="allow-scripts"
+      className={cn('border-0 bg-background', className)}
+    />
+  );
+}
+
+function resolveLanguage(): EnterpriseRendererInitializeMessage['language'] {
+  return navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+}
+
+function resolveTheme(): EnterpriseRendererInitializeMessage['theme'] {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+function operationFailed(): EnterpriseSessionResult {
+  return {
+    ok: false,
+    error: { code: 'OPERATION_FAILED', message: 'Enterprise session operation failed.' },
+  };
+}

--- a/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
 import { EnterpriseSessionGate } from './EnterpriseSessionGate';
+import { publishEnterpriseSessionResult } from '../../services/enterpriseSessionEvents';
 
 const sessionGateEntrypoint = vi.fn<() => Promise<string | null>>();
 const snapshot = vi.fn<() => Promise<EnterpriseSessionResult>>();
@@ -86,6 +87,23 @@ describe('EnterpriseSessionGate', () => {
     );
 
     await waitFor(() => expect(screen.getByTitle('Zhiyuan')).toBeInTheDocument());
+    expect(screen.queryByText('application')).not.toBeInTheDocument();
+  });
+
+  test('reopens the gate when a settings page signs out', async () => {
+    sessionGateEntrypoint.mockResolvedValue('zhiyuan-enterprise-ui://renderer/index.html');
+    snapshot.mockResolvedValue(authenticated(false));
+
+    render(
+      <EnterpriseSessionGate>
+        <div>application</div>
+      </EnterpriseSessionGate>,
+    );
+    expect(await screen.findByText('application')).toBeInTheDocument();
+
+    act(() => publishEnterpriseSessionResult({ ok: true, snapshot: { status: 'signed-out' } }));
+
+    expect(await screen.findByTitle('Zhiyuan')).toBeInTheDocument();
     expect(screen.queryByText('application')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/enterprise/EnterpriseSessionGate.tsx
+++ b/src/renderer/components/enterprise/EnterpriseSessionGate.tsx
@@ -1,19 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  EnterpriseRendererMessageSource,
-  EnterpriseRendererMessageType,
-  type EnterpriseRendererInitializeMessage,
-  type EnterpriseRendererLanguage,
-  type EnterpriseRendererSessionResponseMessage,
-  type EnterpriseRendererTheme,
-} from '../../../shared/enterpriseRenderer';
+import { EnterpriseRendererSurface } from '../../../shared/enterpriseRenderer';
 import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
-import {
-  executeEnterpriseSessionRequest,
-  isEnterpriseRendererReadyMessage,
-  parseEnterpriseSessionRequest,
-} from '../../services/enterpriseRenderer';
+import { subscribeToEnterpriseSession } from '../../services/enterpriseSessionEvents';
+import { EnterpriseRendererFrame } from './EnterpriseRendererFrame';
 import WindowTitleBar from '../window/WindowTitleBar';
 
 export const EnterpriseSessionGateState = {
@@ -35,7 +25,6 @@ interface GateContext {
 }
 
 export function EnterpriseSessionGate({ children }: EnterpriseSessionGateProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
   const [state, setState] = useState<EnterpriseSessionGateState>(
     EnterpriseSessionGateState.Checking,
   );
@@ -49,12 +38,16 @@ export function EnterpriseSessionGate({ children }: EnterpriseSessionGateProps) 
     ])
       .then(([entrypoint, session]) => {
         if (!active) return;
-        if (!entrypoint || canEnterApplication(session)) {
+        if (!entrypoint) {
           setState(EnterpriseSessionGateState.Passed);
           return;
         }
         setGateContext({ entrypoint, session });
-        setState(EnterpriseSessionGateState.Open);
+        setState(
+          canEnterApplication(session)
+            ? EnterpriseSessionGateState.Passed
+            : EnterpriseSessionGateState.Open,
+        );
       })
       .catch(() => {
         if (active) setState(EnterpriseSessionGateState.Passed);
@@ -65,50 +58,17 @@ export function EnterpriseSessionGate({ children }: EnterpriseSessionGateProps) 
   }, []);
 
   useEffect(() => {
-    if (state !== EnterpriseSessionGateState.Open || !gateContext) return;
-
-    const sendInitialization = () => {
-      const target = iframeRef.current?.contentWindow;
-      if (!target) return;
-      const message: EnterpriseRendererInitializeMessage = {
-        source: EnterpriseRendererMessageSource.Host,
-        apiVersion: 1,
-        type: EnterpriseRendererMessageType.Initialize,
-        language: resolveLanguage(),
-        theme: resolveTheme(),
-        session: gateContext.session,
-      };
-      target.postMessage(message, '*');
-    };
-
-    const handleMessage = (event: MessageEvent<unknown>) => {
-      if (event.source !== iframeRef.current?.contentWindow) return;
-      if (isEnterpriseRendererReadyMessage(event.data)) {
-        sendInitialization();
-        return;
-      }
-      const request = parseEnterpriseSessionRequest(event.data);
-      if (!request) return;
-
-      void executeEnterpriseSessionRequest(request).then(result => {
-        const target = iframeRef.current?.contentWindow;
-        if (target) {
-          const response: EnterpriseRendererSessionResponseMessage = {
-            source: EnterpriseRendererMessageSource.Host,
-            apiVersion: 1,
-            type: EnterpriseRendererMessageType.SessionResponse,
-            requestId: request.requestId,
-            result,
-          };
-          target.postMessage(response, '*');
-        }
-        if (canEnterApplication(result)) setState(EnterpriseSessionGateState.Passed);
-      });
-    };
-
-    window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
-  }, [gateContext, state]);
+    const entrypoint = gateContext?.entrypoint;
+    if (!entrypoint) return;
+    return subscribeToEnterpriseSession(session => {
+      setGateContext({ entrypoint, session });
+      setState(
+        canEnterApplication(session)
+          ? EnterpriseSessionGateState.Passed
+          : EnterpriseSessionGateState.Open,
+      );
+    });
+  }, [gateContext?.entrypoint]);
 
   if (state === EnterpriseSessionGateState.Passed) return children;
 
@@ -120,11 +80,11 @@ export function EnterpriseSessionGate({ children }: EnterpriseSessionGateProps) 
         </div>
       ) : null}
       {state === EnterpriseSessionGateState.Open && gateContext ? (
-        <iframe
-          ref={iframeRef}
+        <EnterpriseRendererFrame
           src={gateContext.entrypoint}
           title="Zhiyuan"
-          sandbox="allow-scripts"
+          surface={EnterpriseRendererSurface.SessionGate}
+          session={gateContext.session}
           className="min-h-0 flex-1 border-0 bg-background"
         />
       ) : (
@@ -140,12 +100,4 @@ function canEnterApplication(result: EnterpriseSessionResult): boolean {
     result.snapshot.status === 'unavailable' ||
     (result.snapshot.status === 'authenticated' && !result.snapshot.identity.passwordChangeRequired)
   );
-}
-
-function resolveLanguage(): EnterpriseRendererLanguage {
-  return navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en';
-}
-
-function resolveTheme(): EnterpriseRendererTheme {
-  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
 }

--- a/src/renderer/components/enterprise/EnterpriseSettingsPage.tsx
+++ b/src/renderer/components/enterprise/EnterpriseSettingsPage.tsx
@@ -1,0 +1,58 @@
+import { Skeleton } from '@shared/components/ui/skeleton';
+import { useEffect, useState } from 'react';
+
+import {
+  EnterpriseRendererSurface,
+  type EnterpriseRendererSettingsPage as EnterpriseRendererSettingsPageDescriptor,
+} from '../../../shared/enterpriseRenderer';
+import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
+import { EnterpriseRendererFrame } from './EnterpriseRendererFrame';
+
+interface EnterpriseSettingsPageProps {
+  readonly page: EnterpriseRendererSettingsPageDescriptor;
+  readonly title: string;
+}
+
+export function EnterpriseSettingsPage({ page, title }: EnterpriseSettingsPageProps) {
+  const [session, setSession] = useState<EnterpriseSessionResult | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void window.electron.enterprise.session
+      .snapshot()
+      .catch((): EnterpriseSessionResult => operationFailed())
+      .then(result => {
+        if (active) setSession(result);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (!session) {
+    return (
+      <div className="flex h-full flex-col gap-4 p-6" aria-busy="true">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <EnterpriseRendererFrame
+      src={page.entrypoint}
+      title={title}
+      surface={EnterpriseRendererSurface.Settings}
+      session={session}
+      className="size-full"
+    />
+  );
+}
+
+function operationFailed(): EnterpriseSessionResult {
+  return {
+    ok: false,
+    error: { code: 'OPERATION_FAILED', message: 'Enterprise session snapshot failed.' },
+  };
+}

--- a/src/renderer/services/enterpriseSessionEvents.ts
+++ b/src/renderer/services/enterpriseSessionEvents.ts
@@ -1,0 +1,19 @@
+import type { EnterpriseSessionResult } from '../../shared/enterpriseSession';
+
+export const EnterpriseSessionEvent = {
+  Changed: 'zhiyuan:enterprise-session-changed',
+} as const;
+
+export function publishEnterpriseSessionResult(result: EnterpriseSessionResult): void {
+  window.dispatchEvent(new CustomEvent(EnterpriseSessionEvent.Changed, { detail: result }));
+}
+
+export function subscribeToEnterpriseSession(
+  listener: (result: EnterpriseSessionResult) => void,
+): () => void {
+  const handleEvent = (event: Event) => {
+    listener((event as CustomEvent<EnterpriseSessionResult>).detail);
+  };
+  window.addEventListener(EnterpriseSessionEvent.Changed, handleEvent);
+  return () => window.removeEventListener(EnterpriseSessionEvent.Changed, handleEvent);
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1207,6 +1207,9 @@ interface IElectronAPI {
     } | null>;
     renderer: {
       sessionGateEntrypoint: () => Promise<string | null>;
+      settingsPage: () => Promise<
+        import('../../shared/enterpriseRenderer').EnterpriseRendererSettingsPage | null
+      >;
     };
     session: {
       snapshot: () => Promise<EnterpriseSessionResult>;

--- a/src/shared/enterpriseRenderer.ts
+++ b/src/shared/enterpriseRenderer.ts
@@ -6,7 +6,24 @@ import type {
 
 export const EnterpriseRendererIpc = {
   SessionGateEntrypoint: 'enterprise:renderer:session-gate-entrypoint',
+  SettingsPage: 'enterprise:renderer:settings-page',
 } as const;
+
+export interface EnterpriseRendererSettingsPage {
+  readonly entrypoint: string;
+  readonly labels: {
+    readonly zh: string;
+    readonly en: string;
+  };
+}
+
+export const EnterpriseRendererSurface = {
+  SessionGate: 'session-gate',
+  Settings: 'settings',
+} as const;
+
+export type EnterpriseRendererSurface =
+  (typeof EnterpriseRendererSurface)[keyof typeof EnterpriseRendererSurface];
 
 export const EnterpriseRendererMessageSource = {
   Host: 'zhiyuan.enterprise.host',
@@ -43,6 +60,7 @@ export interface EnterpriseRendererInitializeMessage {
   readonly source: typeof EnterpriseRendererMessageSource.Host;
   readonly apiVersion: 1;
   readonly type: typeof EnterpriseRendererMessageType.Initialize;
+  readonly surface: EnterpriseRendererSurface;
   readonly language: EnterpriseRendererLanguage;
   readonly theme: EnterpriseRendererTheme;
   readonly session: EnterpriseSessionResult;


### PR DESCRIPTION
## Summary

- add an optional versioned settings capability for extension-owned pages and localized labels
- mount registered pages in the existing Settings surface through the scoped `zhiyuan-enterprise-ui` protocol
- reuse one sandboxed renderer frame for the login gate and settings page session proxy
- reopen the top-level session gate immediately after a successful sign-out
- keep the community Settings surface unchanged when no page is registered

## Security

- validate entrypoints, real paths, label length, control characters, and duplicate registrations
- restrict settings assets to the registered UI directory and keep extension code/configuration inaccessible
- expose normalized session snapshots only; no access, refresh, or model token enters the iframe

## Verification

- 22 focused tests pass
- `bun run build:tsc`
- `bun run compile:electron`
- `bun run lint`
- `bun run build:vite`
- local full suite: 2,394 pass, 1 skipped; 13 unrelated baseline/environment failures (missing Python/Get-FileHash, Windows release path fixtures, existing dependency patch checks)
