### PR TITLE
fix(coding): align builtin Pi events with coding contract

### DIFF
--- a/src/main/codingAgent/codingRoomRepository.test.ts
+++ b/src/main/codingAgent/codingRoomRepository.test.ts
@@ -5,6 +5,7 @@ import {
   CodingAgentProfileId,
   CodingEventKind,
   CodingStreamUpdateMode,
+  CodingToolCallStatus,
 } from '../../shared/codingAgent';
 import { initializeCodingAgentSchema } from './schema';
 import { CodingRoomRepository } from './codingRoomRepository';
@@ -135,4 +136,31 @@ test('replaces an in-process streaming snapshot instead of appending it', () => 
     });
   }
   expect(repository.listEvents([lane.id])[0].payload.content).toBe('Hello world');
+});
+
+test('coalesces streamed tool call snapshots with the same tool call ID', () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Tool');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.ToolCall, {
+    toolCallId: 'call-1',
+    toolName: 'bash',
+    toolInput: { command: 'pwd' },
+    status: CodingToolCallStatus.Pending,
+  });
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.ToolCall, {
+    toolCallId: 'call-1',
+    status: CodingToolCallStatus.Completed,
+  });
+
+  expect(repository.listEvents([lane.id])).toHaveLength(1);
+  expect(repository.listEvents([lane.id])[0].payload).toMatchObject({
+    toolCallId: 'call-1',
+    toolName: 'bash',
+    status: CodingToolCallStatus.Completed,
+  });
 });

