### PR TITLE
fix(cowork): keep terminal errors visible

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -2799,6 +2799,7 @@ describe('PiRuntimeAdapter', () => {
     };
     let errors: CoworkError[];
     let completes: string[];
+    let emittedMessages: Array<Record<string, unknown>>;
 
     const failedAttempt = (errorMessage: string) => {
       listener!({
@@ -2847,6 +2848,10 @@ describe('PiRuntimeAdapter', () => {
       adapter.setCoworkStore(mockStore as unknown as CoworkStore);
       errors = [];
       completes = [];
+      emittedMessages = [];
+      adapter.on('message', (_sid, message) =>
+        emittedMessages.push(message as unknown as Record<string, unknown>),
+      );
       adapter.on('error', (_sid, error) => errors.push(error as CoworkError));
       adapter.on('complete', sessionId => completes.push(sessionId));
     });
@@ -2863,6 +2868,7 @@ describe('PiRuntimeAdapter', () => {
 
       expect(errors).toHaveLength(0);
       expect(systemErrorMessages()).toHaveLength(0);
+      expect(emittedMessages.filter(message => message.type === 'system')).toHaveLength(0);
       expect(mockStore.updateSession).not.toHaveBeenCalledWith(
         'test',
         expect.objectContaining({ status: 'error' }),
@@ -2893,6 +2899,7 @@ describe('PiRuntimeAdapter', () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].kind).toBe(CoworkErrorKind.RateLimited);
       expect(systemErrorMessages()).toHaveLength(1);
+      expect(emittedMessages.filter(message => message.type === 'system')).toHaveLength(1);
       expect(mockStore.updateSession).toHaveBeenCalledWith('test', { status: 'error' });
       expect(mockStore.updateSession).not.toHaveBeenCalledWith('test', { status: 'completed' });
       expect(completes).toHaveLength(0);
@@ -2908,7 +2915,38 @@ describe('PiRuntimeAdapter', () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].kind).toBe(CoworkErrorKind.AuthExpired);
       expect(systemErrorMessages()).toHaveLength(1);
+      expect(emittedMessages.filter(message => message.type === 'system')).toHaveLength(1);
       expect(completes).toHaveLength(0);
+    });
+
+    it('finalizes a partial answer before surfacing the terminal error', async () => {
+      const updates: Array<{
+        messageId: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }> = [];
+      adapter.on('messageUpdate', (_sid, messageId, content, metadata) =>
+        updates.push({ messageId, content, metadata }),
+      );
+      await adapter.startSession('test', 'Hi');
+
+      listener!({ type: 'turn_start' });
+      listener!({
+        type: 'message_update',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Partial answer' }] },
+      });
+      failedAttempt('network error');
+      listener!({ type: 'agent_settled' });
+
+      expect(
+        updates.some(
+          update =>
+            update.content === 'Partial answer' &&
+            update.metadata?.isStreaming === false &&
+            update.metadata?.isFinal === true,
+        ),
+      ).toBe(true);
+      expect(emittedMessages.map(message => message.type)).toEqual(['user', 'assistant', 'system']);
     });
 
     it('does not complete or continue the agent loop on a failed turn', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -2254,10 +2254,14 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         if (event.message?.role === 'assistant') {
           active.writeTokenLimitRecovery.queueIfNeeded(event.message, active.piSession);
           if (event.message.stopReason === 'error') {
-            const { thinking } = active.streamAccumulator.reconcile(event.message);
+            const { text, thinking } = active.streamAccumulator.reconcile(event.message);
             if (thinking && thinking !== active.thinkingText) {
               active.thinkingText = thinking;
               active.thinkingLifecycle.markContentStreaming();
+            }
+            if (text) {
+              active.answerText = text;
+              active.firstVisibleTextAt ??= Date.now();
             }
             this.finalizeActiveThinking(sessionId, active);
             const errMsg = event.message.errorMessage || 'Pi agent error';
@@ -2619,19 +2623,29 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     active.pendingError = null;
     active.turnFailed = true;
     active.isRunning = false;
+    if (active.answerText.trim()) {
+      this.finalizeMessage(sessionId, active, 'answer', active.answerText);
+      active.assistantMessageId = null;
+      active.answerText = '';
+    }
     this.workbenchTaskService?.failRun?.(sessionId, { message: pending.message });
     // Persist a system error message so the error survives session switching
     // and is visible in the message list. The classified kind lets the renderer
     // translate it into a user-friendly i18n message; the raw message is kept
     // for console diagnostics only.
+    const errorMessageSeed: CoworkMessage = {
+      id: randomUUID(),
+      type: 'system',
+      content: '',
+      timestamp: Date.now(),
+      metadata: { error: pending.message, errorKind: pending.classified.kind },
+    };
+    let errorMessage = errorMessageSeed;
     if (this.store) {
       this.store.updateSession(sessionId, { status: 'error' });
-      this.store.addMessage(sessionId, {
-        type: 'system',
-        content: '',
-        metadata: { error: pending.message, errorKind: pending.classified.kind },
-      });
+      errorMessage = this.store.addMessage(sessionId, errorMessageSeed);
     }
+    this.emit('message', sessionId, errorMessage);
     this.emit('error', sessionId, pending.classified);
   }
 

--- a/src/main/main.coworkErrorForwarding.test.ts
+++ b/src/main/main.coworkErrorForwarding.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./main.ts', import.meta.url)), 'utf8');
+
+test('sends structured errors from asynchronous Cowork fallbacks', () => {
+  const fallbackCalls = source.match(/error: classifyCoworkError\(errorMessage\)/g);
+
+  expect(fallbackCalls).toHaveLength(2);
+  expect(source).not.toMatch(/CoworkStreamIpc\.Error,[\s\S]{0,160}error: errorMessage/);
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -24,6 +24,7 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 
 import { buildSessionTitleFromInput } from '../common/sessionTitle';
+import { classifyCoworkError } from '../common/coworkError';
 import {
   migrateLegacyScheduledTaskRunsToCanonical,
   migrateLegacyScheduledTasksToCanonical,
@@ -3731,7 +3732,7 @@ if (!gotTheLock) {
                 if (win.isDestroyed()) return;
                 win.webContents.send(CoworkStreamIpc.Error, {
                   sessionId: session.id,
-                  error: errorMessage,
+                  error: classifyCoworkError(errorMessage),
                 });
               });
             } catch (handlerError) {
@@ -3860,7 +3861,7 @@ if (!gotTheLock) {
               if (win.isDestroyed()) return;
               win.webContents.send(CoworkStreamIpc.Error, {
                 sessionId: options.sessionId,
-                error: errorMessage,
+                error: classifyCoworkError(errorMessage),
               });
             });
           } catch (handlerError) {

--- a/src/renderer/components/cowork/components/TurnBlock.structure.test.ts
+++ b/src/renderer/components/cowork/components/TurnBlock.structure.test.ts
@@ -24,13 +24,22 @@ test('settles execution counts after an answer or when the turn reaches a termin
 });
 
 test('keeps recoverable interruptions outside reasoning and exposes a message action', () => {
-  expect(source).toContain(
-    "item.type === 'system' && Boolean(item.message.metadata?.interruption)",
-  );
+  expect(source).toContain('Boolean(item.message.metadata?.interruption)');
   expect(source).toContain('interruption.taskId === recoverableTaskId');
   expect(source).toContain('<MessageAction');
   expect(source).toContain("i18nService.t('coworkResumeTaskAction')");
   expect(source).toContain('onClick={() => onResumeTask(interruption)}');
+});
+
+test('keeps terminal errors visible outside execution summaries', () => {
+  expect(source).toContain('const isStandaloneSystem = isStandaloneSystemItem(item);');
+  expect(source).toContain('if (isAnswer || isStandaloneSystem)');
+  expect(source).toContain(
+    '(item, index) => index !== finalAnswerIndex && !isStandaloneSystemItem(item)',
+  );
+  expect(source).toContain(
+    '{standaloneSystemItems.map((item, index) => renderItem(item, index, false))}',
+  );
 });
 
 test('keeps active tool details in the total summary without adding a child row', () => {

--- a/src/renderer/components/cowork/components/TurnBlock.test.ts
+++ b/src/renderer/components/cowork/components/TurnBlock.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
+import { CoworkErrorKind } from '../../../../common/coworkError';
+import { CoworkInterruptionCause } from '../../../../shared/cowork/interruption';
 import type { ConversationTurn } from '../helpers/messageGrouping';
-import { getTurnPrimaryExpert } from './TurnBlock';
+import { getTurnPrimaryExpert, isTerminalErrorItem } from './TurnBlock';
 
 const expert = { expertId: 'expert-a', expertName: 'Draft Expert', presetId: 'draft' };
 
@@ -9,7 +11,13 @@ describe('getTurnPrimaryExpert', () => {
   test('prefers the frozen user-message expert identity', () => {
     const turn: ConversationTurn = {
       id: 'turn-1',
-      userMessage: { id: 'user-1', type: 'user', content: 'Write', timestamp: 1, metadata: { experts: [expert] } },
+      userMessage: {
+        id: 'user-1',
+        type: 'user',
+        content: 'Write',
+        timestamp: 1,
+        metadata: { experts: [expert] },
+      },
       assistantItems: [],
     };
 
@@ -23,11 +31,69 @@ describe('getTurnPrimaryExpert', () => {
       assistantItems: [
         {
           type: 'assistant',
-          message: { id: 'assistant-1', type: 'assistant', content: 'Done', timestamp: 2, metadata: { experts: [expert] } },
+          message: {
+            id: 'assistant-1',
+            type: 'assistant',
+            content: 'Done',
+            timestamp: 2,
+            metadata: { experts: [expert] },
+          },
         },
       ],
     };
 
     expect(getTurnPrimaryExpert(turn)).toEqual(expert);
+  });
+});
+
+describe('terminal error presentation', () => {
+  test('identifies terminal system errors independently of their rendered content', () => {
+    expect(
+      isTerminalErrorItem({
+        type: 'system',
+        message: {
+          id: 'error-1',
+          type: 'system',
+          content: '',
+          timestamp: 1,
+          metadata: { error: 'Model failed', errorKind: CoworkErrorKind.Unknown },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test('keeps tool failures and approval interruptions out of terminal-error handling', () => {
+    expect(
+      isTerminalErrorItem({
+        type: 'tool_result',
+        message: {
+          id: 'tool-1',
+          type: 'tool_result',
+          content: 'Command failed',
+          timestamp: 1,
+          metadata: { isError: true, error: 'Command failed' },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isTerminalErrorItem({
+        type: 'system',
+        message: {
+          id: 'interruption-1',
+          type: 'system',
+          content: '',
+          timestamp: 2,
+          metadata: {
+            interruption: {
+              cause: CoworkInterruptionCause.ApprovalDenied,
+              sessionId: 'session-1',
+              interruptionId: 'interruption-1',
+              taskId: null,
+              recoverable: false,
+            },
+          },
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/src/renderer/components/cowork/components/TurnBlock.tsx
+++ b/src/renderer/components/cowork/components/TurnBlock.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../../shared/cowork/interruption';
 import type { CoworkToolActivity } from '../../../../shared/cowork/toolActivity';
 import { i18nService } from '../../../services/i18n';
+import { isCoworkTerminalErrorMessage } from '../../../services/coworkTerminalError';
 import { ArtifactRole, type Artifact } from '../../../types/artifact';
 import type { CoworkMessage, CoworkMessageMetadata } from '../../../types/cowork';
 import ArtifactPreviewCard from '../../artifacts/ArtifactPreviewCard';
@@ -31,7 +32,7 @@ import {
   getFinalAnswerIndex,
   getToolActivityExecutionStatus,
 } from '../helpers/executionStatus';
-import type { ConversationTurn } from '../helpers/messageGrouping';
+import type { AssistantTurnItem, ConversationTurn } from '../helpers/messageGrouping';
 import { getToolResultLineCount, getVisibleAssistantItems } from '../helpers/messageGrouping';
 import { getThinkingPresentation } from '../helpers/thinkingPresentation';
 import { getToolResultDisplay, hasText } from '../helpers/toolUtils';
@@ -63,8 +64,17 @@ export const getTurnPrimaryExpert = (
   const assistantItem = turn.assistantItems.find(
     item => item.type === 'assistant' && Array.isArray(item.message.metadata?.experts),
   );
-  return assistantItem?.type === 'assistant' ? assistantItem.message.metadata?.experts?.[0] : undefined;
+  return assistantItem?.type === 'assistant'
+    ? assistantItem.message.metadata?.experts?.[0]
+    : undefined;
 };
+
+export const isTerminalErrorItem = (item: AssistantTurnItem): boolean =>
+  item.type === 'system' && isCoworkTerminalErrorMessage(item.message);
+
+const isStandaloneSystemItem = (item: AssistantTurnItem): boolean =>
+  item.type === 'system' &&
+  (Boolean(item.message.metadata?.interruption) || isTerminalErrorItem(item));
 
 const TurnBlockComponent: React.FC<{
   turn: ConversationTurn;
@@ -99,7 +109,7 @@ const TurnBlockComponent: React.FC<{
 
   const renderSystemMessage = (message: CoworkMessage) => {
     const interruption = message.metadata?.interruption as CoworkSessionInterruption | undefined;
-    const isError = !hasText(message.content) && typeof message.metadata?.error === 'string';
+    const isError = isCoworkTerminalErrorMessage(message);
     const errorKind = message.metadata?.errorKind as CoworkErrorKind | undefined;
     const i18nKey = isError && errorKind ? getUserErrorI18nKey(errorKind) : null;
     const i18nMessage = i18nKey ? i18nService.t(i18nKey) : null;
@@ -306,7 +316,7 @@ const TurnBlockComponent: React.FC<{
     };
 
     for (const item of visibleAssistantItems) {
-      const isInterruption = item.type === 'system' && Boolean(item.message.metadata?.interruption);
+      const isStandaloneSystem = isStandaloneSystemItem(item);
       const isAnswer =
         item.type === 'assistant' &&
         !item.message.metadata?.isThinking &&
@@ -317,7 +327,7 @@ const TurnBlockComponent: React.FC<{
         item.type === 'tool_result' ||
         item.type === 'system';
 
-      if (isAnswer || isInterruption) {
+      if (isAnswer || isStandaloneSystem) {
         flush(isAnswer);
         result.push({
           items: [item],
@@ -347,15 +357,11 @@ const TurnBlockComponent: React.FC<{
   const visibleGroups = groups.filter(group => !isEmptyAnswerGroup(group));
   const finalAnswerIndex = getFinalAnswerIndex(visibleAssistantItems, isTurnComplete);
   const finalAnswerItem = finalAnswerIndex >= 0 ? visibleAssistantItems[finalAnswerIndex] : null;
-  const interruptionItems = visibleAssistantItems.filter(
-    item => item.type === 'system' && Boolean(item.message.metadata?.interruption),
-  );
+  const standaloneSystemItems = visibleAssistantItems.filter(isStandaloneSystemItem);
   const executionItems =
     finalAnswerIndex >= 0
       ? visibleAssistantItems.filter(
-          (item, index) =>
-            index !== finalAnswerIndex &&
-            !(item.type === 'system' && Boolean(item.message.metadata?.interruption)),
+          (item, index) => index !== finalAnswerIndex && !isStandaloneSystemItem(item),
         )
       : [];
   const executionSummary = getExecutionSummary(executionItems);
@@ -370,13 +376,14 @@ const TurnBlockComponent: React.FC<{
     !(
       lastVisibleGroupFirstItem.type === 'assistant' &&
       !lastVisibleGroupFirstItem.message.metadata?.isThinking
-    ),
+    ) &&
+    !isStandaloneSystemItem(lastVisibleGroupFirstItem),
   );
 
   const isExecutionStep = (item: (typeof visibleAssistantItems)[number] | undefined) =>
     item?.type === 'tool_group' ||
     item?.type === 'tool_result' ||
-    item?.type === 'system' ||
+    (item?.type === 'system' && !isStandaloneSystemItem(item)) ||
     (item?.type === 'assistant' && Boolean(item.message.metadata?.isThinking));
 
   const renderExecutionGroup = (
@@ -386,9 +393,7 @@ const TurnBlockComponent: React.FC<{
   ) => {
     const firstItem = group.items[0];
     const isAnswerItem = firstItem?.type === 'assistant' && !firstItem.message.metadata?.isThinking;
-    const isInterruptionItem =
-      firstItem?.type === 'system' && Boolean(firstItem.message.metadata?.interruption);
-    if (isAnswerItem || isInterruptionItem) {
+    if (isAnswerItem || (firstItem && isStandaloneSystemItem(firstItem))) {
       return renderItem(firstItem, 0, isFinalAnswer);
     }
 
@@ -453,7 +458,7 @@ const TurnBlockComponent: React.FC<{
             {finalAnswerItem ? (
               <>
                 {renderItem(finalAnswerItem, finalAnswerIndex, true)}
-                {interruptionItems.map((item, index) => renderItem(item, index, false))}
+                {standaloneSystemItems.map((item, index) => renderItem(item, index, false))}
               </>
             ) : (
               visibleGroups.map((group, index) =>

--- a/src/renderer/services/cowork.errorHandling.structure.test.ts
+++ b/src/renderer/services/cowork.errorHandling.structure.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./cowork.ts', import.meta.url)), 'utf8');
+
+test('deduplicates the stream error fallback against the canonical terminal message', () => {
+  const listenerStart = source.indexOf('const errorCleanup = cowork.onStreamError');
+  const listenerEnd = source.indexOf('this.streamListenerCleanups.push(errorCleanup);');
+  const listenerSource = source.slice(listenerStart, listenerEnd);
+
+  expect(listenerSource).toContain('hasMatchingLatestTerminalError(');
+  expect(listenerSource).toContain('!terminalMessageAlreadyReceived');
+  expect(listenerSource).toContain('createCoworkTerminalErrorMessage(error)');
+});
+
+test('creates at most one canonical message for a synchronous continue failure', () => {
+  const continueStart = source.indexOf('async continueSession(options: CoworkContinueOptions)');
+  const continueEnd = source.indexOf('async stopSession(sessionId: string)');
+  const continueSource = source.slice(continueStart, continueEnd);
+
+  expect(continueSource).toContain('resolveCoworkTerminalError(result.error, result.code)');
+  expect(continueSource).toContain('hasMatchingLatestTerminalError(');
+  expect(continueSource.match(/createCoworkTerminalErrorMessage\(terminalError\)/g)).toHaveLength(
+    1,
+  );
+  expect(continueSource).not.toContain("i18nService.t('coworkErrorSessionContinueFailed')");
+});

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -52,6 +52,11 @@ import type {
 import { i18nService } from './i18n';
 import { respondToPermissionByOrigin } from './coworkPermissionRouting';
 import { prepareCoworkSessionRender } from './coworkSessionRenderPreparation';
+import {
+  createCoworkTerminalErrorMessage,
+  hasMatchingLatestTerminalError,
+  resolveCoworkTerminalError,
+} from './coworkTerminalError';
 import { RafMessageUpdateBatcher } from './rafMessageUpdateBatcher';
 import { workspaceService } from './workspace';
 
@@ -213,30 +218,29 @@ class CoworkService {
 
     // Error listener
     const errorCleanup = cowork.onStreamError(({ sessionId, error }) => {
+      const stateBeforeStatusUpdate = store.getState().cowork;
+      const terminalMessageAlreadyReceived = hasMatchingLatestTerminalError(
+        [
+          stateBeforeStatusUpdate.currentSession,
+          stateBeforeStatusUpdate.streamingSessions[sessionId],
+        ],
+        sessionId,
+        error,
+      );
       store.dispatch(updateSessionStatus({ sessionId, status: 'error' }));
 
-      // Differentiated behavior by error kind:
-      // - Auth expired → trigger global re-auth flow
-      // - Engine not ready → handled separately by engine status overlay
-      // - Rate limited → show transient warning with retry hint
-      // - Others → surface as system message
+      // The runtime normally sends the persisted terminal message first. The
+      // error event owns status/global side effects and only supplies a message
+      // fallback when that canonical message was not delivered.
       if (error.kind === CoworkErrorKind.AuthExpired) {
         window.dispatchEvent(new CustomEvent('core-rpc-auth-expired'));
       }
 
-      const userMessage = error.message || '';
-      if (userMessage) {
-        const i18nKey = getUserErrorI18nKey(error.kind);
-        const content = i18nKey ? i18nService.t(i18nKey) : userMessage;
+      if (error.message && !terminalMessageAlreadyReceived) {
         store.dispatch(
           addMessage({
             sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: content || userMessage,
-              timestamp: Date.now(),
-            },
+            message: createCoworkTerminalErrorMessage(error),
           }),
         );
       }
@@ -438,41 +442,27 @@ class CoworkService {
       fileAttachments: options.fileAttachments,
     });
     if (!result.success) {
+      const terminalError = result.error
+        ? resolveCoworkTerminalError(result.error, result.code)
+        : null;
       if (result.code !== ENGINE_NOT_READY_CODE) {
         store.dispatch(updateSessionStatus({ sessionId: options.sessionId, status: 'error' }));
-        if (result.error) {
+      }
+      if (terminalError) {
+        const state = store.getState().cowork;
+        const alreadyReceived = hasMatchingLatestTerminalError(
+          [state.currentSession, state.streamingSessions[options.sessionId]],
+          options.sessionId,
+          terminalError,
+        );
+        if (!alreadyReceived) {
           store.dispatch(
             addMessage({
               sessionId: options.sessionId,
-              message: {
-                id: `error-${Date.now()}`,
-                type: 'system',
-                content: i18nService
-                  .t('coworkErrorSessionContinueFailed')
-                  .replace('{error}', result.error),
-                timestamp: Date.now(),
-              },
+              message: createCoworkTerminalErrorMessage(terminalError),
             }),
           );
         }
-      }
-      // Show a user-visible error message in the session
-      if (result.error) {
-        const errorContent =
-          result.code === ENGINE_NOT_READY_CODE
-            ? i18nService.t('coworkErrorEngineNotReady')
-            : classifyError(result.error);
-        store.dispatch(
-          addMessage({
-            sessionId: options.sessionId,
-            message: {
-              id: `error-${Date.now()}`,
-              type: 'system',
-              content: errorContent,
-              timestamp: Date.now(),
-            },
-          }),
-        );
       }
       console.error('Failed to continue session:', result.error);
       return false;

--- a/src/renderer/services/coworkTerminalError.test.ts
+++ b/src/renderer/services/coworkTerminalError.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'vitest';
+
+import { CoworkErrorKind, ENGINE_NOT_READY_CODE } from '../../common/coworkError';
+import type { CoworkMessage, CoworkSession } from '../types/cowork';
+import {
+  createCoworkTerminalErrorMessage,
+  hasMatchingLatestTerminalError,
+  isCoworkTerminalErrorMessage,
+  resolveCoworkTerminalError,
+} from './coworkTerminalError';
+
+const sessionWithMessages = (messages: CoworkMessage[]): CoworkSession =>
+  ({
+    id: 'session-1',
+    messages,
+  }) as CoworkSession;
+
+describe('cowork terminal errors', () => {
+  test('creates a canonical system message that remains identifiable after reload', () => {
+    const error = {
+      kind: CoworkErrorKind.RateLimited,
+      message: '429 Too Many Requests',
+    };
+
+    const message = createCoworkTerminalErrorMessage(error, 42);
+
+    expect(message).toMatchObject({
+      id: 'error-42',
+      type: 'system',
+      content: '',
+      metadata: {
+        error: error.message,
+        errorKind: error.kind,
+      },
+    });
+    expect(isCoworkTerminalErrorMessage(message)).toBe(true);
+  });
+
+  test('suppresses only the matching terminal error at the session tail', () => {
+    const error = {
+      kind: CoworkErrorKind.NetworkError,
+      message: 'network error',
+    };
+    const terminalError = createCoworkTerminalErrorMessage(error, 1);
+
+    expect(
+      hasMatchingLatestTerminalError([sessionWithMessages([terminalError])], 'session-1', error),
+    ).toBe(true);
+    expect(
+      hasMatchingLatestTerminalError(
+        [
+          sessionWithMessages([
+            terminalError,
+            { id: 'user-2', type: 'user', content: 'Retry', timestamp: 2 },
+          ]),
+        ],
+        'session-1',
+        error,
+      ),
+    ).toBe(false);
+  });
+
+  test('does not classify tool failures as terminal conversation errors', () => {
+    const toolFailure: CoworkMessage = {
+      id: 'tool-result-1',
+      type: 'tool_result',
+      content: 'command failed',
+      timestamp: 1,
+      metadata: { isError: true, error: 'command failed' },
+    };
+
+    expect(isCoworkTerminalErrorMessage(toolFailure)).toBe(false);
+  });
+
+  test('uses the explicit engine-not-ready code for synchronous failures', () => {
+    expect(resolveCoworkTerminalError('runtime unavailable', ENGINE_NOT_READY_CODE)).toMatchObject({
+      kind: CoworkErrorKind.EngineNotReady,
+      message: 'runtime unavailable',
+    });
+  });
+});

--- a/src/renderer/services/coworkTerminalError.ts
+++ b/src/renderer/services/coworkTerminalError.ts
@@ -1,0 +1,51 @@
+import {
+  classifyCoworkError,
+  type CoworkError,
+  CoworkErrorKind,
+  ENGINE_NOT_READY_CODE,
+} from '../../common/coworkError';
+import type { CoworkMessage, CoworkSession } from '../types/cowork';
+
+type CoworkMessageSession = Pick<CoworkSession, 'id' | 'messages'>;
+
+export const isCoworkTerminalErrorMessage = (message: CoworkMessage): boolean =>
+  message.type === 'system' && typeof message.metadata?.error === 'string';
+
+export const resolveCoworkTerminalError = (message: string, code?: string): CoworkError =>
+  code === ENGINE_NOT_READY_CODE
+    ? {
+        kind: CoworkErrorKind.EngineNotReady,
+        message,
+        raw: message,
+      }
+    : classifyCoworkError(message);
+
+export const createCoworkTerminalErrorMessage = (
+  error: CoworkError,
+  timestamp = Date.now(),
+): CoworkMessage => ({
+  id: `error-${timestamp}`,
+  type: 'system',
+  content: '',
+  timestamp,
+  metadata: {
+    error: error.message,
+    errorKind: error.kind,
+  },
+});
+
+export const hasMatchingLatestTerminalError = (
+  sessions: Array<CoworkMessageSession | null | undefined>,
+  sessionId: string,
+  error: CoworkError,
+): boolean =>
+  sessions.some(session => {
+    if (session?.id !== sessionId) return false;
+    const latestMessage = session.messages[session.messages.length - 1];
+    return (
+      Boolean(latestMessage) &&
+      isCoworkTerminalErrorMessage(latestMessage) &&
+      latestMessage.metadata?.error === error.message &&
+      latestMessage.metadata?.errorKind === error.kind
+    );
+  });


### PR DESCRIPTION
## Summary

Keep fatal Cowork conversation errors visible instead of hiding them inside collapsed reasoning or intermediate execution steps.

The runtime now emits one canonical persisted terminal-error message before the status-only error event, while the renderer uses that message as the source of truth and creates a fallback only when delivery did not occur.

## Related Issue

No linked issue.

## Changes Made

- Persist and emit one canonical terminal-error system message after automatic retries are exhausted, while preserving silent successful retries.
- Finalize any partial assistant answer before surfacing the terminal error so both remain visible in the conversation.
- Render terminal errors outside collapsed execution summaries and after a partial or final answer when present.
- Deduplicate renderer error fallbacks and consolidate synchronous continuation failures to one standardized message.
- Send structured `CoworkError` payloads from main-process asynchronous fallbacks instead of bare strings.
- Preserve existing behavior for tool failures, approval denials, user stops, and recoverable interruption actions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which would cause existing functionality not to work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

Commands run:

- `vitest run` for terminal-error helpers, renderer grouping, renderer deduplication, and main-process IPC structure: 16 tests passed.
- `vitest run src/main/libs/agentEngine/piRuntimeAdapter.test.ts -t "auto-retry error storm"`: 5 tests passed, 93 unrelated tests skipped.
- `npm run lint`
- `npm run build`
- `git diff --check`

## Screenshots (if applicable)

Not included. The terminal-error state requires an Electron-hosted runtime failure; direct browser rendering cannot initialize the application without Electron preload APIs.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented code where the event ordering is not self-explanatory
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)
- [ ] Changes to preload script (`src/main/preload.ts`)
- [x] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

The full unfiltered `piRuntimeAdapter.test.ts` run could not complete in the reused worktree dependency setup because `better-sqlite3` was built for Electron ABI 143 while the test Node runtime requires ABI 137. The focused runtime tests for this change pass, and the complete production build, including Electron main/preload bundles and runtime dependency validation, succeeds.
