### PR TITLE
fix(cowork): prevent context overflow on session restore

### DIFF
--- a/src/main/libs/agentEngine/piConversationContext.test.ts
+++ b/src/main/libs/agentEngine/piConversationContext.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from 'vitest';
 
 import type { CoworkMessage } from '../../coworkStore';
-import { buildPiConversationPrompt } from './piConversationContext';
+import {
+  buildPiConversationPrompt,
+  calculatePiConversationHistoryCharLimit,
+} from './piConversationContext';
 
 const message = (
   id: string,
@@ -49,4 +52,16 @@ test('keeps the latest complete entries when recovery context exceeds its budget
   expect(prompt).not.toContain('User: 1:');
   expect(prompt).toContain('User: 9:');
   expect(prompt.length).toBeLessThan(61_000);
+});
+
+test('calculates a conservative history budget for the default 32K context', () => {
+  expect(calculatePiConversationHistoryCharLimit()).toBe(10_240);
+  expect(calculatePiConversationHistoryCharLimit(32_768, 8_192)).toBe(8_192);
+});
+
+test('scales history budget down for small and invalid model contexts', () => {
+  expect(calculatePiConversationHistoryCharLimit(16_384, 4_096)).toBe(2_048);
+  expect(calculatePiConversationHistoryCharLimit(8_192, 2_048)).toBe(2_000);
+  expect(calculatePiConversationHistoryCharLimit(0, 0)).toBe(10_240);
+  expect(calculatePiConversationHistoryCharLimit(Number.NaN, -1)).toBe(10_240);
 });

--- a/src/main/libs/agentEngine/piConversationContext.ts
+++ b/src/main/libs/agentEngine/piConversationContext.ts
@@ -3,7 +3,33 @@ import type { CoworkMessage } from '../../coworkStore';
 const PiConversationContextLimit = {
   TotalChars: 60_000,
   EntryChars: 8_000,
+  DefaultContextWindowTokens: 32_768,
+  DefaultMaxOutputTokens: 4_096,
+  ReservedPromptTokens: 8_192,
+  CharsPerToken: 0.5,
 } as const;
