### PR TITLE
perf(cowork): bypass production gate for direct turns

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../shared/providers';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
+import { ProductionSkipSource } from '../../../shared/productionLoop';
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
@@ -778,13 +779,30 @@ describe('PiRuntimeAdapter', () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
-      adapter.setWorkbenchTaskService(new RealWorkbenchTaskService(db));
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
 
       try {
         await adapter.startSession('adaptive-gate', '你好', {
           sessionMode: 'work',
           workspaceRoot: createTemporaryWorkspace(),
         });
+
+        const greetingPrompt = mockSession.prompt.mock.calls[0]?.[0] as string;
+        expect(greetingPrompt).toContain('Answer directly');
+        expect(greetingPrompt).not.toContain('## Production workflow decision');
+        const greetingRunId = service.getCurrent('adaptive-gate')?.runs[0]?.id;
+        expect(greetingRunId).toBeDefined();
+        expect(service.productionLoop.getState(greetingRunId!).skip?.source).toBe(
+          ProductionSkipSource.SystemPolicy,
+        );
+        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
+          type: string;
+        }) => void;
+        listener({ type: 'agent_end' });
+        await Promise.resolve();
+        expect(mockSession.prompt).toHaveBeenCalledOnce();
+
         await adapter.continueSession('adaptive-gate', '修复登录流程中的刷新问题', {
           sessionMode: 'work',
         });

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -85,7 +85,10 @@ import type {
 } from '../../workbenchTask/taskService';
 import { composeWorkbenchWorkflowSnapshot } from '../../workbenchTask/workflowSnapshot';
 import { ProductionLoopController } from '../../productionLoop/controller';
-import { shouldEnableProductionWorkflow } from '../../productionLoop/entryPolicy';
+import {
+  shouldAutoSkipDirectConversation,
+  shouldEnableProductionWorkflow,
+} from '../../productionLoop/entryPolicy';
 import { buildProductionLoopTool } from '../../productionLoop/tool';
 import {
   type ApiConfigResolution,
@@ -714,6 +717,18 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         goalMode: options.goalMode,
         inheritedProductionWorkflow: options._productionWorkflowEnabled,
       });
+      const autoSkipDirectConversation =
+        productionWorkflowEnabled &&
+        shouldAutoSkipDirectConversation({
+          sessionMode: options.sessionMode,
+          prompt,
+          goalMode: options.goalMode,
+          inheritedProductionWorkflow: options._productionWorkflowEnabled,
+          skillIds: resourceState.skillIds,
+          expertIds,
+          attachmentCount:
+            (options.imageAttachments?.length ?? 0) + (options.fileAttachments?.length ?? 0),
+        });
       const workbenchContract = this.createWorkbenchContract(
         options.sessionMode,
         resourceState.skillIds,
@@ -1017,6 +1032,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               completionWorkflow || undefined,
             )
           : null;
+      if (productionLoop && autoSkipDirectConversation) {
+        productionLoop.skipWorkflowBySystemPolicy(
+          'Direct conversational turn matched the system fast path.',
+        );
+      }
       if (productionLoop) customTools.push(buildProductionLoopTool(productionLoop));
       const shouldRunGoalLoop =
         options.goalMode === true && options.sessionMode === CoworkSessionMode.Work;
@@ -1238,6 +1258,18 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       goalMode: nextGoalMode,
       inheritedProductionWorkflow: options._productionWorkflowEnabled,
     });
+    const autoSkipDirectConversation =
+      productionWorkflowEnabled &&
+      shouldAutoSkipDirectConversation({
+        sessionMode: requestedSessionMode,
+        prompt,
+        goalMode: nextGoalMode,
+        inheritedProductionWorkflow: options._productionWorkflowEnabled,
+        skillIds: requestedSkillIds,
+        expertIds: requestedExpertIds,
+        attachmentCount:
+          (options.imageAttachments?.length ?? 0) + (options.fileAttachments?.length ?? 0),
+      });
     const productionWorkflowTopologyChanged =
       productionWorkflowEnabled !== active.productionWorkflowEnabled;
     const mcpToolTopologyChanged =
@@ -1353,6 +1385,11 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           deferDecision: nextGoalMode !== true && options._productionWorkflowEnabled === undefined,
           skipAllowed: nextGoalMode !== true,
         });
