### PR TITLE
feat(enterprise): expose managed skill host

### DIFF
--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -10,6 +10,7 @@ export const ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_MANAGED_PROVIDER_CAPABILITY_API_VERSION = 1 as const;
+export const ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION = 1 as const;
 
 export interface ZhiyuanEnterpriseSessionProvider {
   snapshot(): EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>;
@@ -49,6 +50,17 @@ export interface ZhiyuanManagedProviderHostCapability {
   registerSource(source: ZhiyuanManagedProviderSource): () => void;
 }
 
+export interface ZhiyuanEnterpriseManagedSkillRegistration {
+  readonly directory: string;
+  notifyChanged(): void;
+  unregister(): void;
+}
+
+export interface ZhiyuanEnterpriseSkillHostCapability {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION;
+  registerManagedRoot(): ZhiyuanEnterpriseManagedSkillRegistration;
+}
+
 export interface ZhiyuanEnterpriseSettingsHostCapability {
   readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION;
   registerPage(page: ZhiyuanEnterpriseSettingsPageRegistration): () => void;
@@ -79,6 +91,7 @@ export interface ZhiyuanEnterpriseHostContext {
     readonly renderer: ZhiyuanEnterpriseRendererHostCapability | null;
     readonly settings: ZhiyuanEnterpriseSettingsHostCapability | null;
     readonly managedProvider: ZhiyuanManagedProviderHostCapability | null;
+    readonly skills: ZhiyuanEnterpriseSkillHostCapability | null;
   };
 }
 

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
   ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION,
+  ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION,
   ZhiyuanEnterpriseExtensionStatus,
   type ZhiyuanEnterpriseHostContext,
 } from './contract';
