### PR TITLE
feat: enforce exclusive external model providers

### DIFF
--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -44,6 +44,7 @@ export interface ZhiyuanEnterpriseSettingsHostCapability {
 export interface ExternalModelProvider {
   readonly id: string;
   readonly displayName: string;
+  readonly exclusive?: boolean;
   listModels(): Promise<readonly ExternalModelDescriptor[]>;
   resolveConnection(modelId: string): Promise<ExternalModelConnection>;
   onDidChange?(listener: () => void): () => void;

--- a/src/main/enterpriseExtension/externalModelBridge.test.ts
+++ b/src/main/enterpriseExtension/externalModelBridge.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { ExternalModelProtocol } from '../../shared/externalModels';
+import {
+  ExternalModelAccessMode,
+  ExternalModelProtocol,
+  OPEN_EXTERNAL_MODEL_ACCESS_POLICY,
+} from '../../shared/externalModels';
 import { ModelCapabilityStatus } from '../../shared/providers';
 import type { ExternalModelProvider } from './contract';
 import { ExternalModelBridge } from './externalModelBridge';
@@ -20,6 +24,8 @@ describe('ExternalModelBridge', () => {
     });
 
     const unregister = bridge.registerProvider(provider);
+
+    expect(bridge.accessPolicy()).toBe(OPEN_EXTERNAL_MODEL_ACCESS_POLICY);
 
     await expect(bridge.listModels()).resolves.toEqual([
       {
@@ -102,6 +108,70 @@ describe('ExternalModelBridge', () => {
     await expect(
       invalidConnectionBridge.resolveModelRef('external.fixture/assigned-model'),
     ).rejects.toThrow('base URL is invalid');
+  });
+
+  test('limits model access to exclusive providers and restores open access on disposal', async () => {
+    const bridge = new ExternalModelBridge(vi.fn());
+    bridge.registerProvider(
+      fixtureProvider({
+        id: 'external.optional',
+        displayName: 'Optional Gateway',
+      }),
+    );
+    const unregisterExclusive = bridge.registerProvider(
+      fixtureProvider({
+        id: 'external.managed',
+        displayName: 'Managed Gateway',
+        exclusive: true,
+      }),
+    );
+
+    expect(bridge.accessPolicy()).toEqual({
+      mode: ExternalModelAccessMode.Exclusive,
+      providerIds: ['external.managed'],
+    });
+    await expect(bridge.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        provider: { id: 'external.managed', displayName: 'Managed Gateway' },
+      }),
+    ]);
+    expect(() => bridge.assertModelRefAllowed('external.managed/assigned-model')).not.toThrow();
+    for (const modelRef of [
+      undefined,
+      '',
+      'openai/gpt-5',
+      'external.managed/',
+      'external.optional/assigned-model',
+    ]) {
+      expect(() => bridge.assertModelRefAllowed(modelRef)).toThrow('managed model policy');
+    }
+    await expect(bridge.resolveModelRef('external.optional/assigned-model')).rejects.toThrow(
+      'managed model policy',
+    );
+
+    unregisterExclusive();
+    expect(bridge.accessPolicy()).toBe(OPEN_EXTERNAL_MODEL_ACCESS_POLICY);
+    await expect(bridge.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        provider: { id: 'external.optional', displayName: 'Optional Gateway' },
+      }),
+    ]);
+  });
+
+  test('keeps an exclusive provider closed when its managed catalog is empty', async () => {
+    const bridge = new ExternalModelBridge(vi.fn());
+    bridge.registerProvider(
+      fixtureProvider({
+        exclusive: true,
+        listModels: vi.fn(async () => []),
+      }),
+    );
+
+    expect(bridge.accessPolicy().mode).toBe(ExternalModelAccessMode.Exclusive);
+    await expect(bridge.listModels()).resolves.toEqual([]);
+    await expect(bridge.resolveModelRef('external.fixture/assigned-model')).rejects.toThrow(
+      'unavailable',
+    );
   });
 });
 