+        if (autoSkipDirectConversation) {
+          active.productionLoop?.skipWorkflowBySystemPolicy(
+            'Direct conversational turn matched the system fast path.',
+          );
+        }
       }
     }
 

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -1,7 +1,11 @@
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import { ProductionLoopPhase, ProductionLoopStatus } from '../../shared/productionLoop';
+import {
+  ProductionLoopPhase,
+  ProductionLoopStatus,
+  ProductionSkipSource,
+} from '../../shared/productionLoop';
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
@@ -760,6 +764,28 @@ test('skip_workflow lets the agent finish without the completion gate', () => {
   expect(controller.onAgentEnd({ next: false })).toEqual({
     shouldFinish: true,
     reason: 'Pure information request with no work to plan',
+  });
+  expect(downstream.onAgentEnd).not.toHaveBeenCalled();
+});
+
+test('system policy completes a direct turn before the model sees the decision gate', () => {
+  const { controller, downstream } = createController();
+
+  controller.skipWorkflowBySystemPolicy('Direct conversational turn');
+
+  expect(controller.getState()).toMatchObject({
+    status: ProductionLoopStatus.Completed,
+    skip: {
+      reason: 'Direct conversational turn',
+      source: ProductionSkipSource.SystemPolicy,
+    },
+  });
+  expect(controller.buildInitialPrompt()).toContain('Answer directly');
+  expect(controller.buildInitialPrompt()).not.toContain('Production workflow decision');
+  expect(controller.getSnapshot().skipSource).toBe(ProductionSkipSource.SystemPolicy);
+  expect(controller.onAgentEnd({ next: false })).toEqual({
+    shouldFinish: true,
+    reason: 'Direct conversational turn',
   });
   expect(downstream.onAgentEnd).not.toHaveBeenCalled();
 });

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -3,6 +3,7 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
+  ProductionSkipSource,
   type ProductionArtifactEvidence,
   type ProductionLoopState,
 } from '../../shared/productionLoop';