@@ -70,6 +71,7 @@ describe('Zhiyuan enterprise extension host', () => {
     expect(receivedContext!.capabilities.renderer).toBeNull();
     expect(receivedContext!.capabilities.settings).toBeNull();
     expect(receivedContext!.capabilities.managedProvider).toBeNull();
+    expect(receivedContext!.capabilities.skills).toBeNull();
 
     await host.dispose();
     await host.dispose();
@@ -161,6 +163,33 @@ describe('Zhiyuan enterprise extension host', () => {
 
     expect(createSettingsCapability).toHaveBeenCalledWith(path.dirname(modulePath));
     expect(receivedContext!.capabilities.settings).toBe(settingsCapability);
+  });
+
+  test('passes the versioned managed Skill capability to the extension', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const skillCapability = {
+      apiVersion: ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION,
+      registerManagedRoot: vi.fn(),
+    };
+    const createSkillCapability = vi.fn(() => skillCapability);
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+          receivedContext = context;
+        },
+      }),
+    }));
+
+    await host.initialize({ ...options(root, true), createSkillCapability });
+
+    expect(createSkillCapability).toHaveBeenCalledOnce();
+    expect(receivedContext!.capabilities.skills).toBe(skillCapability);
+    expect(receivedContext!.capabilities.skills?.apiVersion).toBe(1);
   });
 
   test('imports a real CommonJS development bundle', async () => {

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -12,6 +12,7 @@ import {
   type ZhiyuanEnterpriseRendererHostCapability,
   type ZhiyuanEnterpriseSettingsHostCapability,
   type ZhiyuanEnterpriseSessionHostCapability,
+  type ZhiyuanEnterpriseSkillHostCapability,
   type ZhiyuanManagedProviderHostCapability,
 } from './contract';
 
@@ -28,6 +29,7 @@ export interface ZhiyuanEnterpriseExtensionHostOptions {
   readonly developmentExtensionPath?: string;
   readonly sessionCapability?: ZhiyuanEnterpriseSessionHostCapability;
   readonly managedProviderCapability?: ZhiyuanManagedProviderHostCapability;
+  readonly createSkillCapability?: () => ZhiyuanEnterpriseSkillHostCapability;
   readonly createRendererCapability?: (
     extensionDirectory: string,
   ) => ZhiyuanEnterpriseRendererHostCapability;
@@ -191,6 +193,7 @@ function createHostContext(
     renderer: options.createRendererCapability?.(extensionDirectory) ?? null,
     settings: options.createSettingsCapability?.(extensionDirectory) ?? null,
     managedProvider: options.managedProviderCapability ?? null,
+    skills: options.createSkillCapability?.() ?? null,
   });
   return Object.freeze({
     apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,

--- a/src/main/enterpriseExtension/skillBridge.test.ts
+++ b/src/main/enterpriseExtension/skillBridge.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION } from './contract';
+import { ZhiyuanEnterpriseSkillBridge } from './skillBridge';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('Zhiyuan enterprise Skill bridge', () => {
+  test('registers a host-owned managed directory and refreshes on demand', () => {
+    const userDataPath = createTemporaryDirectory();
+    const refreshSkills = vi.fn();
+    const unregisterRoot = vi.fn();
+    const registerSkillRoot = vi.fn(() => unregisterRoot);
+    const bridge = new ZhiyuanEnterpriseSkillBridge({
+      userDataPath,
+      refreshSkills,
+      registerSkillRoot,
+    });
+
+    const registration = bridge.registerManagedRoot();
+    const expectedDirectory = path.join(userDataPath, 'zhiyuan-enterprise', 'managed-skills');
+    expect(bridge.apiVersion).toBe(ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION);
+    expect(registration.directory).toBe(expectedDirectory);
+    expect(fs.statSync(expectedDirectory).isDirectory()).toBe(true);
+    expect(registerSkillRoot).toHaveBeenCalledWith(expectedDirectory);
+
+    registration.notifyChanged();
+    expect(refreshSkills).toHaveBeenCalledOnce();
+  });
+
+  test('allows one active registration and releases it idempotently', () => {
+    const unregisterRoot = vi.fn();
+    const bridge = new ZhiyuanEnterpriseSkillBridge({
+      userDataPath: createTemporaryDirectory(),
+      refreshSkills: vi.fn(),
+      registerSkillRoot: () => unregisterRoot,
+    });
+    const registration = bridge.registerManagedRoot();
+
+    expect(() => bridge.registerManagedRoot()).toThrow(/already registered/);
+    registration.unregister();
+    registration.unregister();
+    registration.notifyChanged();
+    expect(unregisterRoot).toHaveBeenCalledOnce();
+
+    expect(() => bridge.registerManagedRoot()).not.toThrow();
+  });
+
+  test('rejects a relative user data path', () => {
+    expect(
+      () =>
+        new ZhiyuanEnterpriseSkillBridge({
+          userDataPath: 'relative',
+          refreshSkills: vi.fn(),
+        }),
+    ).toThrow(/absolute/);
+  });
+});
+
+function createTemporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-skill-bridge-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/src/main/enterpriseExtension/skillBridge.ts
+++ b/src/main/enterpriseExtension/skillBridge.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION,
+  type ZhiyuanEnterpriseManagedSkillRegistration,
+  type ZhiyuanEnterpriseSkillHostCapability,
+} from './contract';
+import { skillRootRegistry } from '../skillRootRegistry';
+
+const ENTERPRISE_DIRECTORY = 'zhiyuan-enterprise';
+const MANAGED_SKILL_DIRECTORY = 'managed-skills';
+
+type RegisterSkillRoot = (root: string) => () => void;
+
+export interface ZhiyuanEnterpriseSkillBridgeOptions {
+  readonly userDataPath: string;
+  readonly refreshSkills: () => void;
+  readonly registerSkillRoot?: RegisterSkillRoot;
+}
+
+export class ZhiyuanEnterpriseSkillBridge implements ZhiyuanEnterpriseSkillHostCapability {
+  readonly apiVersion = ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION;
+  readonly #managedDirectory: string;
+  readonly #refreshSkills: () => void;
+  readonly #registerSkillRoot: RegisterSkillRoot;
+  #registered = false;
+
+  constructor(options: ZhiyuanEnterpriseSkillBridgeOptions) {
+    if (!path.isAbsolute(options.userDataPath)) {
+      throw new Error('Zhiyuan enterprise user data path must be absolute.');
+    }
+    this.#managedDirectory = path.join(
+      path.resolve(options.userDataPath),
+      ENTERPRISE_DIRECTORY,
+      MANAGED_SKILL_DIRECTORY,
+    );
+    this.#refreshSkills = options.refreshSkills;
+    this.#registerSkillRoot =
+      options.registerSkillRoot ?? (root => skillRootRegistry.register(root));
+  }
+
+  registerManagedRoot(): ZhiyuanEnterpriseManagedSkillRegistration {
+    if (this.#registered) {
+      throw new Error('A Zhiyuan enterprise managed Skill root is already registered.');
+    }
+    fs.mkdirSync(this.#managedDirectory, { recursive: true });
+    const unregisterRoot = this.#registerSkillRoot(this.#managedDirectory);
+    this.#registered = true;
+    let active = true;
+    return Object.freeze({
+      directory: this.#managedDirectory,
+      notifyChanged: () => {
+        if (active) this.#refreshSkills();
+      },
+      unregister: () => {
+        if (!active) return;
+        active = false;
+        unregisterRoot();
+        this.#registered = false;
+      },
+    });
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -208,6 +208,7 @@ import {
 } from './enterpriseExtension/rendererProtocol';
 import { zhiyuanEnterpriseSessionBridge } from './enterpriseExtension/sessionBridge';
 import { zhiyuanManagedProviderBridge } from './enterpriseExtension/managedProviderBridge';
+import { ZhiyuanEnterpriseSkillBridge } from './enterpriseExtension/skillBridge';
 import { LlamaCppManager } from './libs/llamacppManager';
 import { CcConnectBridgeServer } from './libs/ccConnectBridgeServer';
 import { serializeCcConnectSidecarConfig } from './libs/ccConnectSidecarConfig';
@@ -6672,6 +6673,11 @@ if (!gotTheLock) {
       developmentExtensionPath: process.env.ZHIYUAN_ENTERPRISE_EXTENSION_DEV_PATH,
       sessionCapability: zhiyuanEnterpriseSessionBridge,
       managedProviderCapability: zhiyuanManagedProviderBridge,
+      createSkillCapability: () =>
+        new ZhiyuanEnterpriseSkillBridge({
+          userDataPath: app.getPath('userData'),
+          refreshSkills: () => getSkillManager().handleWorkingDirectoryChange(),
+        }),
       createRendererCapability: extensionDirectory =>
         zhiyuanEnterpriseRendererBridge.createScopedCapability(extensionDirectory),
       createSettingsCapability: extensionDirectory =>

--- a/src/main/skillManager.enterpriseRoots.test.ts
+++ b/src/main/skillManager.enterpriseRoots.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { SkillManager } from './skillManager';
+import { skillRootRegistry } from './skillRootRegistry';
+import type { SqliteStore } from './sqliteStore';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('discovers Skills from a registered additional root until it is unregistered', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-additional-skills-'));
+  temporaryDirectories.push(root);
+  const skillDirectory = path.join(root, 'managed-demo');
+  fs.mkdirSync(skillDirectory);
+  fs.writeFileSync(
+    path.join(skillDirectory, 'SKILL.md'),
+    '---\nname: Managed Demo\ndescription: Managed by the host\n---\n\n# Managed Demo\n',
+  );
+  const store = {
+    get: vi.fn(() => undefined),
+    set: vi.fn(),
+  } as unknown as SqliteStore;
+  const manager = new SkillManager(() => store);
+  const unregister = skillRootRegistry.register(root);
+
+  try {
+    expect(manager.listSkills()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'managed-demo',
+          name: 'Managed Demo',
+          skillPath: path.join(skillDirectory, 'SKILL.md'),
+        }),
+      ]),
+    );
+  } finally {
+    unregister();
+  }
+
+  expect(manager.listSkills().some(skill => skill.id === 'managed-demo')).toBe(false);
+});

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -24,6 +24,7 @@ import type {
   SkillSecurityReport,
 } from './libs/skillSecurity/skillSecurityTypes';
 import { SqliteStore } from './sqliteStore';
