### PR TITLE
fix(pi): remap developer role for OpenAI-compatible gateways

### DIFF
--- a/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
@@ -7,12 +7,51 @@ import {
   normalizeOpenAISSETextForPi,
   openAIStreamPayloadHasFinishReason,
   registerPiOpenAICompatUpstream,
+  remapDeveloperRolesForOpenAICompletions,
   stopPiOpenAICompatProxyForTests,
 } from './piOpenAICompatProxy';
 
 describe('piOpenAICompatProxy', () => {
   afterEach(async () => {
     await stopPiOpenAICompatProxyForTests();
+  });
+
+  it('remaps developer roles to system for gateway compatibility', () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: 'kimi-for-coding',
+        stream: true,
+        messages: [
+          { role: 'developer', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello' },
+        ],
+      }),
+      'utf8',
+    );
+
+    const remapped = remapDeveloperRolesForOpenAICompletions(body);
+
+    const parsed = JSON.parse(remapped.toString('utf8')) as {
+      stream?: boolean;
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(parsed.messages.map(message => message.role)).toEqual(['system', 'user', 'assistant']);
+    expect(parsed.stream).toBe(true);
+    expect(parsed.messages[0].content).toBe('You are a helpful assistant.');
+  });
+
+  it('passes payloads without developer roles through unchanged', () => {
+    const body = Buffer.from(
+      JSON.stringify({ messages: [{ role: 'user', content: 'Hi' }] }),
+      'utf8',
+    );
+    expect(remapDeveloperRolesForOpenAICompletions(body)).toEqual(body);
+  });
+
+  it('passes malformed payloads through unchanged', () => {
+    const body = Buffer.from('not-json', 'utf8');
+    expect(remapDeveloperRolesForOpenAICompletions(body)).toEqual(body);
   });
   it('detects OpenAI stream finish reasons', () => {
     expect(
@@ -90,6 +129,56 @@ describe('piOpenAICompatProxy', () => {
 
     expect((normalized.match(/finish_reason/g) ?? []).length).toBe(1);
     expect(normalized).toContain('"finish_reason":"tool_calls"');
+  });
+
+  it('remaps developer roles to system before forwarding to the upstream', async () => {
+    let receivedBody = '';
+    const upstream = http.createServer(async (request, response) => {
+      for await (const chunk of request) {
+        receivedBody += chunk.toString('utf8');
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+        }),
+      );
+    });
+    const upstreamBaseURL = await new Promise<string>((resolve, reject) => {
+      upstream.once('error', reject);
+      upstream.listen(0, '127.0.0.1', () => {
+        const address = upstream.address();
+        if (!address || typeof address === 'string') {
+          reject(new Error('upstream did not receive a TCP port'));
+          return;
+        }
+        resolve(`http://127.0.0.1:${address.port}`);
+      });
+    });
+
+    try {
+      const proxyBaseURL = await registerPiOpenAICompatUpstream('custom_9', {
+        baseURL: upstreamBaseURL,
+        apiKey: 'sk-test',
+      });
+      const response = await fetch(`${proxyBaseURL}/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'agent-model',
+          messages: [
+            { role: 'developer', content: 'You are a helpful assistant.' },
+            { role: 'user', content: 'Hi' },
+          ],
+        }),
+      });
+      expect(response.ok).toBe(true);
+
+      const parsed = JSON.parse(receivedBody) as { messages: Array<{ role: string }> };
+      expect(parsed.messages.map(message => message.role)).toEqual(['system', 'user']);
+    } finally {
+      upstream.close();
+    }
   });
 
   it('proxies upstream SSE and injects missing finish_reason through the local server', async () => {

--- a/src/main/libs/agentEngine/piOpenAICompatProxy.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.ts
@@ -78,6 +78,37 @@ function extractRequestModel(body: Buffer): string | undefined {
   }
 }
 
+/**
+ * OpenAI's newer protocol uses the 'developer' role; most self-hosted
+ * OpenAI-compatible gateways (new-api / one-api and similar) validate
+ * roles against user/assistant/system/tool and reject it. The proxy
+ * serves user-added providers exactly, so remap developer to system
+ * before forwarding. Both roles are accepted by the models themselves;
+ * system is the broadly supported spelling.
+ */
+export function remapDeveloperRolesForOpenAICompletions(body: Buffer): Buffer {
+  try {
+    const parsed = JSON.parse(body.toString('utf8')) as Record<string, unknown>;
+    const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+    let changed = false;
+    for (const message of messages) {
+      if (typeof message !== 'object' || message === null || Array.isArray(message)) {
+        continue;
+      }
+      const record = message as Record<string, unknown>;
+      if (record.role === 'developer') {
+        record.role = 'system';
+        changed = true;
+      }
+    }
+    if (!changed) return body;
+    return Buffer.from(JSON.stringify(parsed), 'utf8');
+  } catch {
+    // Non-JSON or an unexpected payload shape: pass through unchanged.
+    return body;
+  }
+}
+
 function requestWantsStream(body: Buffer): boolean {
   try {
     const parsed = JSON.parse(body.toString('utf8')) as { stream?: unknown };
@@ -357,7 +388,7 @@ async function handleProxyRequest(
     return;
   }
 
-  const body = await readRequestBody(request);
+  const body = remapDeveloperRolesForOpenAICompletions(await readRequestBody(request));
   const model = extractRequestModel(body);
   const upstreamURL = buildOpenAIChatCompletionsURL(upstream.baseURL);
   const upstreamResponse = await fetch(upstreamURL, {


### PR DESCRIPTION
## Problem

Self-hosted OpenAI-compatible gateways (new-api / one-api and clones) validate chat-completions roles against `user/assistant/system/tool` and reject the `developer` role that pi emits under the newer OpenAI protocol. The pi openai-compat proxy ([piOpenAICompatProxy.ts](src/main/libs/agentEngine/piOpenAICompatProxy.ts)) serves user-added providers 1:1 (auth injection only), so the agent loop failed with:

```
role 'developer' is not allowed   (invalid_request_error, type: new_api_error)
```

…and the UI surfaced the generic "任务执行出错" task-failure message.

Reproduction (against a real new-api gateway): the identical request succeeds with `user` role and fails with `developer` role at the validation stage — before any quota/route checks.

## Fix

The proxy remaps `developer` → `system` before forwarding ([handleProxyRequest](src/main/libs/agentEngine/piOpenAICompatProxy.ts)):

- Both roles are accepted by the underlying models; `system` is the broadly supported spelling (this is the same compatibility rule the cowork proxy already applies for MiniMax).
- Non-JSON payloads and messages without `developer` pass through byte-identical.
- Applies to every upstream registered through the proxy (all user-added `custom_*` providers using OpenAI completions).

## Scope note

This covers the pi path for **custom_* providers** (self-hosted gateways registered as custom). The cowork compat proxy is unrelated — it serves the Claude Code client config, not pi. Standard providers (deepseek etc.) pointed at a gateway are out of scope of fix A; if that configuration is in use, see next step.

## Tests

- unit: remap behavior, no-op when no developer role, malformed payload passthrough
- end-to-end: real proxy → upstream integration asserting the upstream receives `system` instead of `developer`
- piOpenAICompatProxy 9/9; full agentEngine suite 248/248; tsc + oxlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)