### PR TITLE
feat(enterprise): expose read-only model catalog to settings

### DIFF
--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
@@ -15,6 +15,7 @@ import { EnterpriseSessionEvent } from '../../services/enterpriseSessionEvents';
 import { EnterpriseRendererFrame } from './EnterpriseRendererFrame';
 
 const snapshot = vi.fn<() => Promise<EnterpriseSessionResult>>();
+const listModels = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -29,6 +30,7 @@ beforeEach(() => {
           logout: vi.fn(),
         },
       },
+      externalModels: { list: listModels },
     },
   });
 });
@@ -147,6 +149,93 @@ describe('EnterpriseRendererFrame', () => {
     );
     expect(sessionChanged).not.toHaveBeenCalled();
     window.removeEventListener(EnterpriseSessionEvent.Changed, sessionChanged);
+  });
+
+  test('projects only model metadata into the enterprise settings frame', async () => {
+    listModels.mockResolvedValue([
+      {
+        id: 'model-1',
+        displayName: 'Managed model',
+        protocol: 'openai-compatible',
+        provider: { id: 'external.zhiyuan', displayName: 'Zhiyuan' },
+        contextWindow: 128_000,
+      },
+    ]);
+    render(
+      <EnterpriseRendererFrame
+        src="zhiyuan-enterprise-ui://renderer/settings/settings.html"
+        title="Enterprise account"
+        surface={EnterpriseRendererSurface.Settings}
+        session={signedOut()}
+      />,
+    );
+
+    const frame = screen.getByTitle('Enterprise account') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          source: EnterpriseRendererMessageSource.Module,
+          apiVersion: 1,
+          type: EnterpriseRendererMessageType.ModelCatalogRequest,
+          requestId: 'models-1',
+        },
+      }),
+    );
+
+    await waitFor(() => expect(listModels).toHaveBeenCalledTimes(1));
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: EnterpriseRendererMessageType.ModelCatalogResponse,
+        requestId: 'models-1',
+        result: {
+          ok: true,
+          models: [
+            expect.objectContaining({
+              id: 'model-1',
+              provider: { id: 'external.zhiyuan', displayName: 'Zhiyuan' },
+            }),
+          ],
+        },
+      }),
+      '*',
+    );
+    expect(JSON.stringify(postMessage.mock.calls)).not.toContain('apiKey');
+    expect(JSON.stringify(postMessage.mock.calls)).not.toContain('baseUrl');
+  });
+
+  test('denies model catalog requests from the session gate', async () => {
+    render(
+      <EnterpriseRendererFrame
+        src="zhiyuan-enterprise-ui://renderer/index.html"
+        title="Enterprise sign-in"
+        surface={EnterpriseRendererSurface.SessionGate}
+        session={signedOut()}
+      />,
+    );
+
+    const frame = screen.getByTitle('Enterprise sign-in') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          source: EnterpriseRendererMessageSource.Module,
+          apiVersion: 1,
+          type: EnterpriseRendererMessageType.ModelCatalogRequest,
+          requestId: 'models-denied',
+        },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: 'models-denied', result: { ok: false } }),
+        '*',
+      ),
+    );
+    expect(listModels).not.toHaveBeenCalled();
   });
 });
 

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
@@ -4,14 +4,19 @@ import { useEffect, useRef } from 'react';
 import {
   EnterpriseRendererMessageSource,
   EnterpriseRendererMessageType,
+  EnterpriseRendererSurface,
   type EnterpriseRendererInitializeMessage,
+  type EnterpriseRendererModelCatalogResponseMessage,
+  type EnterpriseRendererModelCatalogResult,
   type EnterpriseRendererSessionResponseMessage,
-  type EnterpriseRendererSurface,
+  type EnterpriseRendererSurface as EnterpriseRendererSurfaceValue,
 } from '../../../shared/enterpriseRenderer';
 import type { EnterpriseSessionResult } from '../../../shared/enterpriseSession';
 import {
+  executeEnterpriseModelCatalogRequest,
   executeEnterpriseSessionRequest,
   isEnterpriseRendererReadyMessage,
+  parseEnterpriseModelCatalogRequest,
   parseEnterpriseSessionRequest,
 } from '../../services/enterpriseRenderer';
 import { publishEnterpriseSessionResult } from '../../services/enterpriseSessionEvents';
@@ -19,7 +24,7 @@ import { publishEnterpriseSessionResult } from '../../services/enterpriseSession
 interface EnterpriseRendererFrameProps {
   readonly src: string;
   readonly title: string;
-  readonly surface: EnterpriseRendererSurface;
+  readonly surface: EnterpriseRendererSurfaceValue;
   readonly session: EnterpriseSessionResult;
   readonly className?: string;
 }
