### PR TITLE
fix(enterprise): enable sandboxed login forms

### DIFF
--- a/src/main/contentSecurityPolicy.test.ts
+++ b/src/main/contentSecurityPolicy.test.ts
@@ -7,6 +7,7 @@ describe('content security policy', () => {
     const policy = createContentSecurityPolicy({ isDev: false });
 
     expect(policy).toContain("frame-src 'self' file: zhiyuan-enterprise-ui:");
+    expect(policy).toContain("form-action 'none'");
     expect(policy).not.toContain('frame-src *');
   });
 

--- a/src/main/contentSecurityPolicy.ts
+++ b/src/main/contentSecurityPolicy.ts
@@ -17,6 +17,7 @@ export function createContentSecurityPolicy(options: ContentSecurityPolicyOption
     "media-src 'self'",
     "worker-src 'self' blob:",
     "frame-src 'self' file: zhiyuan-enterprise-ui:",
+    "form-action 'none'",
   ];
 
   return directives.join('; ');

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
@@ -57,7 +57,7 @@ describe('EnterpriseRendererFrame', () => {
       }),
     );
 
-    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(frame).toHaveAttribute('sandbox', 'allow-forms allow-scripts');
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         source: EnterpriseRendererMessageSource.Host,

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
@@ -85,7 +85,7 @@ export function EnterpriseRendererFrame({
       ref={iframeRef}
       src={src}
       title={title}
-      sandbox="allow-scripts"
+      sandbox="allow-forms allow-scripts"
       className={cn('border-0 bg-background', className)}
     />
   );

--- a/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
@@ -57,7 +57,7 @@ describe('EnterpriseSessionGate', () => {
     );
 
     const frame = await screen.findByTitle('Zhiyuan');
-    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(frame).toHaveAttribute('sandbox', 'allow-forms allow-scripts');
     expect(frame).toHaveAttribute('src', 'zhiyuan-enterprise-ui://renderer/index.html');
     expect(screen.queryByText('application')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Allow trusted enterprise renderer forms to dispatch React submit events while keeping the iframe on an opaque origin. Add form-action none to the host CSP so native form navigation remains blocked. Includes focused renderer and CSP regression tests; verified against the AEP password login flow.