--- a/src/main/enterpriseExtension/externalModelBridge.ts
+++ b/src/main/enterpriseExtension/externalModelBridge.ts
@@ -1,7 +1,10 @@
 import type { ModelCapabilities } from '../../shared/providers';
 import { ModelCapabilityStatus } from '../../shared/providers';
 import {
+  ExternalModelAccessMode,
   ExternalModelProtocol,
+  OPEN_EXTERNAL_MODEL_ACCESS_POLICY,
+  type ExternalModelAccessPolicy,
   type ExternalModel,
   type ExternalModelConnection,
   type ExternalModelDescriptor,
@@ -77,20 +80,55 @@ export class ExternalModelBridge implements ExternalModelHostCapability {
   }
 
   async listModels(): Promise<readonly ExternalModel[]> {
+    const policy = this.accessPolicy();
+    const allowedProviderIds = new Set(policy.providerIds);
     const groups = await Promise.all(
-      [...this.#providers.values()].map(async ({ provider }) => {
-        try {
-          return await listProviderModels(provider);
-        } catch {
-          this.#logError(`[ExternalModels] Could not list models for ${provider.id}.`);
-          return [];
-        }
-      }),
+      [...this.#providers.values()]
+        .filter(
+          ({ provider }) =>
+            policy.mode === ExternalModelAccessMode.Open || allowedProviderIds.has(provider.id),
+        )
+        .map(async ({ provider }) => {
+          try {
+            return await listProviderModels(provider);
+          } catch {
+            this.#logError(`[ExternalModels] Could not list models for ${provider.id}.`);
+            return [];
+          }
+        }),
     );
     return Object.freeze(groups.flat());
   }
 
+  accessPolicy(): ExternalModelAccessPolicy {
+    const providerIds = [...this.#providers.values()]
+      .filter(({ provider }) => provider.exclusive)
+      .map(({ provider }) => provider.id)
+      .sort();
+    if (providerIds.length === 0) return OPEN_EXTERNAL_MODEL_ACCESS_POLICY;
+    return Object.freeze({
+      mode: ExternalModelAccessMode.Exclusive,
+      providerIds: Object.freeze(providerIds),
+    });
+  }
+
+  assertModelRefAllowed(modelRef: string | undefined): void {
+    const policy = this.accessPolicy();
+    if (policy.mode !== ExternalModelAccessMode.Exclusive) return;
+    const normalizedModelRef = modelRef?.trim() ?? '';
+    const separator = normalizedModelRef.indexOf('/');
+    const providerId = separator > 0 ? normalizedModelRef.slice(0, separator) : '';
+    if (
+      !providerId ||
+      separator === normalizedModelRef.length - 1 ||
+      !policy.providerIds.includes(providerId)
+    ) {
+      throw new Error('The selected model is not allowed by the managed model policy.');
+    }
+  }
+
   async resolveModelRef(modelRef: string): Promise<ResolvedExternalModel | null> {
+    this.assertModelRefAllowed(modelRef);
     const separator = modelRef.indexOf('/');
     if (separator <= 0 || separator === modelRef.length - 1) return null;
     const providerId = modelRef.slice(0, separator);
@@ -145,9 +183,13 @@ function normalizeProvider(provider: ExternalModelProvider): ExternalModelProvid
   if (provider.onDidChange !== undefined && typeof provider.onDidChange !== 'function') {
     throw new Error('External model provider change listener is invalid.');
   }
+  if (provider.exclusive !== undefined && typeof provider.exclusive !== 'boolean') {
+    throw new Error('External model provider exclusive flag is invalid.');
+  }
   return Object.freeze({
     id,
     displayName,
+    ...(provider.exclusive === undefined ? {} : { exclusive: provider.exclusive }),
     listModels: () => provider.listModels(),
     resolveConnection: (modelId: string) => provider.resolveConnection(modelId),
     ...(provider.onDidChange

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1111,6 +1111,48 @@ describe('PiRuntimeAdapter', () => {
       }
     });
 
+    it('enforces exclusive external model access before resolving Pi models', async () => {
+      adapter.on('error', () => undefined);
+      const unregister = externalModelBridge.registerProvider({
+        id: 'external.managed',
+        displayName: 'Managed Gateway',
+        exclusive: true,
+        listModels: async () => [
+          {
+            id: 'assigned-model',
+            displayName: 'Assigned Model',
+            protocol: ExternalModelProtocol.OpenAICompatible,
+          },
+        ],
+        resolveConnection: async () => ({
+          baseUrl: 'https://gateway.example/v1',
+          apiKey: 'short-lived-token',
+          modelId: 'upstream-model',
+        }),
+      });
+
+      try {
+        await expect(
+          adapter.startSession('managed-model', 'Hello gateway', {
+            modelOverride: 'external.managed/assigned-model',
+          }),
+        ).resolves.toBeUndefined();
+
+        for (const [sessionId, modelOverride] of [
+          ['builtin-model', 'openai/gpt-5.2'],
+          ['custom-model', 'custom_0/private-model'],
+          ['local-model', 'llamacpp/qwen-local'],
+          ['missing-model', undefined],
+        ] as const) {
+          await expect(
+            adapter.startSession(sessionId, 'Blocked', { modelOverride }),
+          ).rejects.toThrow('managed model policy');
+        }
+      } finally {
+        unregister();
+      }
+    });
+
     it('should keep supported remote models on the Pi built-in path', async () => {
       await adapter.startSession('test', 'Hello Pi', { modelOverride: 'openai/gpt-5.2' });
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -3545,6 +3545,7 @@ async function resolvePiModel(
   existingModelRuntime?: PiModelRuntime | null,
 ): Promise<PiResolvedModel> {
   const normalizedModelRef = modelRef?.trim() || '';
+  externalModelBridge.assertModelRefAllowed(normalizedModelRef);
   const externalModel = normalizedModelRef
     ? await externalModelBridge.resolveModelRef(normalizedModelRef)
     : null;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2484,6 +2484,7 @@ if (!gotTheLock) {
     zhiyuanEnterpriseRendererBridge.settingsPage(),
   );
   ipcMain.handle(ExternalModelIpc.List, () => externalModelBridge.listModels());
+  ipcMain.handle(ExternalModelIpc.Policy, () => externalModelBridge.accessPolicy());
   externalModelBridge.onDidChange(() => {
     for (const window of BrowserWindow.getAllWindows()) {
       if (!window.isDestroyed()) window.webContents.send(ExternalModelIpc.Changed);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -294,6 +294,10 @@ contextBridge.exposeInMainWorld('electron', {
   },
 
   externalModels: {
+    policy: () =>
+      ipcRenderer.invoke(ExternalModelIpc.Policy) as Promise<
+        import('../shared/externalModels').ExternalModelAccessPolicy
+      >,
     list: () =>
       ipcRenderer.invoke(ExternalModelIpc.List) as Promise<
         readonly import('../shared/externalModels').ExternalModel[]

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { type AppUpdateRuntimeState, AppUpdateStatus } from '../shared/appUpdate/constants';
+import { ExternalModelAccessMode, type ExternalModelAccessPolicy } from '../shared/externalModels';
 import { CoworkView } from './components/cowork';
 import {
   hasAskUserQuestions,
@@ -24,6 +25,7 @@ import { agentService } from './services/agent';
 import { apiService } from './services/api';
 import {
   collectAvailableModels,
+  getExternalModelAccessPolicy,
   LLAMACPP_RUNNING_MODELS_CHANGED_EVENT,
 } from './services/availableModels';
 import { configService } from './services/config';
@@ -124,6 +126,9 @@ const App: React.FC = () => {
     ui?: Record<string, 'hide' | 'disable' | 'readonly'>;
     disableUpdate?: boolean;
   } | null>(null);
+  const [externalModelPolicy, setExternalModelPolicy] = useState<ExternalModelAccessPolicy | null>(
+    null,
+  );
   const toastTimerRef = useRef<number | null>(null);
   const toastOnCloseRef = useRef<(() => void) | null>(null);
   const hasInitialized = useRef(false);
@@ -141,6 +146,7 @@ const App: React.FC = () => {
     selectPendingPermissionForSession(state, currentSessionId),
   );
   const isWindows = window.electron.platform === 'win32';
+  const managedModelsOnly = externalModelPolicy?.mode === ExternalModelAccessMode.Exclusive;
 
   const waitWithTimeout = useCallback(
     async <T,>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> => {
@@ -207,11 +213,13 @@ const App: React.FC = () => {
 
         // Enterprise and i18n only depend on config initialization.
         mark('enterprise/i18n init begin');
-        const [entConfig] = await Promise.all([
+        const [entConfig, , modelPolicy] = await Promise.all([
           window.electron.enterprise.getConfig(),
           waitWithTimeout(i18nService.initialize(), initTimeoutMs, 'i18nService.initialize'),
+          getExternalModelAccessPolicy(),
         ]);
         setEnterpriseConfig(entConfig);
+        setExternalModelPolicy(modelPolicy);
         mark('enterprise/i18n init done');
 
         dispatch(setWorkMode(config.workMode ?? WorkMode.Work));
@@ -270,7 +278,15 @@ const App: React.FC = () => {
 
     const refreshAvailableModels = async () => {
       const config = configService.getConfig();
-      const allModels = await collectAvailableModels(config);
+      const [policy, allModels] = await Promise.all([
+        getExternalModelAccessPolicy(),
+        collectAvailableModels(config),
+      ]);
+      setExternalModelPolicy(policy);
+      if (policy.mode === ExternalModelAccessMode.Exclusive) {
+        setLocalInferenceInstallRequestId(undefined);
+        setMainView(currentView => (currentView === 'localInference' ? 'cowork' : currentView));
+      }
       dispatch(setAvailableModels(allModels));
     };
 
@@ -342,6 +358,7 @@ const App: React.FC = () => {
   }, [mainView]);
 
   useEffect(() => {
+    if (!externalModelPolicy || managedModelsOnly) return;
     let active = true;
     void window.electron.appInfo
       .consumePendingLocalInferenceInstall()
@@ -357,7 +374,7 @@ const App: React.FC = () => {
     return () => {
       active = false;
     };
-  }, []);
+  }, [externalModelPolicy, managedModelsOnly]);
 
   // Network status monitoring
   useEffect(() => {
@@ -435,8 +452,9 @@ const App: React.FC = () => {
   }, []);
 
   const handleShowLocalInference = useCallback(() => {
+    if (managedModelsOnly) return;
     setMainView('localInference');
-  }, []);
+  }, [managedModelsOnly]);
 
   const handleShowExpert = useCallback(() => {
     setExpertInitialTab(undefined);
@@ -713,12 +731,13 @@ const App: React.FC = () => {
 
   useEffect(() => {
     const handler = () => {
+      if (managedModelsOnly) return;
       setShowSettings(false);
       setMainView('localInference');
     };
     window.addEventListener('app:show-local-inference', handler);
     return () => window.removeEventListener('app:show-local-inference', handler);
-  }, []);
+  }, [managedModelsOnly]);
 
   // 监听托盘菜单打开设置的 IPC 事件
   useEffect(() => {
@@ -802,6 +821,7 @@ const App: React.FC = () => {
                   notice={settingsOptions.notice}
                   enterpriseConfig={enterpriseConfig}
                   appUpdateState={appUpdateState}
+                  managedModelsOnly={managedModelsOnly}
                 />
               </React.Suspense>
             </LazyChunkErrorBoundary>
@@ -835,13 +855,14 @@ const App: React.FC = () => {
             onToggleCollapse={handleToggleSidebar}
             updateEntry={!isSidebarCollapsed ? updateEntry : null}
             hideLogin={false}
+            managedModelsOnly={managedModelsOnly}
             onPrefetchView={prefetchFeatureView}
           />
           <div
             className={`flex-1 min-w-0 py-1.5 px-1.5 transition-[padding] duration-200 ease-out`}
           >
             <div className="relative h-full min-h-0 rounded-xl bg-background overflow-hidden contain-[layout_style_paint]">
-              {hasMountedLocalInference && (
+              {hasMountedLocalInference && !managedModelsOnly && (
                 <div
                   className={
                     mainView === 'localInference' ? 'h-full min-h-0' : 'hidden h-full min-h-0'
@@ -950,6 +971,7 @@ const App: React.FC = () => {
                 notice={settingsOptions.notice}
                 enterpriseConfig={enterpriseConfig}
                 appUpdateState={appUpdateState}
+                managedModelsOnly={managedModelsOnly}
               />
             </React.Suspense>
           </LazyChunkErrorBoundary>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -123,6 +123,10 @@ import { localInferenceCompactButtonClass } from './localInference/constants';
 import type { EmailSettingsHandle } from './settings/email/types';
 import type { EnterpriseRendererSettingsPage } from '../../shared/enterpriseRenderer';
 import { EnterpriseSettingsPage } from './enterprise/EnterpriseSettingsPage';
+import {
+  filterManagedModelSettingsTabs,
+  resolveManagedModelSettingsTab,
+} from '../services/managedModelUiPolicy';
 
 type TabType =
   | 'general'
@@ -156,6 +160,7 @@ interface SettingsProps extends SettingsOpenOptions {
     disableUpdate?: boolean;
   } | null;
   appUpdateState?: AppUpdateRuntimeState;
+  managedModelsOnly?: boolean;
 }
 
 const CUSTOM_PROVIDER_KEYS = [
@@ -717,11 +722,17 @@ const Settings: React.FC<SettingsProps> = ({
   noticeExtra,
   enterpriseConfig,
   appUpdateState,
+  managedModelsOnly = false,
 }) => {
   // 状态
-  const [activeTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
+  const [requestedActiveTab, setActiveTab] = useState<TabType>(initialTab ?? 'general');
   const [enterpriseSettingsPage, setEnterpriseSettingsPage] =
     useState<EnterpriseRendererSettingsPage | null>(null);
+  const activeTab = resolveManagedModelSettingsTab(
+    requestedActiveTab,
+    managedModelsOnly,
+    Boolean(enterpriseSettingsPage),
+  );
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system');
   const [language, setLanguage] = useState<LanguageType>('zh');
   const [autoLaunch, setAutoLaunchState] = useState(false);
@@ -2905,10 +2916,10 @@ const Settings: React.FC<SettingsProps> = ({
     // Filter out tabs with 'hide' action in enterprise config
     // e.g., ui: { "settings.im": "hide" } → hide the 'im' tab
     const ui = enterpriseConfig?.ui;
-    if (ui) {
-      return allTabs.filter(tab => ui[`settings.${tab.key}`] !== 'hide');
-    }
-    return allTabs;
+    const configuredTabs = ui
+      ? allTabs.filter(tab => ui[`settings.${tab.key}`] !== 'hide')
+      : allTabs;
+    return filterManagedModelSettingsTabs(configuredTabs, managedModelsOnly);
   })();
 
   const activeTabLabel = useMemo(() => {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -61,6 +61,7 @@ interface SidebarProps {
   onToggleCollapse: () => void;
   updateEntry?: React.ReactNode;
   hideLogin?: boolean;
+  managedModelsOnly?: boolean;
   /** Warms the lazily loaded chunk for a view on hover/focus intent. */
   onPrefetchView?: (view: PrefetchableFeatureView) => void;
 }
@@ -82,6 +83,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onToggleCollapse,
   updateEntry,
   hideLogin,
+  managedModelsOnly = false,
   onPrefetchView,
 }) => {
   const dispatch = useDispatch();
@@ -533,6 +535,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               onShowActivity={onShowActivity}
               onWorkModeChange={handleWorkModeChange}
               workMode={workMode}
+              managedModelsOnly={managedModelsOnly}
               onPrefetchView={onPrefetchView}
             />
           </div>

--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -11,6 +11,7 @@ import type { RootState } from '../store';
 import { selectHasActiveActivityRun } from '../store/selectors/activitySelectors';
 import { WorkMode } from '../store/workMode/constants';
 import type { PrefetchableFeatureView } from './featureViewPrefetch';
+import { shouldShowLocalInferenceNavigation } from '../services/managedModelUiPolicy';
 import {
   SidebarAnimatedAlarmClockIcon,
   type SidebarAnimatedAlarmClockIconHandle,
@@ -50,6 +51,7 @@ interface SidebarNavigationControlsProps {
   onShowActivity: () => void;
   onWorkModeChange: (checked: boolean) => void;
   workMode: WorkMode;
+  managedModelsOnly?: boolean;
   /** Warms the lazily loaded chunk for a view on hover/focus intent. */
   onPrefetchView?: (view: PrefetchableFeatureView) => void;
 }
@@ -76,6 +78,7 @@ export const SidebarNavigationControls = ({
   onShowActivity,
   onWorkModeChange,
   workMode,
+  managedModelsOnly = false,
   onPrefetchView,
 }: SidebarNavigationControlsProps) => {
   const hasActiveActivityRun = useSelector((state: RootState) => selectHasActiveActivityRun(state));
@@ -153,7 +156,7 @@ export const SidebarNavigationControls = ({
           {workMode === WorkMode.Chat ? i18nService.t('newChat') : i18nService.t('newTask')}
         </Button>
       </div>
-      {workMode !== WorkMode.Chat && (
+      {shouldShowLocalInferenceNavigation(workMode === WorkMode.Chat, managedModelsOnly) && (
         <Button
           type="button"
           variant="ghost"

--- a/src/renderer/services/availableModels.test.ts
+++ b/src/renderer/services/availableModels.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 
 import { ModelCapabilityStatus, ProviderName } from '../../shared/providers';
-import { ExternalModelProtocol } from '../../shared/externalModels';
+import { ExternalModelAccessMode, ExternalModelProtocol } from '../../shared/externalModels';
 import type { AppConfig } from '../config';
 import { defaultConfig } from '../config';
 import { buildConfiguredAvailableModels, collectAvailableModels } from './availableModels';
@@ -159,6 +159,36 @@ test('collectAvailableModels merges external models without persisting connectio
   });
   expect(external).not.toHaveProperty('apiKey');
   expect(external).not.toHaveProperty('baseUrl');
+});
+
+test('exclusive policy exposes only managed external models without querying local inference', async () => {
+  const listRunningModels = vi.fn(async () => [{ name: 'qwen-local' }]);
+  const getModelPreferences = vi.fn(async () => ({}));
+  vi.stubGlobal('window', {
+    electron: {
+      llamacpp: { listRunningModels, getModelPreferences },
+      externalModels: {
+        policy: vi.fn(async () => ({
+          mode: ExternalModelAccessMode.Exclusive,
+          providerIds: ['external.managed'],
+        })),
+        list: vi.fn(async () => [
+          {
+            id: 'assigned-model',
+            displayName: 'Assigned Model',
+            protocol: ExternalModelProtocol.OpenAICompatible,
+            provider: { id: 'external.managed', displayName: 'Managed Gateway' },
+          },
+        ]),
+      },
+    },
+  });
+
+  await expect(collectAvailableModels(createConfig())).resolves.toEqual([
+    expect.objectContaining({ id: 'assigned-model', providerKey: 'external.managed' }),
+  ]);
+  expect(listRunningModels).not.toHaveBeenCalled();
+  expect(getModelPreferences).not.toHaveBeenCalled();
 });
 
 test('preserves contextTokens for custom cloud models', () => {

--- a/src/renderer/services/availableModels.ts
+++ b/src/renderer/services/availableModels.ts
@@ -1,5 +1,10 @@
 import type { LlamaCppModelPreferences, LlamaCppRunningModel } from '../../shared/llamacpp';
-import type { ExternalModel } from '../../shared/externalModels';
+import {
+  ExternalModelAccessMode,
+  OPEN_EXTERNAL_MODEL_ACCESS_POLICY,
+  type ExternalModel,
+  type ExternalModelAccessPolicy,
+} from '../../shared/externalModels';
 import {
   isProviderEnabled,
   ModelCapabilityStatus,
@@ -142,11 +147,23 @@ export function mergeAvailableModels(
   return merged;
 }
 
+export async function getExternalModelAccessPolicy(): Promise<ExternalModelAccessPolicy> {
+  return (
+    (await window.electron.externalModels?.policy?.().catch(() => null)) ??
+    OPEN_EXTERNAL_MODEL_ACCESS_POLICY
+  );
+}
+
 export async function collectAvailableModels(config: AppConfig): Promise<Model[]> {
-  const configuredModels = buildConfiguredAvailableModels(config);
+  const policy = await getExternalModelAccessPolicy();
   const externalModelsPromise =
     window.electron.externalModels?.list().catch((): readonly ExternalModel[] => []) ??
     Promise.resolve([]);
+  if (policy.mode === ExternalModelAccessMode.Exclusive) {
+    return buildExternalAvailableModels(await externalModelsPromise);
+  }
+
+  const configuredModels = buildConfiguredAvailableModels(config);
 
   try {
     const [runningModels, externalModels] = await Promise.all([

--- a/src/renderer/services/managedModelUiPolicy.test.ts
+++ b/src/renderer/services/managedModelUiPolicy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  filterManagedModelSettingsTabs,
+  resolveManagedModelSettingsTab,
+  shouldShowLocalInferenceNavigation,
+} from './managedModelUiPolicy';
+
+describe('managed model UI policy', () => {
+  test('hides only the model settings tab when managed models are exclusive', () => {
+    const tabs = [{ key: 'general' }, { key: 'model' }, { key: 'about' }];
+
+    expect(filterManagedModelSettingsTabs(tabs, true)).toEqual([
+      { key: 'general' },
+      { key: 'about' },
+    ]);
+    expect(filterManagedModelSettingsTabs(tabs, false)).toEqual(tabs);
+  });
+
+  test('moves a hidden active tab to enterprise settings when available', () => {
+    expect(resolveManagedModelSettingsTab('model', true, true)).toBe('extension');
+    expect(resolveManagedModelSettingsTab('model', true, false)).toBe('general');
+    expect(resolveManagedModelSettingsTab('model', false, true)).toBe('model');
+  });
+
+  test('hides local inference in chat mode and managed model mode', () => {
+    expect(shouldShowLocalInferenceNavigation(false, false)).toBe(true);
+    expect(shouldShowLocalInferenceNavigation(true, false)).toBe(false);
+    expect(shouldShowLocalInferenceNavigation(false, true)).toBe(false);
+  });
+});

--- a/src/renderer/services/managedModelUiPolicy.ts
+++ b/src/renderer/services/managedModelUiPolicy.ts
@@ -1,0 +1,23 @@
+export function filterManagedModelSettingsTabs<T extends { readonly key: string }>(
+  tabs: readonly T[],
+  managedModelsOnly: boolean,
+): T[] {
+  return managedModelsOnly ? tabs.filter(tab => tab.key !== 'model') : [...tabs];
+}
+
+export function resolveManagedModelSettingsTab<T extends string>(
+  activeTab: T,
+  managedModelsOnly: boolean,
+  hasEnterpriseSettingsPage: boolean,
+): T {
+  if (!managedModelsOnly || activeTab !== 'model') return activeTab;
+  const fallback = hasEnterpriseSettingsPage ? 'extension' : 'general';
+  return fallback as T;
+}
+
+export function shouldShowLocalInferenceNavigation(
+  isChatMode: boolean,
+  managedModelsOnly: boolean,
+): boolean {
+  return !isChatMode && !managedModelsOnly;
+}

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1219,6 +1219,7 @@ interface IElectronAPI {
     };
   };
   externalModels: {
+    policy: () => Promise<import('../../shared/externalModels').ExternalModelAccessPolicy>;
     list: () => Promise<readonly import('../../shared/externalModels').ExternalModel[]>;
     onChanged: (callback: () => void) => () => void;
   };

--- a/src/shared/externalModels.ts
+++ b/src/shared/externalModels.ts
@@ -1,5 +1,22 @@
 import type { ModelCapabilities } from './providers';
 
+export const ExternalModelAccessMode = {
+  Open: 'open',
+  Exclusive: 'exclusive',
+} as const;
+export type ExternalModelAccessMode =
+  (typeof ExternalModelAccessMode)[keyof typeof ExternalModelAccessMode];
+
+export interface ExternalModelAccessPolicy {
+  readonly mode: ExternalModelAccessMode;
+  readonly providerIds: readonly string[];
+}
+
+export const OPEN_EXTERNAL_MODEL_ACCESS_POLICY: ExternalModelAccessPolicy = Object.freeze({
+  mode: ExternalModelAccessMode.Open,
+  providerIds: Object.freeze([]),
+});
+
 export const ExternalModelProtocol = {
   OpenAICompatible: 'openai-compatible',
 } as const;

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -81,6 +81,7 @@ export type EnterpriseIpc = (typeof EnterpriseIpc)[keyof typeof EnterpriseIpc];
 // ─── External Models ───────────────────────────────────────────────────────
 export const ExternalModelIpc = {
   List: 'external-models:list',
+  Policy: 'external-models:policy',
   Changed: 'external-models:changed',
 } as const;
 export type ExternalModelIpc = (typeof ExternalModelIpc)[keyof typeof ExternalModelIpc];


### PR DESCRIPTION
Adds an opt-in exclusive external-model policy for enterprise extensions. Exclusive providers become the only visible model catalog; Settings model configuration and local inference navigation are hidden; Pi rejects built-in, custom, local, empty, revoked, and stale model refs before resolution. Open-source behavior remains unchanged unless a provider registers with exclusive=true. Verification: 115 focused tests passed; TypeScript, Electron compilation, focused lint, and clean production build passed. Full suite: 2423 passed, 11 unrelated existing Windows/environment failures (python3/Get-FileHash/release path parsing/source-string assertions).