### PR TITLE
fix(models): refresh managed token after authorization failure

### DIFF
--- a/src/main/enterpriseExtension/managedProviderBridge.test.ts
+++ b/src/main/enterpriseExtension/managedProviderBridge.test.ts
@@ -23,7 +23,13 @@ describe('Zhiyuan managed provider bridge', () => {
         return vi.fn();
       },
     };
-    const bridge = new ZhiyuanManagedProviderBridge();
+    let refreshToken: (() => Promise<string>) | null = null;
+    const unregisterTokenRefresher = vi.fn();
+    const registerTokenRefresher = vi.fn((_providerId, refresher) => {
+      refreshToken = refresher;
+      return unregisterTokenRefresher;
+    });
+    const bridge = new ZhiyuanManagedProviderBridge(registerTokenRefresher);
     const changed = vi.fn();
     bridge.onDidChange(changed);
     const unregister = bridge.registerSource(source);
@@ -55,6 +61,11 @@ describe('Zhiyuan managed provider bridge', () => {
         },
       },
     });
+    expect(registerTokenRefresher).toHaveBeenCalledWith('custom_enterprise', expect.any(Function));
+
+    vi.mocked(source.snapshot).mockResolvedValue(providerConfig({ apiKey: 'refreshed-token' }));
+    await expect(refreshToken?.()).resolves.toBe('refreshed-token');
+    expect(store.get<any>('app_config').providers.custom_enterprise.apiKey).toBe('refreshed-token');
 
     notifyChanged?.();
     await bridge.refresh();
@@ -62,6 +73,7 @@ describe('Zhiyuan managed provider bridge', () => {
     expect(changed).toHaveBeenCalled();
 
     unregister();
+    expect(unregisterTokenRefresher).toHaveBeenCalledOnce();
     expect(store.get<any>('app_config').providers.custom_enterprise).toBeUndefined();
     expect(store.get<any>('app_config').providers.deepseek).toBeDefined();
   });

--- a/src/main/enterpriseExtension/managedProviderBridge.ts
+++ b/src/main/enterpriseExtension/managedProviderBridge.ts
@@ -11,6 +11,10 @@ import {
   type ZhiyuanManagedProviderHostCapability,
   type ZhiyuanManagedProviderSource,
 } from './contract';
+import {
+  registerPiOpenAICompatTokenRefresher,
+  type PiOpenAICompatTokenRefresher,
+} from '../libs/agentEngine/piOpenAICompatProxy';
 
 const MANAGED_PROVIDER_KEY_PATTERN = /^custom_[a-z0-9](?:[a-z0-9_-]{0,62}[a-z0-9])?$/;
 const MAX_MODELS = 256;
@@ -31,21 +35,44 @@ interface StoredAppConfig {
   readonly [key: string]: unknown;
 }
 