@@ -56,23 +61,45 @@ export function EnterpriseRendererFrame({
         return;
       }
       const request = parseEnterpriseSessionRequest(event.data);
-      if (!request) return;
+      if (request) {
+        void executeEnterpriseSessionRequest(request)
+          .catch((): EnterpriseSessionResult => operationFailed())
+          .then(result => {
+            const target = iframeRef.current?.contentWindow;
+            if (target) {
+              const response: EnterpriseRendererSessionResponseMessage = {
+                source: EnterpriseRendererMessageSource.Host,
+                apiVersion: 1,
+                type: EnterpriseRendererMessageType.SessionResponse,
+                requestId: request.requestId,
+                result,
+              };
+              target.postMessage(response, '*');
+            }
+            if (result.ok) publishEnterpriseSessionResult(result);
+          });
+        return;
+      }
 
-      void executeEnterpriseSessionRequest(request)
-        .catch((): EnterpriseSessionResult => operationFailed())
+      const modelCatalogRequest = parseEnterpriseModelCatalogRequest(event.data);
+      if (!modelCatalogRequest) return;
+      const catalog =
+        surface === EnterpriseRendererSurface.Settings
+          ? executeEnterpriseModelCatalogRequest()
+          : Promise.resolve<EnterpriseRendererModelCatalogResult>({ ok: false });
+      void catalog
+        .catch((): EnterpriseRendererModelCatalogResult => ({ ok: false }))
         .then(result => {
           const target = iframeRef.current?.contentWindow;
-          if (target) {
-            const response: EnterpriseRendererSessionResponseMessage = {
-              source: EnterpriseRendererMessageSource.Host,
-              apiVersion: 1,
-              type: EnterpriseRendererMessageType.SessionResponse,
-              requestId: request.requestId,
-              result,
-            };
-            target.postMessage(response, '*');
-          }
-          if (result.ok) publishEnterpriseSessionResult(result);
+          if (!target) return;
+          const response: EnterpriseRendererModelCatalogResponseMessage = {
+            source: EnterpriseRendererMessageSource.Host,
+            apiVersion: 1,
+            type: EnterpriseRendererMessageType.ModelCatalogResponse,
+            requestId: modelCatalogRequest.requestId,
+            result,
+          };
+          target.postMessage(response, '*');
         });
     };
 

--- a/src/renderer/services/enterpriseRenderer.ts
+++ b/src/renderer/services/enterpriseRenderer.ts
@@ -2,6 +2,8 @@ import {
   EnterpriseRendererMessageSource,
   EnterpriseRendererMessageType,
   EnterpriseRendererSessionOperation,
+  type EnterpriseRendererModelCatalogRequestMessage,
+  type EnterpriseRendererModelCatalogResult,
   type EnterpriseRendererReadyMessage,
   type EnterpriseRendererSessionRequestMessage,
 } from '../../shared/enterpriseRenderer';
@@ -52,6 +54,23 @@ export function parseEnterpriseSessionRequest(
   }
 }
 
+export function parseEnterpriseModelCatalogRequest(
+  value: unknown,
+): EnterpriseRendererModelCatalogRequestMessage | null {
+  const message = asRecord(value);
+  if (
+    message?.source !== EnterpriseRendererMessageSource.Module ||
+    message.apiVersion !== 1 ||
+    message.type !== EnterpriseRendererMessageType.ModelCatalogRequest ||
+    typeof message.requestId !== 'string' ||
+    message.requestId.length === 0 ||
+    message.requestId.length > MAX_REQUEST_ID_LENGTH
+  ) {
+    return null;
+  }
+  return message as unknown as EnterpriseRendererModelCatalogRequestMessage;
+}
+
 export function executeEnterpriseSessionRequest(
   request: EnterpriseRendererSessionRequestMessage,
 ): Promise<EnterpriseSessionResult> {
@@ -65,6 +84,12 @@ export function executeEnterpriseSessionRequest(
     case EnterpriseRendererSessionOperation.Logout:
       return window.electron.enterprise.session.logout();
   }
+}
+
+export async function executeEnterpriseModelCatalogRequest(): Promise<EnterpriseRendererModelCatalogResult> {
+  const externalModels = window.electron.externalModels;
+  if (!externalModels) return { ok: false };
+  return { ok: true, models: await externalModels.list() };
 }
 
 function isLoginInput(value: unknown): boolean {

--- a/src/shared/enterpriseRenderer.ts
+++ b/src/shared/enterpriseRenderer.ts
@@ -3,6 +3,7 @@ import type {
   EnterprisePasswordLoginInput,
   EnterpriseSessionResult,
 } from './enterpriseSession';
+import type { ExternalModel } from './externalModels';
 
 export const EnterpriseRendererIpc = {
   SessionGateEntrypoint: 'enterprise:renderer:session-gate-entrypoint',
@@ -35,6 +36,8 @@ export const EnterpriseRendererMessageType = {
   Initialize: 'initialize',
   SessionRequest: 'session-request',
   SessionResponse: 'session-response',
+  ModelCatalogRequest: 'model-catalog-request',
+  ModelCatalogResponse: 'model-catalog-response',
 } as const;
 
 export const EnterpriseRendererSessionOperation = {
@@ -104,4 +107,23 @@ export interface EnterpriseRendererSessionResponseMessage {
   readonly type: typeof EnterpriseRendererMessageType.SessionResponse;
   readonly requestId: string;
   readonly result: EnterpriseSessionResult;
+}
+
+export interface EnterpriseRendererModelCatalogRequestMessage {
+  readonly source: typeof EnterpriseRendererMessageSource.Module;
+  readonly apiVersion: 1;
+  readonly type: typeof EnterpriseRendererMessageType.ModelCatalogRequest;
+  readonly requestId: string;
+}
+
+export type EnterpriseRendererModelCatalogResult =
+  | { readonly ok: true; readonly models: readonly ExternalModel[] }
+  | { readonly ok: false };
+
+export interface EnterpriseRendererModelCatalogResponseMessage {
+  readonly source: typeof EnterpriseRendererMessageSource.Host;
+  readonly apiVersion: 1;
+  readonly type: typeof EnterpriseRendererMessageType.ModelCatalogResponse;
+  readonly requestId: string;
+  readonly result: EnterpriseRendererModelCatalogResult;
 }


### PR DESCRIPTION
Adds a backward-compatible host-to-enterprise-renderer model catalog request for the settings surface. The bridge reuses the normalized external model metadata projection, denies requests from the session gate, and never exposes connection URLs or credentials.

Validation:
- npm run build:tsc
- 18 related Vitest tests
- oxlint
- oxfmt check