### PR TITLE
feat(models): add external provider capability

### DIFF
--- a/docs/enterprise-extension.md
+++ b/docs/enterprise-extension.md
@@ -22,10 +22,16 @@ An extension that is present but invalid or incompatible fails closed and preven
 
 The private repository owns the extension bundle, enterprise tests, release manifest, signing inputs, and Electron Builder overlay. It must pin an exact Zhiyuan tag and commit. It must not copy files over `src/`, patch the public application during packaging, or depend on an unversioned branch.
 
-API v1 is deliberately limited to lifecycle and non-secret host context. Authentication IPC, managed model projection, Skill reconciliation, and control-event operations must be added as explicit versioned capabilities rather than importing renderer state or private application internals.
+API v1 is deliberately limited to lifecycle and explicit versioned capabilities. Skill reconciliation and control-event operations must be added as further capabilities rather than importing renderer state or private application internals.
 
 ### Session capability v1
 
 The API v1 context exposes an optional, independently versioned `capabilities.session` object. An enterprise extension may register one password-session provider and must unregister it during disposal. Community builds expose the same fixed renderer surface but return `UNAVAILABLE` when no provider is registered.
 
 The preload bridge permits only `snapshot`, `login`, `changePassword`, and `logout`. Main-process validation copies bounded input fields, normalizes identity snapshots, never returns tokens, and replaces provider exceptions with a generic error before crossing into the renderer. The bridge does not expose arbitrary extension methods or IPC channel names.
+
+### External model capability v1
+
+The optional `capabilities.models` object accepts providers whose IDs use the reserved `external.*` namespace. A provider supplies a bounded model list, resolves a connection for one selected model, and may signal that its list changed. API v1 supports only OpenAI-compatible endpoints. The host validates provider identity, unique model IDs, model metadata, HTTP(S) endpoints, and connection fields before they reach the renderer or runtime.
+
+The renderer receives model metadata only; base URLs and API keys remain in the main process. The runtime resolves a connection immediately before a model is first used and refreshes it on each following conversation turn. This makes short-lived credentials and authorization revocation effective without persisting secrets in the public application's configuration or database. A provider failure is isolated from other providers and logged without including the provider exception.