+type PiOpenAICompatTokenRefresherRegistrar = (
+  providerId: string,
+  refresher: PiOpenAICompatTokenRefresher,
+) => () => void;
+
 export class ZhiyuanManagedProviderBridge implements ZhiyuanManagedProviderHostCapability {
   readonly apiVersion = ZHIYUAN_MANAGED_PROVIDER_CAPABILITY_API_VERSION;
+  readonly #registerTokenRefresher: PiOpenAICompatTokenRefresherRegistrar;
   readonly #listeners = new Set<() => void>();
   #source: ZhiyuanManagedProviderSource | null = null;
   #disposeSourceListener: (() => void) | null = null;
+  #disposeTokenRefresher: (() => void) | null = null;
   #store: ConfigStore | null = null;
   #snapshot: ManagedProviderSnapshot | null = null;
   #refreshPromise: Promise<void> | null = null;
   #refreshAgain = false;
+
+  constructor(
+    registerTokenRefresher: PiOpenAICompatTokenRefresherRegistrar = registerPiOpenAICompatTokenRefresher,
+  ) {
+    this.#registerTokenRefresher = registerTokenRefresher;
+  }
 
   registerSource(source: ZhiyuanManagedProviderSource): () => void {
     if (this.#source) throw new Error('A Zhiyuan managed provider source is already registered.');
     validateSource(source);
     this.#source = source;
     this.#disposeSourceListener = source.onDidChange?.(() => void this.refresh()) ?? null;
+    this.#disposeTokenRefresher = this.#registerTokenRefresher(source.providerKey, async () => {
+      try {
+        const snapshot = await this.#syncSnapshot(source);
+        this.#emitChanged();
+        return snapshot.config.apiKey;
+      } catch (error) {
+        if (source === this.#source) this.#clearSnapshot();
+        throw error;
+      }
+    });
     void this.refresh();
     let registered = true;
     return () => {
@@ -53,6 +80,8 @@ export class ZhiyuanManagedProviderBridge implements ZhiyuanManagedProviderHostC
       registered = false;
       this.#disposeSourceListener?.();
       this.#disposeSourceListener = null;
+      this.#disposeTokenRefresher?.();
+      this.#disposeTokenRefresher = null;
       this.#source = null;
       this.#clearSnapshot();
     };
@@ -117,18 +146,30 @@ export class ZhiyuanManagedProviderBridge implements ZhiyuanManagedProviderHostC
     const source = this.#source;
     if (!source || !this.#store) return;
     try {
-      const snapshot = normalizeSnapshot(
-        source.providerKey,
-        source.exclusive,
-        await source.snapshot(),
-      );
-      this.#removeStoredProvider(this.#snapshot?.providerKey);
-      this.#snapshot = snapshot;
-      this.#writeSnapshot(snapshot);
+      await this.#syncSnapshot(source);
     } catch {
       this.#clearSnapshot();
+      return;
     }
     this.#emitChanged();
+  }
+
+  async #syncSnapshot(source: ZhiyuanManagedProviderSource): Promise<ManagedProviderSnapshot> {
+    if (!this.#store || source !== this.#source) {
+      throw new Error('Zhiyuan managed provider source is unavailable.');
+    }
+    const snapshot = normalizeSnapshot(
+      source.providerKey,
+      source.exclusive,
+      await source.snapshot(),
+    );
+    if (source !== this.#source) {
+      throw new Error('Zhiyuan managed provider source changed during refresh.');
+    }
+    this.#removeStoredProvider(this.#snapshot?.providerKey);
+    this.#snapshot = snapshot;
+    this.#writeSnapshot(snapshot);
+    return snapshot;
   }
 
   #writeSnapshot(snapshot: ManagedProviderSnapshot): void {
@@ -216,19 +257,17 @@ function normalizeConfig(value: ProviderConfig): ProviderConfig {
     apiFormat: 'openai',
     displayName: normalizeText(value.displayName ?? 'Zhiyuan', 128),
     models: models.map(model => ({
-        id: normalizeText(model.id, 256),
-        name: normalizeText(model.name, 128),
-        ...(model.supportsImage !== undefined
-          ? { supportsImage: model.supportsImage === true }
-          : {}),
-        ...(model.capabilities ? { capabilities: Object.freeze({ ...model.capabilities }) } : {}),
-        ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
-        ...(model.contextTokens ? { contextTokens: model.contextTokens } : {}),
-        ...(model.maxTokens ? { maxTokens: model.maxTokens } : {}),
-        ...(model.piRuntime
-          ? { piRuntime: normalizeProviderModelPiRuntimeConfig(model.piRuntime) }
-          : {}),
-      })),
+      id: normalizeText(model.id, 256),
+      name: normalizeText(model.name, 128),
+      ...(model.supportsImage !== undefined ? { supportsImage: model.supportsImage === true } : {}),
+      ...(model.capabilities ? { capabilities: Object.freeze({ ...model.capabilities }) } : {}),
+      ...(model.contextWindow ? { contextWindow: model.contextWindow } : {}),
+      ...(model.contextTokens ? { contextTokens: model.contextTokens } : {}),
+      ...(model.maxTokens ? { maxTokens: model.maxTokens } : {}),
+      ...(model.piRuntime
+        ? { piRuntime: normalizeProviderModelPiRuntimeConfig(model.piRuntime) }
+        : {}),
+    })),
   });
 }
 

