### PR TITLE
fix(providers): image toggle takes effect despite unknown residue

### DIFF
--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -226,6 +226,26 @@ describe('ProviderRegistry', () => {
         },
       ).imageInput,
     ).toBe(ModelCapabilityStatus.Unsupported);
+    // Catalog declarations stay authoritative against a stale configured
+    // toggle: a non-vision catalog model must not be upgraded to
+    // Supported by an old supportsImage: true (deepseek-reasoner and
+    // qwen3-coder-plus are explicitly non-vision in the catalog).
+    expect(
+      ProviderRegistry.resolveModelCapabilities(
+        ProviderName.DeepSeek,
+        'deepseek-reasoner',
+        ApiFormat.OpenAI,
+        { supportsImage: true },
+      ).imageInput,
+    ).toBe(ModelCapabilityStatus.Unsupported);
+    expect(
+      ProviderRegistry.resolveModelCapabilities(
+        ProviderName.Qwen,
+        'qwen3-coder-plus',
+        ApiFormat.OpenAI,
+        { supportsImage: true },
+      ).imageInput,
+    ).toBe(ModelCapabilityStatus.Unsupported);
     // Providers without an endpoint tool declaration keep failing closed
     // (llamacpp/Ollama/custom rely on runtime probing instead).
     expect(

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -179,6 +179,50 @@ describe('ProviderRegistry', () => {
         },
       ).toolCalling,
     ).toBe(ModelCapabilityStatus.Supported);
+    // Same residue rule for imageInput: the image toggle (supportsImage)
+    // must take effect despite the configured unknown residue, so the
+    // renderer store resolves the model as vision-capable.
+    expect(
+      ProviderRegistry.resolveModelCapabilities(
+        ProviderName.DeepSeek,
+        'deepseek-v4-flash-vision-exp',
+        ApiFormat.OpenAI,
+        {
+          supportsImage: true,
+          capabilities: {
+            imageInput: ModelCapabilityStatus.Unknown,
+          },
+        },
+      ).imageInput,
+    ).toBe(ModelCapabilityStatus.Supported);
+    // Without the toggle, an unregistered model stays conservatively
+    // Unknown (no supportsImage signal to resolve against).
+    expect(
+      ProviderRegistry.resolveModelCapabilities(
+        ProviderName.DeepSeek,
+        'deepseek-v4-flash-vision-exp',
+        ApiFormat.OpenAI,
+        {
+          capabilities: {
+            imageInput: ModelCapabilityStatus.Unknown,
+          },
+        },
+      ).imageInput,
+    ).toBe(ModelCapabilityStatus.Unknown);
+    // An explicit configured unsupported imageInput still wins.
+    expect(
+      ProviderRegistry.resolveModelCapabilities(
+        ProviderName.DeepSeek,
+        'deepseek-v4-flash-vision-exp',
+        ApiFormat.OpenAI,
+        {
+          supportsImage: true,
+          capabilities: {
+            imageInput: ModelCapabilityStatus.Unsupported,
+          },
+        },
+      ).imageInput,
+    ).toBe(ModelCapabilityStatus.Unsupported);
     // Providers without an endpoint tool declaration keep failing closed
     // (llamacpp/Ollama/custom rely on runtime probing instead).
     expect(

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -195,14 +195,17 @@ describe('ProviderRegistry', () => {
         },
       ).imageInput,
     ).toBe(ModelCapabilityStatus.Supported);
