### PR TITLE
fix(coding): disable external diff execution in Git panel

### DIFF
--- a/src/main/codingAgent/codingGitService.test.ts
+++ b/src/main/codingAgent/codingGitService.test.ts
@@ -9,7 +9,11 @@ import { CodingGitService } from './codingGitService';
 
 const git = async (cwd: string, args: string[]): Promise<string> =>
   await new Promise<string>((resolve, reject) => {
-    const child = spawn('git', args, { cwd, shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn('git', args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     let stdout = '';
     let stderr = '';
     child.stdout.setEncoding('utf8');
@@ -45,7 +49,10 @@ test('reports structured staged, unstaged, and untracked Git state', async () =>
   await writeFile(path.join(root, 'untracked.txt'), 'one\ntwo\n');
 
   const service = new CodingGitService();
-  const status = await service.getStatus(root, { isIsolated: false, isBusy: false });
+  const status = await service.getStatus(root, {
+    isIsolated: false,
+    isBusy: false,
+  });
 
   expect(status.isRepository).toBe(true);
   expect(status.branch).toBe('main');
@@ -77,6 +84,17 @@ test('reports structured staged, unstaged, and untracked Git state', async () =>
 test('loads file diffs and stages or unstages only explicit paths', async () => {
   const root = await createRepository();
   const service = new CodingGitService();
+  await git(root, ['config', 'diff.external', 'missing-external-diff-command']);
+  await writeFile(path.join(root, 'tracked.txt'), 'changed\n');
+  const trackedDiff = await service.getDiff({
+    workspaceRoot: root,
+    sourceRoot: root,
+    targetRoot: root,
+    path: 'tracked.txt',
+    scope: CodingGitDiffScope.Unstaged,
+  });
+  expect(trackedDiff).toContain('+changed');
+
   await writeFile(path.join(root, 'untracked file.txt'), 'new file\n');
 
   const diff = await service.getDiff({

--- a/src/main/codingAgent/codingGitService.ts
+++ b/src/main/codingAgent/codingGitService.ts
@@ -320,8 +320,12 @@ export class CodingGitService {
       .stdout;
     const parsed = parsePorcelainStatus(statusOutput);
     const [stagedOutput, unstagedOutput] = await Promise.all([
-      runGit(targetRoot, ['diff', '--cached', '--numstat', '-z']).then(result => result.stdout),
-      runGit(targetRoot, ['diff', '--numstat', '-z']).then(result => result.stdout),
+      runGit(targetRoot, ['diff', '--no-ext-diff', '--cached', '--numstat', '-z']).then(
+        result => result.stdout,
+      ),
+      runGit(targetRoot, ['diff', '--no-ext-diff', '--numstat', '-z']).then(
+        result => result.stdout,
+      ),
     ]);
     const numStats = parseNumStat(stagedOutput);
     mergeNumStats(numStats, parseNumStat(unstagedOutput));
@@ -366,13 +370,13 @@ export class CodingGitService {
     let args: string[];
     switch (input.scope) {
       case CodingGitDiffScope.Staged:
-        args = ['diff', '--cached', '--binary', '--', filePath];
+        args = ['diff', '--no-ext-diff', '--cached', '--binary', '--', filePath];
         break;
       case CodingGitDiffScope.Untracked:
-        args = ['diff', '--no-index', '--binary', '--', '/dev/null', filePath];
+        args = ['diff', '--no-ext-diff', '--no-index', '--binary', '--', '/dev/null', filePath];
         break;
       default:
-        args = ['diff', '--binary', '--', filePath];
+        args = ['diff', '--no-ext-diff', '--binary', '--', filePath];
     }
     const result = await runGit(input.targetRoot, args, {
       acceptedExitCodes: input.scope === CodingGitDiffScope.Untracked ? [0, 1] : [0],


### PR DESCRIPTION
## Summary
- add --no-ext-diff to Git panel diff previews
- apply the flag to staged, unstaged, untracked, and status numstat reads
- add a regression test for repositories with a configured external diff command

## Security impact
Read-only Git panel actions no longer invoke diff.external or other configured external diff drivers, preventing repository or user Git configuration from launching an unintended program during diff display.

## Validation
- unx vitest run src/main/codingAgent/codingGitService.test.ts
- oxlint passed for changed TypeScript files

## Notes
This PR is independent and based on main. Full Electron packaging was not run because the local Windows native dependency toolchain requires additional rebuild setup.