### PR TITLE
feat(enterprise): expose managed Skill host capability

### DIFF
--- a/src/main/contentSecurityPolicy.test.ts
+++ b/src/main/contentSecurityPolicy.test.ts
@@ -7,6 +7,7 @@ describe('content security policy', () => {
     const policy = createContentSecurityPolicy({ isDev: false });
 
     expect(policy).toContain("frame-src 'self' file: zhiyuan-enterprise-ui:");
+    expect(policy).toContain("form-action 'none'");
     expect(policy).not.toContain('frame-src *');
   });
 

--- a/src/main/contentSecurityPolicy.ts
+++ b/src/main/contentSecurityPolicy.ts
@@ -17,6 +17,7 @@ export function createContentSecurityPolicy(options: ContentSecurityPolicyOption
     "media-src 'self'",
     "worker-src 'self' blob:",
     "frame-src 'self' file: zhiyuan-enterprise-ui:",
+    "form-action 'none'",
   ];
 
   return directives.join('; ');

--- a/src/main/enterpriseExtension/contract.ts
+++ b/src/main/enterpriseExtension/contract.ts
@@ -8,6 +8,7 @@ export const ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_RENDERER_CAPABILITY_API_VERSION = 1 as const;
 export const ZHIYUAN_ENTERPRISE_SETTINGS_CAPABILITY_API_VERSION = 1 as const;
+export const ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION = 1 as const;
 
 export interface ZhiyuanEnterpriseSessionProvider {
   snapshot(): EnterpriseSessionSnapshot | Promise<EnterpriseSessionSnapshot>;
@@ -39,6 +40,17 @@ export interface ZhiyuanEnterpriseSettingsHostCapability {
   registerPage(page: ZhiyuanEnterpriseSettingsPageRegistration): () => void;
 }
 
+export interface ZhiyuanEnterpriseManagedSkillRegistration {
+  readonly directory: string;
+  notifyChanged(): void;
+  unregister(): void;
+}
+
+export interface ZhiyuanEnterpriseSkillHostCapability {
+  readonly apiVersion: typeof ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION;
+  registerManagedRoot(): ZhiyuanEnterpriseManagedSkillRegistration;
+}
+
 export const ZhiyuanEnterpriseExtensionStatus = {
   Idle: 'idle',
   Absent: 'absent',
@@ -63,6 +75,7 @@ export interface ZhiyuanEnterpriseHostContext {
     readonly session: ZhiyuanEnterpriseSessionHostCapability | null;
     readonly renderer: ZhiyuanEnterpriseRendererHostCapability | null;
     readonly settings: ZhiyuanEnterpriseSettingsHostCapability | null;
+    readonly skills: ZhiyuanEnterpriseSkillHostCapability | null;
   };
 }
 

--- a/src/main/enterpriseExtension/host.test.ts
+++ b/src/main/enterpriseExtension/host.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,
   ZHIYUAN_ENTERPRISE_SESSION_CAPABILITY_API_VERSION,
+  ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION,
   ZhiyuanEnterpriseExtensionStatus,
   type ZhiyuanEnterpriseHostContext,
 } from './contract';