--- a/docs/enterprise-extension.zh-CN.md
+++ b/docs/enterprise-extension.zh-CN.md
@@ -22,10 +22,16 @@ Bundle 导出 `createZhiyuanEnterpriseExtension`。返回对象声明 `apiVersio
 
 私有仓库负责扩展 bundle、企业测试、发布清单、签名输入和 Electron Builder 覆盖配置，并必须锁定准确的 Zhiyuan tag 与 commit。企业构建不能覆盖 `src/` 文件、不能在打包时修改公开应用源码，也不能依赖未版本化分支。
 
-API v1 有意只开放生命周期和非敏感宿主上下文。认证 IPC、托管模型投影、Skill 收敛和管控事件操作必须作为明确的版本化能力逐步加入，不能直接导入 Renderer 状态或应用私有内部模块。
+API v1 有意只开放生命周期和明确版本化的能力。Skill 收敛和管控事件操作必须继续作为独立能力加入，不能直接导入 Renderer 状态或应用私有内部模块。
 
 ### 会话能力 v1
 
 API v1 上下文提供可选、独立版本化的 `capabilities.session` 对象。企业扩展可以注册一个密码会话 provider，并必须在退出时注销。社区构建保留相同的固定 Renderer 接口，但未注册 provider 时只返回 `UNAVAILABLE`。
 
 Preload 桥只允许 `snapshot`、`login`、`changePassword` 和 `logout`。主进程会复制并校验有长度边界的输入字段、规范化身份快照、禁止返回任何 token，并在进入 Renderer 前将 provider 异常替换为通用错误。该桥不开放任意扩展方法或任意 IPC channel 名称。
+
+### 外部模型能力 v1
+
+可选的 `capabilities.models` 对象允许扩展注册使用保留 `external.*` 命名空间的 provider。Provider 提供有数量边界的模型列表、按所选模型解析连接，并可通知宿主列表已变化。v1 只支持 OpenAI-compatible 端点。模型进入 Renderer 或运行时前，宿主会校验 provider 身份、模型 ID 唯一性、模型元数据、HTTP(S) 端点和连接字段。
+
+Renderer 只能取得模型元数据，base URL 和 API key 始终留在主进程。运行时会在模型首次使用前解析连接，并在后续每个对话回合刷新连接，使短期凭证轮换和授权撤销及时生效，同时不把秘密写入公开应用的配置或数据库。单个 provider 失败不会影响其他 provider，日志也不会包含 provider 抛出的异常内容。

--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -3,11 +3,13 @@ import type {
   EnterprisePasswordLoginInput,
   EnterpriseSessionSnapshot,
 } from '../../shared/enterpriseSession';
+import type { ExternalModelConnection, ExternalModelDescriptor } from '../../shared/externalModels';
 
 export const ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION = 1 as const;
+export const EXTERNAL_MODEL_CAPABILITY_API_VERSION = 1 as const;
 
 export interface ZhiyuanEnterpriseSessionProvider {
   snapshot(): EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>;
@@ -39,6 +41,19 @@ export interface ZhiyuanEnterpriseSettingsHostCapability {
   registerPage(page: ZhiyuanEnterpriseSettingsPageRegistration): () => void;
 }
 
+export interface ExternalModelProvider {
+  readonly id: string;
+  readonly displayName: string;
+  listModels(): Promise<readonly ExternalModelDescriptor[]>;
+  resolveConnection(modelId: string): Promise<ExternalModelConnection>;
+  onDidChange?(listener: () => void): () => void;
+}
+
+export interface ExternalModelHostCapability {
+  readonly apiVersion: typeof EXTERNAL_MODEL_CAPABILITY_API_VERSION;
+  registerProvider(provider: ExternalModelProvider): () => void;
+}
+
 export const ZhiyuanEnterpriseExtensionStatus = {
   Idle: 'idle',
   Absent: 'absent',
@@ -63,6 +78,7 @@ export interface ZhiyuanEnterpriseHostContext {
     readonly session: ZhiyuanEnterpriseSessionHostCapability | null;
     readonly renderer: ZhiyuanEnterpriseRendererHostCapability | null;
     readonly settings: ZhiyuanEnterpriseSettingsHostCapability | null;
+    readonly models: ExternalModelHostCapability | null;
   };
 }
 

--- a/src/main/enterpriseExtension/externalModelBridge.test.ts
+++ b/src/main/enterpriseExtension/externalModelBridge.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { ExternalModelProtocol } from '../../shared/externalModels';
+import { ModelCapabilityStatus } from '../../shared/providers';
+import type { ExternalModelProvider } from './contract';
+import { ExternalModelBridge } from './externalModelBridge';
+
+describe('ExternalModelBridge', () => {
+  test('registers, lists, resolves, and removes an external provider', async () => {
+    let notifyChanged: (() => void) | null = null;
+    const disposeChangeListener = vi.fn();
+    const changed = vi.fn();
+    const bridge = new ExternalModelBridge(vi.fn());
+    bridge.onDidChange(changed);
+    const provider = fixtureProvider({
+      onDidChange: listener => {
+        notifyChanged = listener;
+        return disposeChangeListener;
+      },
+    });
+
+    const unregister = bridge.registerProvider(provider);
+
+    await expect(bridge.listModels()).resolves.toEqual([
+      {
+        id: 'assigned-model',
+        displayName: 'Assigned Model',
+        protocol: ExternalModelProtocol.OpenAICompatible,
+        capabilities: { toolCalling: ModelCapabilityStatus.Supported },
+        contextWindow: 128_000,
+        isDefault: true,
+        provider: { id: 'external.fixture', displayName: 'Fixture Gateway' },
+      },
+    ]);
+    await expect(bridge.resolveModelRef('external.fixture/assigned-model')).resolves.toEqual({
+      id: 'assigned-model',
+      displayName: 'Assigned Model',
+      protocol: ExternalModelProtocol.OpenAICompatible,
+      capabilities: { toolCalling: ModelCapabilityStatus.Supported },
+      contextWindow: 128_000,
+      isDefault: true,
+      provider: { id: 'external.fixture', displayName: 'Fixture Gateway' },
+      connection: {
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'short-lived-token',
+        modelId: 'upstream-model',
+      },
+    });
+    expect(provider.resolveConnection).toHaveBeenCalledWith('assigned-model');
+
+    notifyChanged!();
+    expect(changed).toHaveBeenCalledTimes(2);
+    unregister();
+    unregister();
+    expect(disposeChangeListener).toHaveBeenCalledOnce();
+    expect(changed).toHaveBeenCalledTimes(3);
+    await expect(bridge.listModels()).resolves.toEqual([]);
+  });
+
+  test('isolates list failures and refuses malformed provider output', async () => {
+    const logError = vi.fn();
+    const bridge = new ExternalModelBridge(logError);
+    bridge.registerProvider(fixtureProvider({ id: 'external.valid' }));
+    bridge.registerProvider(
+      fixtureProvider({
+        id: 'external.broken',
+        listModels: vi.fn(async () => [
+          {
+            id: '../escape',
+            displayName: 'Invalid',
+            protocol: ExternalModelProtocol.OpenAICompatible,
+          },
+        ]),
+      }),
+    );
+
+    await expect(bridge.listModels()).resolves.toHaveLength(1);
+    expect(logError).toHaveBeenCalledOnce();
+    await expect(bridge.resolveModelRef('external.broken/escape')).rejects.toThrow(
+      'model ID is invalid',
+    );
+  });
+
+  test('validates provider identity, duplicate registration, and connections', async () => {
+    const bridge = new ExternalModelBridge(vi.fn());
+    expect(() => bridge.registerProvider(fixtureProvider({ id: 'openai' }))).toThrow(
+      'provider ID is invalid',
+    );
+    bridge.registerProvider(fixtureProvider());
+    expect(() => bridge.registerProvider(fixtureProvider())).toThrow('already registered');
+
+    const invalidConnectionBridge = new ExternalModelBridge(vi.fn());
+    invalidConnectionBridge.registerProvider(
+      fixtureProvider({
+        resolveConnection: vi.fn(async () => ({
+          baseUrl: 'file:///secret',
+          apiKey: 'token',
+          modelId: 'upstream-model',
+        })),
+      }),
+    );
+    await expect(
+      invalidConnectionBridge.resolveModelRef('external.fixture/assigned-model'),
+    ).rejects.toThrow('base URL is invalid');
+  });
+});
+
+function fixtureProvider(
+  overrides: Partial<ExternalModelProvider> = {},
+): ExternalModelProvider & { resolveConnection: ReturnType<typeof vi.fn> } {
+  return {
+    id: 'external.fixture',
+    displayName: 'Fixture Gateway',
+    listModels: vi.fn(async () => [
+      {
+        id: 'assigned-model',
+        displayName: 'Assigned Model',
+        protocol: ExternalModelProtocol.OpenAICompatible,
+        capabilities: { toolCalling: ModelCapabilityStatus.Supported },
+        contextWindow: 128_000,
+        isDefault: true,
+      },
+    ]),
+    resolveConnection: vi.fn(async () => ({
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'short-lived-token',
+      modelId: 'upstream-model',
+    })),
+    ...overrides,
+  } as ExternalModelProvider & { resolveConnection: ReturnType<typeof vi.fn> };
+}

--- a/src/main/enterpriseExtension/externalModelBridge.ts
+++ b/src/main/enterpriseExtension/externalModelBridge.ts
@@ -1,0 +1,259 @@
+import type { ModelCapabilities } from '../../shared/providers';
+import { ModelCapabilityStatus } from '../../shared/providers';
+import {
+  ExternalModelProtocol,
+  type ExternalModel,
+  type ExternalModelConnection,
+  type ExternalModelDescriptor,
+  type ResolvedExternalModel,
+} from '../../shared/externalModels';
+import {
+  EXTERNAL_MODEL_CAPABILITY_API_VERSION,
+  type ExternalModelHostCapability,
+  type ExternalModelProvider,
+} from './contract';
+
+const EXTERNAL_PROVIDER_ID_PATTERN = /^external\.[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$/;
+const MODEL_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$/;
+const MAX_DISPLAY_NAME_LENGTH = 128;
+const MAX_MODELS_PER_PROVIDER = 256;
+const MAX_API_KEY_LENGTH = 16_384;
+const HTTP_PROTOCOLS = new Set(['http:', 'https:']);
+const CAPABILITY_VALUES = new Set(Object.values(ModelCapabilityStatus));
+
+type ErrorLogger = (message: string) => void;
+
+interface RegisteredProvider {
+  readonly provider: ExternalModelProvider;
+  readonly disposeChangeListener: (() => void) | null;
+}
+
+export class ExternalModelBridge implements ExternalModelHostCapability {
+  readonly apiVersion = EXTERNAL_MODEL_CAPABILITY_API_VERSION;
+  readonly #providers = new Map<string, RegisteredProvider>();
+  readonly #listeners = new Set<() => void>();
+  readonly #logError: ErrorLogger;
+
+  constructor(
+    logError: ErrorLogger = message => {
+      console.error(message);
+    },
+  ) {
+    this.#logError = logError;
+  }
+
+  registerProvider(provider: ExternalModelProvider): () => void {
+    const normalized = normalizeProvider(provider);
+    if (this.#providers.has(normalized.id)) {
+      throw new Error(`External model provider ${normalized.id} is already registered.`);
+    }
+    let disposeChangeListener: (() => void) | null = null;
+    try {
+      disposeChangeListener = normalized.onDidChange?.(() => this.#emitChanged()) ?? null;
+    } catch {
+      throw new Error(`External model provider ${normalized.id} could not subscribe to changes.`);
+    }
+    this.#providers.set(normalized.id, { provider: normalized, disposeChangeListener });
+    this.#emitChanged();
+    let registered = true;
+    return () => {
+      if (!registered) return;
+      registered = false;
+      const current = this.#providers.get(normalized.id);
+      if (current?.provider !== normalized) return;
+      try {
+        current.disposeChangeListener?.();
+      } catch {
+        this.#logError(`[ExternalModels] Could not release ${normalized.id} change listener.`);
+      }
+      this.#providers.delete(normalized.id);
+      this.#emitChanged();
+    };
+  }
+
+  onDidChange(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  async listModels(): Promise<readonly ExternalModel[]> {
+    const groups = await Promise.all(
+      [...this.#providers.values()].map(async ({ provider }) => {
+        try {
+          return await listProviderModels(provider);
+        } catch {
+          this.#logError(`[ExternalModels] Could not list models for ${provider.id}.`);
+          return [];
+        }
+      }),
+    );
+    return Object.freeze(groups.flat());
+  }
+
+  async resolveModelRef(modelRef: string): Promise<ResolvedExternalModel | null> {
+    const separator = modelRef.indexOf('/');
+    if (separator <= 0 || separator === modelRef.length - 1) return null;
+    const providerId = modelRef.slice(0, separator);
+    const modelId = modelRef.slice(separator + 1);
+    const registered = this.#providers.get(providerId);
+    if (!registered) return null;
+
+    const models = await listProviderModels(registered.provider);
+    const model = models.find(candidate => candidate.id === modelId);
+    if (!model) {
+      throw new Error(`External model ${providerId}/${modelId} is unavailable.`);
+    }
+    let connectionValue: ExternalModelConnection;
+    try {
+      connectionValue = await registered.provider.resolveConnection(modelId);
+    } catch {
+      throw new Error(`External model provider ${providerId} could not resolve a connection.`);
+    }
+    const connection = normalizeConnection(connectionValue);
+    return Object.freeze({ ...model, connection });
+  }
+
+  #emitChanged(): void {
+    for (const listener of this.#listeners) {
+      try {
+        listener();
+      } catch {
+        this.#logError('[ExternalModels] A model change listener failed.');
+      }
+    }
+  }
+}
+
+export const externalModelBridge = new ExternalModelBridge();
+
+function normalizeProvider(provider: ExternalModelProvider): ExternalModelProvider {
+  if (!provider || typeof provider !== 'object') {
+    throw new Error('External model provider is invalid.');
+  }
+  const id = normalizedString(provider.id, 64);
+  const displayName = normalizedString(provider.displayName, MAX_DISPLAY_NAME_LENGTH);
+  if (!id || !EXTERNAL_PROVIDER_ID_PATTERN.test(id)) {
+    throw new Error('External model provider ID is invalid.');
+  }
+  if (!displayName) throw new Error('External model provider display name is invalid.');
+  if (
+    typeof provider.listModels !== 'function' ||
+    typeof provider.resolveConnection !== 'function'
+  ) {
+    throw new Error('External model provider is incomplete.');
+  }
+  if (provider.onDidChange !== undefined && typeof provider.onDidChange !== 'function') {
+    throw new Error('External model provider change listener is invalid.');
+  }
+  return Object.freeze({
+    id,
+    displayName,
+    listModels: () => provider.listModels(),
+    resolveConnection: (modelId: string) => provider.resolveConnection(modelId),
+    ...(provider.onDidChange
+      ? { onDidChange: (listener: () => void) => provider.onDidChange!(listener) }
+      : {}),
+  });
+}
+
+async function listProviderModels(provider: ExternalModelProvider): Promise<ExternalModel[]> {
+  let value: readonly ExternalModelDescriptor[];
+  try {
+    value = await provider.listModels();
+  } catch {
+    throw new Error(`External model provider ${provider.id} could not list models.`);
+  }
+  if (!Array.isArray(value) || value.length > MAX_MODELS_PER_PROVIDER) {
+    throw new Error('External model provider returned an invalid model list.');
+  }
+  const ids = new Set<string>();
+  return value.map(candidate => {
+    const model = normalizeModel(candidate);
+    if (ids.has(model.id)) {
+      throw new Error(`External model provider returned duplicate model ID ${model.id}.`);
+    }
+    ids.add(model.id);
+    return Object.freeze({
+      ...model,
+      provider: Object.freeze({ id: provider.id, displayName: provider.displayName }),
+    });
+  });
+}
+
+function normalizeModel(value: ExternalModelDescriptor): ExternalModelDescriptor {
+  if (!value || typeof value !== 'object') throw new Error('External model is invalid.');
+  const id = normalizedString(value.id, 256);
+  const displayName = normalizedString(value.displayName, MAX_DISPLAY_NAME_LENGTH);
+  if (!id || !MODEL_ID_PATTERN.test(id)) throw new Error('External model ID is invalid.');
+  if (!displayName) throw new Error('External model display name is invalid.');
+  if (value.protocol !== ExternalModelProtocol.OpenAICompatible) {
+    throw new Error('External model protocol is not supported.');
+  }
+  const capabilities = normalizeCapabilities(value.capabilities);
+  const contextWindow = positiveInteger(value.contextWindow);
+  if (value.contextWindow !== undefined && !contextWindow) {
+    throw new Error('External model context window is invalid.');
+  }
+  if (value.isDefault !== undefined && typeof value.isDefault !== 'boolean') {
+    throw new Error('External model default flag is invalid.');
+  }
+  return Object.freeze({
+    id,
+    displayName,
+    protocol: ExternalModelProtocol.OpenAICompatible,
+    ...(capabilities ? { capabilities } : {}),
+    ...(contextWindow ? { contextWindow } : {}),
+    ...(value.isDefault === undefined ? {} : { isDefault: value.isDefault }),
+  });
+}
+
+function normalizeCapabilities(
+  value: Partial<ModelCapabilities> | undefined,
+): Partial<ModelCapabilities> | undefined {
+  if (value === undefined) return undefined;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('External model capabilities are invalid.');
+  }
+  const normalized: {
+    -readonly [Key in keyof ModelCapabilities]?: ModelCapabilities[Key];
+  } = {};
+  for (const key of Object.keys(value) as Array<keyof ModelCapabilities>) {
+    const status = value[key];
+    if (!CAPABILITY_VALUES.has(status as ModelCapabilityStatus)) {
+      throw new Error(`External model capability ${key} is invalid.`);
+    }
+    normalized[key] = status;
+  }
+  return Object.freeze(normalized);
+}
+
+function normalizeConnection(value: ExternalModelConnection): ExternalModelConnection {
+  if (!value || typeof value !== 'object') throw new Error('External model connection is invalid.');
+  const baseUrl = normalizedString(value.baseUrl, 2048);
+  const apiKey = typeof value.apiKey === 'string' ? value.apiKey.trim() : '';
+  const modelId = normalizedString(value.modelId, 256);
+  if (!baseUrl || !isHttpUrl(baseUrl)) throw new Error('External model base URL is invalid.');
+  if (!apiKey || apiKey.length > MAX_API_KEY_LENGTH) {
+    throw new Error('External model API key is invalid.');
+  }
+  if (!modelId) throw new Error('External runtime model ID is invalid.');
+  return Object.freeze({ baseUrl, apiKey, modelId });
+}
+
+function normalizedString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    return HTTP_PROTOCOLS.has(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -69,6 +69,7 @@ describe('Zhiyuan enterprise extension host', () => {
     expect(receivedContext!.capabilities.session).toBeNull();
     expect(receivedContext!.capabilities.renderer).toBeNull();
     expect(receivedContext!.capabilities.settings).toBeNull();
+    expect(receivedContext!.capabilities.models).toBeNull();
 
     await host.dispose();
     await host.dispose();
@@ -114,6 +115,28 @@ describe('Zhiyuan enterprise extension host', () => {
 
     expect(receivedContext!.capabilities.session).toBe(sessionCapability);
     expect(receivedContext!.capabilities.session?.apiVersion).toBe(1);
+  });
+
+  test('passes the versioned external model capability to the extension', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const modelCapability = { apiVersion: 1 as const, registerProvider: vi.fn() };
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+          receivedContext = context;
+        },
+      }),
+    }));
+
+    await host.initialize({ ...options(root, true), modelCapability });
+
+    expect(receivedContext!.capabilities.models).toBe(modelCapability);
+    expect(receivedContext!.capabilities.models?.apiVersion).toBe(1);
   });
 
   test('scopes the renderer capability to the loaded extension directory', async () => {

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -12,6 +12,7 @@ import {
   type ZhiyuanEnterpriseRendererHostCapability,
   type ZhiyuanEnterpriseSettingsHostCapability,
   type ZhiyuanEnterpriseSessionHostCapability,
+  type ExternalModelHostCapability,
 } from './contract';
 
 const ENTERPRISE_RESOURCE_DIRECTORY = 'zhiyuan-enterprise';
@@ -26,6 +27,7 @@ export interface ZhiyuanEnterpriseExtensionHostOptions {
   readonly userDataPath: string;
   readonly developmentExtensionPath?: string;
   readonly sessionCapability?: ZhiyuanEnterpriseSessionHostCapability;
+  readonly modelCapability?: ExternalModelHostCapability;
   readonly createRendererCapability?: (
     extensionDirectory: string,
   ) => ZhiyuanEnterpriseRendererHostCapability;
@@ -188,6 +190,7 @@ function createHostContext(
     session: options.sessionCapability ?? null,
     renderer: options.createRendererCapability?.(extensionDirectory) ?? null,
     settings: options.createSettingsCapability?.(extensionDirectory) ?? null,
+    models: options.modelCapability ?? null,
   });
   return Object.freeze({
     apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -19,6 +19,7 @@ import {
   ProviderModelPiApi,
   ProviderModelPiMaxTokensField,
 } from '../../../shared/providers';
+import { ExternalModelProtocol } from '../../../shared/externalModels';
 import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import { ProductionLoopAction } from '../../../shared/productionLoop';
@@ -29,6 +30,7 @@ import {
   WorkbenchTaskStatus,
 } from '../../../shared/workbenchTask';
 import { ExpertProductionWorkflowHeading } from './piExpertProductionPrompt';
+import { externalModelBridge } from '../../enterpriseExtension/externalModelBridge';
 
 const hoisted = vi.hoisted(() => {
   const mockSession = {
@@ -1045,6 +1047,68 @@ describe('PiRuntimeAdapter', () => {
       expect(mockCreateAgentSession).toHaveBeenCalledWith(
         expect.objectContaining({ modelRuntime: mockModelRuntime }),
       );
+    });
+
+    it('refreshes an external model connection for each conversation turn', async () => {
+      const resolveConnection = vi.fn(async () => ({
+        baseUrl: 'https://gateway.example/v1',
+        apiKey: 'short-lived-token',
+        modelId: 'upstream-model',
+      }));
+      const unregister = externalModelBridge.registerProvider({
+        id: 'external.fixture',
+        displayName: 'Fixture Gateway',
+        listModels: async () => [
+          {
+            id: 'assigned-model',
+            displayName: 'Assigned Model',
+            protocol: ExternalModelProtocol.OpenAICompatible,
+            capabilities: { toolCalling: ModelCapabilityStatus.Supported },
+            contextWindow: 128_000,
+          },
+        ],
+        resolveConnection,
+      });
+
+      try {
+        await adapter.startSession('external-model', 'Hello gateway', {
+          modelOverride: 'external.fixture/assigned-model',
+        });
+
+        expect(resolveConnection).toHaveBeenCalledWith('assigned-model');
+        expect(mockResolveRawApiConfigForModelRef).not.toHaveBeenCalled();
+        expect(mockModelRuntime.registerProvider).toHaveBeenCalledWith(
+          'external.fixture',
+          expect.objectContaining({
+            baseUrl: 'https://gateway.example/v1',
+            models: [
+              expect.objectContaining({
+                id: 'upstream-model',
+                name: 'Assigned Model',
+                provider: 'external.fixture',
+              }),
+            ],
+          }),
+        );
+        expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenCalledWith(
+          'external.fixture',
+          'short-lived-token',
+        );
+        resolveConnection.mockResolvedValueOnce({
+          baseUrl: 'https://gateway.example/v1',
+          apiKey: 'rotated-token',
+          modelId: 'upstream-model',
+        });
+        await adapter.continueSession('external-model', 'Continue');
+        expect(resolveConnection).toHaveBeenCalledTimes(2);
+        expect(mockModelRuntime.setRuntimeApiKey).toHaveBeenLastCalledWith(
+          'external.fixture',
+          'rotated-token',
+        );
+        expect(mockCreateAgentSession).toHaveBeenCalledOnce();
+      } finally {
+        unregister();
+      }
     });
 
     it('should keep supported remote models on the Pi built-in path', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -83,6 +83,7 @@ import type {
   WorkbenchApprovalRequestedEvent,
   WorkbenchTaskService,
 } from '../../workbenchTask/taskService';
+import { externalModelBridge } from '../../enterpriseExtension/externalModelBridge';
 import { composeWorkbenchWorkflowSnapshot } from '../../workbenchTask/workflowSnapshot';
 import { ProductionLoopController } from '../../productionLoop/controller';
 import { shouldExposeProductionControls } from '../../productionLoop/entryPolicy';
@@ -238,6 +239,7 @@ interface ActivePiSession {
   model: Record<string, unknown>;
   modelRuntime: PiModelRuntime | null;
   modelRequestOptions?: { apiKey?: string };
+  externalModelRef?: string;
   capabilities: ModelCapabilities;
   harnessModelProfile: HarnessModelProfileInput;
   /** System prompt requested by the current Cowork session snapshot. */
@@ -375,6 +377,7 @@ type PiResolvedModel = {
   requestOptions?: {
     apiKey?: string;
   };
+  externalModelRef?: string;
 };
 
 function preparePiPrompt(
@@ -1054,6 +1057,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         model: resolvedModel.model,
         modelRuntime: resolvedModel.modelRuntime,
         modelRequestOptions: resolvedModel.requestOptions,
+        externalModelRef: resolvedModel.externalModelRef,
         capabilities: {
           toolCalling: ModelCapabilityStatus.Unknown,
           imageInput: ModelCapabilityStatus.Unknown,
@@ -1232,6 +1236,37 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         ? CoworkSessionMode.Chat
         : CoworkSessionMode.Work);
     const nextGoalMode = options.goalMode ?? active.goalMode;
+    if (active.externalModelRef) {
+      const refreshedModel = await externalModelBridge.resolveModelRef(active.externalModelRef);
+      if (!refreshedModel) {
+        throw new Error(`External model ${active.externalModelRef} is unavailable.`);
+      }
+      const connectionChanged =
+        active.model.provider !== refreshedModel.provider.id ||
+        active.model.id !== refreshedModel.connection.modelId ||
+        normalizePiBaseUrl(active.model.baseUrl) !==
+          normalizePiBaseUrl(refreshedModel.connection.baseUrl);
+      if (connectionChanged) {
+        const history = this.store?.getSession(sessionId)?.messages ?? [];
+        this.disposeSessionForRecreation(sessionId, active);
+        return this.startSession(sessionId, prompt, {
+          ...options,
+          sessionMode: requestedSessionMode,
+          systemPrompt: requestedSystemPrompt ?? active.requestedSystemPrompt,
+          skillIds: requestedSkillIds,
+          expertIds: requestedExpertIds,
+          workspaceRoot: options.workspaceRoot ?? active.workspaceRoot,
+          modelOverride: active.externalModelRef,
+          goalMode: nextGoalMode,
+          _piPromptOverride: buildPiConversationPrompt(history, prompt),
+        });
+      }
+      await active.modelRuntime?.setRuntimeApiKey(
+        refreshedModel.provider.id,
+        refreshedModel.connection.apiKey,
+      );
+      active.modelRequestOptions = { apiKey: refreshedModel.connection.apiKey };
+    }
     const productionControlsAvailable = shouldExposeProductionControls({
       sessionMode: requestedSessionMode,
       prompt,
@@ -3510,9 +3545,29 @@ async function resolvePiModel(
   existingModelRuntime?: PiModelRuntime | null,
 ): Promise<PiResolvedModel> {
   const normalizedModelRef = modelRef?.trim() || '';
-  const resolution = normalizedModelRef
-    ? resolveRawApiConfigForModelRef(normalizedModelRef)
-    : resolveRawApiConfig();
+  const externalModel = normalizedModelRef
+    ? await externalModelBridge.resolveModelRef(normalizedModelRef)
+    : null;
+  const resolution: ApiConfigResolution = externalModel
+    ? {
+        config: {
+          apiKey: externalModel.connection.apiKey,
+          baseURL: externalModel.connection.baseUrl,
+          model: externalModel.connection.modelId,
+          apiType: 'openai',
+        },
+        providerMetadata: {
+          providerName: externalModel.provider.id,
+          codingPlanEnabled: false,
+          supportsImage: externalModel.capabilities?.imageInput === ModelCapabilityStatus.Supported,
+          modelName: externalModel.displayName,
+          contextWindow: externalModel.contextWindow,
+          capabilities: externalModel.capabilities,
+        },
+      }
+    : normalizedModelRef
+      ? resolveRawApiConfigForModelRef(normalizedModelRef)
+      : resolveRawApiConfig();
 
   if (!resolution.config || !resolution.providerMetadata) {
     throw new Error(resolution.error || 'Pi model configuration is unavailable.');
@@ -3549,6 +3604,7 @@ async function resolvePiModel(
     providerName: resolution.providerMetadata.providerName,
     capabilities: resolution.endpoint?.capabilities ?? resolution.providerMetadata.capabilities,
     requestOptions: resolution.config.apiKey ? { apiKey: resolution.config.apiKey } : undefined,
+    externalModelRef: externalModel ? normalizedModelRef : undefined,
   };
 }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -68,6 +68,7 @@ import {
   CoworkQueueIpc,
   CoworkSessionIpc,
   CoworkStreamIpc,
+  ExternalModelIpc,
   HardwareIpc,
   ImIpc,
   McpIpc,
@@ -206,6 +207,7 @@ import {
   ZHIYUAN_ENTERPRISE_RENDERER_PROTOCOL_PRIVILEGES,
 } from './enterpriseExtension/rendererProtocol';
 import { zhiyuanEnterpriseSessionBridge } from './enterpriseExtension/sessionBridge';
+import { externalModelBridge } from './enterpriseExtension/externalModelBridge';
 import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
 import { serializeCcConnectSidecarConfig } from './libs/ccConnectSidecarConfig';
@@ -2481,6 +2483,12 @@ if (!gotTheLock) {
   ipcMain.handle(EnterpriseRendererIpc.SettingsPage, () =>
     zhiyuanEnterpriseRendererBridge.settingsPage(),
   );
+  ipcMain.handle(ExternalModelIpc.List, () => externalModelBridge.listModels());
+  externalModelBridge.onDidChange(() => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) window.webContents.send(ExternalModelIpc.Changed);
+    }
+  });
 
   ipcMain.handle('hardware:nvidia-smi', async () => getNvidiaSmiSnapshot());
   ipcMain.handle(HardwareIpc.SystemMemory, async () => getSystemMemorySnapshot());
@@ -6661,6 +6669,7 @@ if (!gotTheLock) {
       userDataPath: app.getPath('userData'),
       developmentExtensionPath: process.env.ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH,
       sessionCapability: zhiyuanEnterpriseSessionBridge,
+      modelCapability: externalModelBridge,
       createRendererCapability: extensionDirectory =>
         zhiyuanEnterpriseRendererBridge.createScopedCapability(extensionDirectory),
       createSettingsCapability: extensionDirectory =>

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -21,6 +21,7 @@ import {
   DialogIpc,
   DingTalkInstallIpc,
   EnterpriseIpc,
+  ExternalModelIpc,
   FeishuInstallIpc,
   GitHubCopilotIpc,
   HardwareIpc,
@@ -290,6 +291,14 @@ contextBridge.exposeInMainWorld('electron', {
         ipcRenderer.invoke(EnterpriseSessionIpc.ChangePassword, input),
       logout: () => ipcRenderer.invoke(EnterpriseSessionIpc.Logout),
     },
+  },
+
+  externalModels: {
+    list: () =>
+      ipcRenderer.invoke(ExternalModelIpc.List) as Promise<
+        readonly import('../shared/externalModels').ExternalModel[]
+      >,
+    onChanged: (callback: () => void) => onPushVoid(ExternalModelIpc.Changed, callback),
   },
 
   api: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -285,6 +285,9 @@ const App: React.FC = () => {
     const handleLlamaCppRunningModelsChanged = () => {
       void refreshAvailableModels().catch(() => undefined);
     };
+    const unsubscribeExternalModels = window.electron.externalModels?.onChanged(
+      handleLlamaCppRunningModelsChanged,
+    );
 
     window.addEventListener('config-updated', handleConfigUpdated);
     window.addEventListener(
@@ -297,6 +300,7 @@ const App: React.FC = () => {
         LLAMACPP_RUNNING_MODELS_CHANGED_EVENT,
         handleLlamaCppRunningModelsChanged,
       );
+      unsubscribeExternalModels?.();
     };
   }, [dispatch, isInitialized]);
 

--- a/src/renderer/services/availableModels.test.ts
+++ b/src/renderer/services/availableModels.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { ModelCapabilityStatus, ProviderName } from '../../shared/providers';
+import { ExternalModelProtocol } from '../../shared/externalModels';
 import type { AppConfig } from '../config';
 import { defaultConfig } from '../config';
 import { buildConfiguredAvailableModels, collectAvailableModels } from './availableModels';
@@ -48,6 +49,7 @@ test('collectAvailableModels exposes running llama.cpp models when provider is d
       llamacpp: {
         listRunningModels,
       },
+      externalModels: { list: vi.fn(async () => []) },
     },
   });
 
@@ -69,6 +71,7 @@ test('does not expose the legacy default model when no provider is configured', 
   vi.stubGlobal('window', {
     electron: {
       llamacpp: { listRunningModels: vi.fn(async () => []) },
+      externalModels: { list: vi.fn(async () => []) },
     },
   });
 
@@ -89,6 +92,7 @@ test('collectAvailableModels merges running llama.cpp model metadata', async () 
       llamacpp: {
         listRunningModels,
       },
+      externalModels: { list: vi.fn(async () => []) },
     },
   });
   const config = createConfig();
@@ -113,6 +117,48 @@ test('collectAvailableModels merges running llama.cpp model metadata', async () 
     trainedContextWindow: 32768,
   });
   expect(llamaCppModel?.supportsThinkingToggle).toBe(true);
+});
+
+test('collectAvailableModels merges external models without persisting connections', async () => {
+  vi.stubGlobal('window', {
+    electron: {
+      llamacpp: { listRunningModels: vi.fn(async () => []) },
+      externalModels: {
+        list: vi.fn(async () => [
+          {
+            id: 'assigned-model',
+            displayName: 'Assigned Model',
+            protocol: ExternalModelProtocol.OpenAICompatible,
+            provider: { id: 'external.fixture', displayName: 'Fixture Gateway' },
+            capabilities: {
+              imageInput: ModelCapabilityStatus.Supported,
+              toolCalling: ModelCapabilityStatus.Supported,
+            },
+            contextWindow: 128_000,
+          },
+        ]),
+      },
+    },
+  });
+
+  const models = await collectAvailableModels(createConfig());
+  const external = models.find(model => model.providerKey === 'external.fixture');
+
+  expect(external).toEqual({
+    id: 'assigned-model',
+    name: 'Assigned Model',
+    provider: 'Fixture Gateway',
+    providerKey: 'external.fixture',
+    agentProviderId: 'external.fixture',
+    supportsImage: true,
+    capabilities: {
+      imageInput: ModelCapabilityStatus.Supported,
+      toolCalling: ModelCapabilityStatus.Supported,
+    },
+    contextWindow: 128_000,
+  });
+  expect(external).not.toHaveProperty('apiKey');
+  expect(external).not.toHaveProperty('baseUrl');
 });
 
 test('preserves contextTokens for custom cloud models', () => {

--- a/src/renderer/services/availableModels.ts
+++ b/src/renderer/services/availableModels.ts
@@ -1,6 +1,8 @@
 import type { LlamaCppModelPreferences, LlamaCppRunningModel } from '../../shared/llamacpp';
+import type { ExternalModel } from '../../shared/externalModels';
 import {
   isProviderEnabled,
+  ModelCapabilityStatus,
   ProviderName,
   ProviderRegistry,
   resolveCodingPlanBaseUrl,
@@ -110,6 +112,21 @@ export function buildLlamaCppRunningModels(
   return models;
 }
 
+export function buildExternalAvailableModels(models: readonly ExternalModel[]): Model[] {
+  return [...models]
+    .sort((left, right) => Number(right.isDefault) - Number(left.isDefault))
+    .map(model => ({
+      id: model.id,
+      name: model.displayName,
+      provider: model.provider.displayName,
+      providerKey: model.provider.id,
+      agentProviderId: model.provider.id,
+      supportsImage: model.capabilities?.imageInput === ModelCapabilityStatus.Supported,
+      capabilities: model.capabilities,
+      contextWindow: model.contextWindow,
+    }));
+}
+
 export function mergeAvailableModels(
   configuredModels: Model[],
   llamaCppRunningModels: Model[],
@@ -127,9 +144,15 @@ export function mergeAvailableModels(
 
 export async function collectAvailableModels(config: AppConfig): Promise<Model[]> {
   const configuredModels = buildConfiguredAvailableModels(config);
+  const externalModelsPromise =
+    window.electron.externalModels?.list().catch((): readonly ExternalModel[] => []) ??
+    Promise.resolve([]);
 
   try {
-    const runningModels = await window.electron.llamacpp.listRunningModels();
+    const [runningModels, externalModels] = await Promise.all([
+      window.electron.llamacpp.listRunningModels(),
+      externalModelsPromise,
+    ]);
     let preferences: LlamaCppModelPreferences = {};
     try {
       preferences = (await window.electron.llamacpp.getModelPreferences?.()) ?? {};
@@ -137,11 +160,17 @@ export async function collectAvailableModels(config: AppConfig): Promise<Model[]
       // Model preferences are optional metadata; keep the running model list available.
     }
     return mergeAvailableModels(
-      configuredModels,
-      buildLlamaCppRunningModels(runningModels, preferences),
+      mergeAvailableModels(
+        configuredModels,
+        buildLlamaCppRunningModels(runningModels, preferences),
+      ),
+      buildExternalAvailableModels(externalModels),
     );
   } catch {
-    return configuredModels;
+    return mergeAvailableModels(
+      configuredModels,
+      buildExternalAvailableModels(await externalModelsPromise),
+    );
   }
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1218,6 +1218,10 @@ interface IElectronAPI {
       logout: () => Promise<EnterpriseSessionResult>;
     };
   };
+  externalModels: {
+    list: () => Promise<readonly import('../../shared/externalModels').ExternalModel[]>;
+    onChanged: (callback: () => void) => () => void;
+  };
   networkStatus: {
     send: (status: 'online' | 'offline') => void;
   };

--- a/src/shared/externalModels.ts
+++ b/src/shared/externalModels.ts
@@ -1,0 +1,35 @@
+import type { ModelCapabilities } from './providers';
+
+export const ExternalModelProtocol = {
+  OpenAICompatible: 'openai-compatible',
+} as const;
+export type ExternalModelProtocol =
+  (typeof ExternalModelProtocol)[keyof typeof ExternalModelProtocol];
+
+export interface ExternalModelDescriptor {
+  readonly id: string;
+  readonly displayName: string;
+  readonly protocol: ExternalModelProtocol;
+  readonly capabilities?: Partial<ModelCapabilities>;
+  readonly contextWindow?: number;
+  readonly isDefault?: boolean;
+}
+
+export interface ExternalModelProviderDescriptor {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+export interface ExternalModel extends ExternalModelDescriptor {
+  readonly provider: ExternalModelProviderDescriptor;
+}
+
+export interface ExternalModelConnection {
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly modelId: string;
+}
+
+export interface ResolvedExternalModel extends ExternalModel {
+  readonly connection: ExternalModelConnection;
+}

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -78,6 +78,13 @@ export const EnterpriseIpc = {
 } as const;
 export type EnterpriseIpc = (typeof EnterpriseIpc)[keyof typeof EnterpriseIpc];
 
+// ─── External Models ───────────────────────────────────────────────────────
+export const ExternalModelIpc = {
+  List: 'external-models:list',
+  Changed: 'external-models:changed',
+} as const;
+export type ExternalModelIpc = (typeof ExternalModelIpc)[keyof typeof ExternalModelIpc];
+
 // ─── API (HTTP proxy) ───────────────────────────────────────────────────────
 export const ApiIpc = {
   Fetch: 'api:fetch',


### PR DESCRIPTION
## Summary
- add a validated, versioned external model provider capability to the extension host
- project dynamic model metadata into the renderer without exposing connection secrets
- resolve and rotate short-lived runtime credentials per conversation turn
- document the public boundary in English and Chinese

## Verification
- renderer TypeScript compile
- Electron TypeScript compile
- 21 focused bridge, host, and model list tests
- external model Pi runtime test
- focused oxlint