+import { skillRootRegistry } from './skillRootRegistry';
 
 /**
  * Resolve the user's login shell PATH on macOS/Linux.
@@ -2922,7 +2923,7 @@ export class SkillManager {
     if (appRoot !== resolvedPrimary && fs.existsSync(appRoot)) {
       roots.push(appRoot);
     }
-    return roots;
+    return skillRootRegistry.appendTo(roots);
   }
 
   getBundledSkillsRoot(): string {

--- a/src/main/skillRootRegistry.test.ts
+++ b/src/main/skillRootRegistry.test.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { SkillRootRegistry } from './skillRootRegistry';
+
+describe('Skill root registry', () => {
+  test('appends registered absolute roots without duplicating existing roots', () => {
+    const registry = new SkillRootRegistry();
+    const primary = path.resolve('primary-skills');
+    const managed = path.resolve('managed-skills');
+    registry.register(primary);
+    registry.register(managed);
+
+    expect(registry.appendTo([primary])).toEqual([primary, managed]);
+  });
+
+  test('reference-counts duplicate registrations and unregisters idempotently', () => {
+    const registry = new SkillRootRegistry();
+    const managed = path.resolve('managed-skills');
+    const unregisterFirst = registry.register(managed);
+    const unregisterSecond = registry.register(managed);
+
+    unregisterFirst();
+    unregisterFirst();
+    expect(registry.appendTo([])).toEqual([managed]);
+
+    unregisterSecond();
+    expect(registry.appendTo([])).toEqual([]);
+  });
+
+  test('rejects relative roots', () => {
+    expect(() => new SkillRootRegistry().register('relative/skills')).toThrow(/absolute/);
+  });
+});

--- a/src/main/skillRootRegistry.ts
+++ b/src/main/skillRootRegistry.ts
@@ -1,0 +1,32 @@
+import path from 'node:path';
+
+export class SkillRootRegistry {
+  readonly #registrations = new Map<string, number>();
+
+  register(root: string): () => void {
+    if (!path.isAbsolute(root)) throw new Error('Additional Skill roots must be absolute.');
+    const resolved = path.resolve(root);
+    this.#registrations.set(resolved, (this.#registrations.get(resolved) ?? 0) + 1);
+    let registered = true;
+    return () => {
+      if (!registered) return;
+      registered = false;
+      const remaining = (this.#registrations.get(resolved) ?? 1) - 1;
+      if (remaining === 0) this.#registrations.delete(resolved);
+      else this.#registrations.set(resolved, remaining);
+    };
+  }
+
+  appendTo(roots: readonly string[]): string[] {
+    const result = roots.map(root => path.resolve(root));
+    const known = new Set(result);
+    for (const root of this.#registrations.keys()) {
+      if (known.has(root)) continue;
+      known.add(root);
+      result.push(root);
+    }
+    return result;
+  }
+}
+
+export const skillRootRegistry = new SkillRootRegistry();


### PR DESCRIPTION
Adds a versioned host capability for enterprise extensions to register a managed Skill directory and notify SkillManager after filesystem changes. Includes registry, bridge, lifecycle, and real scan coverage. No AEP or backend logic is added to the public host.