@@ -69,6 +70,7 @@ describe('Zhiyuan enterprise extension host', () => {
     expect(receivedContext!.capabilities.session).toBeNull();
     expect(receivedContext!.capabilities.renderer).toBeNull();
     expect(receivedContext!.capabilities.settings).toBeNull();
+    expect(receivedContext!.capabilities.skills).toBeNull();
 
     await host.dispose();
     await host.dispose();
@@ -160,6 +162,36 @@ describe('Zhiyuan enterprise extension host', () => {
 
     expect(createSettingsCapability).toHaveBeenCalledWith(path.dirname(modulePath));
     expect(receivedContext!.capabilities.settings).toBe(settingsCapability);
+  });
+
+  test('passes the versioned managed Skill capability to the extension', async () => {
+    const root = createTemporaryDirectory();
+    const modulePath = path.join(root, 'resources', 'zhiyuan-enterprise', 'extension.cjs');
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'module placeholder');
+    const skillCapability = {
+      apiVersion: ZHIYUAN_ENTERPRISE_SKILL_CAPABILITY_API_VERSION,
+      registerManagedRoot: vi.fn(() => ({
+        directory: path.join(root, 'skills'),
+        notifyChanged: vi.fn(),
+        unregister: vi.fn(),
+      })),
+    };
+    let receivedContext: ZhiyuanEnterpriseHostContext | null = null;
+    const host = new ZhiyuanEnterpriseExtensionHost(async () => ({
+      createZhiyuanEnterpriseExtension: () => ({
+        ...validExtension(),
+        initialize: async (context: ZhiyuanEnterpriseHostContext) => {
+          receivedContext = context;
+        },
+      }),
+    }));
+
+    await host.initialize({ ...options(root, true), createSkillCapability: () => skillCapability });
+
+    expect(receivedContext!.capabilities.skills).toBe(skillCapability);
+    expect(receivedContext!.capabilities.skills?.apiVersion).toBe(1);
+    expect(skillCapability.registerManagedRoot).not.toHaveBeenCalled();
   });
 
   test('imports a real CommonJS development bundle', async () => {

--- a/src/main/enterpriseExtension/host.ts
+++ b/src/main/enterpriseExtension/host.ts
@@ -12,6 +12,7 @@ import {
   type ZhiyuanEnterpriseRendererHostCapability,
   type ZhiyuanEnterpriseSettingsHostCapability,
   type ZhiyuanEnterpriseSessionHostCapability,
+  type ZhiyuanEnterpriseSkillHostCapability,
 } from './contract';
 
 const ENTERPRISE_RESOURCE_DIRECTORY = 'zhiyuan-enterprise';
@@ -32,6 +33,7 @@ export interface ZhiyuanEnterpriseExtensionHostOptions {
   readonly createSettingsCapability?: (
     extensionDirectory: string,
   ) => ZhiyuanEnterpriseSettingsHostCapability;
+  readonly createSkillCapability?: () => ZhiyuanEnterpriseSkillHostCapability;
 }
 
 type ExtensionModuleImporter = (modulePath: string) => Promise<unknown>;
@@ -188,6 +190,7 @@ function createHostContext(
     session: options.sessionCapability ?? null,
     renderer: options.createRendererCapability?.(extensionDirectory) ?? null,
     settings: options.createSettingsCapability?.(extensionDirectory) ?? null,
+    skills: options.createSkillCapability?.() ?? null,
   });
   return Object.freeze({
     apiVersion: ZHIYUAN_ENTERPRISE_EXTENSION_API_VERSION,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6664,6 +6664,23 @@ if (!gotTheLock) {
         zhiyuanEnterpriseRendererBridge.createScopedCapability(extensionDirectory),
       createSettingsCapability: extensionDirectory =>
         zhiyuanEnterpriseRendererBridge.createScopedSettingsCapability(extensionDirectory),
+      createSkillCapability: () => ({
+        apiVersion: 1,
+        registerManagedRoot: () => {
+          let active = true;
+          return {
+            // The extension is initialized before the main SQLite store. Resolve the
+            // filesystem root eagerly, but defer manager access until a sync completes.
+            directory: getSkillsRoot(),
+            notifyChanged: () => {
+              if (active) getSkillManager().notifySkillsChanged();
+            },
+            unregister: () => {
+              active = false;
+            },
+          };
+        },
+      }),
     });
     if (enterpriseExtension.extensionId) {
       console.log(

--- a/src/main/skillManager.ts
+++ b/src/main/skillManager.ts
@@ -2668,7 +2668,8 @@ export class SkillManager {
     }, WATCH_DEBOUNCE_MS);
   }
 
-  private notifySkillsChanged(): void {
+  /** Notify renderer and runtime listeners that managed Skill contents changed externally. */
+  notifySkillsChanged(): void {
     BrowserWindow.getAllWindows().forEach(win => {
       if (!win.isDestroyed()) {
         win.webContents.send('skills:changed');

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.test.tsx
@@ -57,7 +57,7 @@ describe('EnterpriseRendererFrame', () => {
       }),
     );
 
-    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(frame).toHaveAttribute('sandbox', 'allow-forms allow-scripts');
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         source: EnterpriseRendererMessageSource.Host,

--- a/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
+++ b/src/renderer/components/enterprise/EnterpriseRendererFrame.tsx
@@ -85,7 +85,7 @@ export function EnterpriseRendererFrame({
       ref={iframeRef}
       src={src}
       title={title}
-      sandbox="allow-scripts"
+      sandbox="allow-forms allow-scripts"
       className={cn('border-0 bg-background', className)}
     />
   );

--- a/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
+++ b/src/renderer/components/enterprise/EnterpriseSessionGate.test.tsx
@@ -57,7 +57,7 @@ describe('EnterpriseSessionGate', () => {
     );
 
     const frame = await screen.findByTitle('Zhiyuan');
-    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(frame).toHaveAttribute('sandbox', 'allow-forms allow-scripts');
     expect(frame).toHaveAttribute('src', 'zhiyuan-enterprise-ui://renderer/index.html');
     expect(screen.queryByText('application')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add versioned managed Skill capability to the enterprise extension host contract
- pass the capability through the extension host and expose the active Skill root
- notify Zhiyuan SkillManager when the closed-source Agent-control runtime changes managed Skills
- keep manager access lazy because enterprise extension initialization precedes SQLite store initialization
- add host contract coverage for capability propagation

## Verification
- npm run build:tsc
- npx vitest run src/main/enterpriseExtension/host.test.ts src/main/skillManager.test.ts
- git diff --check

This PR only wires the public host boundary. The closed-source Agent-control implementation remains in ZhiyuanAaaS.
