### PR TITLE
feat(shell): widen default window to 16:10 and soften structural dividers

### DIFF
--- a/src/main/windowState.test.ts
+++ b/src/main/windowState.test.ts
@@ -9,13 +9,13 @@ import {
   resolveInitialAppWindowState,
 } from './windowState';
 
-test('resolveInitialAppWindowState uses the image-like default size on large displays', () => {
+test('resolveInitialAppWindowState uses the 16:10 default size on large displays', () => {
   const state = resolveInitialAppWindowState(undefined, [
     { x: 0, y: 0, width: 2560, height: 1440 },
   ]);
 
   expect(state).toEqual({
-    x: 680,
+    x: 640,
     y: 320,
     width: DEFAULT_APP_WINDOW_WIDTH,
     height: DEFAULT_APP_WINDOW_HEIGHT,

--- a/src/main/windowState.ts
+++ b/src/main/windowState.ts
@@ -2,7 +2,7 @@ export const AppWindowStoreKey = {
   State: 'app_window_state',
 } as const;
 
-export const DEFAULT_APP_WINDOW_WIDTH = 1200;
+export const DEFAULT_APP_WINDOW_WIDTH = 1280;
 export const DEFAULT_APP_WINDOW_HEIGHT = 800;
 export const MIN_APP_WINDOW_WIDTH = 1024;
 export const MIN_APP_WINDOW_HEIGHT = 740;

--- a/src/renderer/components/PageHeader.tsx
+++ b/src/renderer/components/PageHeader.tsx
@@ -49,7 +49,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
       <div
         className={cn(
           'draggable flex h-12 items-center justify-between gap-3 px-4',
-          !tabs && 'border-b border-border',
+          !tabs && 'border-b border-border-subtle',
         )}
       >
         <div className="flex h-8 min-w-0 items-center gap-3">
@@ -94,7 +94,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
           <WindowTitleBar inline />
         </div>
       </div>
-      {tabs ? <div className="non-draggable border-b border-border px-4">{tabs}</div> : null}
+      {tabs ? <div className="non-draggable border-b border-border-subtle px-4">{tabs}</div> : null}
     </header>
   );
 };

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,4 +1,4 @@
-﻿import { Button } from '@shared/components/ui/button';
+import { Button } from '@shared/components/ui/button';
 import { Checkbox } from '@shared/components/ui/checkbox';
 import { Input } from '@shared/components/ui/input';
 import { RadioGroup, RadioGroupItem } from '@shared/components/ui/radio-group';
@@ -5197,7 +5197,7 @@ const Settings: React.FC<SettingsProps> = ({
         onClick={handleSettingsClick}
       >
         {/* Left sidebar */}
-        <div className="w-[180px] sm:w-[220px] shrink-0 flex flex-col bg-surface-raised border-r border-border rounded-l-2xl overflow-y-auto">
+        <div className="w-[180px] sm:w-[220px] shrink-0 flex flex-col bg-surface-raised border-r border-border-subtle rounded-l-2xl overflow-y-auto">
           <div className="px-5 pt-5 pb-3">
             <h2 className="text-lg font-semibold text-foreground">{i18nService.t('settings')}</h2>
           </div>

--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -327,7 +327,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
         className={`non-draggable bg-background flex flex-col h-full overflow-hidden ${
           layoutMode === ArtifactLayoutMode.Workspace || isFullscreen
             ? 'fixed inset-0 z-200 w-screen border-0'
-            : 'relative min-w-0 flex-1 border-l border-border'
+            : 'relative min-w-0 flex-1 border-l border-border-subtle'
         }`}
       >
         {/* Floating file list overlay */}

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -943,7 +943,7 @@ export const CodingWorkbenchView = ({
         {error && <p className="px-3 pb-2 text-xs text-destructive">{error}</p>}
       </main>
       {desktopSidePanelOpen && (
-        <aside className="min-h-0 border-l border-border max-lg:hidden">
+        <aside className="min-h-0 border-l border-border-subtle max-lg:hidden">
           {sidePanelView === CodingSidePanelView.Git ? (
             <CodingGitPanel
               workspaceRoot={workspaceRoot}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -160,7 +160,7 @@ class ArtifactPanelErrorBoundary extends React.Component<
   render() {
     if (this.state.hasError) {
       return (
-        <aside className="w-[420px] shrink-0 border-l border-border bg-background flex flex-col h-full items-center justify-center p-4">
+        <aside className="w-[420px] shrink-0 border-l border-border-subtle bg-background flex flex-col h-full items-center justify-center p-4">
           <p className="text-sm text-red-500 mb-2">Artifact panel error</p>
           <pre className="text-xs text-muted whitespace-pre-wrap max-w-full overflow-auto mb-3">
             {this.state.error?.message}

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -23,7 +23,7 @@
   --zy-text-secondary: oklch(0.553 0.013 58.071);
   --zy-text-muted: oklch(0.553 0.013 58.071);
   --zy-border: oklch(0.923 0.003 48.717);
-  --zy-border-subtle: oklch(0.923 0.003 48.717);
+  --zy-border-subtle: oklch(0.952 0.002 48.717);
   --zy-input-border: oklch(0.923 0.003 48.717);
   --zy-destructive: oklch(0.577 0.245 27.325);
   --zy-destructive-foreground: oklch(0.985 0.001 106.423);

--- a/src/renderer/theme/themes/classic-light.ts
+++ b/src/renderer/theme/themes/classic-light.ts
@@ -44,7 +44,7 @@ export const classicLight: ThemeDefinition = {
     'text-muted-foreground': 'oklch(0.553 0.013 58.071)',
     'text-muted': 'oklch(0.553 0.013 58.071)',
     border: 'oklch(0.923 0.003 48.717)',
-    'border-subtle': 'oklch(0.923 0.003 48.717)',
+    'border-subtle': 'oklch(0.952 0.002 48.717)',
     'input-border': 'oklch(0.923 0.003 48.717)',
     'scroll-thumb': 'oklch(0.709 0.01 56.259)',
     'scroll-thumb-hover': 'oklch(0.553 0.013 58.071)',


### PR DESCRIPTION
## What

Two chrome-level refinements, redesign-preserve (no layout structure changes):

1. **Default window aspect ratio**: 1200x800 (3:2) becomes 1280x800 (16:10). Content area next to the 244px sidebar goes from about 930px to about 1010px, which keeps chat plus artifact panel comfortable. Min size, small-display scaling, and stored-bounds restore are unchanged; windowState tests updated.

2. **Divider system**: light theme previously set border and border-subtle to the same oklch(0.923) value, so the weaker tier did nothing. border-subtle now resolves to oklch(0.952) (themes.css regenerated in sync). Structural chrome dividers drop one tier from border-border to border-border-subtle:
   - PageHeader main row and tabs row (horizontal, every feature page)
   - Settings nav rail (vertical)
   - Artifact panel edge, coding side panel edge, cowork artifact error fallback (vertical)

   Content-level dividers (dialogs, tables, cards) keep border-border. Dark theme already had distinct tiers (10% / 5% white) and only benefits from the demotions.

## Verification

- vitest windowState: 7/7 pass
- oxlint clean, tsc --noEmit passes