### PR TITLE
fix(coding): stabilize chat auto-scroll and trim streaming re-renders

### DIFF
--- a/src/renderer/components/coding/CodingConversationTurn.tsx
+++ b/src/renderer/components/coding/CodingConversationTurn.tsx
@@ -121,4 +121,68 @@ const CodingConversationTurnComponent = ({
   </section>
 );
 
-export const CodingConversationTurn = memo(CodingConversationTurnComponent);
+const messageContentsEqual = (
+  a:
+    | { id: string; content: string; createdAt: number; role: string }
+    | null,
+  b:
+    | { id: string; content: string; createdAt: number; role: string }
+    | null,
+): boolean =>
+  a === b ||
+  (a !== null &&
+    b !== null &&
+    a.id === b.id &&
+    a.content === b.content &&
+    a.createdAt === b.createdAt &&
+    a.role === b.role);
+
+const reasoningContentsEqual = (
+  a: { id: string; content: string; createdAt: number } | null,
+  b: { id: string; content: string; createdAt: number } | null,
+): boolean =>
+  a === b ||
+  (a !== null &&
+    b !== null &&
+    a.id === b.id &&
+    a.content === b.content &&
+    a.createdAt === b.createdAt);
+
+const turnContentsEqual = (a: CodingConversationTurnModel, b: CodingConversationTurnModel): boolean =>
+  a === b ||
+  (a.id === b.id &&
+    a.status === b.status &&
+    a.statusDetail === b.statusDetail &&
+    messageContentsEqual(a.userMessage, b.userMessage) &&
+    reasoningContentsEqual(a.reasoning, b.reasoning) &&
+    a.assistantMessages.length === b.assistantMessages.length &&
+    a.assistantMessages.every((message, index) =>
+      messageContentsEqual(message, b.assistantMessages[index]),
+    ) &&
+    a.activities.length === b.activities.length &&
+    a.activities.every(
+      (activity, index) =>
+        activity.id === b.activities[index].id &&
+        activity.kind === b.activities[index].kind &&
+        activity.event.kind === b.activities[index].event.kind &&
+        JSON.stringify(activity.event.payload) ===
+          JSON.stringify(b.activities[index].event.payload),
+    ));
+
+// CodingEventStream re-projects every event on each streamed chunk, which
+// re-creates all turn objects and defeats the default shallow memo. Comparing
+// the actual turn content lets unchanged completed turns skip re-rendering
+// while the streaming turn (and any turn whose content changed) still updates.
+const conversationTurnPropsEqual = (
+  prev: CodingConversationTurnProps,
+  next: CodingConversationTurnProps,
+): boolean =>
+  prev.isStreaming === next.isStreaming &&
+  prev.artifactsByMessageId === next.artifactsByMessageId &&
+  prev.artifactsByToolCallId === next.artifactsByToolCallId &&
+  turnContentsEqual(prev.turn, next.turn);
+
+export const CodingConversationTurn = memo(
+  CodingConversationTurnComponent,
+  conversationTurnPropsEqual,
+);

--- a/src/renderer/components/coding/CodingEventStream.tsx
+++ b/src/renderer/components/coding/CodingEventStream.tsx
@@ -115,7 +115,10 @@ export const CodingEventStream = ({
 
   // Artifact detection runs on the settled transcript only — scanning on every
   // streamed chunk would redo the whole parse per token.
-  const detectableMessages = useMemo(() => toDetectableMessages(turns), [turns]);
+  const detectableMessages = useMemo(
+    () => (isStreaming ? [] : toDetectableMessages(turns)),
+    [turns, isStreaming],
+  );
   const fileArtifacts = useMemo(
     () =>
       artifactSessionKey

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -324,16 +324,27 @@ export const CodingWorkbenchView = ({
   const recoveryLane =
     activeLane?.pendingRecoveryPrompt && activeLane.pendingRecoveryContext ? activeLane : null;
 
+  // The activeLane object is re-created on every streamed snapshot update, so
+  // an effect keyed on it would re-assign viewport.scrollTop on each streamed
+  // event — overriding the stick-to-bottom auto-scroll and making the viewport
+  // jump away from the latest message. Restore the saved scroll position only
+  // when the lane id actually changes (lane switch or initial load).
+  const activeLaneSnapshotRef = useRef(activeLane);
+  activeLaneSnapshotRef.current = activeLane;
+  const restoredScrollLaneRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!activeLane) return;
+    const lane = activeLaneSnapshotRef.current;
+    if (!lane) return;
+    if (restoredScrollLaneRef.current === lane.id) return;
+    restoredScrollLaneRef.current = lane.id;
     const frame = requestAnimationFrame(() => {
       const viewport = eventStreamRef.current?.querySelector<HTMLElement>(
         '.coding-conversation-scroll',
       );
-      if (viewport) viewport.scrollTop = activeLane.scrollPosition;
+      if (viewport) viewport.scrollTop = lane.scrollPosition;
     });
     return () => cancelAnimationFrame(frame);
-  }, [activeLane]);
+  }, [activeLane?.id]);
 
   useEffect(() => {
     setSidePanelView(current => (current === CodingSidePanelView.Inspector ? null : current));


### PR DESCRIPTION
## Summary
Fixes #636. The coding chat viewport no longer jumps away from the latest message during streaming, and streaming re-renders are reduced.

## Root cause
The scroll-restore effect in `CodingWorkbenchView` was keyed on the `activeLane` object, which is re-created on every streamed snapshot update. Each streamed event therefore re-assigned `viewport.scrollTop = activeLane.scrollPosition`, overriding the stick-to-bottom auto-scroll and making the viewport jump.

## Changes
- **`CodingWorkbenchView.tsx`**: restore the saved scroll position only when the lane id actually changes (lane switch / initial load), using a ref to dedupe so streamed updates no longer override the stick-to-bottom auto-scroll.
- **`CodingConversationTurn.tsx`**: add a memo comparator that compares real turn content, so completed turns skip re-rendering when their content is unchanged (turn objects are rebuilt on every streamed projection).
- **`CodingEventStream.tsx`**: skip artifact detection message extraction while streaming (the detection effect already guards on `isStreaming`).

## Verification
- `npm run lint`: 0 warnings, 0 errors.
- `tsc -p tsconfig.json`: 0 errors.
- `npm test -- coding`: 25 test files / 157 cases passed.
- Style and behavior unchanged; only the scroll-follow behavior and render cost are addressed. Manual UI confirmation via `npm run electron:dev` recommended.

Closes #636