### PR TITLE
feat(coding): add built-in model selector

### DIFF
--- a/src/main/codingAgent/codingRoomRepository.ts
+++ b/src/main/codingAgent/codingRoomRepository.ts
@@ -46,6 +46,7 @@ const rowLane = (row: Record<string, unknown>): CodingAgentLane => ({
   id: String(row.id),
   missionId: String(row.mission_id),
   profileId: String(row.profile_id),
+  modelOverride: (row.model_override as string | null) ?? null,
   sourceRoot: String(row.source_root || row.execution_root || ''),
   executionRoot: String(row.execution_root ?? ''),
   configOptions: JSON.parse(String(row.config_options_json ?? '[]')) as CodingAgentConfigOption[],
@@ -345,12 +346,14 @@ export class CodingRoomRepository {
     executionRoot = sourceRoot,
     id: string = randomUUID(),
     localSessionId: string = randomUUID(),
+    modelOverride: string | null = null,
   ): CodingAgentLane {
     const now = Date.now();
     const lane: CodingAgentLane = {
       id,
       missionId,
       profileId,
+      modelOverride,
       sourceRoot,
       executionRoot,
       configOptions: [],
@@ -365,12 +368,13 @@ export class CodingRoomRepository {
     };
     this.db
       .prepare(
-        'INSERT INTO coding_agent_lanes (id, mission_id, profile_id, source_root, execution_root, config_options_json, available_commands_json, local_session_id, remote_session_id, status, draft, scroll_position, pending_recovery_prompt, pending_recovery_context, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, NULL, ?, ?)',
+        'INSERT INTO coding_agent_lanes (id, mission_id, profile_id, model_override, source_root, execution_root, config_options_json, available_commands_json, local_session_id, remote_session_id, status, draft, scroll_position, pending_recovery_prompt, pending_recovery_context, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, NULL, ?, ?)',
       )
       .run(
         lane.id,
         missionId,
         profileId,
+        modelOverride,
         lane.sourceRoot,
         lane.executionRoot,
         JSON.stringify(lane.configOptions),

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -53,6 +53,7 @@ export interface CodingRoomRuntime {
     sessionId: string;
     workspaceRoot: string;
     prompt: string;
+    modelOverride?: string | null;
   }): Promise<void>;
   cancelBuiltinSession(sessionId: string): Promise<void>;
   getBuiltinWorkbenchLink(sessionId: string): { taskId: string; runId: string } | null;
@@ -123,8 +124,13 @@ export class CodingRoomService extends EventEmitter {
     this.git = new CodingGitController(repository);
     this.driverFactory = new CodingDriverFactory(
       {
-        start: (sessionId, workspaceRoot, prompt) =>
-          this.runtime.startBuiltinSession({ sessionId, workspaceRoot, prompt }),
+        start: (sessionId, workspaceRoot, prompt, modelOverride) =>
+          this.runtime.startBuiltinSession({
+            sessionId,
+            workspaceRoot,
+            prompt,
+            ...(modelOverride ? { modelOverride } : {}),
+          }),
         cancel: sessionId => this.runtime.cancelBuiltinSession(sessionId),
       },
       Object.fromEntries(ACP_ENVIRONMENT_KEYS.map(key => [key, process.env[key]])),
@@ -1125,6 +1131,7 @@ export class CodingRoomService extends EventEmitter {
         sessionId,
         workspaceRoot: executionRoot,
         prompt,
+        modelOverride: lane.modelOverride,
       })) {
         this.repository.appendOrMergeStreamEvent(lane.id, event.kind, event.payload);
         this.repository.updateLaneConfigOptions(lane.id, driver.getSessionConfigOptions(sessionId));

--- a/src/main/codingAgent/codingSessionStartup.ts
+++ b/src/main/codingAgent/codingSessionStartup.ts
@@ -58,6 +58,7 @@ export const persistCodingSessionRecord = async (input: {
   title: string;
   laneId?: string;
   localSessionId?: string;
+  modelOverride?: string | null;
   getWorkspaceBaseline: (sourceRoot: string) => Promise<string | null>;
 }): Promise<CodingAgentLane> => {
   const { repository, target } = input;
@@ -74,6 +75,7 @@ export const persistCodingSessionRecord = async (input: {
       target.sourceRoot,
       input.laneId,
       input.localSessionId,
+      input.modelOverride ?? null,
     );
     repository.createAssignment({
       missionId: mission.id,
@@ -118,7 +120,7 @@ export const prepareCodingSession = async (input: {
   getWorkspaceBaseline: (sourceRoot: string) => Promise<string | null>;
 }): Promise<PreparedCodingSession> => {
   const target = resolveSessionTarget(input.repository, input.registry, input.request);
-  if (target.profile.driverKind === CodingAgentDriverKind.Builtin) {
+  if (target.profile.driverKind === CodingAgentDriverKind.Builtin && !input.request.modelOverride) {
     await input.validateBuiltinModel?.();
   }
 
@@ -152,6 +154,7 @@ export const prepareCodingSession = async (input: {
         buildSessionTitleFromInput(input.prompt, t('codingAgentDefaultMissionTitle')),
       laneId,
       localSessionId,
+      modelOverride: input.request.modelOverride,
       getWorkspaceBaseline: input.getWorkspaceBaseline,
     });
     input.repository.updateLaneRemoteSession(lane.id, driverSession.remoteSessionId);

--- a/src/main/codingAgent/drivers/acpCodingDriver.ts
+++ b/src/main/codingAgent/drivers/acpCodingDriver.ts
@@ -286,6 +286,7 @@ export class AcpCodingDriver implements CodingAgentDriver {
     sessionId: string;
     workspaceRoot: string;
     prompt: string;
+    modelOverride?: string | null;
   }): AsyncIterable<DriverEvent> {
     await this.ensureConnected(input.workspaceRoot);
     this.fallbackMessageIds.delete(this.messageFallbackKey(input.sessionId, 'assistant'));

--- a/src/main/codingAgent/drivers/builtinCodingDriver.test.ts
+++ b/src/main/codingAgent/drivers/builtinCodingDriver.test.ts
@@ -25,3 +25,25 @@ test('starts the in-process runtime while the room owns streamed event projectio
   await driver.cancel(session.id);
   expect(calls).toEqual([session.id, `cancel:${session.id}`]);
 });
+
+test('forwards the selected model to the in-process runtime', async () => {
+  const received: string[] = [];
+  const driver = new BuiltinCodingDriver({
+    start: async (_sessionId, _workspaceRoot, _prompt, modelOverride) => {
+      if (modelOverride) received.push(modelOverride);
+    },
+    cancel: async () => undefined,
+  });
+  const session = await driver.createSession({ workspaceRoot: '/workspace' });
+
+  for await (const _event of driver.prompt({
+    sessionId: session.id,
+    workspaceRoot: '/workspace',
+    prompt: 'work',
+    modelOverride: 'deepseek/deepseek-v4-pro',
+  })) {
+    // The built-in runtime owns the stream projection.
+  }
+
+  expect(received).toEqual(['deepseek/deepseek-v4-pro']);
+});

--- a/src/main/codingAgent/drivers/builtinCodingDriver.ts
+++ b/src/main/codingAgent/drivers/builtinCodingDriver.ts
@@ -29,7 +29,12 @@ const BUILTIN_CAPABILITIES: CodingAgentCapabilities = {
 export class BuiltinCodingDriver implements CodingAgentDriver {
   constructor(
     private readonly runtime: {
-      start(sessionId: string, workspaceRoot: string, prompt: string): Promise<void>;
+      start(
+        sessionId: string,
+        workspaceRoot: string,
+        prompt: string,
+        modelOverride?: string | null,
+      ): Promise<void>;
       cancel(sessionId: string): Promise<void>;
     },
   ) {}
@@ -65,8 +70,14 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
     sessionId: string;
     workspaceRoot: string;
     prompt: string;
+    modelOverride?: string | null;
   }): AsyncIterable<Omit<CodingEvent, 'id' | 'laneId' | 'sequence' | 'createdAt'>> {
-    await this.runtime.start(input.sessionId, input.workspaceRoot, input.prompt);
+    await this.runtime.start(
+      input.sessionId,
+      input.workspaceRoot,
+      input.prompt,
+      input.modelOverride,
+    );
     // The in-process runtime emits streaming events after start() returns. The
     // CodingRoomService subscribes to that runtime directly, which avoids
     // snapshotting a race-prone event buffer and writing every event twice.

--- a/src/main/codingAgent/drivers/codingAgentDriver.ts
+++ b/src/main/codingAgent/drivers/codingAgentDriver.ts
@@ -43,6 +43,7 @@ export interface CodingAgentDriver {
     sessionId: string;
     workspaceRoot: string;
     prompt: string;
+    modelOverride?: string | null;
   }): AsyncIterable<Omit<CodingEvent, 'id' | 'laneId' | 'sequence' | 'createdAt'>>;
   cancel(sessionId: string): Promise<void>;
   respondToPermission(response: CodingPermissionResponse): Promise<void>;

--- a/src/main/codingAgent/schema.ts
+++ b/src/main/codingAgent/schema.ts
@@ -25,7 +25,7 @@ export function initializeCodingAgentSchema(db: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_coding_agent_profiles_command ON coding_agent_profiles(command);
     CREATE TABLE IF NOT EXISTS coding_agent_lanes (
-      id TEXT PRIMARY KEY, mission_id TEXT NOT NULL, profile_id TEXT NOT NULL, source_root TEXT NOT NULL DEFAULT '', execution_root TEXT NOT NULL DEFAULT '', config_options_json TEXT NOT NULL DEFAULT '[]', available_commands_json TEXT NOT NULL DEFAULT '[]', local_session_id TEXT NOT NULL,
+      id TEXT PRIMARY KEY, mission_id TEXT NOT NULL, profile_id TEXT NOT NULL, model_override TEXT, source_root TEXT NOT NULL DEFAULT '', execution_root TEXT NOT NULL DEFAULT '', config_options_json TEXT NOT NULL DEFAULT '[]', available_commands_json TEXT NOT NULL DEFAULT '[]', local_session_id TEXT NOT NULL,
       remote_session_id TEXT, status TEXT NOT NULL, draft TEXT NOT NULL DEFAULT '', scroll_position INTEGER NOT NULL DEFAULT 0,
       pending_recovery_prompt TEXT, pending_recovery_context TEXT,
       created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
@@ -72,6 +72,9 @@ export function initializeCodingAgentSchema(db: Database.Database): void {
   }>;
   if (!laneColumns.some(column => column.name === 'execution_root')) {
     db.exec("ALTER TABLE coding_agent_lanes ADD COLUMN execution_root TEXT NOT NULL DEFAULT ''");
+  }
+  if (!laneColumns.some(column => column.name === 'model_override')) {
+    db.exec('ALTER TABLE coding_agent_lanes ADD COLUMN model_override TEXT');
   }
   if (!laneColumns.some(column => column.name === 'source_root')) {
     db.exec("ALTER TABLE coding_agent_lanes ADD COLUMN source_root TEXT NOT NULL DEFAULT ''");

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -883,7 +883,7 @@ const getCodingRoomService = (): CodingRoomService => {
         app.getAppPath(),
       ),
       {
-        startBuiltinSession: async ({ sessionId, workspaceRoot, prompt }) => {
+        startBuiltinSession: async ({ sessionId, workspaceRoot, prompt, modelOverride }) => {
           const coworkStoreInstance = getCoworkStore();
           if (!coworkStoreInstance.getSession(sessionId)) {
             coworkStoreInstance.createSession(
@@ -904,6 +904,7 @@ const getCodingRoomService = (): CodingRoomService => {
             workspaceRoot,
             sessionMode: 'work',
             confirmationMode: 'modal',
+            ...(modelOverride ? { modelOverride } : {}),
           });
         },
         cancelBuiltinSession: async sessionId => runtime.stopSession(sessionId),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -989,15 +989,40 @@ const getCodingRoomService = (): CodingRoomService => {
     );
     codingRoomService.registry.hydrate();
     runtime.on('message', (sessionId: string, message: unknown) => {
-      codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.Message, { message });
+      const metadata =
+        message && typeof message === 'object' && 'metadata' in message
+          ? (message as { metadata?: unknown }).metadata
+          : null;
+      const isThinking =
+        metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+          ? (metadata as { isThinking?: unknown }).isThinking === true
+          : false;
+      codingRoomService?.recordBuiltinEvent(
+        sessionId,
+        isThinking ? CodingEventKind.Reasoning : CodingEventKind.Message,
+        { message, ...(isThinking ? { streamUpdateMode: CodingStreamUpdateMode.Replace } : {}) },
+      );
     });
-    runtime.on('messageUpdate', (sessionId: string, messageId: string, content: string) => {
-      codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.MessageDelta, {
-        content,
-        messageId,
-        streamUpdateMode: CodingStreamUpdateMode.Replace,
-      });
-    });
+    runtime.on(
+      'messageUpdate',
+      (
+        sessionId: string,
+        messageId: string,
+        content: string,
+        metadata?: Record<string, unknown>,
+      ) => {
+        const isThinking = metadata?.isThinking === true;
+        codingRoomService?.recordBuiltinEvent(
+          sessionId,
+          isThinking ? CodingEventKind.Reasoning : CodingEventKind.MessageDelta,
+          {
+            content,
+            messageId,
+            streamUpdateMode: CodingStreamUpdateMode.Replace,
+          },
+        );
+      },
+    );
     runtime.on('toolActivity', (sessionId: string, event: unknown) => {
       codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.ToolCall, { event });
     });

--- a/src/renderer/components/coding/CodingDraftControls.tsx
+++ b/src/renderer/components/coding/CodingDraftControls.tsx
@@ -6,9 +6,18 @@ import {
   SelectValue,
 } from '@shared/components/ui/select';
 import { Bot, Folder } from 'lucide-react';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
-import type { CodingAgentProfile, CodingWorkspaceSource } from '../../../shared/codingAgent';
+import {
+  CodingAgentDriverKind,
+  type CodingAgentProfile,
+  type CodingWorkspaceSource,
+} from '../../../shared/codingAgent';
 import { i18nService } from '../../services/i18n';
+import { resolveAgentModelRef, toAgentModelRef } from '../../utils/agentModelRef';
+import { CoworkModelPicker } from '../cowork/CoworkModelPicker';
+import type { RootState } from '../../store';
 import type { CodingSessionDraft } from './CodingWorkspaceSidebar';
 import { CodingAgentStatusI18nKey } from './constants';
 
@@ -26,11 +35,31 @@ export const CodingDraftControls = ({
   onChange,
 }: CodingDraftControlsProps) => {
   const activeProfile = profiles.find(profile => profile.id === draft.profileId);
+  const modelState = useSelector((state: RootState) => state.model);
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const isBuiltin = activeProfile?.driverKind === CodingAgentDriverKind.Builtin;
+  const selectedModel =
+    (draft.modelOverride
+      ? resolveAgentModelRef(draft.modelOverride, modelState.availableModels)
+      : null) ??
+    modelState.defaultSelectedModel ??
+    null;
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-1.5">
       <Select
         value={draft.profileId}
-        onValueChange={profileId => profileId && onChange({ ...draft, profileId })}
+        onValueChange={profileId => {
+          if (!profileId) return;
+          const nextProfile = profiles.find(profile => profile.id === profileId);
+          onChange({
+            ...draft,
+            profileId,
+            modelOverride:
+              nextProfile?.driverKind === CodingAgentDriverKind.Builtin
+                ? draft.modelOverride
+                : null,
+          });
+        }}
       >
         <SelectTrigger
           size="sm"
@@ -55,6 +84,15 @@ export const CodingDraftControls = ({
           ))}
         </SelectContent>
       </Select>
+      {isBuiltin ? (
+        <CoworkModelPicker
+          models={modelState.availableModels}
+          selectedModel={selectedModel}
+          open={modelPickerOpen}
+          onOpenChange={setModelPickerOpen}
+          onSelect={model => onChange({ ...draft, modelOverride: toAgentModelRef(model) })}
+        />
+      ) : null}
       {sources.length > 1 ? (
         <Select
           value={draft.sourceRoot}

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -25,6 +25,7 @@ import {
   Settings2,
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import type { CodingRoomSnapshot } from '../../../shared/codingAgent';
 import {
@@ -35,6 +36,8 @@ import {
   CodingPermissionOutcome,
 } from '../../../shared/codingAgent';
 import { i18nService } from '../../services/i18n';
+import type { RootState } from '../../store';
+import { toAgentModelRef } from '../../utils/agentModelRef';
 import { CodingAgentManager } from './CodingAgentManager';
 import { CodingAuthAndPermissionDialogs } from './CodingAuthAndPermissionDialogs';
 import { CodingComposer } from './CodingComposer';
@@ -90,6 +93,7 @@ export const CodingWorkbenchView = ({
   } | null>(null);
   const [authTerminalInput, setAuthTerminalInput] = useState('');
   const [agentManagerOpen, setAgentManagerOpen] = useState(false);
+  const defaultSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const draftSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const eventStreamRef = useRef<HTMLDivElement | null>(null);
@@ -382,6 +386,11 @@ export const CodingWorkbenchView = ({
         workspaceId: draftSession.workspaceId,
         sourceRoot: draftSession.sourceRoot,
         profileId: draftSession.profileId,
+        modelOverride:
+          draftSession.modelOverride ??
+          (activeProfile?.isBuiltin && defaultSelectedModel
+            ? toAgentModelRef(defaultSelectedModel)
+            : undefined),
         prompt,
       });
       const laneId = result.snapshot?.room.activeLaneId;

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -29,6 +29,7 @@ export interface CodingSessionDraft {
   workspaceId: string;
   sourceRoot: string;
   profileId: string;
+  modelOverride: string | null;
   sources: CodingWorkspaceSummary['sources'];
 }
 
@@ -152,6 +153,7 @@ export const CodingWorkspaceSidebar = ({
         workspaceId: workspace.id,
         sourceRoot: workspace.sources[0]?.path ?? workspace.primaryRoot,
         profileId: workspace.defaultProfileId || CodingAgentProfileId.Builtin,
+        modelOverride: null,
         sources: workspace.sources,
       },
     });

--- a/src/renderer/components/coding/codingEventProjection.test.ts
+++ b/src/renderer/components/coding/codingEventProjection.test.ts
@@ -44,6 +44,22 @@ describe('projectCodingEvents', () => {
     expect(turns[0].status).toBe(CodingConversationTurnStatus.Complete);
   });
 
+  test('replaces cumulative built-in reasoning snapshots', () => {
+    const turns = projectCodingEvents([
+      event(1, CodingEventKind.Message, { role: 'user', content: '分析问题' }),
+      event(2, CodingEventKind.Reasoning, {
+        content: '先检查',
+        streamUpdateMode: CodingStreamUpdateMode.Replace,
+      }),
+      event(3, CodingEventKind.Reasoning, {
+        content: '先检查认证流程。',
+        streamUpdateMode: CodingStreamUpdateMode.Replace,
+      }),
+    ]);
+
+    expect(turns[0].reasoning?.content).toBe('先检查认证流程。');
+  });
+
   test('keeps tool activity but leaves file and terminal events to the inspector', () => {
     const turns = projectCodingEvents([
       event(1, CodingEventKind.Message, { role: 'user', content: '运行测试' }),

--- a/src/renderer/components/coding/codingEventProjection.ts
+++ b/src/renderer/components/coding/codingEventProjection.ts
@@ -190,7 +190,9 @@ export const projectCodingEvents = (events: CodingEvent[]): CodingConversationTu
       const content = getCodingEventText(event);
       if (!content) continue;
       const turn = ensureTurn(event);
-      if (turn.reasoning) turn.reasoning.content += content;
+      if (turn.reasoning && event.payload.streamUpdateMode === CodingStreamUpdateMode.Replace) {
+        turn.reasoning.content = content;
+      } else if (turn.reasoning) turn.reasoning.content += content;
       else turn.reasoning = { id: event.id, content, createdAt: event.createdAt };
       continue;
     }

--- a/src/shared/codingAgent/types.ts
+++ b/src/shared/codingAgent/types.ts
@@ -100,6 +100,8 @@ export interface CodingAgentLane {
   id: string;
   missionId: string;
   profileId: string;
+  /** Explicit provider/model reference for the built-in agent, when selected. */
+  modelOverride: string | null;
   /** Immutable source folder selected when this Agent session was created. */
   sourceRoot: string;
   /** Actual cwd. Collaborators use an isolated worktree derived from sourceRoot. */
@@ -215,6 +217,7 @@ export interface CreateCodingSessionInput {
   profileId: string;
   sourceRoot: string;
   title?: string;
+  modelOverride?: string;
 }
 
 export interface StartCodingSessionInput extends CreateCodingSessionInput {


### PR DESCRIPTION
## Summary

- Add a model picker to new coding sessions that use the built-in ZhiYuan agent.
- Persist the selected `provider/model` reference on the coding lane.
- Forward the lane model override through the coding driver into the in-process runtime.
- Project built-in reasoning streams into the coding conversation.
- Keep the selector hidden for external ACP agents and preserve the global Cowork default.

## Implementation

- Reuse the existing Cowork model picker and available-model Redux state.
- Add a nullable `model_override` lane column with startup migration for existing databases.
- Skip the default-model probe when an explicit model is selected; the runtime validates the selected model during startup.
- Normalize built-in thinking metadata to `CodingEventKind.Reasoning` with cumulative `Replace` snapshots.
- Preserve ACP thought chunks as incremental `Append` reasoning events.
- Add regression coverage for model forwarding and cumulative reasoning projection.

## Verification

- `bun run lint`
- `bun run build:tsc`
- `bun run build:vite`
- `bun run build:electron:dev`
- `bunx vitest run src/main/codingAgent/drivers/builtinCodingDriver.test.ts`
- `bunx vitest run src/renderer/components/coding/codingEventProjection.test.ts`

The full coding room test file was not runnable in the local Windows environment because the installed `better-sqlite3` binary uses Node ABI 143 while the active runtime requires ABI 137. CI should rebuild the native dependency as part of the test setup.

## Electron impact

The change affects coding-session IPC payloads and SQLite lane persistence. Existing lanes remain valid with a null model override, and ACP session behavior is unchanged. Built-in runtime thinking metadata is now projected to the same reasoning event format used by ACP agents.