-    // Without the toggle, an unregistered model stays conservatively
-    // Unknown (no supportsImage signal to resolve against).
+    // Without the toggle, the unstated imageInput stays conservatively
+    // Unknown. Settings always writes a supportsImage boolean (Unknown
+    // derives to false), so the real stored shape must not degrade an
+    // unstated capability into an explicit "unsupported".
     expect(
       ProviderRegistry.resolveModelCapabilities(
         ProviderName.DeepSeek,
         'deepseek-v4-flash-vision-exp',
         ApiFormat.OpenAI,
         {
+          supportsImage: false,
           capabilities: {
             imageInput: ModelCapabilityStatus.Unknown,
           },

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -1474,8 +1474,20 @@ class ProviderRegistryImpl {
       modelId,
       configured?.supportsImage,
     );
+    // Same residue rule as toolCalling: an explicit configured
+    // supported/unsupported is user intent and wins; "unknown" is the
+    // default residue of the capability form and must fall through to the
+    // supportsImage-based resolution so the image toggle actually takes
+    // effect.
     const declaredImageCapability =
-      providerModel?.capabilities?.imageInput ?? configuredCapabilities?.imageInput;
+      (providerModel?.capabilities?.imageInput === ModelCapabilityStatus.Supported ||
+      providerModel?.capabilities?.imageInput === ModelCapabilityStatus.Unsupported
+        ? providerModel?.capabilities?.imageInput
+        : undefined) ??
+      (configuredCapabilities?.imageInput === ModelCapabilityStatus.Supported ||
+      configuredCapabilities?.imageInput === ModelCapabilityStatus.Unsupported
+        ? configuredCapabilities?.imageInput
+        : undefined);
     const imageCapability =
       declaredImageCapability ??
       (isCatalogModel || configured?.supportsImage !== undefined

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -1493,12 +1493,16 @@ class ProviderRegistryImpl {
         : undefined);
     const imageCapability =
       declaredImageCapability ??
-      (configured?.supportsImage === true
-        ? ModelCapabilityStatus.Supported
-        : isCatalogModel
-          ? imageSupport
-            ? ModelCapabilityStatus.Supported
-            : ModelCapabilityStatus.Unsupported
+      (isCatalogModel
+        ? // Catalog declarations are authoritative even against a stale
+          // configured toggle (resolveModelSupportsImage repairs known
+          // provider metadata); only user-added models fall back to the
+          // positively checked toggle.
+          imageSupport
+          ? ModelCapabilityStatus.Supported
+          : ModelCapabilityStatus.Unsupported
+        : configured?.supportsImage === true
+          ? ModelCapabilityStatus.Supported
           : ModelCapabilityStatus.Unknown);
     return {
       ...UNKNOWN_MODEL_CAPABILITIES,

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -1476,9 +1476,12 @@ class ProviderRegistryImpl {
     );
     // Same residue rule as toolCalling: an explicit configured
     // supported/unsupported is user intent and wins; "unknown" is the
-    // default residue of the capability form and must fall through to the
-    // supportsImage-based resolution so the image toggle actually takes
-    // effect.
+    // default residue of the capability form and must fall through.
+    // Falling through lands on the toggle only when it is positively
+    // checked — Settings always writes a supportsImage boolean, so a
+    // derived false must not turn an unstated "unknown" into
+    // "unsupported" (it would lose the three-state capability selector's
+    // unknown state on reload).
     const declaredImageCapability =
       (providerModel?.capabilities?.imageInput === ModelCapabilityStatus.Supported ||
       providerModel?.capabilities?.imageInput === ModelCapabilityStatus.Unsupported
@@ -1490,11 +1493,13 @@ class ProviderRegistryImpl {
         : undefined);
     const imageCapability =
       declaredImageCapability ??
-      (isCatalogModel || configured?.supportsImage !== undefined
-        ? imageSupport
-          ? ModelCapabilityStatus.Supported
-          : ModelCapabilityStatus.Unsupported
-        : ModelCapabilityStatus.Unknown);
+      (configured?.supportsImage === true
+        ? ModelCapabilityStatus.Supported
+        : isCatalogModel
+          ? imageSupport
+            ? ModelCapabilityStatus.Supported
+            : ModelCapabilityStatus.Unsupported
+          : ModelCapabilityStatus.Unknown);
     return {
       ...UNKNOWN_MODEL_CAPABILITIES,
       ...catalogCapabilities,

--- a/src/shared/providers/modelEndpoint.test.ts
+++ b/src/shared/providers/modelEndpoint.test.ts
@@ -159,6 +159,32 @@ test('explicit unsupported user capability still wins in the endpoint layer', ()
   expect(endpoint.capabilities.toolCalling).toBe(ModelCapabilityStatus.Unsupported);
 });
 
+test('derived supportsImage false preserves an unstated image capability', () => {
+  // Settings always persists supportsImage (unstated -> false). The
+  // endpoint layer must not convert that derived false into an explicit
+  // Unsupported, or the three-state capability selector's unknown state
+  // is lost on reload.
+  const endpoint = resolveModelEndpoint(ProviderName.DeepSeek, 'deepseek-v4-flash-vision-exp', {
+    providerConfig: {
+      apiKey: 'key',
+      baseUrl: 'https://api.deepseek.com',
+      apiFormat: 'openai',
+      models: [
+        {
+          id: 'deepseek-v4-flash-vision-exp',
+          name: 'DeepSeek V4 Flash Vision Exp',
+          supportsImage: false,
+          capabilities: {
+            imageInput: ModelCapabilityStatus.Unknown,
+          },
+        },
+      ],
+    },
+  });
+
+  expect(endpoint.capabilities.imageInput).toBe(ModelCapabilityStatus.Unknown);
+});
+
 test('runtime context never exceeds trained context', () => {
   expect(clampRuntimeContextWindow(32_000, 16_000)).toBe(16_000);
   expect(clampRuntimeContextWindow(8_000, 16_000)).toBe(8_000);

--- a/src/shared/providers/modelEndpoint.ts
+++ b/src/shared/providers/modelEndpoint.ts
@@ -228,10 +228,12 @@ export function resolveModelEndpoint(
     ...(runtime.detectedCapabilities ?? {}),
     ...explicitUserCapabilities,
   } as { -readonly [K in keyof ModelCapabilities]: ModelCapabilities[K] };
-  if (userSupportsImage !== undefined) {
-    capabilities.imageInput = userSupportsImage
-      ? ModelCapabilityStatus.Supported
-      : ModelCapabilityStatus.Unsupported;
+  // Settings always persists a supportsImage boolean (an unstated
+  // capability derives to false). Only a positively checked toggle is a
+  // verdict here; a derived false must not overwrite an unknown
+  // capability that the resolver preserved.
+  if (userSupportsImage === true) {
+    capabilities.imageInput = ModelCapabilityStatus.Supported;
   }
   const explicitApiKey = options.apiKey ?? providerConfig?.apiKey;
   const contextWindow =


### PR DESCRIPTION
## Problem

Companion to #591 (merged Aug 25): the tool-calling chain was fixed,
but the **same residue bug on the image path is still in main**. The
capability form's default `imageInput: "unknown"`
(`DEFAULT_CUSTOM_MODEL_CAPABILITIES`) short-circuited
`resolveModelCapabilities`, so the image toggle result never reached
the renderer store — chat attachment gating read
`imageInput !== Supported` and dropped images even after the user
checked "supports image input".

Why it survived #591: the shared endpoint layer already forced
`imageInput` from `userSupportsImage` (modelEndpoint.ts), so endpoint
tests passed and the review did not surface the renderer-side
mis-resolution.

## Fix

Same residue rule as the toolCalling fix, with two review rounds
applied:

- **Three-state correctness** (round 2): Settings always persists a
  `supportsImage` boolean (an unstated capability derives to `false`),
  so the residue `Unknown` falls through to the toggle **only when
  positively checked** (`supportsImage === true`). A derived `false`
  keeps `Unknown` for user-added models instead of degrading the
  three-state selector's unknown state into an explicit unsupported.
  The endpoint layer's `userSupportsImage` forced assignment is
  likewise true-only.
- **Catalog authority** (round 3): the positively-checked toggle
  fallback applies **only to user-added models**. Catalog declarations
  stay authoritative — a stale `supportsImage: true` in storage cannot
  upgrade a catalog-declared non-vision model
  (`deepseek-reasoner`, `qwen3-coder-plus`) to Supported; the existing
  `resolveModelSupportsImage` metadata repair applies unchanged.

## Semantics matrix (residue `unknown`, both layers)

| Storage state / model | Before (main) | After |
|---|---|---|
| user-added, toggle checked | unknown → images dropped | **supported → images work** |
| user-added, toggle unstated (Settings-derived false) | unknown | **unknown** (three-state preserved) |
| catalog non-vision + stale configured true | unsupported | **unsupported** (catalog authoritative) |
| explicit configured unsupported (any model) | unsupported | unsupported (unchanged) |
| catalog models, no stale config | unchanged | unchanged |

## Tests

- resolver & endpoint: real Settings shape (`supportsImage: false` +
  unknown residue) stays Unknown in both layers
- checked toggle + residue resolves Supported
- catalog `deepseek-reasoner` / `qwen3-coder-plus` with configured
  `supportsImage: true` still resolve Unsupported (stale toggle cannot
  override catalog)
- explicit unsupported still wins
- providers/availableModels/webSearch 81/81; tsc + oxlint clean

> Re-applied as a separate PR because #591 merged before the image
> chain commit landed; based on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)