### PR TITLE
fix(ui): stabilize streaming reasoning rendering

### DIFF
--- a/src/shared/components/ai-elements/reasoning.structure.test.ts
+++ b/src/shared/components/ai-elements/reasoning.structure.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./reasoning.tsx', import.meta.url)), 'utf8');
+
+test('renders streaming reasoning as stable preformatted text', () => {
+  const contentStart = source.indexOf('export const ReasoningContent');
+  const contentEnd = source.indexOf('Reasoning.displayName');
+  const contentSource = source.slice(contentStart, contentEnd);
+
+  expect(contentSource).toContain('const { isStreaming, showConnector } = useReasoning();');
+  expect(contentSource).toContain('isStreaming ?');
+  expect(contentSource).toContain('whitespace-pre-wrap wrap-break-word');
+});
+
+test('keeps Markdown rendering for completed reasoning', () => {
+  const contentStart = source.indexOf('export const ReasoningContent');
+  const contentEnd = source.indexOf('Reasoning.displayName');
+  const contentSource = source.slice(contentStart, contentEnd);
+
+  expect(contentSource).toContain('RICH_CONTENT_PATTERN.test(text)');
+  expect(contentSource).toContain('<RichMessageResponse>{children}</RichMessageResponse>');
+  expect(contentSource).toContain('<Streamdown plugins={basePlugins}>{children}</Streamdown>');
+});

--- a/src/shared/components/ai-elements/reasoning.tsx
+++ b/src/shared/components/ai-elements/reasoning.tsx
@@ -210,10 +210,19 @@ const basePlugins = { cjk };
 const RICH_CONTENT_PATTERN = /```|~~~|\$\$|\\\(|\\\[|\$[^$\n]+?\$|(?:^|\n)(?: {4,}|\t+)\S/;
 
 export const ReasoningContent = memo(({ className, children, ...props }: ReasoningContentProps) => {
-  const { showConnector } = useReasoning();
+  const { isStreaming, showConnector } = useReasoning();
 
   const base = <Streamdown plugins={basePlugins}>{children}</Streamdown>;
   const text = typeof children === 'string' ? children : '';
+  const content = isStreaming ? (
+    <div className="whitespace-pre-wrap wrap-break-word">{children}</div>
+  ) : RICH_CONTENT_PATTERN.test(text) ? (
+    <React.Suspense fallback={base}>
+      <RichMessageResponse>{children}</RichMessageResponse>
+    </React.Suspense>
+  ) : (
+    base
+  );
 
   return (
     <CollapsibleContent
@@ -225,13 +234,7 @@ export const ReasoningContent = memo(({ className, children, ...props }: Reasoni
       )}
       {...props}
     >
-      {RICH_CONTENT_PATTERN.test(text) ? (
-        <React.Suspense fallback={base}>
-          <RichMessageResponse>{children}</RichMessageResponse>
-        </React.Suspense>
-      ) : (
-        base
-      )}
+      {content}
     </CollapsibleContent>
   );
 });


### PR DESCRIPTION
## Summary

- Render reasoning content as stable preformatted text while the model is streaming.
- Keep the existing Streamdown and rich Markdown rendering once reasoning is complete.
- Add a structural regression test covering both streaming and completed paths.

## Root cause and impact

Streaming reasoning was reparsed as Markdown on every content update. As paragraph and incomplete-Markdown boundaries changed, Streamdown rebuilt its block structure and the browser briefly placed new text in a following block before reflowing it, producing visible line jitter. The shared component is used by Cowork and Coding reasoning views.

This change preserves whitespace and line wrapping during streaming without changing message state, persistence, IPC, or final Markdown support. Completed reasoning still uses the existing Streamdown pipeline, including rich content handling.

## Verification

- `node_modules/.bin/vitest.cmd run src/shared/components/ai-elements/reasoning.structure.test.ts src/renderer/components/cowork/components/TurnBlock.structure.test.ts src/renderer/utils/streamingMarkdownSegments.test.ts`
- `npm run lint`
- `npm run build:tsc`