@@ -237,6 +238,9 @@ export class ProductionLoopController {
   buildInitialPrompt(): string {
     this.refreshIfStarted();
     if (!this.state) return this.buildDecisionPrompt();
+    if (this.state.skip?.source === ProductionSkipSource.SystemPolicy) {
+      return 'Production control is already complete for this direct conversational turn. Answer directly without calling production_loop or agent_loop.';
+    }
     const phaseInstruction = (() => {
       if (this.state.phase === ProductionLoopPhase.Explore) {
         return 'Begin by creating a concrete prototype or materially distinct direction, then record it with production_loop record_prototype.';
@@ -421,6 +425,16 @@ export class ProductionLoopController {
     return this.update(this.service.skipWorkflow(state.runId, reason));
   }
 
+  skipWorkflowBySystemPolicy(reason: string): ProductionLoopState {
+    if (this.initial.skipAllowed === false) {
+      throw new Error('This run requires the production workflow and cannot be skipped.');
+    }
+    const state = this.activate();
+    return this.update(
+      this.service.skipWorkflow(state.runId, reason, ProductionSkipSource.SystemPolicy),
+    );
+  }
+
   requestCompletion(reason: string): string {
     this.refreshIfStarted();
     if (!this.state) {
@@ -576,6 +590,7 @@ export class ProductionLoopController {
       phase: this.state.phase,
       status: this.state.status,
       skipped: Boolean(this.state.skip),
+      skipSource: this.state.skip ? (this.state.skip.source ?? ProductionSkipSource.Model) : null,
       // Distinguishes "reviewer passed" from "reviewer skipped (lightweight)"
       // for the completion verification chain and audit UIs.
       criticSkipped: this.state.critic.skipped === true,

--- a/src/main/productionLoop/entryPolicy.test.ts
+++ b/src/main/productionLoop/entryPolicy.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 
 import { CoworkSessionMode } from '../../shared/cowork/constants';
-import { shouldEnableProductionWorkflow } from './entryPolicy';
+import { shouldAutoSkipDirectConversation, shouldEnableProductionWorkflow } from './entryPolicy';
 
 const workRequest = (prompt: string) => ({ sessionMode: CoworkSessionMode.Work, prompt });
 
@@ -55,4 +55,39 @@ test('does not classify natural-language intent or incidental resources', () => 
       prompt: 'Read package.json',
     }),
   ).toBe(true);
+});
+
+test.each(['哈喽', '你好！', '您好', '谢谢', '收到', 'hello', 'got it'])(
+  'auto-skips an exact direct-conversation turn: %s',
+  prompt => {
+    expect(shouldAutoSkipDirectConversation(workRequest(prompt))).toBe(true);
+  },
+);
+
+test.each(['你好，删除这个文件', '谢谢，继续执行', '为什么天空是蓝色的？', '可以？'])(
+  'keeps ambiguous or substantive text in the model decision path: %s',
+  prompt => {
+    expect(shouldAutoSkipDirectConversation(workRequest(prompt))).toBe(false);
+  },
+);
+
+test('disables the direct-conversation fast path when runtime context may carry work', () => {
+  const greeting = workRequest('你好');
+  expect(
+    shouldAutoSkipDirectConversation({ ...greeting, sessionMode: CoworkSessionMode.Chat }),
+  ).toBe(false);
+  expect(shouldAutoSkipDirectConversation({ ...greeting, goalMode: true })).toBe(false);
+  expect(shouldAutoSkipDirectConversation({ ...greeting, inheritedProductionWorkflow: true })).toBe(
+    false,
+  );
+  expect(
+    shouldAutoSkipDirectConversation({ ...greeting, inheritedProductionWorkflow: false }),
+  ).toBe(false);
+  expect(shouldAutoSkipDirectConversation({ ...greeting, skillIds: ['report'] })).toBe(false);
+  expect(shouldAutoSkipDirectConversation({ ...greeting, expertIds: ['reviewer'] })).toBe(false);
+  expect(shouldAutoSkipDirectConversation({ ...greeting, attachmentCount: 1 })).toBe(false);
+});
+
+test('treats an omitted session mode as Work, matching the production entry policy', () => {
+  expect(shouldAutoSkipDirectConversation({ prompt: 'Hello!' })).toBe(true);
 });

--- a/src/main/productionLoop/entryPolicy.ts
+++ b/src/main/productionLoop/entryPolicy.ts
@@ -10,10 +10,79 @@ export interface ProductionWorkflowEntryInput {
   inheritedProductionWorkflow?: boolean;
 }
 
+export interface DirectConversationFastPathInput extends ProductionWorkflowEntryInput {
+  skillIds?: readonly string[];
+  expertIds?: readonly string[];
+  attachmentCount?: number;
+}
+
+const DIRECT_CONVERSATION_PHRASES = new Set([
+  '你好',
+  '您好',
+  '哈喽',
+  '哈啰',
+  '嗨',
+  '早上好',
+  '上午好',
+  '中午好',
+  '下午好',
+  '晚上好',
+  '谢谢',
+  '多谢',
+  '感谢',
+  '好',
+  '好的',
+  '行',
+  '可以',
+  '收到',
+  '明白',
+  '明白了',
+  '知道了',
+  '了解',
+  '没问题',
+  '再见',
+  '拜拜',
+  '回见',
+  'hi',
+  'hello',
+  'hey',
+  'thanks',
+  'thank you',
+  'thx',
+  'ok',
+  'okay',
+  'got it',
+  'sounds good',
+  'bye',
+  'goodbye',
+  'see you',
+]);
+
+const normalizeDirectConversation = (prompt: string): string =>
+  prompt
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/[!.\s,~。！、，～]+$/u, '')
+    .toLowerCase();
+
 /**
- * This gate only resolves deterministic runtime state. The model decides whether
- * a new Work turn needs the production workflow by calling commit_plan or
- * skip_workflow; natural-language intent must not be classified here.
+ * Strict system-owned fast path for turns that cannot contain substantive
+ * work. Full-string matching is intentional: prefixed instructions such as
+ * "你好，删除这个文件" must continue through the model decision gate.
+ */
+export const shouldAutoSkipDirectConversation = (
+  input: DirectConversationFastPathInput,
+): boolean => {
+  if (input.sessionMode === CoworkSessionMode.Chat) return false;
+  if (input.goalMode || input.inheritedProductionWorkflow !== undefined) return false;
+  if (input.skillIds?.length || input.expertIds?.length || input.attachmentCount) return false;
+  return DIRECT_CONVERSATION_PHRASES.has(normalizeDirectConversation(input.prompt));
+};
+
+/**
+ * This gate only resolves deterministic runtime state and keeps the production
+ * tool topology stable for Work sessions. The separate direct-conversation
+ * fast path may persist a system-owned skip without disabling these tools.
  */
 export const shouldEnableProductionWorkflow = (input: ProductionWorkflowEntryInput): boolean => {
   if (input.sessionMode === CoworkSessionMode.Chat) return false;

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -6,6 +6,7 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
+  ProductionSkipSource,
 } from '../../shared/productionLoop';
 import {
   WorkbenchContractKind,
@@ -100,6 +101,22 @@ test('repeated skip_workflow stays a no-op without advancing progressVersion', (
   expect(second.progressVersion).toBe(first.progressVersion);
   expect(second.skip?.reason).toBe('Direct answer');
   expect(second.status).toBe(ProductionLoopStatus.Completed);
+});
+
+test('records whether the model or system policy skipped the workflow', () => {
+  const modelRun = begin().run;
+  expect(service.skipWorkflow(modelRun.id, 'Direct answer').skip?.source).toBe(
+    ProductionSkipSource.Model,
+  );
+
+  const systemRun = begin().run;
+  expect(
+    service.skipWorkflow(
+      systemRun.id,
+      'Direct conversational turn',
+      ProductionSkipSource.SystemPolicy,
+    ).skip?.source,
+  ).toBe(ProductionSkipSource.SystemPolicy);
 });
 
 test('skipCritique moves a critique-phase run to delivery without a reviewer', () => {

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -8,6 +8,7 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
+  ProductionSkipSource,
   type ProductionAvailableVerifierEvidence,
   type ProductionCriticFinding,
   type ProductionCriticExecution,
@@ -691,7 +692,11 @@ export class ProductionLoopService {
    * is marked completed so the agent may end the turn without a completion
    * gate; deterministic verification still applies on run completion.
    */
-  skipWorkflow(runId: string, reason: string): ProductionLoopState {
+  skipWorkflow(
+    runId: string,
+    reason: string,
+    source: ProductionSkipSource = ProductionSkipSource.Model,
+  ): ProductionLoopState {
     // allowAfterSkip: the internal skip guard below is the idempotency — a
     // repeated skip must stay a successful no-op (and not advance
     // progressVersion), not become an error behind the generic guard.
@@ -704,13 +709,13 @@ export class ProductionLoopService {
         }
         const normalized = reason.trim();
         if (!normalized) throw new Error('A skip reason is required.');
-        state.skip = { reason: normalized, createdAt: Date.now() };
+        state.skip = { reason: normalized, source, createdAt: Date.now() };
         state.status = ProductionLoopStatus.Completed;
         state.progressVersion += 1;
         this.measurement.recordActivation(runId, {
           activation: HarnessActivationType.WorkflowSkipped,
           mechanism: 'production_loop',
-          evidence: { reason: normalized },
+          evidence: { reason: normalized, source },
         });
       },
       { allowAfterSkip: true },

--- a/src/shared/productionLoop/constants.ts
+++ b/src/shared/productionLoop/constants.ts
@@ -64,6 +64,12 @@ export const ProductionLoopAction = {
 } as const;
 export type ProductionLoopAction = (typeof ProductionLoopAction)[keyof typeof ProductionLoopAction];
 
+export const ProductionSkipSource = {
+  Model: 'model',
+  SystemPolicy: 'system_policy',
+} as const;
+export type ProductionSkipSource = (typeof ProductionSkipSource)[keyof typeof ProductionSkipSource];
+
 export const ProductionLoopToolName = 'production_loop';
 
 /** Stop automatic continuation after repeated turns make no production progress. */

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -5,6 +5,7 @@ import type {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
+  ProductionSkipSource,
 } from './constants';
 
 export interface ProductionPlanItem {
@@ -89,8 +90,8 @@ export interface ProductionCriticState {
   execution: ProductionCriticExecution | null;
   /**
    * True when the critique phase was bypassed by lightweight review mode.
-   * passed stays true so reviewed-artifact projection keeps working; the
-   * flag preserves the distinction for audit.
+   * passed stays false so skipped review cannot be mistaken for approval;
+   * the flag preserves the distinction for audit.
    */
   skipped?: boolean;
 }
@@ -110,6 +111,8 @@ export interface ProductionRecovery {
 
 export interface ProductionSkip {
   reason: string;
+  /** Missing on production-loop records created before skip sources existed. */
+  source?: ProductionSkipSource;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary

- bypass the model-owned production workflow decision for exact direct-conversation turns in Work mode
- persist the bypass as a system-policy skip while keeping the Work tool topology stable
- preserve the existing model decision path for ambiguous, substantive, or context-bearing requests

## Problem

Simple Work-mode messages such as `哈喽` were forced through the production control protocol. The model had to reason about whether production work was required and call `skip_workflow` before it could answer, adding avoidable reasoning tokens, tool traffic, and latency to a conversational turn.

## Implementation

- add a strict system-owned fast path backed by an exact greeting, acknowledgement, thanks, and farewell allowlist
- activate the fast path before prompt construction for both new and continued Work sessions
- record skip provenance as `system_policy`; existing persisted skips without provenance remain compatible and are treated as model-authored in snapshots
- replace the full production decision prompt with a short direct-answer instruction after a system-policy skip
- keep `production_loop` and `agent_loop` registered so a later substantive follow-up does not recreate the Pi session

## Safety boundaries

The fast path is disabled when any of the following applies:

- the text contains anything beyond an exact allowlisted phrase and trailing non-question punctuation
- Goal mode is active
- production workflow policy is inherited from an owning task
- a Skill or expert is selected
- an image or file attachment is present
- the session is in Chat mode

Examples such as `你好，删除这个文件`, `谢谢，继续执行`, and `可以？` therefore remain in the model decision path.

## Verification

- `npx vitest run src/main/productionLoop/entryPolicy.test.ts src/main/productionLoop/controller.test.ts src/main/productionLoop/service.test.ts src/main/libs/agentEngine/piRuntimeAdapter.test.ts` (167 tests passed)
- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
- `git diff --check`

No renderer or Electron IPC behavior changed.