+
+export const calculatePiConversationHistoryCharLimit = (
+  contextWindowTokens?: number,
+  maxOutputTokens?: number,
+): number => {
+  const contextWindow =
+    Number.isFinite(contextWindowTokens) && (contextWindowTokens ?? 0) > 0
+      ? contextWindowTokens!
+      : PiConversationContextLimit.DefaultContextWindowTokens;
+  const outputTokens =
+    Number.isFinite(maxOutputTokens) && (maxOutputTokens ?? 0) > 0
+      ? maxOutputTokens!
+      : PiConversationContextLimit.DefaultMaxOutputTokens;
+  const availableTokens = Math.max(
+    1,
+    contextWindow - outputTokens - PiConversationContextLimit.ReservedPromptTokens,
+  );
+  return Math.min(
+    PiConversationContextLimit.TotalChars,
+    Math.max(2_000, Math.floor(availableTokens * PiConversationContextLimit.CharsPerToken)),
+  );
+};
 
 const truncateEntry = (value: string): string => {
   const normalized = value.trim();
@@ -38,14 +64,19 @@ const formatHistoryMessage = (message: CoworkMessage): string | null => {
 export const buildPiConversationPrompt = (
   messages: CoworkMessage[],
   currentPrompt: string,
+  options: { maxChars?: number } = {},
 ): string => {
+  const totalChars = Math.min(
+    PiConversationContextLimit.TotalChars,
+    Math.max(2_000, Math.floor(options.maxChars ?? PiConversationContextLimit.TotalChars)),
+  );
   const entries = messages.map(formatHistoryMessage).filter((entry): entry is string => !!entry);
   const selected: string[] = [];
   let selectedChars = 0;
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
     const nextChars = selectedChars + entry.length + 2;
-    if (nextChars > PiConversationContextLimit.TotalChars) break;
+    if (nextChars > totalChars) break;
     selected.unshift(entry);
     selectedChars = nextChars;
   }

--- a/src/main/libs/agentEngine/piModules.d.ts
+++ b/src/main/libs/agentEngine/piModules.d.ts
@@ -8,6 +8,10 @@
  */
 
 declare module '@earendil-works/pi-coding-agent' {
+  export class SessionManager {
+    static inMemory(cwd?: string): SessionManager;
+  }
+
   export class DefaultResourceLoader {
     constructor(options: {
       cwd: string;
@@ -21,7 +25,14 @@ declare module '@earendil-works/pi-coding-agent' {
   export class SettingsManager {
     static create(cwd: string, agentDir?: string): SettingsManager;
     static inMemory(): SettingsManager;
-    applyOverrides(overrides: { shellPath?: string }): void;
+    applyOverrides(overrides: {
+      shellPath?: string;
+      compaction?: {
+        enabled?: boolean;
+        reserveTokens?: number;
+        keepRecentTokens?: number;
+      };
+    }): void;
     getShellPath(): string | undefined;
   }
 

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -53,6 +53,7 @@ const hoisted = vi.hoisted(() => {
     applyOverrides: vi.fn(),
     getShellPath: vi.fn(),
   }));
+  const mockSessionManagerInMemory = vi.fn((cwd?: string) => ({ cwd }));
   const mockCompleteSimple = vi.fn().mockResolvedValue({
     content: [{ type: 'text', text: 'Hello from Pi' }],
     stopReason: 'stop',
@@ -62,6 +63,7 @@ const hoisted = vi.hoisted(() => {
     mockSession,
     mockSettingsManagerCreate,
     mockSettingsManagerInMemory,
+    mockSessionManagerInMemory,
     mockCreateAgentSession: vi.fn().mockResolvedValue({ session: mockSession }),
     mockDefaultResourceLoader: vi.fn(function (this: { reload: () => Promise<void> }) {
       this.reload = vi.fn().mockResolvedValue(undefined);
@@ -181,6 +183,7 @@ const mockCreateAgentSession = hoisted.mockCreateAgentSession;
 const mockDefaultResourceLoader = hoisted.mockDefaultResourceLoader;
 const mockSettingsManagerCreate = hoisted.mockSettingsManagerCreate;
 const mockSettingsManagerInMemory = hoisted.mockSettingsManagerInMemory;
+const mockSessionManagerInMemory = hoisted.mockSessionManagerInMemory;
 const mockGetModel = hoisted.mockGetModel;
 const mockModelRuntime = hoisted.mockModelRuntime;
 const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
@@ -192,6 +195,9 @@ const mockApplyApplicationRuntimeEnv = hoisted.mockApplyApplicationRuntimeEnv;
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: hoisted.mockCreateAgentSession,
   DefaultResourceLoader: hoisted.mockDefaultResourceLoader,
+  SessionManager: {
+    inMemory: hoisted.mockSessionManagerInMemory,
+  },
   SettingsManager: {
     create: hoisted.mockSettingsManagerCreate,
     inMemory: hoisted.mockSettingsManagerInMemory,
@@ -276,6 +282,17 @@ describe('PiRuntimeAdapter', () => {
       expect(mockApplyApplicationRuntimeEnv).toHaveBeenCalledWith(process.env);
       expect(mockSession.subscribe).toHaveBeenCalled();
       expect(mockSession.prompt).toHaveBeenCalledWith('Hello Pi');
+    });
+
+    it('uses an in-memory Pi session manager so SQLite remains the only restore source', async () => {
+      await adapter.startSession('memory-session', 'Hello Pi');
+
+      expect(mockSessionManagerInMemory).toHaveBeenCalledWith(process.cwd());
+      expect(mockCreateAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionManager: { cwd: process.cwd() },
+        }),
+      );
     });
 
     it('rolls up session memory after a successful agent run', async () => {
@@ -995,7 +1012,7 @@ describe('PiRuntimeAdapter', () => {
         systemPromptOverride: (base: string | undefined) => string | undefined;
       };
       expect(loaderOptions.systemPromptOverride('Pi default prompt')).toBe(
-        'You are the selected expert.',
+        'Pi default prompt\n\nYou are the selected expert.',
       );
       expect(mockCreateAgentSession).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1017,6 +1034,13 @@ describe('PiRuntimeAdapter', () => {
       expect(mockCreateAgentSession.mock.calls[0]?.[0]).toEqual(
         expect.objectContaining({ settingsManager }),
       );
+      expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+        compaction: {
+          enabled: true,
+          reserveTokens: 8_192,
+          keepRecentTokens: 16_384,
+        },
+      });
     });
 
     it('should resolve the explicit model override for a new session', async () => {
@@ -1984,7 +2008,8 @@ describe('PiRuntimeAdapter', () => {
       const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
         appendSystemPromptOverride: () => string[];
       };
-      expect(loaderOptions.appendSystemPromptOverride()).toEqual([
+      expect(loaderOptions.appendSystemPromptOverride(['existing Pi append'])).toEqual([
+        'existing Pi append',
         PiAskUserQuestionSystemPrompt,
         expect.stringContaining('## Local document reading'),
         expect.stringContaining('## File tool usage'),

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -111,7 +111,10 @@ import {
   extractPiBackgroundCompletionText,
   type PiBackgroundCompletionResult,
 } from './piBackgroundCompletion';
-import { buildPiConversationPrompt } from './piConversationContext';
+import {
+  buildPiConversationPrompt,
+  calculatePiConversationHistoryCharLimit,
+} from './piConversationContext';
 import { prependProductionWorkflowPrompt } from './piExpertProductionPrompt';
 import { isAcademicResearchSkillSet, PiResearchRunController } from './piResearchRun';
 import { buildPiResearchStateTool } from './piResearchStateTool';
@@ -316,6 +319,9 @@ interface ActivePiSession {
 interface PiModules {
   createAgentSession: (options: Record<string, unknown>) => Promise<{ session: PiSession }>;
   DefaultResourceLoader: new (options: Record<string, unknown>) => PiResourceLoader;
+  SessionManager?: {
+    inMemory(cwd?: string): unknown;
+  };
   SettingsManager?: {
     create(cwd: string, agentDir?: string): PiSettingsManager;
     inMemory?(): PiSettingsManager;
@@ -338,7 +344,14 @@ interface PiResourceLoader {
 }
 
 interface PiSettingsManager {
-  applyOverrides(overrides: { shellPath?: string }): void;
+  applyOverrides(overrides: {
+    shellPath?: string;
+    compaction?: {
+      enabled?: boolean;
+      reserveTokens?: number;
+      keepRecentTokens?: number;
+    };
+  }): void;
   getShellPath?(): string | undefined;
 }
 
@@ -447,6 +460,10 @@ async function getPiModules(): Promise<PiModules> {
         createAgentSession: codingAgent.createAgentSession as PiModules['createAgentSession'],
         DefaultResourceLoader:
           codingAgent.DefaultResourceLoader as PiModules['DefaultResourceLoader'],
+        SessionManager: Object.prototype.hasOwnProperty.call(codingAgent, 'SessionManager')
+          ? ((codingAgent as typeof codingAgent & { SessionManager?: unknown })
+              .SessionManager as PiModules['SessionManager'])
+          : undefined,
         SettingsManager: Object.prototype.hasOwnProperty.call(codingAgent, 'SettingsManager')
           ? ((codingAgent as typeof codingAgent & { SettingsManager?: unknown })
               .SettingsManager as PiModules['SettingsManager'])
@@ -695,6 +712,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         hasAppliedApplicationRuntimeEnv = true;
       }
       const sessionOptions: Record<string, unknown> = { cwd: workspaceRoot };
+      // Cowork owns the canonical transcript in SQLite. Pi's default session
+      // manager persists its own transcript, which would be duplicated by the
+      // SQLite history prompt used when a session is recreated.
+      if (pi.SessionManager?.inMemory) {
+        sessionOptions.sessionManager = pi.SessionManager.inMemory(workspaceRoot);
+      }
 
       // System prompt — user config only. Skills are discovered and appended
       // by the resource loader (additionalSkillPaths), which renders them via
@@ -799,6 +822,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
       console.debug(`[PiRuntime] loading isolated resources for session ${sessionId}`);
       const settingsManager = this.createPiSettingsManager(pi, workspaceRoot);
+      const contextWindowTokens =
+        typeof resolvedModel.model.contextWindow === 'number'
+          ? resolvedModel.model.contextWindow
+          : undefined;
       const resourceLoader = await this.createPiResourceLoader(pi, workspaceRoot, resourceState, {
         sessionId,
         getRunId: () => this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId,
@@ -806,6 +833,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         getAutoApprove: () =>
           this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
       });
+      this.applyPiCompactionOverrides(settingsManager, contextWindowTokens);
       if (!isCurrentInitialization()) return;
       sessionOptions.resourceLoader = resourceLoader;
       if (settingsManager) {
@@ -1211,7 +1239,9 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       );
       const storedSession = this.store?.getSession(sessionId);
       const history = storedSession?.messages ?? [];
-      const piPrompt = buildPiConversationPrompt(history, prompt);
+      const piPrompt = buildPiConversationPrompt(history, prompt, {
+        maxChars: calculatePiConversationHistoryCharLimit(),
+      });
       return this.startSession(sessionId, prompt, {
         ...options,
         skipInitialUserMessage: options._skipUserMessage,
@@ -1282,7 +1312,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
         goalMode: nextGoalMode,
-        _piPromptOverride: buildPiConversationPrompt(history, prompt),
+        _piPromptOverride: buildPiConversationPrompt(history, prompt, {
+          maxChars: calculatePiConversationHistoryCharLimit(
+            typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
+            typeof active.model.maxTokens === 'number' ? active.model.maxTokens : undefined,
+          ),
+        }),
       });
     }
 
@@ -1305,7 +1340,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
         goalMode: nextGoalMode,
-        _piPromptOverride: buildPiConversationPrompt(history, prompt),
+        _piPromptOverride: buildPiConversationPrompt(history, prompt, {
+          maxChars: calculatePiConversationHistoryCharLimit(
+            typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
+            typeof active.model.maxTokens === 'number' ? active.model.maxTokens : undefined,
+          ),
+        }),
       });
     }
 
@@ -1323,6 +1363,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         // AgentSession.reload() reloads SettingsManager from disk, so restore
         // the per-process bundled PortableGit override after every reload.
         this.applyPiShellOverride(active.settingsManager);
+        this.applyPiCompactionOverrides(
+          active.settingsManager,
+          typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
+        );
         active.requestedSystemPrompt = nextSystemPrompt;
         active.requestedSkillIds = requestedSkillIds;
         console.debug('[PiRuntime] reloaded session resources after prompt change');
@@ -1542,6 +1586,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         active.resourceState.maxOutputTokens = resolvedModel.maxOutputTokens;
         await active.piSession.reload();
         this.applyPiShellOverride(active.settingsManager);
+        this.applyPiCompactionOverrides(
+          active.settingsManager,
+          typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
+        );
       }
       console.log('[PiRuntime] Model updated via patchSession:', patch.model);
     } catch (err) {
@@ -1970,6 +2018,32 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     return pi.SettingsManager.inMemory?.() ?? pi.SettingsManager.create(cwd, pi.getAgentDir());
   }
 
+  private applyPiCompactionOverrides(
+    settingsManager: PiSettingsManager | null,
+    contextWindowTokens?: number,
+  ): void {
+    if (!settingsManager) return;
+    const contextWindow =
+      Number.isFinite(contextWindowTokens) && (contextWindowTokens ?? 0) > 0
+        ? Math.floor(contextWindowTokens!)
+        : 32_768;
+    // Keep compaction's summary request and retained conversation inside the
+    // active model window. Pi's defaults (16K reserve, 20K recent) are tuned
+    // for large hosted models and can exceed a local 16K/32K model's budget.
+    const reserveTokens = Math.max(2_048, Math.min(16_384, Math.floor(contextWindow * 0.25)));
+    const keepRecentTokens = Math.max(
+      2_048,
+      Math.min(20_000, Math.floor(contextWindow * 0.5)),
+    );
+    settingsManager.applyOverrides({
+      compaction: {
+        enabled: true,
+        reserveTokens,
+        keepRecentTokens,
+      },
+    });
+  }
+
   private applyPiShellOverride(settingsManager: PiSettingsManager | null): void {
     if (!settingsManager || process.platform !== 'win32') return;
     const bashPath = resolveGitBashPathForPi();
@@ -2018,14 +2092,21 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                   resourceState.skillIds?.includes(skill.name || ''),
               ),
             },
-      systemPromptOverride: () => resourceState.systemPrompt,
+      systemPromptOverride: base => {
+        const custom = resourceState.systemPrompt.trim();
+        if (!custom) return base;
+        if (!base?.trim()) return custom;
+        return `${base.trim()}\n\n${custom}`;
+      },
       // Pi bypasses tool promptGuidelines when systemPromptOverride is non-empty.
       // The registry is the single collection point for tool-usage policies.
-      appendSystemPromptOverride: (): string[] =>
-        collectPiSystemPromptContributions({
+      appendSystemPromptOverride: (base: string[] = []): string[] => [
+        ...base,
+        ...collectPiSystemPromptContributions({
           fileToolsEnabled: resourceState.fileToolsEnabled,
           maxOutputTokens: resourceState.maxOutputTokens,
         }),
+      ],
       extensionFactories: [
         ...(approvalContext?.getRunId()
           ? [

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -2092,7 +2092,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                   resourceState.skillIds?.includes(skill.name || ''),
               ),
             },
-      systemPromptOverride: base => {
+      systemPromptOverride: (base: string | undefined): string | undefined => {
         const custom = resourceState.systemPrompt.trim();
         if (!custom) return base;
         if (!base?.trim()) return custom;


### PR DESCRIPTION
## Summary

- Use an in-memory Pi session manager so SQLite remains the single transcript source.
- Bound restored history by model context and output budgets.
- Scale and reapply Pi compaction settings for local model windows.
- Preserve Pi native system and append prompts when adding ZhiYuan instructions.

## Verification

- npm run build
- npm run lint
- npx tsc --project electron-tsconfig.json --noEmit
- npx vitest run src/main/libs/agentEngine/piConversationContext.test.ts
- Targeted PiRuntimeAdapter tests

The full adapter suite has 13 local environment failures when Vitest loads better-sqlite3 because the installed binary targets Electron ABI 143 while Node requires ABI 137.