### PR TITLE
fix(enterprise): serve sandboxed renderer assets

### DIFF
--- a/src/main/enterpriseExtension/rendererProtocol.test.ts
+++ b/src/main/enterpriseExtension/rendererProtocol.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  allowEnterpriseRendererOpaqueOrigin,
+  ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES,
+} from './rendererProtocol';
+
+describe('Zhiyuan enterprise renderer protocol', () => {
+  test('supports CORS without bypassing CSP or weakening the secure scheme', () => {
+    expect(ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES).toEqual({
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+    });
+    expect(ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES).not.toHaveProperty('bypassCSP');
+  });
+
+  test('allows public renderer assets from a sandboxed opaque origin', async () => {
+    const response = allowEnterpriseRendererOpaqueOrigin(
+      new Response('asset', {
+        status: 200,
+        headers: { 'Content-Type': 'text/javascript' },
+      }),
+    );
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Content-Type')).toBe('text/javascript');
+    expect(await response.text()).toBe('asset');
+  });
+});

--- a/src/main/enterpriseExtension/rendererProtocol.ts
+++ b/src/main/enterpriseExtension/rendererProtocol.ts
@@ -1,0 +1,16 @@
+export const ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES = Object.freeze({
+  standard: true,
+  secure: true,
+  supportFetchAPI: true,
+  corsEnabled: true,
+});
+
+export function allowEnterpriseRendererOpaqueOrigin(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -200,6 +200,10 @@ import {
   ZHIYUAN_ENTERPRISE_RENDERER_SCHEME,
   zhiyuanEnterpriseRendererBridge,
 } from './enterpriseExtension/rendererBridge';
+import {
+  allowEnterpriseRendererOpaqueOrigin,
+  ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES,
+} from './enterpriseExtension/rendererProtocol';
 import { zhiyuanEnterpriseSessionBridge } from './enterpriseExtension/sessionBridge';
 import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
@@ -277,7 +281,7 @@ app.setName(APP_NAME);
 protocol.registerSchemesAsPrivileged([
   {
     scheme: ZHIYUAN_ENTERPRISE_RENDERER_SCHEME,
-    privileges: { standard: true, secure: true, supportFetchAPI: true },
+    privileges: ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES,
   },
 ]);
 
@@ -6641,11 +6645,11 @@ if (!gotTheLock) {
     profiler.measure('app.whenReady');
     console.log('[Main] initApp: app is ready');
 
-    protocol.handle(ZHIYUAN_ENTERPRISE_RENDERER_SCHEME, request => {
+    protocol.handle(ZHIYUAN_ENTERPRISE_RENDERER_SCHEME, async request => {
       const assetPath = zhiyuanEnterpriseRendererBridge.resolveAsset(request.url);
-      return assetPath
-        ? net.fetch(pathToFileURL(assetPath).toString())
-        : Promise.resolve(new Response(null, { status: 404 }));
+      if (!assetPath) return new Response(null, { status: 404 });
+      const response = await net.fetch(pathToFileURL(assetPath).toString());
+      return allowEnterpriseRendererOpaqueOrigin(response);
     });
 
     const enterpriseExtension = await initializeZhiyuanEnterpriseExtension({


### PR DESCRIPTION
## Summary
- register the Zhiyuan enterprise renderer scheme as CORS-capable
- allow immutable renderer assets to load from the sandboxed iframe opaque origin
- preserve the existing sandbox without adding allow-same-origin or bypassing CSP

## Verification
- bunx vitest run src/main/enterpriseExtension/rendererProtocol.test.ts src/main/enterpriseExtension/rendererBridge.test.ts src/main/contentSecurityPolicy.test.ts
- bunx tsc --project electron-tsconfig.json
- bunx oxlint src/main/enterpriseExtension/rendererProtocol.ts src/main/enterpriseExtension/rendererProtocol.test.ts src/main/main.ts
- bunx oxfmt --check src/main/enterpriseExtension/rendererProtocol.ts src/main/enterpriseExtension/rendererProtocol.test.ts

The full electron-rebuild step was blocked by the currently running development Electron process locking better_sqlite3.node; direct Electron TypeScript compilation passed.