--- a/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
@@ -6,6 +6,7 @@ import {
   convertOpenAIChatCompletionTextToSSEForPi,
   normalizeOpenAISSETextForPi,
   openAIStreamPayloadHasFinishReason,
+  registerPiOpenAICompatTokenRefresher,
   registerPiOpenAICompatUpstream,
   stopPiOpenAICompatProxyForTests,
 } from './piOpenAICompatProxy';
@@ -134,4 +135,103 @@ describe('piOpenAICompatProxy', () => {
       await new Promise<void>(resolve => upstream.close(() => resolve()));
     }
   });
+
+  it('refreshes a rejected provider token once and retries the request', async () => {
+    const authorizations: Array<string | undefined> = [];
+    const upstream = http.createServer((request, response) => {
+      authorizations.push(request.headers.authorization);
+      if (request.headers.authorization === 'Bearer old-token') {
+        response.writeHead(401, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: 'expired token' }));
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          choices: [{ index: 0, message: { content: 'refreshed' }, finish_reason: 'stop' }],
+        }),
+      );
+    });
+    const upstreamBaseURL = await listen(upstream);
+    let refreshCount = 0;
+
+    try {
+      const proxyBaseURL = await registerPiOpenAICompatUpstream('custom_enterprise', {
+        baseURL: upstreamBaseURL,
+        apiKey: 'old-token',
+      });
+      registerPiOpenAICompatTokenRefresher('custom_enterprise', async () => {
+        refreshCount += 1;
+        return 'new-token';
+      });
+
+      const response = await fetch(`${proxyBaseURL}/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'enterprise-chat', messages: [] }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain('refreshed');
+      expect(authorizations).toEqual(['Bearer old-token', 'Bearer new-token']);
+      expect(refreshCount).toBe(1);
+    } finally {
+      await close(upstream);
+    }
+  });
+
+  it('coalesces concurrent token refreshes and never retries more than once', async () => {
+    let upstreamRequestCount = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequestCount += 1;
+      response.writeHead(401, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ error: 'rejected token' }));
+    });
+    const upstreamBaseURL = await listen(upstream);
+    let refreshCount = 0;
+
+    try {
+      const proxyBaseURL = await registerPiOpenAICompatUpstream('custom_enterprise', {
+        baseURL: upstreamBaseURL,
+        apiKey: 'old-token',
+      });
+      registerPiOpenAICompatTokenRefresher('custom_enterprise', async () => {
+        refreshCount += 1;
+        await new Promise(resolve => setTimeout(resolve, 20));
+        return 'new-token';
+      });
+      const request = () =>
+        fetch(`${proxyBaseURL}/chat/completions`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ model: 'enterprise-chat', messages: [] }),
+        });
+
+      const responses = await Promise.all([request(), request()]);
+
+      expect(responses.map(response => response.status)).toEqual([401, 401]);
+      expect(refreshCount).toBe(1);
+      expect(upstreamRequestCount).toBe(4);
+    } finally {
+      await close(upstream);
+    }
+  });
 });
+
+async function listen(server: http.Server): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('upstream did not receive a TCP port'));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}

--- a/src/main/libs/agentEngine/piOpenAICompatProxy.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.ts
@@ -7,6 +7,13 @@ interface PiOpenAICompatUpstream {
   apiKey?: string;
 }
 
+export type PiOpenAICompatTokenRefresher = () => Promise<string>;
+
+interface PiOpenAICompatTokenRefreshRegistration {
+  readonly refresher: PiOpenAICompatTokenRefresher;
+  refreshPromise: Promise<string> | null;
+}
+
 interface OpenAIStreamNormalizeState {
   hasFinishReason: boolean;
   sentDone: boolean;
@@ -17,6 +24,7 @@ const OPENAI_STREAM_DONE_MARKER = '[DONE]';
 const FALLBACK_FINISH_REASON = 'stop';
 
 const upstreams = new Map<string, PiOpenAICompatUpstream>();
+const tokenRefreshers = new Map<string, PiOpenAICompatTokenRefreshRegistration>();
 let proxyServer: http.Server | null = null;
 let proxyPort: number | null = null;
 let proxyStartPromise: Promise<number> | null = null;
@@ -59,6 +67,46 @@ function createFetchHeaders(request: IncomingMessage, upstream: PiOpenAICompatUp
   }
 
   return headers;
+}
+
+async function refreshPiOpenAICompatToken(
+  providerId: string,
+  rejectedApiKey: string | undefined,
+): Promise<boolean> {
+  const upstream = upstreams.get(providerId);
+  if (!upstream) return false;
+  if (upstream.apiKey !== rejectedApiKey) return true;
+
+  const registration = tokenRefreshers.get(providerId);
+  if (!registration) return false;
+  if (!registration.refreshPromise) {
+    registration.refreshPromise = registration
+      .refresher()
+      .then(apiKey => {
+        const normalized = apiKey.trim();
+        if (!normalized)
+          throw new Error('Pi OpenAI compatibility token refresh returned no token.');
+        return normalized;
+      })
+      .finally(() => {
+        registration.refreshPromise = null;
+      });
+  }
+
+  try {
+    const apiKey = await registration.refreshPromise;
+    if (tokenRefreshers.get(providerId) !== registration) return false;
+    const currentUpstream = upstreams.get(providerId);
+    if (!currentUpstream) return false;
+    currentUpstream.apiKey = apiKey;
+    return true;
+  } catch (error) {
+    console.warn(
+      `[PiOpenAICompatProxy] failed to refresh credentials for provider ${providerId}:`,
+      error,
+    );
+    return false;
+  }
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<Buffer> {
@@ -360,11 +408,22 @@ async function handleProxyRequest(
   const body = await readRequestBody(request);
   const model = extractRequestModel(body);
   const upstreamURL = buildOpenAIChatCompletionsURL(upstream.baseURL);
-  const upstreamResponse = await fetch(upstreamURL, {
-    method: 'POST',
-    headers: createFetchHeaders(request, upstream),
-    body: body.toString('utf8'),
-  });
+  const rejectedApiKey = upstream.apiKey;
+  const fetchUpstream = (): Promise<Response> =>
+    fetch(upstreamURL, {
+      method: 'POST',
+      headers: createFetchHeaders(request, upstream),
+      body: body.toString('utf8'),
+    });
+  let upstreamResponse = await fetchUpstream();
+
+  if (
+    (upstreamResponse.status === 401 || upstreamResponse.status === 403) &&
+    (await refreshPiOpenAICompatToken(providerId, rejectedApiKey))
+  ) {
+    await upstreamResponse.body?.cancel();
+    upstreamResponse = await fetchUpstream();
+  }
 
   const contentType = upstreamResponse.headers.get('content-type') ?? '';
   const upstreamTextShouldPassThrough = !upstreamResponse.ok;
@@ -454,8 +513,25 @@ export async function registerPiOpenAICompatUpstream(
   )}/v1`;
 }
 
+export function registerPiOpenAICompatTokenRefresher(
+  providerId: string,
+  refresher: PiOpenAICompatTokenRefresher,
+): () => void {
+  const registration: PiOpenAICompatTokenRefreshRegistration = {
+    refresher,
+    refreshPromise: null,
+  };
+  tokenRefreshers.set(providerId, registration);
+  return () => {
+    if (tokenRefreshers.get(providerId) === registration) {
+      tokenRefreshers.delete(providerId);
+    }
+  };
+}
+
 export async function stopPiOpenAICompatProxyForTests(): Promise<void> {
   upstreams.clear();
+  tokenRefreshers.clear();
   proxyPort = null;
   proxyStartPromise = null;
   const server = proxyServer;


### PR DESCRIPTION
Refresh managed custom-provider credentials after an upstream 401 or 403, coalesce concurrent refreshes, and retry each request at most once. The enterprise bridge refreshes the existing custom_enterprise snapshot without introducing a new provider or UI path. Verified with unit tests, TypeScript checks, targeted lint, and a real Electron short-lived-token rotation scenario showing gateway 401 followed by 200 in the same conversation.