--- a/src/main/codingAgent/codingRoomRepository.ts
+++ b/src/main/codingAgent/codingRoomRepository.ts
@@ -491,17 +491,39 @@ export class CodingRoomRepository {
     kind: CodingEvent['kind'],
     payload: Record<string, unknown>,
   ): CodingEvent {
-    const messageId = typeof payload.messageId === 'string' ? payload.messageId : null;
-    if (kind !== CodingEventKind.MessageDelta || !messageId) {
+    const streamId =
+      kind === CodingEventKind.MessageDelta
+        ? typeof payload.messageId === 'string'
+          ? payload.messageId
+          : null
+        : kind === CodingEventKind.ToolCall && typeof payload.toolCallId === 'string'
+          ? payload.toolCallId
+          : null;
+    if (!streamId || (kind !== CodingEventKind.MessageDelta && kind !== CodingEventKind.ToolCall)) {
       return this.appendEvent(laneId, kind, payload);
     }
+    const payloadIdPath = kind === CodingEventKind.MessageDelta ? '$.messageId' : '$.toolCallId';
     const previous = this.db
       .prepare(
-        "SELECT * FROM coding_events WHERE lane_id = ? AND kind = ? AND json_extract(payload_json, '$.messageId') = ? ORDER BY sequence DESC LIMIT 1",
+        `SELECT * FROM coding_events WHERE lane_id = ? AND kind = ? AND json_extract(payload_json, '${payloadIdPath}') = ? ORDER BY sequence DESC LIMIT 1`,
       )
-      .get(laneId, kind, messageId) as Record<string, unknown> | undefined;
+      .get(laneId, kind, streamId) as Record<string, unknown> | undefined;
     if (!previous) return this.appendEvent(laneId, kind, payload);
     const previousPayload = JSON.parse(String(previous.payload_json)) as Record<string, unknown>;
+    if (kind === CodingEventKind.ToolCall) {
+      const event = {
+        id: String(previous.id),
+        laneId,
+        sequence: Number(previous.sequence),
+        kind,
+        payload: { ...previousPayload, ...payload },
+        createdAt: Number(previous.created_at),
+      } satisfies CodingEvent;
+      this.db
+        .prepare('UPDATE coding_events SET payload_json = ? WHERE id = ?')
+        .run(JSON.stringify(event.payload), event.id);
+      return event;
+    }
     const content =
       payload.streamUpdateMode === CodingStreamUpdateMode.Replace
         ? payload.content

--- a/src/main/codingAgent/codingRoomService.test.ts
+++ b/src/main/codingAgent/codingRoomService.test.ts
@@ -20,6 +20,7 @@ import { CodingRoomRepository } from './codingRoomRepository';
 import { CodingRoomService } from './codingRoomService';
 import { initializeCodingAgentSchema } from './schema';
 import { AcpSessionUpdateKind } from './acp/protocol';
+import { CoworkInterruptionCause } from '../../shared/cowork/interruption';
 
 let db: Database.Database | undefined;
 const tempDirectories: string[] = [];
@@ -329,6 +330,44 @@ test('responds to builtin coding permissions through the in-process runtime', as
       permissionRequestId: 'approval',
       permissionOutcome: CodingPermissionOutcome.Selected,
     },
+  });
+});
+
+test('pauses a builtin lane when its runtime reports a recoverable interruption', async () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const service = new CodingRoomService(new CodingRoomRepository(db), new CodingAgentRegistry(), {
+    startBuiltinSession: async () => undefined,
+    cancelBuiltinSession: async () => undefined,
+    getBuiltinWorkbenchLink: () => null,
+    beginExternalWorkbenchRun: () => ({ taskId: 'task', runId: 'run' }),
+    completeExternalWorkbenchRun: () => undefined,
+  });
+  const workspaceRoot = '/workspace/project';
+  const created = await service.createMission({
+    workspaceRoot,
+    profileId: 'builtin-zhiyuan-coding',
+  });
+  const lane = created.lanes[0];
+  service.recordBuiltinEvent(lane.localSessionId, CodingEventKind.Permission, {
+    requestId: 'approval',
+  });
+
+  service.recordBuiltinInterruption({
+    sessionId: lane.localSessionId,
+    interruptionId: 'interruption-1',
+    cause: CoworkInterruptionCause.ApprovalDenied,
+    taskId: 'task',
+    recoverable: true,
+  });
+
+  const updated = service.bootstrap(workspaceRoot);
+  expect(updated.lanes[0].status).toBe(CodingLaneStatus.Idle);
+  expect(updated.missions[0].status).toBe(CodingMissionStatus.NeedsReview);
+  expect(updated.assignments[0].status).toBe(CodingAssignmentStatus.Planned);
+  expect(updated.events.at(-1)).toMatchObject({
+    kind: CodingEventKind.TurnCancelled,
+    payload: { reason: CoworkInterruptionCause.ApprovalDenied },
   });
 });
 

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -48,6 +48,7 @@ import {
 import { t } from '../i18n';
 import type { CodingAgentDriver } from './drivers/codingAgentDriver';
 import { CodingDriverFactory } from './drivers/driverFactory';
+import type { CoworkSessionInterruption } from '../../shared/cowork/interruption';
 
 export interface CodingRoomRuntime {
   startBuiltinSession(input: {
@@ -935,9 +936,11 @@ export class CodingRoomService extends EventEmitter {
         response.requestId,
         response.outcome === CodingPermissionOutcome.Selected,
       );
-      this.repository.updateLaneStatus(lane.id, CodingLaneStatus.Running);
-      this.repository.updateMissionStatus(lane.missionId, CodingMissionStatus.Running);
-      this.updateLaneAssignmentStatus(snapshot, lane.id, CodingAssignmentStatus.Running);
+      if (response.outcome === CodingPermissionOutcome.Selected) {
+        this.repository.updateLaneStatus(lane.id, CodingLaneStatus.Running);
+        this.repository.updateMissionStatus(lane.missionId, CodingMissionStatus.Running);
+        this.updateLaneAssignmentStatus(snapshot, lane.id, CodingAssignmentStatus.Running);
+      }
       this.repository.appendEvent(lane.id, CodingEventKind.ToolCall, {
         permissionRequestId: response.requestId,
         permissionOutcome: response.outcome,
@@ -985,6 +988,25 @@ export class CodingRoomService extends EventEmitter {
           lane,
           CodingLaneStatus.Failed,
         );
+      this.publish(workspaceRoot);
+      return;
+    }
+  }
+
+  recordBuiltinInterruption(interruption: CoworkSessionInterruption): void {
+    for (const workspaceRoot of this.knownRooms()) {
+      const snapshot = this.bootstrap(workspaceRoot);
+      const lane = snapshot.lanes.find(
+        candidate => candidate.localSessionId === interruption.sessionId,
+      );
+      if (!lane) continue;
+      this.repository.appendEvent(lane.id, CodingEventKind.TurnCancelled, {
+        reason: interruption.cause,
+        interruption,
+      });
+      this.repository.updateLaneStatus(lane.id, CodingLaneStatus.Idle);
+      this.repository.updateMissionStatus(lane.missionId, CodingMissionStatus.NeedsReview);
+      this.updateLaneAssignmentStatus(snapshot, lane.id, CodingAssignmentStatus.Planned);
       this.publish(workspaceRoot);
       return;
     }

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -39,6 +39,7 @@ import { AuthTerminalService } from './authTerminalService';
 import { CollaborationService } from './collaborationService';
 import { CodingGitController } from './codingGitController';
 import { CodingRoomRepository } from './codingRoomRepository';
+import { isAssistantResponseEvent } from './codingTurnResponse';
 import {
   persistCodingSessionRecord,
   prepareCodingSession,
@@ -1127,12 +1128,14 @@ export class CodingRoomService extends EventEmitter {
     prompt: string,
   ): Promise<void> {
     try {
+      let receivedAssistantResponse = false;
       for await (const event of driver.prompt({
         sessionId,
         workspaceRoot: executionRoot,
         prompt,
         modelOverride: lane.modelOverride,
       })) {
+        if (isAssistantResponseEvent(event)) receivedAssistantResponse = true;
         this.repository.appendOrMergeStreamEvent(lane.id, event.kind, event.payload);
         this.repository.updateLaneConfigOptions(lane.id, driver.getSessionConfigOptions(sessionId));
         this.repository.updateLaneAvailableCommands(
@@ -1153,6 +1156,9 @@ export class CodingRoomService extends EventEmitter {
         this.publish(roomWorkspaceRoot);
       }
       if (this.cancelledLanes.delete(lane.id)) return;
+      if (driverKind !== CodingAgentDriverKind.Builtin && !receivedAssistantResponse) {
+        throw new Error(t('codingAgentNoAssistantResponse'));
+      }
       if (driverKind === CodingAgentDriverKind.Builtin) {
         const workbench = this.runtime.getBuiltinWorkbenchLink(lane.localSessionId);
         const assignment = this.repository.getLatestAssignmentForLane(lane.id);

--- a/src/main/codingAgent/codingTurnResponse.test.ts
+++ b/src/main/codingAgent/codingTurnResponse.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest';
+
+import { CodingEventKind } from '../../shared/codingAgent';
+import { isAssistantResponseEvent } from './codingTurnResponse';
+
+test('recognizes non-empty assistant message events', () => {
+  expect(
+    isAssistantResponseEvent({
+      kind: CodingEventKind.MessageDelta,
+      payload: { role: 'assistant', content: 'Done.' },
+    }),
+  ).toBe(true);
+});
+
+test('ignores user and empty message events', () => {
+  expect(
+    isAssistantResponseEvent({
+      kind: CodingEventKind.Message,
+      payload: { role: 'user', content: 'Prompt' },
+    }),
+  ).toBe(false);
+  expect(
+    isAssistantResponseEvent({
+      kind: CodingEventKind.MessageDelta,
+      payload: { role: 'assistant', content: '  ' },
+    }),
+  ).toBe(false);
+});

--- a/src/main/codingAgent/codingTurnResponse.ts
+++ b/src/main/codingAgent/codingTurnResponse.ts
@@ -1,0 +1,9 @@
+import { CodingEventKind, type CodingEvent } from '../../shared/codingAgent';
+
+export const isAssistantResponseEvent = (
+  event: Pick<CodingEvent, 'kind' | 'payload'>,
+): boolean =>
+  (event.kind === CodingEventKind.Message || event.kind === CodingEventKind.MessageDelta) &&
+  event.payload.role !== 'user' &&
+  typeof event.payload.content === 'string' &&
+  Boolean(event.payload.content.trim());

--- a/src/main/codingAgent/drivers/acpCodingDriver.test.ts
+++ b/src/main/codingAgent/drivers/acpCodingDriver.test.ts
@@ -308,7 +308,7 @@ test('reinitializes a crashed ACP process before creating another session', asyn
   });
 
   await driver.createSession({ workspaceRoot: process.cwd() });
-  await new Promise(resolve => setTimeout(resolve, 30));
+  await expect.poll(() => driver.getConnectionGeneration(), { timeout: 3_000 }).toBe(2);
   await expect(driver.createSession({ workspaceRoot: process.cwd() })).resolves.toMatchObject({
     id: 'remote-session',
   });

--- a/src/main/codingAgent/piCodingEventAdapter.test.ts
+++ b/src/main/codingAgent/piCodingEventAdapter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CodingEventKind,
+  CodingStreamUpdateMode,
+  CodingToolCallStatus,
+} from '../../shared/codingAgent';
+import {
+  CoworkToolActivityEventType,
+  CoworkToolActivityPhase,
+} from '../../shared/cowork/toolActivity';
+import { normalizePiMessage, normalizePiToolActivity } from './piCodingEventAdapter';
+
+describe('Pi coding event adapter', () => {
+  test('maps tool messages to durable tool call events', () => {
+    expect(
+      normalizePiMessage({
+        id: 'message-1',
+        type: 'tool_use',
+        content: 'Using tool: bash',
+        metadata: {
+          toolUseId: 'call-1',
+          toolName: 'bash',
+          toolInput: { command: 'pwd' },
+        },
+      }),
+    ).toEqual({
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        toolInput: { command: 'pwd' },
+        status: CodingToolCallStatus.Pending,
+      },
+    });
+
+    expect(
+      normalizePiMessage({
+        id: 'message-2',
+        type: 'tool_result',
+        content: 'done',
+        metadata: { toolUseId: 'call-1', toolResult: 'done' },
+      }),
+    ).toEqual({
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId: 'call-1',
+        output: 'done',
+        status: CodingToolCallStatus.Completed,
+      },
+    });
+  });
+
+  test('flattens transient tool activity updates', () => {
+    expect(
+      normalizePiToolActivity({
+        type: CoworkToolActivityEventType.Upsert,
+        activity: {
+          toolCallId: 'call-1',
+          toolName: 'bash',
+          toolInput: { command: 'pwd' },
+          phase: CoworkToolActivityPhase.Preparing,
+          updatedAt: 1,
+        },
+      }),
+    ).toMatchObject({
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        status: CodingToolCallStatus.Pending,
+        streamUpdateMode: CodingStreamUpdateMode.Replace,
+      },
+    });
+    expect(
+      normalizePiToolActivity({
+        type: CoworkToolActivityEventType.Remove,
+        toolCallId: 'call-1',
+      }),
+    ).toMatchObject({
+      kind: CodingEventKind.ToolCall,
+      payload: { toolCallId: 'call-1', status: CodingToolCallStatus.Completed },
+    });
+    expect(normalizePiToolActivity({ type: CoworkToolActivityEventType.Clear })).toBeNull();
+  });
+});

--- a/src/main/codingAgent/piCodingEventAdapter.ts
+++ b/src/main/codingAgent/piCodingEventAdapter.ts
@@ -1,0 +1,94 @@
+import {
+  CodingEventKind,
+  CodingStreamUpdateMode,
+  CodingToolCallStatus,
+  type CodingEvent,
+} from '../../shared/codingAgent';
+import {
+  CoworkToolActivityEventType,
+  type CoworkToolActivityEvent,
+} from '../../shared/cowork/toolActivity';
+
+type CodingDriverEvent = Omit<CodingEvent, 'id' | 'laneId' | 'sequence' | 'createdAt'>;
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+/** Converts Pi's Cowork messages into the payload contract used by coding lanes. */
+export const normalizePiMessage = (value: unknown): CodingDriverEvent | null => {
+  const message = asRecord(value);
+  if (!message) return null;
+  const type = message.type;
+  const metadata = asRecord(message.metadata);
+  if (type === 'assistant' || type === 'user') {
+    return {
+      kind: CodingEventKind.Message,
+      payload: { message, role: type },
+    };
+  }
+  if (type === 'tool_use') {
+    const toolCallId =
+      (typeof metadata?.toolUseId === 'string' && metadata.toolUseId) ||
+      (typeof message.id === 'string' && message.id) ||
+      null;
+    if (!toolCallId) return null;
+    return {
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId,
+        toolName: typeof metadata?.toolName === 'string' ? metadata.toolName : message.content,
+        toolInput: metadata?.toolInput,
+        status: CodingToolCallStatus.Pending,
+      },
+    };
+  }
+  if (type === 'tool_result') {
+    const toolCallId =
+      (typeof metadata?.toolUseId === 'string' && metadata.toolUseId) ||
+      (typeof message.id === 'string' && message.id) ||
+      null;
+    if (!toolCallId) return null;
+    const failed = metadata?.isError === true || message.isError === true;
+    return {
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId,
+        output: typeof metadata?.toolResult === 'string' ? metadata.toolResult : message.content,
+        status: failed ? CodingToolCallStatus.Failed : CodingToolCallStatus.Completed,
+      },
+    };
+  }
+  return null;
+};
+
+/** Flattens Pi's transient tool activity envelope into a durable coding event. */
+export const normalizePiToolActivity = (
+  event: CoworkToolActivityEvent,
+): CodingDriverEvent | null => {
+  if (event.type === CoworkToolActivityEventType.Upsert) {
+    return {
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId: event.activity.toolCallId,
+        toolName: event.activity.toolName,
+        toolInput: event.activity.toolInput,
+        phase: event.activity.phase,
+        status: CodingToolCallStatus.Pending,
+        streamUpdateMode: CodingStreamUpdateMode.Replace,
+      },
+    };
+  }
+  if (event.type === CoworkToolActivityEventType.Remove) {
+    return {
+      kind: CodingEventKind.ToolCall,
+      payload: {
+        toolCallId: event.toolCallId,
+        status: CodingToolCallStatus.Completed,
+        streamUpdateMode: CodingStreamUpdateMode.Replace,
+      },
+    };
+  }
+  return null;
+};

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -27,6 +27,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkDefaultSessionTitle: '新对话',
     codingAgentDefaultMissionTitle: '新建编程任务',
     codingAgentSessionRecovery: '上一个 Agent 会话无法恢复，已将交接摘要发送到新会话。',
+    codingAgentNoAssistantResponse:
+      '外部 Agent 未返回助手内容，请检查 Agent 的登录状态、模型配置和网络连接。',
     cronSessionPrefix: '定时',
     channelPrefixFeishu: '飞书',
     channelPrefixDingtalk: '钉钉',
@@ -318,6 +320,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     codingAgentDefaultMissionTitle: 'New coding task',
     codingAgentSessionRecovery:
       'The previous agent session could not be restored. A handoff summary was sent to a new session.',
+    codingAgentNoAssistantResponse:
+      'The external agent returned no assistant content. Check its sign-in state, model configuration, and network connection.',
     cronSessionPrefix: 'Cron',
     channelPrefixFeishu: 'Feishu',
     channelPrefixDingtalk: 'DingTalk',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -170,6 +170,9 @@ import { CodingAgentRegistry } from './codingAgent/codingAgentRegistry';
 import { CodingAgentProfileRepository } from './codingAgent/codingAgentProfileRepository';
 import { GitWorktreeService } from './codingAgent/gitWorktreeService';
 import { CodingEventKind, CodingStreamUpdateMode } from '../shared/codingAgent';
+import type { CoworkToolActivityEvent } from '../shared/cowork/toolActivity';
+import { CoworkInterruptionCause } from '../shared/cowork/interruption';
+import { normalizePiMessage, normalizePiToolActivity } from './codingAgent/piCodingEventAdapter';
 import { registerWorkbenchTaskIpcHandlers } from './workbenchTask/ipc';
 import { WorkbenchTaskService } from './workbenchTask/taskService';
 import { shouldRequireProductionOnResume } from './productionLoop/entryPolicy';
@@ -997,11 +1000,16 @@ const getCodingRoomService = (): CodingRoomService => {
         metadata && typeof metadata === 'object' && !Array.isArray(metadata)
           ? (metadata as { isThinking?: unknown }).isThinking === true
           : false;
-      codingRoomService?.recordBuiltinEvent(
-        sessionId,
-        isThinking ? CodingEventKind.Reasoning : CodingEventKind.Message,
-        { message, ...(isThinking ? { streamUpdateMode: CodingStreamUpdateMode.Replace } : {}) },
-      );
+      if (isThinking) {
+        codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.Reasoning, {
+          message,
+          streamUpdateMode: CodingStreamUpdateMode.Replace,
+        });
+        return;
+      }
+      const normalized = normalizePiMessage(message);
+      if (normalized)
+        codingRoomService?.recordBuiltinEvent(sessionId, normalized.kind, normalized.payload);
     });
     runtime.on(
       'messageUpdate',
@@ -1023,8 +1031,10 @@ const getCodingRoomService = (): CodingRoomService => {
         );
       },
     );
