### PR TITLE
fix(enterprise): allow renderer scheme in CSP

### DIFF
--- a/src/main/contentSecurityPolicy.test.ts
+++ b/src/main/contentSecurityPolicy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import { createContentSecurityPolicy } from './contentSecurityPolicy';
+
+describe('content security policy', () => {
+  test('allows the scoped enterprise renderer frame', () => {
+    const policy = createContentSecurityPolicy({ isDev: false });
+
+    expect(policy).toContain("frame-src 'self' file: zhiyuan-enterprise-ui:");
+    expect(policy).not.toContain('frame-src *');
+  });
+
+  test('uses the configured development server port for scripts and HMR', () => {
+    const policy = createContentSecurityPolicy({
+      isDev: true,
+      electronStartUrl: 'http://localhost:6175',
+    });
+
+    expect(policy).toContain('http://localhost:6175');
+    expect(policy).toContain('ws://localhost:6175');
+  });
+});

--- a/src/main/contentSecurityPolicy.ts
+++ b/src/main/contentSecurityPolicy.ts
@@ -1,0 +1,23 @@
+export interface ContentSecurityPolicyOptions {
+  readonly isDev: boolean;
+  readonly electronStartUrl?: string;
+}
+
+export function createContentSecurityPolicy(options: ContentSecurityPolicyOptions): string {
+  const devPort = options.electronStartUrl?.match(/:(\d+)/)?.[1] || '5175';
+  const directives = [
+    "default-src 'self'",
+    options.isDev
+      ? `script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:${devPort} ws://localhost:${devPort}`
+      : "script-src 'self' 'unsafe-eval'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https: http: localfile:",
+    'connect-src *',
+    "font-src 'self' data:",
+    "media-src 'self'",
+    "worker-src 'self' blob:",
+    "frame-src 'self' file: zhiyuan-enterprise-ui:",
+  ];
+
+  return directives.join('; ');
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -189,6 +189,7 @@ import {
   probeCoworkModelReadiness,
 } from './libs/coworkUtil';
 import { resolveBundledNpmRuntime, NpmCli } from './libs/npmRuntime';
+import { createContentSecurityPolicy } from './contentSecurityPolicy';
 import { refreshEndpointsTestMode } from './libs/endpoints';
 import { resolveEnterpriseConfigPath, syncEnterpriseConfig } from './libs/enterpriseConfigSync';
 import {
@@ -6215,26 +6216,13 @@ if (!gotTheLock) {
         return;
       }
 
-      const devPort = process.env.ELECTRON_START_URL?.match(/:(\d+)/)?.[1] || '5175';
-      const cspDirectives = [
-        "default-src 'self'",
-        isDev
-          ? `script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:${devPort} ws://localhost:${devPort}`
-          : "script-src 'self' 'unsafe-eval'",
-        "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data: https: http: localfile:",
-        // 允许连接到所有域名，不做限制
-        'connect-src *',
-        "font-src 'self' data:",
-        "media-src 'self'",
-        "worker-src 'self' blob:",
-        "frame-src 'self' file:",
-      ];
-
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': cspDirectives.join('; '),
+          'Content-Security-Policy': createContentSecurityPolicy({
+            isDev,
+            electronStartUrl: process.env.ELECTRON_START_URL,
+          }),
         },
       });
     });


### PR DESCRIPTION
## Summary
- allow the sandboxed Zhiyuan enterprise renderer scheme in frame-src
- keep the CSP source list scoped instead of permitting arbitrary frames
- extract CSP construction for focused regression coverage

## Verification
- bunx vitest run src/main/contentSecurityPolicy.test.ts
- bun run compile:electron
- bunx oxlint src/main/contentSecurityPolicy.ts src/main/contentSecurityPolicy.test.ts src/main/main.ts

Fixes the development white screen reported as ERR_BLOCKED_BY_CSP when loading the enterprise session gate.