### PR TITLE
fix(cowork): resolve runtime provider aliases and retry errors

### DIFF
--- a/src/main/libs/claudeSettings.test.ts
+++ b/src/main/libs/claudeSettings.test.ts
@@ -450,6 +450,41 @@ test('resolveRawApiConfigForModelRef resolves an explicit llama.cpp model ref', 
   });
 });
 
+test('resolveRawApiConfigForModelRef accepts the runtime provider ID for Zhipu', () => {
+  setStoreGetter(
+    () =>
+      ({
+        get: (key: string) =>
+          key === 'app_config'
+            ? {
+                model: {
+                  defaultModel: 'glm-5.2',
+                  defaultModelProvider: ProviderName.Zhipu,
+                },
+                providers: {
+                  [ProviderName.Zhipu]: {
+                    enabled: true,
+                    apiKey: 'sk-zhipu',
+                    baseUrl: 'https://open.bigmodel.cn/api/anthropic',
+                    apiFormat: 'anthropic' as const,
+                    models: [{ id: 'glm-5.2', name: 'GLM 5.2' }],
+                  },
+                },
+              }
+            : undefined,
+      }) as never,
+  );
+
+  const result = resolveRawApiConfigForModelRef('zai/glm-5.2');
+  expect(result.config).toEqual({
+    apiKey: 'sk-zhipu',
+    baseURL: 'https://open.bigmodel.cn/api/anthropic',
+    model: 'glm-5.2',
+    apiType: 'anthropic',
+  });
+  expect(result.providerMetadata?.providerName).toBe(ProviderName.Zhipu);
+});
+
 test('resolveRawApiConfigForModelRef resolves explicit llama.cpp model when provider is disabled', () => {
   const runningModel = buildLlamaCppRunningModelBinding({
     name: 'qwen-explicit-disabled',

--- a/src/main/libs/claudeSettings.ts
+++ b/src/main/libs/claudeSettings.ts
@@ -506,25 +506,38 @@ function resolveMatchedProviderForModelRef(
     return { matched: null, error: `Invalid model ref: ${normalizedRef}` };
   }
 
-  const providerName = normalizedRef.slice(0, slashIndex);
+  const requestedProviderName = normalizedRef.slice(0, slashIndex);
   const modelId = normalizedRef.slice(slashIndex + 1).trim();
   if (!modelId) {
     return { matched: null, error: `Invalid model ref: ${normalizedRef}` };
   }
 
-  if (providerName === ProviderName.LlamaCpp) {
+  const configuredProviderName = appConfig.providers?.[requestedProviderName]
+    ? requestedProviderName
+    : (ProviderRegistry.getProviderNameByAgentProviderId(requestedProviderName) ??
+      requestedProviderName);
+
+  if (configuredProviderName === ProviderName.LlamaCpp) {
     const runningProviderConfig = buildLlamaCppRunningProviderConfig(appConfig, modelId);
     if (runningProviderConfig) {
-      return resolveMatchedProviderFromSelection(providerName, runningProviderConfig, modelId);
+      return resolveMatchedProviderFromSelection(
+        configuredProviderName,
+        runningProviderConfig,
+        modelId,
+      );
     }
   }
 
-  const storedProviderConfig = appConfig.providers?.[providerName];
-  if (!storedProviderConfig || !isProviderEnabled(providerName, storedProviderConfig)) {
-    return { matched: null, error: `Provider ${providerName} is not enabled.` };
+  const storedProviderConfig = appConfig.providers?.[configuredProviderName];
+  if (!storedProviderConfig || !isProviderEnabled(configuredProviderName, storedProviderConfig)) {
+    return { matched: null, error: `Provider ${requestedProviderName} is not enabled.` };
   }
 
-  return resolveMatchedProviderFromSelection(providerName, storedProviderConfig, modelId);
+  return resolveMatchedProviderFromSelection(
+    configuredProviderName,
+    storedProviderConfig,
+    modelId,
+  );
 }
 
 function buildRawApiResolutionFromMatched(matched: MatchedProvider): ApiConfigResolution {

--- a/src/renderer/services/cowork.errorHandling.structure.test.ts
+++ b/src/renderer/services/cowork.errorHandling.structure.test.ts
@@ -27,3 +27,11 @@ test('creates at most one canonical message for a synchronous continue failure',
   );
   expect(continueSource).not.toContain("i18nService.t('coworkErrorSessionContinueFailed')");
 });
+
+test('does not reload a stale database snapshot after continue is accepted', () => {
+  const continueStart = source.indexOf('async continueSession(options: CoworkContinueOptions)');
+  const continueEnd = source.indexOf('async stopSession(sessionId: string)');
+  const continueSource = source.slice(continueStart, continueEnd);
+
+  expect(continueSource).not.toContain('this.loadSession(options.sessionId)');
+});

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -472,7 +472,6 @@ class CoworkService {
       workspaceService.promoteWorkspace(result.session.workspaceId);
     }
     await workspaceService.refreshWorkspaces();
-    void this.loadSession(options.sessionId);
     return true;
   }
 

--- a/src/shared/providers/constants.test.ts
+++ b/src/shared/providers/constants.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
-import { ApiFormat, ModelCapabilityStatus, ProviderName, ProviderRegistry } from './constants';
+import {
+  AgentProviderId,
+  ApiFormat,
+  ModelCapabilityStatus,
+  ProviderName,
+  ProviderRegistry,
+} from './constants';
 
 describe('ProviderName constants', () => {
   test('contains expected provider keys', () => {
@@ -25,6 +31,16 @@ describe('ProviderRegistry', () => {
     expect(def!.id).toBe(ProviderName.OpenAI);
     expect(def!.defaultApiFormat).toBe(ApiFormat.OpenAI);
     expect(def!.region).toBe('global');
+  });
+
+  test('resolves runtime provider IDs back to configuration keys', () => {
+    expect(ProviderRegistry.getProviderNameByAgentProviderId(AgentProviderId.Zai)).toBe(
+      ProviderName.Zhipu,
+    );
+    expect(ProviderRegistry.getProviderNameByAgentProviderId(AgentProviderId.Google)).toBe(
+      ProviderName.Gemini,
+    );
+    expect(ProviderRegistry.getProviderNameByAgentProviderId('unknown')).toBeUndefined();
   });
 
   test('stores official model capacity metadata', () => {

--- a/src/shared/providers/constants.ts
+++ b/src/shared/providers/constants.ts
@@ -1415,6 +1415,11 @@ class ProviderRegistryImpl {
     );
   }
 
+  /** Resolve a runtime provider ID back to its application configuration key. */
+  getProviderNameByAgentProviderId(agentProviderId: string): string | undefined {
+    return this.defs.find(def => def.agentProviderId === agentProviderId)?.id;
+  }
+
   getProviderModelSupportsImage(providerName: string, modelId: string): boolean | undefined {
     const model = this.getModel(providerName, modelId);
     return model?.supportsImage;


### PR DESCRIPTION
## Summary

- Resolve agent runtime provider IDs back to configured provider keys when building Cowork API settings.
- Fix `zai/glm-5.2` resolving against `providers.zhipu`; the same registry mapping also covers Gemini and Qwen-style aliases.
- Remove the immediate post-continue session reload that could overwrite stream errors with a stale SQLite snapshot.
- Keep synchronous and asynchronous terminal errors visible without duplicate canonical error messages.

## Root cause and impact

The settings page validates and discovers models using application provider keys, while the agent runtime emits provider IDs. For Zhipu these are `zhipu` and `zai`, so runtime execution incorrectly reported `Provider zai is not enabled.` despite a valid configuration. Gemini and Qwen use the same split identifier pattern and were exposed to the same class of failure.

A second race occurred because the continue IPC handler returns before runtime execution settles. The renderer then reloaded the session immediately, allowing a stale database snapshot to replace the transient error state and leaving the retry with no visible response.

## Verification

- `npm test -- src/shared/providers/constants.test.ts src/main/libs/claudeSettings.test.ts src/renderer/services/cowork.errorHandling.structure.test.ts`
- `npm run lint`
- `npm run build:tsc`
