### PR TITLE
fix(cowork): keep production controls dormant by default

### DIFF
--- a/src/main/libs/agentEngine/piExpertProductionPrompt.test.ts
+++ b/src/main/libs/agentEngine/piExpertProductionPrompt.test.ts
@@ -6,13 +6,13 @@ import {
   prependProductionWorkflowPrompt,
 } from './piExpertProductionPrompt';
 
-test('defines production as the sole outer controller and experts as domain methods', () => {
+test('defines activated production as the sole outer controller and experts as domain methods', () => {
   const prompt = buildExpertProductionPrompt();
 
   expect(prompt).toContain('sole outer progress controller');
   expect(prompt).toContain('expert workflow only as the domain method');
   expect(prompt).toContain('map the applicable expert phases into plan items');
-  expect(prompt).toContain('may skip production with a concrete reason');
+  expect(prompt).toContain('answer normally without calling production_loop');
   expect(prompt).toContain('Do not create or maintain a separate Markdown checklist');
 });
 

--- a/src/main/libs/agentEngine/piExpertProductionPrompt.ts
+++ b/src/main/libs/agentEngine/piExpertProductionPrompt.ts
@@ -3,9 +3,9 @@ export const ExpertProductionWorkflowHeading = '## Expert workflow coordination'
 export const buildExpertProductionPrompt = (): string =>
   [
     ExpertProductionWorkflowHeading,
-    'The production workflow decision and, when started, its lifecycle are the sole outer progress controller for this turn.',
-    'Treat the expert workflow only as the domain method. A substantive request that needs the expert SOP, domain Skills, evidence, or a deliverable should start production and map the applicable expert phases into plan items.',
-    'A direct conversational or meta question that needs no tools or deliverable may skip production with a concrete reason.',
+    'When activated, the production workflow is the sole outer progress controller for this turn.',
+    'Treat the expert workflow only as the domain method. For a substantive request that needs the expert SOP, domain Skills, evidence, or a deliverable, activate production and map the applicable expert phases into plan items.',
+    'For direct conversation or a simple meta question, answer normally without calling production_loop.',
     'When production starts, use production_loop for plan state. Do not create or maintain a separate Markdown checklist, todo list, phase tracker, or completion protocol.',
     'The production workflow decides when to plan, inspect, critique, revise, skip, and deliver. Expert instructions must not override those gates.',
   ].join('\n');

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../shared/providers';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
-import { ProductionSkipSource } from '../../../shared/productionLoop';
+import { ProductionLoopAction } from '../../../shared/productionLoop';
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
@@ -438,7 +438,8 @@ describe('PiRuntimeAdapter', () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
-      adapter.setWorkbenchTaskService(new RealWorkbenchTaskService(db));
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
       const onPermissionRequest = vi.fn();
       const onComplete = vi.fn();
       adapter.on('permissionRequest', onPermissionRequest);
@@ -456,8 +457,11 @@ describe('PiRuntimeAdapter', () => {
         );
 
         expect(mockSession.prompt).toHaveBeenCalledWith(
-          expect.stringContaining('## Production workflow decision'),
+          expect.not.stringContaining('## Production workflow decision'),
         );
+        expect(
+          db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
+        ).toEqual({ count: 0 });
 
         const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
           customTools: Array<{
@@ -470,9 +474,24 @@ describe('PiRuntimeAdapter', () => {
         };
         const toolNames = sessionOptions.customTools.map(tool => tool.name);
         const loopTool = sessionOptions.customTools.find(tool => tool.name === 'agent_loop');
+        const productionTool = sessionOptions.customTools.find(
+          tool => tool.name === 'production_loop',
+        );
         expect(toolNames).toContain('production_loop');
         expect(toolNames).toContain('run_skill_script');
         expect(toolNames).not.toContain('work_acceptance');
+
+        await productionTool!.execute('start-production', {
+          action: ProductionLoopAction.CommitPlan,
+          items: [{ title: 'Analyze and report' }],
+          constraints: [],
+          acceptanceCriteria: ['Report findings are verified'],
+          expectedArtifacts: [{ kind: 'report', description: 'Review report' }],
+          expectedVerifiers: [{ name: 'report_check', deterministic: true }],
+        });
+        const runId = service.getCurrent('generic-work-skill')?.runs[0]?.id;
+        expect(runId).toBeDefined();
+        expect(service.productionLoop.getState(runId!).planItems).toHaveLength(1);
 
         const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
           type: string;
@@ -484,7 +503,7 @@ describe('PiRuntimeAdapter', () => {
         listener({ type: 'agent_end' });
         await Promise.resolve();
         expect(mockSession.prompt).toHaveBeenLastCalledWith(
-          expect.stringContaining('Production workflow decision required'),
+          expect.stringContaining('Production workflow continuation'),
           { streamingBehavior: 'followUp' },
         );
         expect(onPermissionRequest).not.toHaveBeenCalled();
@@ -493,7 +512,7 @@ describe('PiRuntimeAdapter', () => {
         db.close();
       }
     });
-    it('offers a lazy production decision for every Work turn', async () => {
+    it('keeps production controls available but dormant for ordinary Work turns', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
@@ -537,22 +556,29 @@ describe('PiRuntimeAdapter', () => {
         expect(chatOptions.customTools?.map(tool => tool.name) || []).not.toContain(
           'production_loop',
         );
+        expect(mockSession.prompt.mock.calls[0]?.[0]).not.toContain(
+          '## Production workflow decision',
+        );
+        expect(mockSession.prompt.mock.calls[1]?.[0]).not.toContain(
+          '## Production workflow decision',
+        );
         expect(
           db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
         ).toEqual({ count: 0 });
         expect(
-          service.getCurrent('production-work')?.task.contract.metadata?.productionWorkflowEnabled,
+          service.getCurrent('production-work')?.task.contract.metadata
+            ?.productionControlsAvailable,
         ).toBe(true);
         expect(
           service.getCurrent('production-simple')?.task.contract.metadata
-            ?.productionWorkflowEnabled,
+            ?.productionControlsAvailable,
         ).toBe(true);
       } finally {
         db.close();
       }
     });
 
-    it('lets the model coordinate or skip expert methods through the outer decision', async () => {
+    it('lets the model activate expert production only for substantive requests', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
@@ -580,10 +606,10 @@ describe('PiRuntimeAdapter', () => {
         expect(productionPrompt).toContain(ExpertProductionWorkflowHeading);
         expect(productionPrompt).toContain('expert workflow only as the domain method');
         expect(directPrompt).toContain(ExpertProductionWorkflowHeading);
-        expect(directPrompt).toContain('may skip production with a concrete reason');
+        expect(directPrompt).toContain('answer normally without calling production_loop');
         expect(directOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
         expect(
-          service.getCurrent('expert-direct')?.task.contract.metadata?.productionWorkflowEnabled,
+          service.getCurrent('expert-direct')?.task.contract.metadata?.productionControlsAvailable,
         ).toBe(true);
       } finally {
         db.close();
@@ -649,6 +675,26 @@ describe('PiRuntimeAdapter', () => {
           workspaceRoot,
         });
         const originalTask = service.getCurrent('resume-production')!.task;
+        const originalOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+          customTools: Array<{
+            name: string;
+            execute(
+              toolCallId: string,
+              params: Record<string, unknown>,
+            ): Promise<{ content: Array<{ text: string }> }>;
+          }>;
+        };
+        const productionTool = originalOptions.customTools.find(
+          tool => tool.name === 'production_loop',
+        );
+        await productionTool!.execute('start-production', {
+          action: ProductionLoopAction.CommitPlan,
+          items: [{ title: 'Create release report' }],
+          constraints: [],
+          acceptanceCriteria: ['Release report is verified'],
+          expectedArtifacts: [{ kind: 'report', description: 'Release report' }],
+          expectedVerifiers: [{ name: 'report_check', deterministic: true }],
+        });
         await adapter.stopSession('resume-production');
         const prepared = service.prepareRun(originalTask.id, WorkbenchRunTrigger.Resume);
 
@@ -656,8 +702,7 @@ describe('PiRuntimeAdapter', () => {
           sessionMode: 'work',
           workspaceRoot,
           _workbenchRunId: prepared.run.id,
-          _productionWorkflowEnabled:
-            originalTask.contract.metadata?.productionWorkflowEnabled === true,
+          _productionWorkflowRequired: true,
           _skipUserMessage: true,
         });
 
@@ -668,14 +713,54 @@ describe('PiRuntimeAdapter', () => {
         expect(service.getCurrent('resume-production')?.task.id).toBe(originalTask.id);
         expect(service.productionLoop.getState(prepared.run.id).goal).toBe(originalTask.goal);
         expect(mockSession.prompt).toHaveBeenLastCalledWith(
-          expect.stringContaining('Persistent phase: plan'),
+          expect.stringContaining('Persistent phase: execute'),
         );
       } finally {
         db.close();
       }
     });
 
-    it('reinjects the production protocol when a reused runtime starts a new task', async () => {
+    it('keeps production optional when resuming a task that never activated it', async () => {
+      const db = new Database(':memory:');
+      initializeWorkbenchTaskSchema(db);
+      initializeProductionLoopSchema(db);
+      const service = new RealWorkbenchTaskService(db);
+      adapter.setWorkbenchTaskService(service);
+      const workspaceRoot = createTemporaryWorkspace();
+
+      try {
+        await adapter.startSession('resume-dormant', '你好', {
+          sessionMode: 'work',
+          workspaceRoot,
+        });
+        const originalTask = service.getCurrent('resume-dormant')!.task;
+        await adapter.stopSession('resume-dormant');
+        const prepared = service.prepareRun(originalTask.id, WorkbenchRunTrigger.Resume);
+
+        await adapter.continueSession('resume-dormant', 'Please expand this into a report', {
+          sessionMode: 'work',
+          workspaceRoot,
+          _workbenchRunId: prepared.run.id,
+          _productionWorkflowRequired: false,
+          _skipUserMessage: true,
+        });
+
+        const resumedOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+          customTools?: Array<{ name: string }>;
+        };
+        expect(resumedOptions.customTools?.map(tool => tool.name)).toContain('production_loop');
+        expect(
+          db.prepare('SELECT COUNT(*) AS count FROM workbench_production_loops').get(),
+        ).toEqual({ count: 0 });
+        expect(mockSession.prompt).toHaveBeenLastCalledWith(
+          expect.not.stringContaining('## Production workflow decision'),
+        );
+      } finally {
+        db.close();
+      }
+    });
+
+    it('keeps production dormant when a reused runtime starts a new task', async () => {
       const db = new Database(':memory:');
       initializeWorkbenchTaskSchema(db);
       initializeProductionLoopSchema(db);
@@ -699,10 +784,7 @@ describe('PiRuntimeAdapter', () => {
 
         expect(mockCreateAgentSession).toHaveBeenCalledOnce();
         expect(mockSession.prompt).toHaveBeenLastCalledWith(
-          expect.stringContaining('## Production workflow'),
-        );
-        expect(mockSession.prompt).toHaveBeenLastCalledWith(
-          expect.stringContaining('## Production workflow decision'),
+          'Create and validate a second release report',
         );
       } finally {
         db.close();
@@ -759,12 +841,33 @@ describe('PiRuntimeAdapter', () => {
         const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
           type: string;
         }) => void;
+        const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+          customTools: Array<{
+            name: string;
+            execute(
+              toolCallId: string,
+              params: Record<string, unknown>,
+            ): Promise<{ content: Array<{ text: string }> }>;
+          }>;
+        };
+        const productionTool = sessionOptions.customTools.find(
+          tool => tool.name === 'production_loop',
+        );
+        await productionTool!.execute('start-production', {
+          action: ProductionLoopAction.CommitPlan,
+          items: [{ title: 'Create report' }],
+          constraints: [],
+          acceptanceCriteria: ['Report is verified'],
+          expectedArtifacts: [{ kind: 'report', description: 'Release report' }],
+          expectedVerifiers: [{ name: 'report_check', deterministic: true }],
+        });
 
         listener({ type: 'agent_end' });
         listener({ type: 'agent_end' });
         listener({ type: 'agent_end' });
+        listener({ type: 'agent_end' });
 
-        expect(mockSession.prompt).toHaveBeenCalledTimes(3);
+        expect(mockSession.prompt).toHaveBeenCalledTimes(4);
         expect(mockSession.abort).toHaveBeenCalledOnce();
         expect(service.getCurrent('stale-production')?.runs[0].status).toBe(
           WorkbenchRunStatus.Paused,
@@ -789,19 +892,26 @@ describe('PiRuntimeAdapter', () => {
         });
 
         const greetingPrompt = mockSession.prompt.mock.calls[0]?.[0] as string;
-        expect(greetingPrompt).toContain('Answer directly');
+        expect(greetingPrompt).toBe('你好');
         expect(greetingPrompt).not.toContain('## Production workflow decision');
         const greetingRunId = service.getCurrent('adaptive-gate')?.runs[0]?.id;
         expect(greetingRunId).toBeDefined();
-        expect(service.productionLoop.getState(greetingRunId!).skip?.source).toBe(
-          ProductionSkipSource.SystemPolicy,
-        );
-        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: {
-          type: string;
-        }) => void;
+        expect(service.productionLoop.repository.get(greetingRunId!)).toBeNull();
+        const listener = mockSession.subscribe.mock.calls[0]?.[0] as (event: unknown) => void;
+        listener({
+          type: 'message_end',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: '你好，有什么可以帮你？' }],
+            stopReason: 'stop',
+          },
+        });
         listener({ type: 'agent_end' });
         await Promise.resolve();
         expect(mockSession.prompt).toHaveBeenCalledOnce();
+        expect(service.getCurrent('adaptive-gate')?.runs[0].status).toBe(
+          WorkbenchRunStatus.Succeeded,
+        );
 
         await adapter.continueSession('adaptive-gate', '修复登录流程中的刷新问题', {
           sessionMode: 'work',
@@ -817,9 +927,9 @@ describe('PiRuntimeAdapter', () => {
         expect(mockCreateAgentSession).toHaveBeenCalledOnce();
         expect(mockSession.abort).not.toHaveBeenCalled();
         expect(mockSession.prompt).toHaveBeenCalledTimes(3);
-        expect(mockSession.prompt).toHaveBeenLastCalledWith(
-          expect.stringContaining('## Production workflow decision'),
-        );
+        for (const [sentPrompt] of mockSession.prompt.mock.calls) {
+          expect(sentPrompt).not.toContain('## Production workflow decision');
+        }
       } finally {
         db.close();
       }

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -85,10 +85,7 @@ import type {
 } from '../../workbenchTask/taskService';
 import { composeWorkbenchWorkflowSnapshot } from '../../workbenchTask/workflowSnapshot';
 import { ProductionLoopController } from '../../productionLoop/controller';
-import {
-  shouldAutoSkipDirectConversation,
-  shouldEnableProductionWorkflow,
-} from '../../productionLoop/entryPolicy';
+import { shouldExposeProductionControls } from '../../productionLoop/entryPolicy';
 import { buildProductionLoopTool } from '../../productionLoop/tool';
 import {
   type ApiConfigResolution,
@@ -284,7 +281,7 @@ interface ActivePiSession {
   shortcutWorkflow: PiShortcutWorkflowController | null;
   productionLoop: ProductionLoopController | null;
   /** Whether the current turn owns durable completion and production gates. */
-  productionWorkflowEnabled: boolean;
+  productionControlsAvailable: boolean;
   /** Whether this Work session was explicitly started in Goal mode. */
   goalMode: boolean;
   writeTokenLimitRecovery: PiWriteTokenLimitRecovery;
@@ -711,28 +708,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const shortcutKindForContract = isAcademicResearchSkillSet(resourceState.skillIds)
         ? null
         : resolveShortcutWorkflowKind(resourceState.skillIds);
-      const productionWorkflowEnabled = shouldEnableProductionWorkflow({
+      const productionControlsAvailable = shouldExposeProductionControls({
         sessionMode: options.sessionMode,
         prompt,
         goalMode: options.goalMode,
-        inheritedProductionWorkflow: options._productionWorkflowEnabled,
+        inheritedProductionRequired: options._productionWorkflowRequired,
       });
-      const autoSkipDirectConversation =
-        productionWorkflowEnabled &&
-        shouldAutoSkipDirectConversation({
-          sessionMode: options.sessionMode,
-          prompt,
-          goalMode: options.goalMode,
-          inheritedProductionWorkflow: options._productionWorkflowEnabled,
-          skillIds: resourceState.skillIds,
-          expertIds,
-          attachmentCount:
-            (options.imageAttachments?.length ?? 0) + (options.fileAttachments?.length ?? 0),
-        });
       const workbenchContract = this.createWorkbenchContract(
         options.sessionMode,
         resourceState.skillIds,
-        productionWorkflowEnabled,
+        productionControlsAvailable,
       );
       if (this.workbenchTaskService) {
         const workbench = this.workbenchTaskService.beginRun({
@@ -890,7 +875,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // It owns durable state and completion gates for the lifetime of this
       // session (and reloads the same state directory after a session restart).
       const researchRun =
-        productionWorkflowEnabled && isAcademicResearchSkillSet(resourceState.skillIds)
+        productionControlsAvailable && isAcademicResearchSkillSet(resourceState.skillIds)
           ? new PiResearchRunController({
               sessionId,
               workspaceRoot,
@@ -904,7 +889,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       }
       const shortcutKind = researchRun ? null : shortcutKindForContract;
       const shortcutWorkflow =
-        shortcutKind && productionWorkflowEnabled
+        shortcutKind && productionControlsAvailable
           ? new PiShortcutWorkflowController({
               sessionId,
               workspaceRoot,
@@ -962,7 +947,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workspaceRoot,
         webSearchSkillPath:
           researchRun ||
-          (productionWorkflowEnabled && shortcutKind === ShortcutWorkflowKind.DeepResearch)
+          (productionControlsAvailable && shortcutKind === ShortcutWorkflowKind.DeepResearch)
             ? path.join(getSkillsRoot(), 'web-search')
             : undefined,
         createPiResourceLoader: (
@@ -999,7 +984,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // loops; the controller continues the session on agent_end.
       const completionWorkflow = researchRun || shortcutWorkflow;
       const productionLoop =
-        productionWorkflowEnabled &&
+        productionControlsAvailable &&
         workbenchTaskId &&
         workbenchRunId &&
         this.workbenchTaskService?.productionLoop
@@ -1012,7 +997,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                 goal: workbenchTaskGoal,
                 prototypeRequired: workbenchContract.metadata?.requiresPrototype === true,
                 deferDecision:
-                  options.goalMode !== true && options._productionWorkflowEnabled === undefined,
+                  options.goalMode !== true && options._productionWorkflowRequired !== true,
                 skipAllowed: options.goalMode !== true,
                 // System-side risk probe: an approved approval whose risk was
                 // classified as irreversible OR unknown (e.g. mcp tools,
@@ -1032,11 +1017,6 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               completionWorkflow || undefined,
             )
           : null;
-      if (productionLoop && autoSkipDirectConversation) {
-        productionLoop.skipWorkflowBySystemPolicy(
-          'Direct conversational turn matched the system fast path.',
-        );
-      }
       if (productionLoop) customTools.push(buildProductionLoopTool(productionLoop));
       const shouldRunGoalLoop =
         options.goalMode === true && options.sessionMode === CoworkSessionMode.Work;
@@ -1116,7 +1096,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         researchRun,
         shortcutWorkflow,
         productionLoop,
-        productionWorkflowEnabled,
+        productionControlsAvailable,
         goalMode: options.goalMode === true,
         writeTokenLimitRecovery: new PiWriteTokenLimitRecovery(resolvedModel.maxOutputTokens),
         pendingError: null,
@@ -1252,26 +1232,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         ? CoworkSessionMode.Chat
         : CoworkSessionMode.Work);
     const nextGoalMode = options.goalMode ?? active.goalMode;
-    const productionWorkflowEnabled = shouldEnableProductionWorkflow({
+    const productionControlsAvailable = shouldExposeProductionControls({
       sessionMode: requestedSessionMode,
       prompt,
       goalMode: nextGoalMode,
-      inheritedProductionWorkflow: options._productionWorkflowEnabled,
+      inheritedProductionRequired: options._productionWorkflowRequired,
     });
-    const autoSkipDirectConversation =
-      productionWorkflowEnabled &&
-      shouldAutoSkipDirectConversation({
-        sessionMode: requestedSessionMode,
-        prompt,
-        goalMode: nextGoalMode,
-        inheritedProductionWorkflow: options._productionWorkflowEnabled,
-        skillIds: requestedSkillIds,
-        expertIds: requestedExpertIds,
-        attachmentCount:
-          (options.imageAttachments?.length ?? 0) + (options.fileAttachments?.length ?? 0),
-      });
     const productionWorkflowTopologyChanged =
-      productionWorkflowEnabled !== active.productionWorkflowEnabled;
+      productionControlsAvailable !== active.productionControlsAvailable;
     const mcpToolTopologyChanged =
       active.mcpToolManifestGeneration !== this.mcpToolManifestGeneration;
     if (
@@ -1349,7 +1317,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       const workbenchContract = this.createWorkbenchContract(
         requestedSessionMode,
         requestedSkillIds,
-        productionWorkflowEnabled,
+        productionControlsAvailable,
       );
       const workbench = this.workbenchTaskService.beginRun({
         sessionId,
@@ -1375,21 +1343,16 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workspaceRoot: active.workspaceRoot,
         skillIds: requestedSkillIds ?? [],
       });
-      if (productionWorkflowEnabled && workbench.task?.id) {
+      if (productionControlsAvailable && workbench.task?.id) {
         active.productionLoop?.startRun({
           taskId: workbench.task.id,
           runId: workbench.run.id,
           workflowKind: workbenchContract.kind,
           goal: workbench.task.goal,
           prototypeRequired: workbenchContract.metadata?.requiresPrototype === true,
-          deferDecision: nextGoalMode !== true && options._productionWorkflowEnabled === undefined,
+          deferDecision: nextGoalMode !== true && options._productionWorkflowRequired !== true,
           skipAllowed: nextGoalMode !== true,
         });
-        if (autoSkipDirectConversation) {
-          active.productionLoop?.skipWorkflowBySystemPolicy(
-            'Direct conversational turn matched the system fast path.',
-          );
-        }
       }
     }
 
@@ -1448,10 +1411,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
 
     let nextPrompt = prompt;
-    const domainCompletionWorkflow = active.productionWorkflowEnabled
+    const domainCompletionWorkflow = active.productionControlsAvailable
       ? active.researchRun || active.shortcutWorkflow
       : null;
-    const completionWorkflow = active.productionWorkflowEnabled
+    const completionWorkflow = active.productionControlsAvailable
       ? active.productionLoop || domainCompletionWorkflow
       : null;
     if (options.goalMode !== undefined && !completionWorkflow) {
@@ -1479,7 +1442,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         nextPrompt = `${loopPrompt}\n\n${nextPrompt}`;
       }
     }
-    if (active.productionLoop && productionWorkflowEnabled) {
+    if (active.productionLoop && productionControlsAvailable) {
       nextPrompt = prependProductionWorkflowPrompt(
         nextPrompt,
         active.productionLoop.buildInitialPrompt(),
@@ -2565,7 +2528,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               : null;
           const workflowSnapshot = composeWorkbenchWorkflowSnapshot({
             production:
-              active.productionWorkflowEnabled && active.productionLoop
+              active.productionControlsAvailable && active.productionLoop
                 ? active.productionLoop.getSnapshot()
                 : null,
             domain: domainWorkflowSnapshot,
@@ -2574,24 +2537,22 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           // outcome: a reviewer pass marks them Verified, a lightweight skip
           // leaves them Pending so user acceptance can elevate them
           // (markArtifactsVerified on accept).
-          const deliveryArtifacts = active.productionLoop
-            ?.getDeliveryArtifacts()
-            .map(artifact => ({
-              path: artifact.reference,
-              kind: artifact.kind,
-              role: artifact.kind,
-              source: WorkbenchArtifactCandidateSource.ProductionInspection,
-              verificationStatus: active.productionLoop?.getReviewOutcome().skipped
-                ? WorkbenchArtifactVerificationStatus.Pending
-                : WorkbenchArtifactVerificationStatus.Verified,
-            }));
+          const deliveryArtifacts = active.productionLoop?.getDeliveryArtifacts().map(artifact => ({
+            path: artifact.reference,
+            kind: artifact.kind,
+            role: artifact.kind,
+            source: WorkbenchArtifactCandidateSource.ProductionInspection,
+            verificationStatus: active.productionLoop?.getReviewOutcome().skipped
+              ? WorkbenchArtifactVerificationStatus.Pending
+              : WorkbenchArtifactVerificationStatus.Verified,
+          }));
           this.workbenchTaskService.completeRun({
             sessionId,
             runId: active.workbenchRunId,
             workspaceRoot: active.workspaceRoot,
             finalAnswer: active.lastCompletedAnswerText,
             finalMessageId: active.lastCompletedAnswerMessageId,
-            workflowCompleted: active.productionWorkflowEnabled
+            workflowCompleted: active.productionControlsAvailable
               ? active.agentLoop.getState().done
               : undefined,
             workflowSnapshot,
@@ -3317,27 +3278,29 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
   private createWorkbenchContract(
     sessionMode: PiStartOptions['sessionMode'],
     skillIds: string[] | undefined,
-    managedWorkflow = true,
+    productionControlsAvailable = true,
   ): WorkbenchTaskContract {
-    const research = managedWorkflow && isAcademicResearchSkillSet(skillIds);
+    const research = productionControlsAvailable && isAcademicResearchSkillSet(skillIds);
     const shortcut = research ? null : resolveShortcutWorkflowKind(skillIds);
     const kind =
       sessionMode === 'chat'
         ? WorkbenchContractKind.Chat
         : research
           ? WorkbenchContractKind.Research
-          : managedWorkflow && shortcut
+          : productionControlsAvailable && shortcut
             ? WorkbenchContractKind.Shortcut
             : WorkbenchContractKind.GenericWork;
     return {
       kind,
-      // Generic work without the production workflow (simple questions, trivial
-      // requests) is gated by the baseline checks alone and never needs manual
-      // acceptance. The production workflow owns the acceptance gate instead.
+      // Generic Work keeps production controls available. Verification uses
+      // the controller snapshot to distinguish a dormant direct answer from
+      // an activated production run; only the latter owns the acceptance gate.
       requiresUserAcceptance:
-        sessionMode !== 'chat' && kind === WorkbenchContractKind.GenericWork && managedWorkflow,
+        sessionMode !== 'chat' &&
+        kind === WorkbenchContractKind.GenericWork &&
+        productionControlsAvailable,
       metadata: {
-        productionWorkflowEnabled: managedWorkflow,
+        productionControlsAvailable,
         ...(skillIds?.length ? { skillIds } : {}),
       },
     };

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -84,8 +84,8 @@ export type PiStartOptions = {
   _piPromptOverride?: string;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
-  /** Internal: production workflow policy inherited from the owning task. */
-  _productionWorkflowEnabled?: boolean;
+  /** Internal: the owning task already has a controlled production workflow. */
+  _productionWorkflowRequired?: boolean;
 };
 
 export type PiContinueOptions = {
@@ -105,8 +105,8 @@ export type PiContinueOptions = {
   autoApprove?: boolean;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
-  /** Internal: production workflow policy inherited from the owning task. */
-  _productionWorkflowEnabled?: boolean;
+  /** Internal: the owning task already has a controlled production workflow. */
+  _productionWorkflowRequired?: boolean;
   /** Internal: do not persist a synthetic Resume/Retry prompt as a user message. */
   _skipUserMessage?: boolean;
   /** Internal: marks a queued follow-up in the persisted transcript. */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -158,6 +158,7 @@ import {
 import { registerTriageIpcHandlers } from './ipcHandlers/triage';
 import { registerWorkbenchTaskIpcHandlers } from './workbenchTask/ipc';
 import { WorkbenchTaskService } from './workbenchTask/taskService';
+import { shouldRequireProductionOnResume } from './productionLoop/entryPolicy';
 import { type PermissionResult, PiRuntimeAdapter } from './libs/agentEngine';
 import { PiModelCatalogRefreshCoordinator } from './libs/agentEngine/piModelCatalogRefresh';
 import { AppUpdateCoordinator } from './libs/appUpdateCoordinator';
@@ -6793,6 +6794,8 @@ if (!gotTheLock) {
         const amendment = resumeInput?.amendment?.trim() ?? '';
         const prompt =
           amendment || 'Continue the current task from its persisted state and verify the result.';
+        const previousProduction =
+          getWorkbenchTaskService().productionLoop.repository.getLatestForTask(task.id, run.id);
         await getPiRuntimeAdapter().continueSession(session.id, prompt, {
           systemPrompt: session.systemPrompt,
           skillIds: resumeInput?.skillIds ?? session.activeSkillIds,
@@ -6809,7 +6812,10 @@ if (!gotTheLock) {
           imageAttachments: resumeInput?.imageAttachments,
           fileAttachments: resumeInput?.fileAttachments,
           _workbenchRunId: run.id,
-          _productionWorkflowEnabled: task.contract.metadata?.productionWorkflowEnabled === true,
+          _productionWorkflowRequired: shouldRequireProductionOnResume(
+            task.contract.kind,
+            previousProduction,
+          ),
           _skipUserMessage: !amendment,
         });
       },

--- a/src/main/productionLoop/controller.test.ts
+++ b/src/main/productionLoop/controller.test.ts
@@ -1,11 +1,7 @@
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import {
-  ProductionLoopPhase,
-  ProductionLoopStatus,
-  ProductionSkipSource,
-} from '../../shared/productionLoop';
+import { ProductionLoopPhase, ProductionLoopStatus } from '../../shared/productionLoop';
 import {
   WorkbenchContractKind,
   WorkbenchRunTrigger,
@@ -271,7 +267,12 @@ test('elevated-risk probe consulted at critique time revokes lightweight mode', 
   for (const item of riskyPlanned.planItems) {
     riskyController.updatePlanItem(item.id, 'completed');
   }
-  riskyController.recordToolResult('preview-check', 'bash', 'Preview completed successfully.', false);
+  riskyController.recordToolResult(
+    'preview-check',
+    'bash',
+    'Preview completed successfully.',
+    false,
+  );
   const riskyEvidenceRef =
     riskyController.getAvailableVerifierEvidence()[0]?.evidenceRef ?? 'missing';
   riskyController.startInspection({
@@ -398,7 +399,7 @@ test('blocks premature finalization and returns a recovery prompt', () => {
   expect(controller.onAgentEnd({ next: false })).toMatchObject({ shouldFinish: false });
 });
 
-test('defers persistent state until the model records a start or skip decision', () => {
+test('keeps production dormant until the model starts a substantive workflow', () => {
   const workbench = new WorkbenchTaskRepository(db);
   const task = workbench.createTask('session', 'Answer or build', {
     kind: WorkbenchContractKind.GenericWork,
@@ -418,18 +419,16 @@ test('defers persistent state until the model records a start or skip decision',
     deferDecision: true,
   });
 
-  expect(controller.getModelState()).toMatchObject({ decision: 'undecided' });
+  expect(controller.getModelState()).toMatchObject({ productionActive: false });
   expect(service.repository.get(run.id)).toBeNull();
-  expect(controller.buildInitialPrompt()).toContain('Before any other tool call');
-  expect(controller.buildInitialPrompt()).toContain('Final user acceptance is Workbench-owned');
-  expect(controller.onAgentEnd({ next: false })).toMatchObject({ shouldFinish: false });
-  expect(service.repository.get(run.id)).toBeNull();
-
-  controller.skipWorkflow('Direct answer requiring no tools or deliverable');
-  expect(service.repository.get(run.id)).toMatchObject({
-    status: ProductionLoopStatus.Completed,
-    skip: { reason: 'Direct answer requiring no tools or deliverable' },
+  expect(controller.buildInitialPrompt()).toBe('');
+  expect(controller.requestCompletion('answered')).toContain('No production workflow is active');
+  expect(controller.onAgentEnd({ next: false })).toEqual({
+    shouldFinish: true,
+    reason: 'No production workflow was activated.',
   });
+  expect(service.repository.get(run.id)).toBeNull();
+  expect(controller.getSnapshot()).toMatchObject({ productionActive: false, skipped: false });
 });
 
 test('exposes record_prototype as the first action for deferred prototype workflows', () => {
@@ -453,11 +452,11 @@ test('exposes record_prototype as the first action for deferred prototype workfl
   });
 
   expect(controller.getModelState()).toMatchObject({
-    decision: 'undecided',
+    productionActive: false,
     prototypeRequired: true,
-    availableActions: ['record_prototype', 'skip_workflow'],
+    availableActions: ['record_prototype'],
   });
-  expect(controller.buildInitialPrompt()).toContain('start with production_loop record_prototype');
+  expect(controller.buildInitialPrompt()).toBe('');
 });
 
 test('starts deferred production state when the model commits a plan', () => {
@@ -764,28 +763,6 @@ test('skip_workflow lets the agent finish without the completion gate', () => {
   expect(controller.onAgentEnd({ next: false })).toEqual({
     shouldFinish: true,
     reason: 'Pure information request with no work to plan',
-  });
-  expect(downstream.onAgentEnd).not.toHaveBeenCalled();
-});
-
-test('system policy completes a direct turn before the model sees the decision gate', () => {
-  const { controller, downstream } = createController();
-
-  controller.skipWorkflowBySystemPolicy('Direct conversational turn');
-
-  expect(controller.getState()).toMatchObject({
-    status: ProductionLoopStatus.Completed,
-    skip: {
-      reason: 'Direct conversational turn',
-      source: ProductionSkipSource.SystemPolicy,
-    },
-  });
-  expect(controller.buildInitialPrompt()).toContain('Answer directly');
-  expect(controller.buildInitialPrompt()).not.toContain('Production workflow decision');
-  expect(controller.getSnapshot().skipSource).toBe(ProductionSkipSource.SystemPolicy);
-  expect(controller.onAgentEnd({ next: false })).toEqual({
-    shouldFinish: true,
-    reason: 'Direct conversational turn',
   });
   expect(downstream.onAgentEnd).not.toHaveBeenCalled();
 });

--- a/src/main/productionLoop/controller.ts
+++ b/src/main/productionLoop/controller.ts
@@ -1,21 +1,15 @@
 import {
+  ProductionLoopAction,
   ProductionLoopPhase,
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
-  ProductionSkipSource,
   type ProductionArtifactEvidence,
   type ProductionLoopState,
 } from '../../shared/productionLoop';
-import {
-  WorkbenchContractKind,
-  type WorkbenchJsonObject,
-} from '../../shared/workbenchTask';
+import { WorkbenchContractKind, type WorkbenchJsonObject } from '../../shared/workbenchTask';
 import type { PiAgentLoopEndSignal } from '../libs/agentEngine/piAgentLoop';
-import {
-  PiAgentLoopAction,
-  PiAgentLoopToolName,
-} from '../libs/agentEngine/piAgentLoop';
+import { PiAgentLoopAction, PiAgentLoopToolName } from '../libs/agentEngine/piAgentLoop';
 import {
   PiSubagentProfileId,
   PiSubagentTerminationReason,
@@ -130,7 +124,6 @@ const samePlan = (
 export class ProductionLoopController {
   private state: ProductionLoopState | null;
   private initial: ProductionLoopRunInput;
-  private decisionMissCount = 0;
 
   constructor(
     private readonly service: ProductionLoopService,
@@ -149,7 +142,7 @@ export class ProductionLoopController {
   getState(): ProductionLoopState {
     this.refreshIfStarted();
     if (!this.state) {
-      throw new Error('The production workflow decision is still pending.');
+      throw new Error('The production workflow is not active.');
     }
     return structuredClone(this.state);
   }
@@ -166,21 +159,19 @@ export class ProductionLoopController {
     this.refreshIfStarted();
     if (!this.state) {
       return {
-        decision: 'undecided',
+        productionActive: false,
         goal: this.initial.goal,
         prototypeRequired: this.initial.prototypeRequired,
-        skipAllowed: this.initial.skipAllowed !== false,
-        availableActions:
-          this.initial.skipAllowed === false
-            ? [this.initial.prototypeRequired ? 'record_prototype' : 'commit_plan']
-            : [
-                this.initial.prototypeRequired ? 'record_prototype' : 'commit_plan',
-                'skip_workflow',
-              ],
+        availableActions: [
+          this.initial.prototypeRequired
+            ? ProductionLoopAction.RecordPrototype
+            : ProductionLoopAction.CommitPlan,
+        ],
       };
     }
     const state = this.state;
     const view: Record<string, unknown> = {
+      productionActive: true,
       phase: state.phase,
       status: state.status,
       progressVersion: state.progressVersion,
@@ -220,7 +211,7 @@ export class ProductionLoopController {
 
   getStaleCount(): number {
     this.refreshIfStarted();
-    return this.state?.staleCount ?? this.decisionMissCount;
+    return this.state?.staleCount ?? 0;
   }
 
   getAvailableVerifierEvidence() {
@@ -231,16 +222,12 @@ export class ProductionLoopController {
   startRun(input: ProductionLoopRunInput): void {
     this.downstream?.resumeForPrompt?.(input.goal);
     this.initial = input;
-    this.decisionMissCount = 0;
     this.state = input.deferDecision ? null : this.service.beginRun(input);
   }
 
   buildInitialPrompt(): string {
     this.refreshIfStarted();
-    if (!this.state) return this.buildDecisionPrompt();
-    if (this.state.skip?.source === ProductionSkipSource.SystemPolicy) {
-      return 'Production control is already complete for this direct conversational turn. Answer directly without calling production_loop or agent_loop.';
-    }
+    if (!this.state) return '';
     const phaseInstruction = (() => {
       if (this.state.phase === ProductionLoopPhase.Explore) {
         return 'Begin by creating a concrete prototype or materially distinct direction, then record it with production_loop record_prototype.';
@@ -263,24 +250,6 @@ export class ProductionLoopController {
       'A reviewer PASS does not replace artifact verification or the completion contract.',
       'When findings exist, revise the work, record_revision, inspect again, and request another critique.',
       'Call agent_loop done only after the production loop reports ready_to_deliver.',
-      'Final user acceptance is Workbench-owned. Never use AskUserQuestion or another model-initiated question as a final acceptance gate.',
-    ].join('\n');
-  }
-
-  private buildDecisionPrompt(): string {
-    return [
-      '## Production workflow decision',
-      'Before any other tool call, decide whether this Work request needs the production workflow.',
-      'Start it when the request needs external evidence, a domain Skill, multiple steps, an artifact, modification, validation, review, or another substantive deliverable.',
-      this.initial.prototypeRequired
-        ? 'This workflow requires exploration: start with production_loop record_prototype, then commit_plan after selecting a direction.'
-        : 'Start the workflow with production_loop commit_plan.',
-      'An expert SOP is the domain method, not a reason to bypass production control. Map the applicable expert phases into the production plan.',
-      'Do not skip merely because the request is short. When uncertain, start the workflow.',
-      this.initial.skipAllowed === false
-        ? 'This run requires the production workflow. Commit the plan; skip_workflow is not allowed.'
-        : 'Only direct conversation or a simple answer requiring no tools or deliverable may call production_loop skip_workflow with a concrete reason, then answer directly.',
-      'Do not answer the user until this decision has been recorded.',
       'Final user acceptance is Workbench-owned. Never use AskUserQuestion or another model-initiated question as a final acceptance gate.',
     ].join('\n');
   }
@@ -313,7 +282,11 @@ export class ProductionLoopController {
     // item IDs the model already holds valid, without advancing
     // progressVersion, so the stale-progress detector still catches
     // models that spin on re-commits.
-    if (this.state && this.state.phase === ProductionLoopPhase.Execute && samePlan(this.state, input)) {
+    if (
+      this.state &&
+      this.state.phase === ProductionLoopPhase.Execute &&
+      samePlan(this.state, input)
+    ) {
       return this.getState();
     }
     const state = this.activate();
@@ -425,21 +398,10 @@ export class ProductionLoopController {
     return this.update(this.service.skipWorkflow(state.runId, reason));
   }
 
-  skipWorkflowBySystemPolicy(reason: string): ProductionLoopState {
-    if (this.initial.skipAllowed === false) {
-      throw new Error('This run requires the production workflow and cannot be skipped.');
-    }
-    const state = this.activate();
-    return this.update(
-      this.service.skipWorkflow(state.runId, reason, ProductionSkipSource.SystemPolicy),
-    );
-  }
-
   requestCompletion(reason: string): string {
     this.refreshIfStarted();
     if (!this.state) {
-      this.decisionMissCount += 1;
-      return 'Completion blocked: decide whether to commit_plan or skip_workflow before answering.';
+      return 'No production workflow is active. End the turn normally.';
     }
     if (this.state.skip) {
       return this.downstream
@@ -469,14 +431,9 @@ export class ProductionLoopController {
   } {
     this.refreshIfStarted();
     if (!this.state) {
-      this.decisionMissCount += 1;
       return {
-        shouldFinish: false,
-        nextPrompt: [
-          '## Production workflow decision required',
-          'The previous turn ended without choosing commit_plan or skip_workflow.',
-          this.buildDecisionPrompt(),
-        ].join('\n'),
+        shouldFinish: true,
+        reason: 'No production workflow was activated.',
       };
     }
     if (this.state.skip) {
@@ -579,7 +536,7 @@ export class ProductionLoopController {
     this.refreshIfStarted();
     if (!this.state) {
       return {
-        decision: 'undecided',
+        productionActive: false,
         skipped: false,
         planItems: [],
         inspections: 0,
@@ -589,8 +546,8 @@ export class ProductionLoopController {
     return {
       phase: this.state.phase,
       status: this.state.status,
+      productionActive: true,
       skipped: Boolean(this.state.skip),
-      skipSource: this.state.skip ? (this.state.skip.source ?? ProductionSkipSource.Model) : null,
       // Distinguishes "reviewer passed" from "reviewer skipped (lightweight)"
       // for the completion verification chain and audit UIs.
       criticSkipped: this.state.critic.skipped === true,
@@ -640,7 +597,6 @@ export class ProductionLoopController {
   private activate(): ProductionLoopState {
     if (!this.state) {
       this.state = this.service.beginRun(this.initial);
-      this.decisionMissCount = 0;
     } else {
       this.refreshIfStarted();
     }
@@ -650,7 +606,7 @@ export class ProductionLoopController {
   private requireState(): ProductionLoopState {
     this.refreshIfStarted();
     if (!this.state) {
-      throw new Error('Choose commit_plan or skip_workflow before using this production action.');
+      throw new Error('Start production with commit_plan or record_prototype before this action.');
     }
     return this.state;
   }

--- a/src/main/productionLoop/entryPolicy.test.ts
+++ b/src/main/productionLoop/entryPolicy.test.ts
@@ -1,23 +1,24 @@
 import { expect, test } from 'vitest';
 
 import { CoworkSessionMode } from '../../shared/cowork/constants';
-import { shouldAutoSkipDirectConversation, shouldEnableProductionWorkflow } from './entryPolicy';
+import { WorkbenchContractKind } from '../../shared/workbenchTask';
+import { shouldExposeProductionControls, shouldRequireProductionOnResume } from './entryPolicy';
 
 const workRequest = (prompt: string) => ({ sessionMode: CoworkSessionMode.Work, prompt });
 
-test('offers the model a production workflow decision for every new Work turn', () => {
-  expect(shouldEnableProductionWorkflow(workRequest('你好'))).toBe(true);
-  expect(shouldEnableProductionWorkflow(workRequest('为什么天空是蓝色的？'))).toBe(true);
-  expect(shouldEnableProductionWorkflow(workRequest('预测一下五粮液走向'))).toBe(true);
-  expect(shouldEnableProductionWorkflow(workRequest('Create and validate a release report'))).toBe(
+test('keeps production controls available for every new Work turn', () => {
+  expect(shouldExposeProductionControls(workRequest('你好'))).toBe(true);
+  expect(shouldExposeProductionControls(workRequest('为什么天空是蓝色的？'))).toBe(true);
+  expect(shouldExposeProductionControls(workRequest('预测一下五粮液走向'))).toBe(true);
+  expect(shouldExposeProductionControls(workRequest('Create and validate a release report'))).toBe(
     true,
   );
-  expect(shouldEnableProductionWorkflow({ prompt: 'Handle the request' })).toBe(true);
+  expect(shouldExposeProductionControls({ prompt: 'Handle the request' })).toBe(true);
 });
 
 test('keeps Chat mode outside the production workflow', () => {
   expect(
-    shouldEnableProductionWorkflow({
+    shouldExposeProductionControls({
       sessionMode: CoworkSessionMode.Chat,
       prompt: 'Create and validate a release report',
       goalMode: true,
@@ -25,19 +26,19 @@ test('keeps Chat mode outside the production workflow', () => {
   ).toBe(false);
 });
 
-test('uses the owning task policy for explicit resume and retry operations', () => {
+test('keeps controls available while carrying resume activation separately', () => {
   expect(
-    shouldEnableProductionWorkflow({
+    shouldExposeProductionControls({
       ...workRequest('Continue'),
-      inheritedProductionWorkflow: true,
+      inheritedProductionRequired: true,
     }),
   ).toBe(true);
   expect(
-    shouldEnableProductionWorkflow({
+    shouldExposeProductionControls({
       ...workRequest('Continue'),
-      inheritedProductionWorkflow: false,
+      inheritedProductionRequired: false,
     }),
-  ).toBe(false);
+  ).toBe(true);
 });
 
 test('does not classify natural-language intent or incidental resources', () => {
@@ -48,46 +49,26 @@ test('does not classify natural-language intent or incidental resources', () => 
     imageAttachmentCount: 1,
     resumeRun: true,
   };
-  expect(shouldEnableProductionWorkflow(incidentalContext)).toBe(true);
+  expect(shouldExposeProductionControls(incidentalContext)).toBe(true);
   expect(
-    shouldEnableProductionWorkflow({
+    shouldExposeProductionControls({
       ...incidentalContext,
       prompt: 'Read package.json',
     }),
   ).toBe(true);
 });
 
-test.each(['哈喽', '你好！', '您好', '谢谢', '收到', 'hello', 'got it'])(
-  'auto-skips an exact direct-conversation turn: %s',
-  prompt => {
-    expect(shouldAutoSkipDirectConversation(workRequest(prompt))).toBe(true);
-  },
-);
-
-test.each(['你好，删除这个文件', '谢谢，继续执行', '为什么天空是蓝色的？', '可以？'])(
-  'keeps ambiguous or substantive text in the model decision path: %s',
-  prompt => {
-    expect(shouldAutoSkipDirectConversation(workRequest(prompt))).toBe(false);
-  },
-);
-
-test('disables the direct-conversation fast path when runtime context may carry work', () => {
-  const greeting = workRequest('你好');
-  expect(
-    shouldAutoSkipDirectConversation({ ...greeting, sessionMode: CoworkSessionMode.Chat }),
-  ).toBe(false);
-  expect(shouldAutoSkipDirectConversation({ ...greeting, goalMode: true })).toBe(false);
-  expect(shouldAutoSkipDirectConversation({ ...greeting, inheritedProductionWorkflow: true })).toBe(
-    false,
+test('resumes only production that was previously activated or domain-controlled', () => {
+  expect(shouldRequireProductionOnResume(WorkbenchContractKind.GenericWork, null)).toBe(false);
+  expect(shouldRequireProductionOnResume(WorkbenchContractKind.GenericWork, { skip: null })).toBe(
+    true,
   );
   expect(
-    shouldAutoSkipDirectConversation({ ...greeting, inheritedProductionWorkflow: false }),
+    shouldRequireProductionOnResume(WorkbenchContractKind.GenericWork, {
+      skip: { reason: 'Direct answer', createdAt: 1 },
+    }),
   ).toBe(false);
-  expect(shouldAutoSkipDirectConversation({ ...greeting, skillIds: ['report'] })).toBe(false);
-  expect(shouldAutoSkipDirectConversation({ ...greeting, expertIds: ['reviewer'] })).toBe(false);
-  expect(shouldAutoSkipDirectConversation({ ...greeting, attachmentCount: 1 })).toBe(false);
-});
-
-test('treats an omitted session mode as Work, matching the production entry policy', () => {
-  expect(shouldAutoSkipDirectConversation({ prompt: 'Hello!' })).toBe(true);
+  expect(shouldRequireProductionOnResume(WorkbenchContractKind.Research, null)).toBe(true);
+  expect(shouldRequireProductionOnResume(WorkbenchContractKind.Shortcut, null)).toBe(true);
+  expect(shouldRequireProductionOnResume(WorkbenchContractKind.Chat, null)).toBe(false);
 });

--- a/src/main/productionLoop/entryPolicy.ts
+++ b/src/main/productionLoop/entryPolicy.ts
@@ -2,92 +2,37 @@ import {
   CoworkSessionMode,
   type CoworkSessionMode as CoworkSessionModeValue,
 } from '../../shared/cowork/constants';
+import type { ProductionLoopState } from '../../shared/productionLoop';
+import { WorkbenchContractKind } from '../../shared/workbenchTask';
 
 export interface ProductionWorkflowEntryInput {
   sessionMode?: CoworkSessionModeValue;
   prompt: string;
   goalMode?: boolean;
-  inheritedProductionWorkflow?: boolean;
+  inheritedProductionRequired?: boolean;
 }
-
-export interface DirectConversationFastPathInput extends ProductionWorkflowEntryInput {
-  skillIds?: readonly string[];
-  expertIds?: readonly string[];
-  attachmentCount?: number;
-}
-
-const DIRECT_CONVERSATION_PHRASES = new Set([
-  '你好',
-  '您好',
-  '哈喽',
-  '哈啰',
-  '嗨',
-  '早上好',
-  '上午好',
-  '中午好',
-  '下午好',
-  '晚上好',
-  '谢谢',
-  '多谢',
-  '感谢',
-  '好',
-  '好的',
-  '行',
-  '可以',
-  '收到',
-  '明白',
-  '明白了',
-  '知道了',
-  '了解',
-  '没问题',
-  '再见',
-  '拜拜',
-  '回见',
-  'hi',
-  'hello',
-  'hey',
-  'thanks',
-  'thank you',
-  'thx',
-  'ok',
-  'okay',
-  'got it',
-  'sounds good',
-  'bye',
-  'goodbye',
-  'see you',
-]);
-
-const normalizeDirectConversation = (prompt: string): string =>
-  prompt
-    .trim()
-    .replace(/\s+/g, ' ')
-    .replace(/[!.\s,~。！、，～]+$/u, '')
-    .toLowerCase();
 
 /**
- * Strict system-owned fast path for turns that cannot contain substantive
- * work. Full-string matching is intentional: prefixed instructions such as
- * "你好，删除这个文件" must continue through the model decision gate.
+ * This gate controls production tool topology, not per-turn activation. New
+ * Work turns keep the controls available in a dormant state; the model starts
+ * the workflow only when the request is substantive. Chat stays tool-free and
+ * resume activation is resolved separately from the owning task's state.
  */
-export const shouldAutoSkipDirectConversation = (
-  input: DirectConversationFastPathInput,
-): boolean => {
+export const shouldExposeProductionControls = (input: ProductionWorkflowEntryInput): boolean => {
   if (input.sessionMode === CoworkSessionMode.Chat) return false;
-  if (input.goalMode || input.inheritedProductionWorkflow !== undefined) return false;
-  if (input.skillIds?.length || input.expertIds?.length || input.attachmentCount) return false;
-  return DIRECT_CONVERSATION_PHRASES.has(normalizeDirectConversation(input.prompt));
+  return true;
 };
 
-/**
- * This gate only resolves deterministic runtime state and keeps the production
- * tool topology stable for Work sessions. The separate direct-conversation
- * fast path may persist a system-owned skip without disabling these tools.
- */
-export const shouldEnableProductionWorkflow = (input: ProductionWorkflowEntryInput): boolean => {
-  if (input.sessionMode === CoworkSessionMode.Chat) return false;
-  if (input.inheritedProductionWorkflow !== undefined) {
-    return input.inheritedProductionWorkflow;
+export const shouldRequireProductionOnResume = (
+  workflowKind: WorkbenchContractKind,
+  previousProduction: Pick<ProductionLoopState, 'skip'> | null,
+): boolean => {
+  if (
+    workflowKind === WorkbenchContractKind.Research ||
+    workflowKind === WorkbenchContractKind.Shortcut
+  ) {
+    return true;
   }
-  return true;
+  if (workflowKind !== WorkbenchContractKind.GenericWork) return false;
+  return Boolean(previousProduction && !previousProduction.skip);
 };

--- a/src/main/productionLoop/service.test.ts
+++ b/src/main/productionLoop/service.test.ts
@@ -6,7 +6,6 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
-  ProductionSkipSource,
 } from '../../shared/productionLoop';
 import {
   WorkbenchContractKind,
@@ -101,22 +100,6 @@ test('repeated skip_workflow stays a no-op without advancing progressVersion', (
   expect(second.progressVersion).toBe(first.progressVersion);
   expect(second.skip?.reason).toBe('Direct answer');
   expect(second.status).toBe(ProductionLoopStatus.Completed);
-});
-
-test('records whether the model or system policy skipped the workflow', () => {
-  const modelRun = begin().run;
-  expect(service.skipWorkflow(modelRun.id, 'Direct answer').skip?.source).toBe(
-    ProductionSkipSource.Model,
-  );
-
-  const systemRun = begin().run;
-  expect(
-    service.skipWorkflow(
-      systemRun.id,
-      'Direct conversational turn',
-      ProductionSkipSource.SystemPolicy,
-    ).skip?.source,
-  ).toBe(ProductionSkipSource.SystemPolicy);
 });
 
 test('skipCritique moves a critique-phase run to delivery without a reviewer', () => {

--- a/src/main/productionLoop/service.ts
+++ b/src/main/productionLoop/service.ts
@@ -8,7 +8,6 @@ import {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
-  ProductionSkipSource,
   type ProductionAvailableVerifierEvidence,
   type ProductionCriticFinding,
   type ProductionCriticExecution,
@@ -692,11 +691,7 @@ export class ProductionLoopService {
    * is marked completed so the agent may end the turn without a completion
    * gate; deterministic verification still applies on run completion.
    */
-  skipWorkflow(
-    runId: string,
-    reason: string,
-    source: ProductionSkipSource = ProductionSkipSource.Model,
-  ): ProductionLoopState {
+  skipWorkflow(runId: string, reason: string): ProductionLoopState {
     // allowAfterSkip: the internal skip guard below is the idempotency — a
     // repeated skip must stay a successful no-op (and not advance
     // progressVersion), not become an error behind the generic guard.
@@ -704,18 +699,21 @@ export class ProductionLoopService {
       runId,
       state => {
         if (state.skip) return;
-        if (state.phase !== ProductionLoopPhase.Explore && state.phase !== ProductionLoopPhase.Plan) {
+        if (
+          state.phase !== ProductionLoopPhase.Explore &&
+          state.phase !== ProductionLoopPhase.Plan
+        ) {
           throw new Error('The workflow can only be skipped before a plan is committed.');
         }
         const normalized = reason.trim();
         if (!normalized) throw new Error('A skip reason is required.');
-        state.skip = { reason: normalized, source, createdAt: Date.now() };
+        state.skip = { reason: normalized, createdAt: Date.now() };
         state.status = ProductionLoopStatus.Completed;
         state.progressVersion += 1;
         this.measurement.recordActivation(runId, {
           activation: HarnessActivationType.WorkflowSkipped,
           mechanism: 'production_loop',
-          evidence: { reason: normalized, source },
+          evidence: { reason: normalized },
         });
       },
       { allowAfterSkip: true },

--- a/src/main/productionLoop/tool.test.ts
+++ b/src/main/productionLoop/tool.test.ts
@@ -46,6 +46,15 @@ const createTool = () => {
   return { controller, tool };
 };
 
+test('describes production as opt-in for substantive Work', () => {
+  const { tool } = createTool();
+  const description = (tool as unknown as { description: string }).description;
+
+  expect(description).toContain('Optional control for substantive Work requests');
+  expect(description).toContain('Do not call this tool for direct conversation');
+  expect(description).toContain('Activate production work with');
+});
+
 test('publishes concrete nested schemas for model-generated plans', () => {
   const { tool } = createTool();
   const parameters = (

--- a/src/main/productionLoop/tool.ts
+++ b/src/main/productionLoop/tool.ts
@@ -84,7 +84,7 @@ export function buildProductionLoopTool(
     name: ProductionLoopToolName,
     label: 'Production Workflow',
     description:
-      'Decide and control the Work production workflow. Start substantive work with the first action named by get_state (record_prototype when exploration is required, otherwise commit_plan), or use skip_workflow only for a direct answer requiring no tools or deliverable. Active workflows must be inspected, independently reviewed, revised when needed, and delivered only after all gates pass.',
+      'Optional control for substantive Work requests. Do not call this tool for direct conversation or a simple answer; answer those normally. Activate production work with record_prototype when exploration is required, otherwise commit_plan. Once activated, the workflow must be inspected, independently reviewed when required, revised when needed, and delivered only after all gates pass.',
     parameters: {
       type: 'object',
       properties: {
@@ -165,7 +165,8 @@ export function buildProductionLoopTool(
         evidence: { type: 'object' },
         reason: {
           type: 'string',
-          description: 'Required for skip_workflow: why this task needs no production workflow.',
+          description:
+            'Required for skip_workflow. Direct answers do not need this action; end those turns normally.',
         },
         sinceVersion: {
           type: 'number',
@@ -258,10 +259,7 @@ export function buildProductionLoopTool(
             );
           case ProductionLoopAction.SkipWorkflow:
             const skipState = controller.skipWorkflow(String(params.reason || ''));
-            return step(
-              'Production workflow skipped for this task.',
-              skipState,
-            );
+            return step('Production workflow skipped for this task.', skipState);
           case ProductionLoopAction.GetState: {
             const view = stateForModel();
             const sinceVersion =

--- a/src/main/workbenchTask/verification.test.ts
+++ b/src/main/workbenchTask/verification.test.ts
@@ -88,6 +88,22 @@ test('generic work without user acceptance passes on baseline checks alone', () 
   expect(failed.outcome).toBe(WorkbenchVerificationOutcome.Failed);
 });
 
+test('dormant production controls do not force acceptance for a direct Work answer', () => {
+  const result = verifyWorkbenchRun({
+    contract: {
+      kind: WorkbenchContractKind.GenericWork,
+      requiresUserAcceptance: true,
+    },
+    finalAnswer: '你好，有什么可以帮你？',
+    streamClosedCleanly: true,
+    workflowCompleted: true,
+    workflowSnapshot: { productionActive: false, skipped: false },
+  });
+
+  expect(result.outcome).toBe(WorkbenchVerificationOutcome.Passed);
+  expect(result.checks.some(check => check.name === 'production_not_activated')).toBe(true);
+});
+
 test('a skipped production workflow passes without manual acceptance', () => {
   const result = verifyWorkbenchRun({
     contract: {

--- a/src/main/workbenchTask/verification.ts
+++ b/src/main/workbenchTask/verification.ts
@@ -88,6 +88,25 @@ export function verifyWorkbenchRun(
     };
   }
 
+  // Production controls are available to every Work turn, but a simple answer
+  // may finish without activating them. In that dormant state the baseline is
+  // the complete contract; activation changes this snapshot to true and makes
+  // the production controller enforce its full lifecycle before agent_end.
+  if (context.workflowSnapshot?.productionActive === false) {
+    return {
+      outcome: WorkbenchVerificationOutcome.Passed,
+      checks: [
+        {
+          name: 'production_not_activated',
+          status: WorkbenchVerificationCheckStatus.Passed,
+        },
+        ...baselineChecks,
+      ],
+      evidence: [context.workflowSnapshot],
+      summary: 'The response passed baseline checks without activating production control.',
+    };
+  }
+
   // The production workflow was declared unnecessary (skip_workflow): the
   // baseline checks already passed, so there is nothing left to accept.
   if (context.workflowSnapshot?.skipped === true) {

--- a/src/shared/productionLoop/constants.ts
+++ b/src/shared/productionLoop/constants.ts
@@ -64,12 +64,6 @@ export const ProductionLoopAction = {
 } as const;
 export type ProductionLoopAction = (typeof ProductionLoopAction)[keyof typeof ProductionLoopAction];
 
-export const ProductionSkipSource = {
-  Model: 'model',
-  SystemPolicy: 'system_policy',
-} as const;
-export type ProductionSkipSource = (typeof ProductionSkipSource)[keyof typeof ProductionSkipSource];
-
 export const ProductionLoopToolName = 'production_loop';
 
 /** Stop automatic continuation after repeated turns make no production progress. */

--- a/src/shared/productionLoop/types.ts
+++ b/src/shared/productionLoop/types.ts
@@ -5,7 +5,6 @@ import type {
   ProductionLoopRecoveryReason,
   ProductionLoopStatus,
   ProductionPlanItemStatus,
-  ProductionSkipSource,
 } from './constants';
 
 export interface ProductionPlanItem {
@@ -111,8 +110,6 @@ export interface ProductionRecovery {
 
 export interface ProductionSkip {
   reason: string;
-  /** Missing on production-loop records created before skip sources existed. */
-  source?: ProductionSkipSource;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary

- keep production controls available in Work sessions while leaving the workflow dormant by default
- let the model semantically activate production through `commit_plan` or `record_prototype`; direct conversation and simple answers finish normally without `skip_workflow`
- preserve the full planning, inspection, review, revision, delivery, and stale-loop gates after activation
- restore hard gating for Goal, Research, Shortcut, and previously activated production runs while keeping dormant Generic Work resumes optional

## Behavior

| Scenario | Production tools | Initial state | Completion behavior |
| --- | --- | --- | --- |
| New Generic Work | Available | Dormant | Normal `agent_end` unless the model activates production |
| Goal / Research / Shortcut | Available | Active | Existing production gates remain mandatory |
| Resume previously activated work | Available | Active | Durable production state and gates are restored |
| Resume dormant or skipped Generic Work | Available | Dormant | The model may activate production for a substantive amendment |
| Chat | Unavailable | None | Existing tool-free chat behavior |

## Implementation

- remove the direct-conversation phrase allowlist and system-policy auto-skip path introduced by #589
- remove mandatory production-decision and recovery prompts from ordinary Work turns
- expose dormant/active state explicitly through `productionActive`
- keep tool topology independent from production activation requirements on resume
- allow Workbench baseline verification to complete dormant direct-answer runs without user acceptance while retaining artifact acceptance rules

## Validation

- `npx vitest run src/main/productionLoop/entryPolicy.test.ts src/main/productionLoop/controller.test.ts src/main/productionLoop/service.test.ts src/main/productionLoop/tool.test.ts src/main/libs/agentEngine/piExpertProductionPrompt.test.ts src/main/libs/agentEngine/piRuntimeAdapter.test.ts src/main/workbenchTask/verification.test.ts src/main/workbenchTask/taskService.test.ts` - 205 tests passed
- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run lint`
- `git diff --check`
- full suite attempted: 2,404 passed, 1 skipped, and 12 unrelated environment/baseline failures involving missing Python/7-Zip/Get-FileHash, Windows release-path fixtures, and two existing source-text assertions