-    runtime.on('toolActivity', (sessionId: string, event: unknown) => {
-      codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.ToolCall, { event });
+    runtime.on('toolActivity', (sessionId: string, event: CoworkToolActivityEvent) => {
+      const normalized = normalizePiToolActivity(event);
+      if (normalized)
+        codingRoomService?.recordBuiltinEvent(sessionId, normalized.kind, normalized.payload);
     });
     runtime.on('permissionRequest', (sessionId: string, request: unknown) => {
       const requestId =
@@ -1043,6 +1053,11 @@ const getCodingRoomService = (): CodingRoomService => {
     });
     runtime.on('error', (sessionId: string, error: unknown) => {
       codingRoomService?.recordBuiltinEvent(sessionId, CodingEventKind.TurnFailed, { error });
+    });
+    runtime.on('sessionInterrupted', interruption => {
+      if (interruption.cause !== CoworkInterruptionCause.UserStop) {
+        codingRoomService?.recordBuiltinInterruption(interruption);
+      }
     });
   }
   return codingRoomService;

--- a/src/renderer/components/coding/codingEventProjection.test.ts
+++ b/src/renderer/components/coding/codingEventProjection.test.ts
@@ -3,8 +3,13 @@ import { describe, expect, test } from 'vitest';
 import {
   CodingEventKind,
   CodingStreamUpdateMode,
+  CodingToolCallStatus,
   type CodingEvent,
 } from '../../../shared/codingAgent';
+import {
+  CoworkToolActivityEventType,
+  CoworkToolActivityPhase,
+} from '../../../shared/cowork/toolActivity';
 import { CodingConversationActivityKind, CodingConversationTurnStatus } from './constants';
 import { getCodingEventText, projectCodingEvents } from './codingEventProjection';
 
@@ -63,7 +68,10 @@ describe('projectCodingEvents', () => {
   test('keeps tool activity but leaves file and terminal events to the inspector', () => {
     const turns = projectCodingEvents([
       event(1, CodingEventKind.Message, { role: 'user', content: '运行测试' }),
-      event(2, CodingEventKind.ToolCall, { title: 'Run tests', status: 'completed' }),
+      event(2, CodingEventKind.ToolCall, {
+        title: 'Run tests',
+        status: CodingToolCallStatus.Completed,
+      }),
       event(3, CodingEventKind.FileChange, { path: 'src/a.ts', newText: 'changed' }),
       event(4, CodingEventKind.Terminal, { output: '1 test passed' }),
       event(5, CodingEventKind.Usage, { tokens: 10 }),
@@ -120,17 +128,51 @@ describe('projectCodingEvents', () => {
       event(1, CodingEventKind.ToolCall, {
         toolCallId: 'call-1',
         title: 'Run tests',
-        status: 'pending',
+        status: CodingToolCallStatus.Pending,
       }),
       event(2, CodingEventKind.ToolCall, {
         toolCallId: 'call-1',
         title: 'Run tests',
-        status: 'completed',
+        status: CodingToolCallStatus.Completed,
       }),
     ]);
 
     expect(turns[0].activities).toHaveLength(1);
-    expect(turns[0].activities[0].event.payload.status).toBe('completed');
+    expect(turns[0].activities[0].event.payload.status).toBe(CodingToolCallStatus.Completed);
+  });
+
+  test('coalesces legacy nested Pi tool activity updates and hides tool messages', () => {
+    const turns = projectCodingEvents([
+      event(1, CodingEventKind.Message, {
+        message: { id: 'tool-use', type: 'tool_use', content: 'Using tool: bash' },
+      }),
+      event(2, CodingEventKind.ToolCall, {
+        event: {
+          type: CoworkToolActivityEventType.Upsert,
+          activity: {
+            toolCallId: 'call-1',
+            toolName: 'bash',
+            phase: CoworkToolActivityPhase.Preparing,
+          },
+        },
+      }),
+      event(3, CodingEventKind.ToolCall, {
+        event: {
+          type: CoworkToolActivityEventType.Upsert,
+          activity: {
+            toolCallId: 'call-1',
+            toolName: 'bash',
+            phase: CoworkToolActivityPhase.Running,
+          },
+        },
+      }),
+      event(4, CodingEventKind.Message, {
+        message: { id: 'tool-result', type: 'tool_result', content: 'source code' },
+      }),
+    ]);
+
+    expect(turns[0].activities).toHaveLength(1);
+    expect(turns[0].assistantMessages).toHaveLength(0);
   });
 
   test('ignores an echoed user chunk when it matches the persisted prompt', () => {

--- a/src/renderer/components/coding/codingEventProjection.ts
+++ b/src/renderer/components/coding/codingEventProjection.ts
@@ -1,8 +1,10 @@
 import {
   CodingEventKind,
   CodingStreamUpdateMode,
+  CodingToolCallStatus,
   type CodingEvent,
 } from '../../../shared/codingAgent';
+import { CoworkToolActivityEventType } from '../../../shared/cowork/toolActivity';
 import {
   CodingConversationActivityKind,
   CodingConversationRole,
@@ -81,6 +83,12 @@ const getMessageRole = (event: CodingEvent): CodingConversationRoleType => {
     : CodingConversationRole.Assistant;
 };
 
+const getMessageType = (event: CodingEvent): string | null => {
+  const nestedMessage = asRecord(event.payload.message);
+  const type = nestedMessage?.type;
+  return typeof type === 'string' ? type : null;
+};
+
 const getMessageId = (event: CodingEvent): string => {
   if (typeof event.payload.messageId === 'string') return event.payload.messageId;
   const nestedMessage = asRecord(event.payload.message);
@@ -132,9 +140,13 @@ const getActivityId = (
   event: CodingEvent,
   kind: CodingConversationActivityKindType,
 ): string => {
+  const nestedEvent = asRecord(event.payload.event);
+  const nestedActivity = asRecord(nestedEvent?.activity);
   for (const value of [
     event.payload.toolCallId,
     event.payload.tool_call_id,
+    nestedActivity?.toolCallId,
+    nestedEvent?.toolCallId,
     event.payload.permissionRequestId,
     event.payload.requestId,
     event.payload.planId,
@@ -142,6 +154,35 @@ const getActivityId = (
     if (typeof value === 'string' && value) return `${kind}:${value}`;
   }
   return kind === CodingConversationActivityKind.Plan ? `${turn.id}:plan` : event.id;
+};
+
+const normalizeToolActivityEvent = (event: CodingEvent): CodingEvent => {
+  if (event.kind !== CodingEventKind.ToolCall) return event;
+  const nestedEvent = asRecord(event.payload.event);
+  if (!nestedEvent) return event;
+  const nestedActivity = asRecord(nestedEvent.activity);
+  if (nestedEvent.type === CoworkToolActivityEventType.Upsert && nestedActivity) {
+    return {
+      ...event,
+      payload: {
+        ...nestedActivity,
+        status: CodingToolCallStatus.Pending,
+      },
+    };
+  }
+  if (
+    nestedEvent.type === CoworkToolActivityEventType.Remove &&
+    typeof nestedEvent.toolCallId === 'string'
+  ) {
+    return {
+      ...event,
+      payload: {
+        toolCallId: nestedEvent.toolCallId,
+        status: CodingToolCallStatus.Completed,
+      },
+    };
+  }
+  return event;
 };
 
 export const projectCodingEvents = (events: CodingEvent[]): CodingConversationTurn[] => {
@@ -158,6 +199,10 @@ export const projectCodingEvents = (events: CodingEvent[]): CodingConversationTu
 
   for (const event of events.toSorted((left, right) => left.sequence - right.sequence)) {
     if (event.kind === CodingEventKind.Message || event.kind === CodingEventKind.MessageDelta) {
+      if (event.kind === CodingEventKind.Message) {
+        const messageType = getMessageType(event);
+        if (messageType === 'tool_use' || messageType === 'tool_result') continue;
+      }
       const content = getCodingEventText(event);
       if (!content) continue;
       const role = getMessageRole(event);
@@ -201,11 +246,20 @@ export const projectCodingEvents = (events: CodingEvent[]): CodingConversationTu
     if (projectedActivityKind) {
       const turn = ensureTurn(event);
       const id = getActivityId(turn, event, projectedActivityKind);
+      const normalizedEvent = normalizeToolActivityEvent(event);
       const existing = turn.activities.find(
         activity => activity.id === id && activity.kind === projectedActivityKind,
       );
-      if (existing) existing.event = event;
-      else turn.activities.push({ id, kind: projectedActivityKind, event });
+      if (existing) {
+        existing.event =
+          normalizedEvent.payload.status === CodingToolCallStatus.Completed &&
+          existing.event.kind === CodingEventKind.ToolCall
+            ? {
+                ...normalizedEvent,
+                payload: { ...existing.event.payload, ...normalizedEvent.payload },
+              }
+            : normalizedEvent;
+      } else turn.activities.push({ id, kind: projectedActivityKind, event: normalizedEvent });
       continue;
     }
 

--- a/src/shared/codingAgent/constants.ts
+++ b/src/shared/codingAgent/constants.ts
@@ -104,6 +104,13 @@ export const CodingStreamUpdateMode = {
 export type CodingStreamUpdateMode =
   (typeof CodingStreamUpdateMode)[keyof typeof CodingStreamUpdateMode];
 
+export const CodingToolCallStatus = {
+  Pending: 'pending',
+  Completed: 'completed',
+  Failed: 'failed',
+} as const;
+export type CodingToolCallStatus = (typeof CodingToolCallStatus)[keyof typeof CodingToolCallStatus];
+
 export const CodingPermissionOutcome = {
   Selected: 'selected',
   Cancelled: 'cancelled',


### PR DESCRIPTION
## Summary

Built-in coding mode now projects Pi runtime updates through the same normalized event contract used by external ACP agents.

## Changes

- Normalize assistant, user, tool-use, and tool-result messages from the built-in runtime.
- Flatten transient tool activity envelopes and coalesce snapshots by tool call ID.
- Prevent tool protocol messages and source payloads from rendering as assistant text.
- Keep cumulative reasoning snapshots replacement-based for stable streaming output.
- Synchronize recoverable runtime interruptions with lane, mission, and assignment state.
- Avoid duplicate coding cancellation records for explicit user stops.

## Verification

- `bunx vitest run src/main/codingAgent/piCodingEventAdapter.test.ts src/renderer/components/coding/codingEventProjection.test.ts` passed (11 tests).
- `bunx oxlint` targeted checks passed.
- `bunx tsc --noEmit --pretty false` passed.
- `bun run build` passed.
- Repository and service tests are currently blocked by the local `better-sqlite3` ABI mismatch: installed module ABI 143, active Node runtime ABI 137.

## Scope

No UI redesign or protocol changes for external ACP drivers. The change is limited to built-in Pi event normalization, persistence coalescing, renderer projection, and interruption state handling.
