### PR TITLE
fix(ci): read Windows signing config as UTF-8

### DIFF
--- a/scripts/ci/verify-windows-authenticode.ps1
+++ b/scripts/ci/verify-windows-authenticode.ps1
@@ -31,7 +31,7 @@ $expectedCertificateDer = [Convert]::ToBase64String(
 
 $builderConfig = Get-Content -LiteralPath (
   Join-Path $ProjectRoot 'electron-builder.json'
-) -Raw | ConvertFrom-Json
+) -Raw -Encoding UTF8 | ConvertFrom-Json
 $appExecutable = Join-Path $ProjectRoot (
   "release\win-unpacked\$($builderConfig.executableName).exe"
 )

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -324,6 +324,15 @@ test("protected Windows releases authenticate with Certum and require valid sign
   );
   assert.deepEqual(signedConfig.signingHashAlgorithms, ["sha256"]);
   assert.equal(signedConfig.rfc3161TimeStampServer, "http://time.certum.pl");
+
+  const signatureVerifier = readFileSync(
+    path.join(root, "scripts", "ci", "verify-windows-authenticode.ps1"),
+    "utf8",
+  );
+  assert.match(
+    signatureVerifier,
+    /electron-builder\.json'[\s\S]*-Raw -Encoding UTF8 \| ConvertFrom-Json/,
+  );
 });
 
 test("installer-related pull requests build and exercise the Windows installer", () => {


### PR DESCRIPTION
## Summary
- read `electron-builder.json` explicitly as UTF-8 in the Windows Authenticode verifier
- prevent PowerShell 5 from mangling the Chinese executable name
- add a regression assertion for the encoding boundary

## Failure evidence
Release candidate run 32723763545 completed Certum setup and signed packaging, then failed verification because `知远.exe` was decoded as `çŸ¥è¿œ.exe`.

## Validation
- `bunx vitest run tests/runtimePackagingConfig.test.ts` (13/13)
- `bun run lint`
- `git diff --check`