### PR TITLE
feat(coding-agent): add three-tier permission mode for builtin agent

### DIFF
--- a/src/main/codingAgent/codingRoomService.test.ts
+++ b/src/main/codingAgent/codingRoomService.test.ts
@@ -21,6 +21,7 @@ import { CodingRoomService } from './codingRoomService';
 import { initializeCodingAgentSchema } from './schema';
 import { AcpSessionUpdateKind } from './acp/protocol';
 import { PiThinkingLevel } from '../libs/agentEngine/piRuntimeTypes';
+import { WorkbenchApprovalMode } from '../../shared/workbenchTask';
 import { BuiltinCodingConfigId } from './drivers/builtinCodingDriver';
 import { CoworkInterruptionCause } from '../../shared/cowork/interruption';
 
@@ -213,6 +214,7 @@ test('routes a builtin lane through its driver and projects runtime completion',
     workspaceRoot,
     prompt: 'Investigate the failure.',
     thinkingLevel: PiThinkingLevel.Medium,
+    permissionMode: WorkbenchApprovalMode.Ask,
   });
   service.recordBuiltinEvent(lane.localSessionId, CodingEventKind.TurnComplete, {});
 
@@ -591,6 +593,7 @@ test('creates collaborator lanes in isolated workspaces and runs them independen
     workspaceRoot: lane.executionRoot,
     prompt: 'Review the implementation.',
     thinkingLevel: PiThinkingLevel.Medium,
+    permissionMode: WorkbenchApprovalMode.Ask,
   });
 });
 

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -50,6 +50,7 @@ import { t } from '../i18n';
 import type { CodingAgentDriver } from './drivers/codingAgentDriver';
 import { CodingDriverFactory } from './drivers/driverFactory';
 import type { CoworkSessionInterruption } from '../../shared/cowork/interruption';
+import type { WorkbenchApprovalMode } from '../../shared/workbenchTask';
 
 export interface CodingRoomRuntime {
   startBuiltinSession(input: {
@@ -58,7 +59,10 @@ export interface CodingRoomRuntime {
     prompt: string;
     modelOverride?: string | null;
     thinkingLevel?: string;
+    permissionMode?: WorkbenchApprovalMode;
   }): Promise<void>;
+  /** Applies approval-mode changes to a live built-in session. */
+  setBuiltinApprovalMode?(sessionId: string, mode: WorkbenchApprovalMode): void;
   cancelBuiltinSession(sessionId: string): Promise<void>;
   /** Applies model/thinking-level changes to a live built-in session. */
   patchBuiltinSession?(
@@ -157,9 +161,11 @@ export class CodingRoomService extends EventEmitter {
             prompt,
             ...(options?.modelOverride ? { modelOverride: options.modelOverride } : {}),
             ...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+            ...(options?.permissionMode ? { permissionMode: options.permissionMode } : {}),
           }),
         cancel: sessionId => this.runtime.cancelBuiltinSession(sessionId),
         patchSession: patchBuiltinSession,
+        setApprovalMode: this.runtime.setBuiltinApprovalMode?.bind(this.runtime),
       },
       Object.fromEntries(ACP_ENVIRONMENT_KEYS.map(key => [key, process.env[key]])),
     );

--- a/src/main/codingAgent/drivers/builtinCodingDriver.test.ts
+++ b/src/main/codingAgent/drivers/builtinCodingDriver.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from 'vitest';
 
 import type { CodingAgentConfigOption } from '../../../shared/codingAgent';
+import { WorkbenchApprovalMode } from '../../../shared/workbenchTask';
 import { PiThinkingLevel } from '../../libs/agentEngine/piRuntimeTypes';
 import {
   BuiltinCodingConfigId,
@@ -13,10 +14,12 @@ const createRuntime = (
 ): BuiltinCodingRuntime & {
   start: ReturnType<typeof vi.fn>;
   patchSession: ReturnType<typeof vi.fn>;
+  setApprovalMode: ReturnType<typeof vi.fn>;
 } => ({
   start: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn().mockResolvedValue(undefined),
   patchSession: vi.fn().mockResolvedValue(undefined),
+  setApprovalMode: vi.fn(),
   ...overrides,
 });
 
@@ -131,6 +134,84 @@ test('setConfigOption updates the selection and patches the live session', async
   expect(findOption(updated, BuiltinCodingConfigId.ThinkingLevel)?.currentValue).toBe('high');
 });
 
+test('setConfigOption applies the permission mode to the live session', async () => {
+  const runtime = createRuntime();
+  const driver = new BuiltinCodingDriver(runtime);
+  await driver.createSession({ workspaceRoot: '/ws', localSessionId: 's1' });
+
+  const updated = await driver.setConfigOption(
+    's1',
+    BuiltinCodingConfigId.PermissionMode,
+    WorkbenchApprovalMode.AllowAll,
+  );
+
+  expect(runtime.setApprovalMode).toHaveBeenCalledWith('s1', WorkbenchApprovalMode.AllowAll);
+  expect(findOption(updated, BuiltinCodingConfigId.PermissionMode)?.currentValue).toBe(
+    WorkbenchApprovalMode.AllowAll,
+  );
+});
+
+test('prompt forwards the selected permission mode to the runtime', async () => {
+  const runtime = createRuntime();
+  const driver = new BuiltinCodingDriver(runtime);
+  await driver.createSession({ workspaceRoot: '/ws', localSessionId: 's1' });
+  await driver.setConfigOption(
+    's1',
+    BuiltinCodingConfigId.PermissionMode,
+    WorkbenchApprovalMode.Auto,
+  );
+
+  for await (const _event of driver.prompt({
+    sessionId: 's1',
+    workspaceRoot: '/ws',
+    prompt: 'hi',
+  })) {
+    // The built-in driver never yields events; draining starts the runtime.
+  }
+
+  expect(runtime.start).toHaveBeenCalledWith(
+    's1',
+    '/ws',
+    'hi',
+    expect.objectContaining({ permissionMode: WorkbenchApprovalMode.Auto }),
+  );
+});
+
+test('createSession restores a persisted permission mode and rejects invalid values', async () => {
+  const driver = new BuiltinCodingDriver(createRuntime());
+  const restored = await driver.createSession({
+    workspaceRoot: '/ws',
+    localSessionId: 's1',
+    existingConfigOptions: [
+      {
+        id: BuiltinCodingConfigId.PermissionMode,
+        name: 'Permission mode',
+        type: 'select',
+        currentValue: WorkbenchApprovalMode.Auto,
+      },
+    ],
+  });
+  expect(
+    findOption(restored.configOptions, BuiltinCodingConfigId.PermissionMode)?.currentValue,
+  ).toBe(WorkbenchApprovalMode.Auto);
+
+  const invalid = await driver.createSession({
+    workspaceRoot: '/ws',
+    localSessionId: 's2',
+    existingConfigOptions: [
+      {
+        id: BuiltinCodingConfigId.PermissionMode,
+        name: 'Permission mode',
+        type: 'select',
+        currentValue: 'yolo',
+      },
+    ],
+  });
+  expect(
+    findOption(invalid.configOptions, BuiltinCodingConfigId.PermissionMode)?.currentValue,
+  ).toBe(WorkbenchApprovalMode.Ask);
+});
+
 test('setConfigOption rejects unknown options and values', async () => {
   const driver = new BuiltinCodingDriver(createRuntime());
   await driver.createSession({ workspaceRoot: '/ws', localSessionId: 's1' });
@@ -154,7 +235,10 @@ test('prompt forwards the selected thinking level to the runtime', async () => {
     // The built-in driver never yields events; draining starts the runtime.
   }
 
-  expect(runtime.start).toHaveBeenCalledWith('s1', '/ws', 'hi', { thinkingLevel: 'high' });
+  expect(runtime.start).toHaveBeenCalledWith('s1', '/ws', 'hi', {
+    thinkingLevel: 'high',
+    permissionMode: WorkbenchApprovalMode.Ask,
+  });
 });
 
 test('getDefaultConfigOptions builds options without binding them to a session', async () => {
@@ -164,6 +248,10 @@ test('getDefaultConfigOptions builds options without binding them to a session',
     expect.objectContaining({
       id: BuiltinCodingConfigId.ThinkingLevel,
       currentValue: PiThinkingLevel.Medium,
+    }),
+    expect.objectContaining({
+      id: BuiltinCodingConfigId.PermissionMode,
+      currentValue: WorkbenchApprovalMode.Ask,
     }),
   ]);
   // Defaults are not bound to any session yet.

--- a/src/main/codingAgent/drivers/builtinCodingDriver.ts
+++ b/src/main/codingAgent/drivers/builtinCodingDriver.ts
@@ -8,6 +8,7 @@ import {
   type CodingPermissionResponse,
 } from '../../../shared/codingAgent';
 import { t } from '../../i18n';
+import { WorkbenchApprovalMode } from '../../../shared/workbenchTask';
 import { PiThinkingLevel } from '../../libs/agentEngine/piRuntimeTypes';
 import type {
   CodingAgentAuthRequest,
@@ -18,6 +19,7 @@ import type {
 
 export const BuiltinCodingConfigId = {
   ThinkingLevel: 'thinking-level',
+  PermissionMode: 'permission-mode',
 } as const;
 export type BuiltinCodingConfigId =
   (typeof BuiltinCodingConfigId)[keyof typeof BuiltinCodingConfigId];
@@ -25,6 +27,7 @@ export type BuiltinCodingConfigId =
 export interface BuiltinCodingSessionStartOptions {
   modelOverride?: string | null;
   thinkingLevel?: string;
+  permissionMode?: WorkbenchApprovalMode;
 }
 
 export interface BuiltinCodingRuntime {
@@ -40,6 +43,8 @@ export interface BuiltinCodingRuntime {
     sessionId: string,
     patch: { model?: string | null; thinkingLevel?: string | null },
   ): Promise<void>;
+  /** Applies approval-mode changes to a live Pi session. */
+  setApprovalMode?(sessionId: string, mode: WorkbenchApprovalMode): void;
 }
 
 const BUILTIN_CAPABILITIES: CodingAgentCapabilities = {
@@ -61,6 +66,9 @@ const THINKING_LEVEL_OPTIONS = Object.values(PiThinkingLevel).map(level => ({
 
 const isValidThinkingLevel = (value: string): value is PiThinkingLevel =>
   (Object.values(PiThinkingLevel) as string[]).includes(value);
+
+const isValidApprovalMode = (value: string): value is WorkbenchApprovalMode =>
+  (Object.values(WorkbenchApprovalMode) as string[]).includes(value);
 
 export class BuiltinCodingDriver implements CodingAgentDriver {
   private readonly sessionConfigOptions = new Map<string, CodingAgentConfigOption[]>();
@@ -115,6 +123,7 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
     await this.runtime.start(input.sessionId, input.workspaceRoot, input.prompt, {
       ...(input.modelOverride ? { modelOverride: input.modelOverride } : {}),
       ...(thinkingLevel ? { thinkingLevel } : {}),
+      permissionMode: this.currentPermissionMode(input.sessionId),
     });
     // The in-process runtime emits streaming events after start() returns. The
     // CodingRoomService subscribes to that runtime directly, which avoids
@@ -146,6 +155,10 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
     if (configId === BuiltinCodingConfigId.ThinkingLevel) {
       await this.runtime.patchSession?.(sessionId, { thinkingLevel: value });
     }
+    if (configId === BuiltinCodingConfigId.PermissionMode) {
+      // The select-option whitelist above already validated the value.
+      this.runtime.setApprovalMode?.(sessionId, value as WorkbenchApprovalMode);
+    }
     return options;
   }
   getSessionConfigOptions(sessionId: string): CodingAgentConfigOption[] {
@@ -173,6 +186,9 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
     const persistedThinking = existing?.find(
       candidate => candidate.id === BuiltinCodingConfigId.ThinkingLevel,
     )?.currentValue;
+    const persistedPermissionMode = existing?.find(
+      candidate => candidate.id === BuiltinCodingConfigId.PermissionMode,
+    )?.currentValue;
     return [
       {
         id: BuiltinCodingConfigId.ThinkingLevel,
@@ -184,6 +200,21 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
             : PiThinkingLevel.Medium,
         options: THINKING_LEVEL_OPTIONS,
       },
+      {
+        id: BuiltinCodingConfigId.PermissionMode,
+        name: t('codingAgentConfigPermissionMode'),
+        type: 'select',
+        currentValue:
+          typeof persistedPermissionMode === 'string' &&
+          isValidApprovalMode(persistedPermissionMode)
+            ? persistedPermissionMode
+            : WorkbenchApprovalMode.Ask,
+        options: [
+          { value: WorkbenchApprovalMode.Ask, name: t('codingAgentPermissionModeAsk') },
+          { value: WorkbenchApprovalMode.Auto, name: t('codingAgentPermissionModeAuto') },
+          { value: WorkbenchApprovalMode.AllowAll, name: t('codingAgentPermissionModeAllowAll') },
+        ],
+      },
     ];
   }
 
@@ -194,5 +225,14 @@ export class BuiltinCodingDriver implements CodingAgentDriver {
     return typeof option?.currentValue === 'string' && option.currentValue
       ? option.currentValue
       : undefined;
+  }
+
+  private currentPermissionMode(sessionId: string): WorkbenchApprovalMode {
+    const option = this.sessionConfigOptions
+      .get(sessionId)
+      ?.find(candidate => candidate.id === BuiltinCodingConfigId.PermissionMode);
+    return typeof option?.currentValue === 'string' && isValidApprovalMode(option.currentValue)
+      ? option.currentValue
+      : WorkbenchApprovalMode.Ask;
   }
 }

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -29,6 +29,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
     codingAgentSessionRecovery: '上一个 Agent 会话无法恢复，已将交接摘要发送到新会话。',
     codingAgentConfigModel: '模型',
     codingAgentConfigThinkingLevel: '思考等级',
+    codingAgentConfigPermissionMode: '权限模式',
+    codingAgentPermissionModeAsk: '每次询问',
+    codingAgentPermissionModeAuto: '自动放行低风险',
+    codingAgentPermissionModeAllowAll: '全部允许',
     codingAgentNoAssistantResponse:
       '外部 Agent 未返回助手内容，请检查 Agent 的登录状态、模型配置和网络连接。',
     cronSessionPrefix: '定时',
@@ -324,6 +328,10 @@ const translations: Record<LanguageType, Record<string, string>> = {
       'The previous agent session could not be restored. A handoff summary was sent to a new session.',
     codingAgentConfigModel: 'Model',
     codingAgentConfigThinkingLevel: 'Thinking level',
+    codingAgentConfigPermissionMode: 'Permission mode',
+    codingAgentPermissionModeAsk: 'Ask every time',
+    codingAgentPermissionModeAuto: 'Auto-approve low risk',
+    codingAgentPermissionModeAllowAll: 'Allow all',
     codingAgentNoAssistantResponse:
       'The external agent returned no assistant content. Check its sign-in state, model configuration, and network connection.',
     cronSessionPrefix: 'Cron',

--- a/src/main/im/imCoworkHandler.test.ts
+++ b/src/main/im/imCoworkHandler.test.ts
@@ -486,7 +486,7 @@ test('IM turns use workspace session configuration without disabling Pi tools', 
     'Use the workspace conversation context.',
   );
   expect(runtime.startCalls[0].options).not.toHaveProperty('confirmationMode');
-  expect(runtime.startCalls[0].options).not.toHaveProperty('autoApprove');
+  expect(runtime.startCalls[0].options).not.toHaveProperty('approvalMode');
 
   runtime.emit('message', 'session-1', {
     id: 'assistant-1',

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -23,6 +23,7 @@ import { AcademicResearchSkillIds } from '../../../shared/skills/constants';
 import { CoworkInterruptionCause } from '../../../shared/cowork/interruption';
 import { ProductionLoopAction } from '../../../shared/productionLoop';
 import {
+  WorkbenchApprovalMode,
   WorkbenchContractKind,
   WorkbenchRunTrigger,
   WorkbenchRunStatus,
@@ -1719,7 +1720,7 @@ describe('PiRuntimeAdapter', () => {
           toolCallId: 'write-call',
           toolName: 'write',
           toolInput: { path: 'slides.md', content: 'draft' },
-          autoApprove: false,
+          approvalMode: WorkbenchApprovalMode.Ask,
         });
         const approval = service.getDetail(first.task.id)?.approvals[0];
         service.respondToApproval({ approvalId: approval!.id, approved: false });
@@ -2000,7 +2001,7 @@ describe('PiRuntimeAdapter', () => {
           toolCallId: 'write-call',
           toolName: 'write',
           toolInput: { path: 'release.md', content: 'draft' },
-          autoApprove: false,
+          approvalMode: WorkbenchApprovalMode.Ask,
         });
         await vi.waitFor(() => expect(requests).toHaveLength(1));
 
@@ -3073,7 +3074,7 @@ describe('PiRuntimeAdapter', () => {
     it('preserves Allow All across internal follow-up continuations', async () => {
       await adapter.startSession('allow-all-session', 'Start work', {
         sessionMode: 'work',
-        autoApprove: true,
+        approvalMode: WorkbenchApprovalMode.AllowAll,
       });
 
       await adapter.continueSession('allow-all-session', 'Continue work', {
@@ -3082,10 +3083,12 @@ describe('PiRuntimeAdapter', () => {
 
       const activeSessions = (
         adapter as unknown as {
-          activeSessions: Map<string, { autoApprove: boolean }>;
+          activeSessions: Map<string, { approvalMode: WorkbenchApprovalMode }>;
         }
       ).activeSessions;
-      expect(activeSessions.get('allow-all-session')?.autoApprove).toBe(true);
+      expect(activeSessions.get('allow-all-session')?.approvalMode).toBe(
+        WorkbenchApprovalMode.AllowAll,
+      );
     });
 
     it('delivers queued follow-ups in order after Pi settles', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -48,6 +48,7 @@ import {
 } from '../../../shared/productionLoop';
 import {
   WorkbenchApprovalDecision,
+  WorkbenchApprovalMode,
   WorkbenchApprovalRiskLevel,
   WorkbenchContractKind,
   WorkbenchArtifactCandidateSource,
@@ -301,7 +302,7 @@ interface ActivePiSession {
   workbenchContract: WorkbenchTaskContract;
   workspaceRoot: string;
   settingsManager: PiSettingsManager | null;
-  autoApprove: boolean;
+  approvalMode: WorkbenchApprovalMode;
   /** True while Pi is executing the current Work/Chat turn. */
   isRunning: boolean;
   /** True when the current turn settled with an unrecoverable Pi error. */
@@ -804,8 +805,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         sessionId,
         getRunId: () => this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId,
         settingsManager,
-        getAutoApprove: () =>
-          this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
+        getApprovalMode: () =>
+          this.activeSessions.get(sessionId)?.approvalMode ??
+          options.approvalMode ??
+          WorkbenchApprovalMode.Ask,
       });
       if (!isCurrentInitialization()) return;
       sessionOptions.resourceLoader = resourceLoader;
@@ -980,8 +983,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
             {
               sessionId,
               getRunId: () => this.activeSessions.get(sessionId)?.workbenchRunId ?? workbenchRunId,
-              getAutoApprove: () =>
-                this.activeSessions.get(sessionId)?.autoApprove ?? Boolean(options.autoApprove),
+              getApprovalMode: () =>
+                this.activeSessions.get(sessionId)?.approvalMode ??
+                options.approvalMode ??
+                WorkbenchApprovalMode.Ask,
             },
             extensionFactories,
           ),
@@ -1114,7 +1119,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workbenchContract,
         workspaceRoot,
         settingsManager,
-        autoApprove: Boolean(options.autoApprove),
+        approvalMode: options.approvalMode ?? WorkbenchApprovalMode.Ask,
         isRunning: true,
         turnFailed: false,
         queueFlushInFlight: false,
@@ -1287,8 +1292,8 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       });
     }
 
-    if (options.autoApprove !== undefined) {
-      active.autoApprove = Boolean(options.autoApprove);
+    if (options.approvalMode !== undefined) {
+      active.approvalMode = options.approvalMode;
     }
     active.isRunning = true;
     active.turnFailed = false;
@@ -1681,10 +1686,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     }
   }
 
-  /** Applies the global permission mode to sessions that are already running. */
-  setAutoApproveForSession(sessionId: string, autoApprove: boolean): void {
+  /** Applies the current approval mode to sessions that are already running. */
+  setApprovalModeForSession(sessionId: string, approvalMode: WorkbenchApprovalMode): void {
     const active = this.activeSessions.get(sessionId);
-    if (active) active.autoApprove = autoApprove;
+    if (active) active.approvalMode = approvalMode;
   }
 
   respondToPermission(requestId: string, result: PiPermissionResult): void {
@@ -1987,7 +1992,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       sessionId: string;
       getRunId: () => string | null;
       settingsManager?: PiSettingsManager | null;
-      getAutoApprove: () => boolean;
+      getApprovalMode: () => WorkbenchApprovalMode;
     },
     additionalExtensionFactories: PiExtensionFactory[] = [],
   ): Promise<PiResourceLoader> {
@@ -2051,7 +2056,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
                     toolCallId: event.toolCallId,
                     toolName: event.toolName,
                     toolInput,
-                    autoApprove: approvalContext.getAutoApprove(),
+                    approvalMode: approvalContext.getApprovalMode(),
                   });
                   return authorization && !authorization.allow
                     ? {

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -5,6 +5,7 @@ import type { CoworkPendingMessage } from '../../../shared/cowork/pendingMessage
 import type { CoworkQueueDelivery } from '../../../shared/cowork/pendingMessageQueue';
 import type { ProductionLoopMode } from '../../../shared/productionLoop';
 import type { CoworkSessionInterruption } from '../../../shared/cowork/interruption';
+import type { WorkbenchApprovalMode } from '../../../shared/workbenchTask';
 
 /**
  * Pi-native workbench runtime types (issue #225).
@@ -80,7 +81,7 @@ export type PiStartOptions = {
   skipInitialUserMessage?: boolean;
   skillIds?: string[];
   systemPrompt?: string;
-  autoApprove?: boolean;
+  approvalMode?: WorkbenchApprovalMode;
   workspaceRoot?: string;
   confirmationMode?: 'modal' | 'text';
   /** UI session mode, used to apply Work-only execution controls. */
@@ -121,7 +122,7 @@ export type PiContinueOptions = {
   /** Forwarded to startSession when the runtime has to recreate the session. */
   thinkingLevel?: PiThinkingLevel;
   /** Forwarded to startSession when the runtime has to recreate the session. */
-  autoApprove?: boolean;
+  approvalMode?: WorkbenchApprovalMode;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
   /** Internal: the owning task already has a controlled production workflow. */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -95,6 +95,7 @@ import {
 } from '../shared/ipc/schemas';
 import { WorkspaceIpc, WorkspaceStoreKey } from '../shared/workspace';
 import {
+  WorkbenchApprovalMode,
   WorkbenchContractKind,
   WorkbenchRunTrigger,
   type WorkbenchRun,
@@ -898,7 +899,13 @@ const getCodingRoomService = (): CodingRoomService => {
           prompt,
           modelOverride,
           thinkingLevel,
+          permissionMode,
         }) => {
+          const approvalMode =
+            permissionMode === WorkbenchApprovalMode.Auto ||
+            permissionMode === WorkbenchApprovalMode.AllowAll
+              ? permissionMode
+              : WorkbenchApprovalMode.Ask;
           const coworkStoreInstance = getCoworkStore();
           if (!coworkStoreInstance.getSession(sessionId)) {
             coworkStoreInstance.createSession(
@@ -919,12 +926,15 @@ const getCodingRoomService = (): CodingRoomService => {
             workspaceRoot,
             sessionMode: 'work',
             confirmationMode: 'modal',
+            approvalMode,
             ...(modelOverride ? { modelOverride } : {}),
             ...(thinkingLevel
               ? { thinkingLevel: thinkingLevel as PiThinkingLevel }
               : {}),
           });
         },
+        setBuiltinApprovalMode: (sessionId, mode) =>
+          runtime.setApprovalModeForSession(sessionId, mode),
         patchBuiltinSession: (sessionId, patch) =>
           runtime.patchSession(sessionId, {
             model: patch.model,
@@ -3940,7 +3950,10 @@ if (!gotTheLock) {
             sessionMode: options.mode ?? CoworkSessionMode.Work,
             goalMode: options.goalMode,
             productionLoopMode: options.productionLoopMode,
-            autoApprove: options.permissionMode === CoworkPermissionMode.AllowAll,
+            approvalMode:
+              options.permissionMode === CoworkPermissionMode.AllowAll
+                ? WorkbenchApprovalMode.AllowAll
+                : WorkbenchApprovalMode.Ask,
             imageAttachments: options.imageAttachments,
             fileAttachments: options.fileAttachments,
             agentId: options.agentId,
@@ -4075,7 +4088,10 @@ if (!gotTheLock) {
           agentId: existingSession?.agentId,
           expertIds: existingSession?.experts.map(expert => expert.expertId),
           modelOverride: existingSession?.modelOverride,
-          autoApprove: options.permissionMode === CoworkPermissionMode.AllowAll,
+          approvalMode:
+            options.permissionMode === CoworkPermissionMode.AllowAll
+              ? WorkbenchApprovalMode.AllowAll
+              : WorkbenchApprovalMode.Ask,
         })
         .catch(error => {
           console.error('[Cowork] continue error:', error);
@@ -4982,9 +4998,11 @@ if (!gotTheLock) {
             normalizedPermissionModeBySession,
             normalizedPermissionMode ?? previousConfig.permissionMode,
           )) {
-            getPiRuntimeAdapter().setAutoApproveForSession(
+            getPiRuntimeAdapter().setApprovalModeForSession(
               sessionId,
-              mode === CoworkPermissionMode.AllowAll,
+              mode === CoworkPermissionMode.AllowAll
+                ? WorkbenchApprovalMode.AllowAll
+                : WorkbenchApprovalMode.Ask,
             );
           }
         }
@@ -7062,7 +7080,10 @@ if (!gotTheLock) {
               ? session.experts.slice(0, 1).map(expert => expert.expertId)
               : normalizeSingleExpertIds(resumeInput.expertIds),
           modelOverride: session.modelOverride,
-          autoApprove: config.permissionMode === CoworkPermissionMode.AllowAll,
+          approvalMode:
+            config.permissionMode === CoworkPermissionMode.AllowAll
+              ? WorkbenchApprovalMode.AllowAll
+              : WorkbenchApprovalMode.Ask,
           goalMode: resumeInput?.goalMode,
           productionLoopMode: resumeInput?.productionLoopMode,
           imageAttachments: resumeInput?.imageAttachments,

--- a/src/main/workbenchTask/taskService.test.ts
+++ b/src/main/workbenchTask/taskService.test.ts
@@ -8,6 +8,7 @@ import {
   WorkbenchApprovalDecision,
   WorkbenchApprovalDecisionSource,
   WorkbenchApprovalEffectStatus,
+  WorkbenchApprovalMode,
   WorkbenchApprovalRiskLevel,
   WorkbenchArtifactCandidateSource,
   WorkbenchArtifactProvenance,
@@ -626,7 +627,7 @@ test('supersedes a paused task instead of reusing its contract', async () => {
       toolCallId: 'write-call',
       toolName: 'write',
       toolInput: { path: 'slides.md', content: 'draft' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
     const approval = service.getDetail(first.task.id)?.approvals[0];
     service.respondToApproval({ approvalId: approval!.id, approved: false });
@@ -664,7 +665,7 @@ test('expires pending approvals when a new message supersedes the task', async (
       toolCallId: 'write-call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'draft' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
 
     service.beginRun({ sessionId: 'session', goal: 'new request', contract: chatContract });
@@ -723,7 +724,7 @@ test('successful side effects are not authorized twice', async () => {
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     };
     expect((await service.authorizeToolCall(input)).allow).toBe(true);
     service.recordToolResult(run.id, 'call', { ok: true }, false);
@@ -757,7 +758,7 @@ test('skip_workflow executes without creating a user approval', async () => {
           action: ProductionLoopAction.SkipWorkflow,
           reason: 'Simple information request',
         },
-        autoApprove: false,
+        approvalMode: WorkbenchApprovalMode.Ask,
       }),
     ).resolves.toEqual({ allow: true });
     expect(service.getDetail(task.id)?.approvals).toEqual([]);
@@ -783,7 +784,7 @@ test('pending, denied, and failed side effects cannot be authorized again', asyn
       toolCallId: 'pending-call',
       toolName: 'write',
       toolInput: { path: 'pending.txt', content: 'ok' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     };
     const pendingAuthorization = service.authorizeToolCall(pendingInput);
     expect((await service.authorizeToolCall(pendingInput)).allow).toBe(false);
@@ -804,7 +805,7 @@ test('pending, denied, and failed side effects cannot be authorized again', asyn
       ...pendingInput,
       runId: next.run.id,
       toolCallId: 'failed-call',
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     };
     expect((await service.authorizeToolCall(failedInput)).allow).toBe(true);
     service.recordToolResult(next.run.id, failedInput.toolCallId, new Error('failed'), true);
@@ -828,12 +829,55 @@ test('allow-all auto-approves irreversible effects', async () => {
       toolCallId: 'call',
       toolName: 'bash',
       toolInput: { command: 'git push origin main' },
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     });
     const approval = service.getDetail(task.id)?.approvals[0];
     expect(approval?.riskLevel).toBe(WorkbenchApprovalRiskLevel.Irreversible);
     expect(approval?.decision).toBe(WorkbenchApprovalDecision.Approved);
     expect((await authorization).allow).toBe(true);
+  } finally {
+    db.close();
+  }
+});
+
+test('auto mode approves reversible effects but still prompts for irreversible ones', async () => {
+  const { db, service } = createService();
+  try {
+    const { task, run } = service.beginRun({
+      sessionId: 'session',
+      goal: 'write then delete',
+      contract: chatContract,
+    });
+    const writeAuthorization = await service.authorizeToolCall({
+      sessionId: 'session',
+      runId: run.id,
+      toolCallId: 'write-call',
+      toolName: 'write',
+      toolInput: { path: 'result.txt', content: 'ok' },
+      approvalMode: WorkbenchApprovalMode.Auto,
+    });
+    const writeApproval = service
+      .getDetail(task.id)
+      ?.approvals.find(candidate => candidate.toolCallId === 'write-call');
+    expect(writeAuthorization.allow).toBe(true);
+    expect(writeApproval?.riskLevel).toBe(WorkbenchApprovalRiskLevel.Reversible);
+    expect(writeApproval?.decision).toBe(WorkbenchApprovalDecision.Approved);
+
+    const rmAuthorization = service.authorizeToolCall({
+      sessionId: 'session',
+      runId: run.id,
+      toolCallId: 'rm-call',
+      toolName: 'bash',
+      toolInput: { command: 'rm result.txt' },
+      approvalMode: WorkbenchApprovalMode.Auto,
+    });
+    const rmApproval = service
+      .getDetail(task.id)
+      ?.approvals.find(candidate => candidate.toolCallId === 'rm-call');
+    expect(rmApproval?.riskLevel).toBe(WorkbenchApprovalRiskLevel.Irreversible);
+    expect(rmApproval?.decision).toBe(WorkbenchApprovalDecision.Pending);
+    service.respondToApproval({ approvalId: rmApproval!.id, approved: false });
+    expect((await rmAuthorization).allow).toBe(false);
   } finally {
     db.close();
   }
@@ -866,7 +910,7 @@ test('rejects tool calls from another session or an inactive run', async () => {
         toolCallId: 'stale-call',
         toolName: 'write',
         toolInput: { path: 'stale.txt' },
-        autoApprove: true,
+        approvalMode: WorkbenchApprovalMode.AllowAll,
       }),
     ).resolves.toMatchObject({ allow: false, reason: expect.stringContaining('active run') });
     await expect(
@@ -876,7 +920,7 @@ test('rejects tool calls from another session or an inactive run', async () => {
         toolCallId: 'foreign-call',
         toolName: 'write',
         toolInput: { path: 'foreign.txt' },
-        autoApprove: true,
+        approvalMode: WorkbenchApprovalMode.AllowAll,
       }),
     ).resolves.toMatchObject({ allow: false, reason: expect.stringContaining('session') });
     expect(service.repository.listApprovalsForRun(first.run.id)).toHaveLength(0);
@@ -900,7 +944,7 @@ test('agent end does not verify a run paused by a denied approval', async () => 
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
     const approval = service.getDetail(task.id)?.approvals[0];
     service.respondToApproval({ approvalId: approval!.id, approved: false });
@@ -952,7 +996,7 @@ test('pausing a run expires and resolves its pending approval', async () => {
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
 
     service.pauseRun('session', 'The user stopped this run.');
@@ -985,7 +1029,7 @@ test('deleting a session resolves pending approvals before removing their record
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
 
     service.deleteSession('session');
@@ -1014,7 +1058,7 @@ test('startup recovery preserves pending approval projection until resume', asyn
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: false,
+      approvalMode: WorkbenchApprovalMode.Ask,
     });
 
     expect(service.recoverInterruptedState()).toBe(1);
@@ -1055,7 +1099,7 @@ test('tool results are persisted as bounded circular-safe JSON', async () => {
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     });
     const result: Record<string, unknown> = { payload: 'x'.repeat(100_000) };
     result.self = result;
@@ -1087,7 +1131,7 @@ test('startup recovery marks executing effects and their runs for review', async
       toolCallId: 'call',
       toolName: 'write',
       toolInput: { path: 'result.txt', content: 'ok' },
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     });
     expect(service.recoverInterruptedState()).toBe(1);
     const detail = service.getDetail(task.id);
@@ -1146,7 +1190,7 @@ test('keeps declared artifact identity scoped to its run after tool-effect colle
       toolCallId: 'write-call',
       toolName: 'write',
       toolInput: { path: filePath, content: '# result' },
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     });
     service.recordToolResult(first.run.id, 'write-call', { path: filePath }, false);
 

--- a/src/main/workbenchTask/taskService.ts
+++ b/src/main/workbenchTask/taskService.ts
@@ -5,6 +5,7 @@ import {
   WorkbenchApprovalDecision,
   WorkbenchApprovalDecisionSource,
   WorkbenchApprovalEffectStatus,
+  WorkbenchApprovalMode,
   WorkbenchApprovalRiskLevel,
   WorkbenchArtifactCandidateSource,
   WorkbenchArtifactVerificationStatus,
@@ -523,7 +524,7 @@ export class WorkbenchTaskService extends EventEmitter {
     toolCallId: string;
     toolName: string;
     toolInput: Record<string, unknown>;
-    autoApprove: boolean;
+    approvalMode: WorkbenchApprovalMode;
   }): Promise<WorkbenchToolAuthorizationResult> {
     const run = this.requireRun(input.runId);
     const task = this.requireTask(run.taskId);
@@ -558,9 +559,14 @@ export class WorkbenchTaskService extends EventEmitter {
       }
       return { allow: false, reason: this.getDuplicateApprovalReason(existing) };
     }
-    // "Allow all" means the user has explicitly disabled tool authorization
-    // prompts for this run, including irreversible effects.
-    const canAutoApprove = input.autoApprove;
+    // Ask prompts for every side effect; Auto auto-approves only reversible
+    // effects while irreversible/unknown ones still prompt; AllowAll means the
+    // user has explicitly disabled tool authorization prompts for this run,
+    // including irreversible effects.
+    const canAutoApprove =
+      input.approvalMode === WorkbenchApprovalMode.AllowAll ||
+      (input.approvalMode === WorkbenchApprovalMode.Auto &&
+        riskLevel === WorkbenchApprovalRiskLevel.Reversible);
     const approval = this.repository.transaction(() => {
       const created = this.repository.createApproval({
         taskId: task.id,

--- a/src/scheduledTask/piScheduledTaskExecutor.test.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import { expect, test, vi } from 'vitest';
 
 import { CoworkSessionSource } from '../shared/cowork/constants';
+import { WorkbenchApprovalMode } from '../shared/workbenchTask';
 
 import {
   DeliveryMode,
@@ -124,7 +125,7 @@ test('runs a canonical task in its workspace and waits for complete', async () =
     session.id,
     'run',
     expect.objectContaining({
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
       skillIds: session.activeSkillIds,
       modelOverride: session.modelOverride,
     }),

--- a/src/scheduledTask/piScheduledTaskExecutor.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.ts
@@ -4,6 +4,7 @@ import type { PiRuntime } from '../main/libs/agentEngine/piRuntimeTypes';
 import { getDefaultConversationWorkspacePath } from '../main/defaultConversationWorkspace';
 import { parseManagedSessionKey } from '../main/libs/channelSessionKey';
 import { CoworkSessionSource } from '../shared/cowork/constants';
+import { WorkbenchApprovalMode } from '../shared/workbenchTask';
 
 import { PayloadKind, SessionTarget } from './constants';
 import type { ScheduledTask, ScheduledTaskRun } from './types';
@@ -58,7 +59,7 @@ export class PiScheduledTaskExecutor {
       modelOverride: session.modelOverride || undefined,
       // Scheduled runs have no foreground permission UI. Their creator opted
       // into unattended execution, so tools must follow that run policy.
-      autoApprove: true,
+      approvalMode: WorkbenchApprovalMode.AllowAll,
     };
     try {
       const execution = this.runtime.isSessionActive(session.id)

--- a/src/shared/workbenchTask/constants.ts
+++ b/src/shared/workbenchTask/constants.ts
@@ -64,6 +64,14 @@ export const WorkbenchApprovalRiskLevel = {
 export type WorkbenchApprovalRiskLevel =
   (typeof WorkbenchApprovalRiskLevel)[keyof typeof WorkbenchApprovalRiskLevel];
 
+export const WorkbenchApprovalMode = {
+  Ask: 'ask',
+  Auto: 'auto',
+  AllowAll: 'allowAll',
+} as const;
+export type WorkbenchApprovalMode =
+  (typeof WorkbenchApprovalMode)[keyof typeof WorkbenchApprovalMode];
+
 export const WorkbenchApprovalDecision = {
   Pending: 'pending',
   Approved: 'approved',


### PR DESCRIPTION
## Summary

The built-in coding agent (编程模式 / 知远编程 Agent) hardcoded `confirmationMode: 'modal'`, so every tool call prompted for approval with no way to opt out. This PR exposes a **permission mode** selector in the coding composer toolbar with three tiers:

- **每次询问 (ask)** — default, unchanged behavior
- **自动放行低风险 (auto)** — reversible effects (`write`/`edit`) auto-approve via the existing workbench risk classifier; irreversible or unclassifiable calls still prompt
- **全部允许 (allowAll)** — everything auto-approves, including irreversible effects

## Implementation

- Generalized workbench tool authorization from boolean `autoApprove` to tri-state `WorkbenchApprovalMode` (`src/shared/workbenchTask/constants.ts`, `taskService.ts`, `piRuntimeAdapter.ts`, `piRuntimeTypes.ts`)
- Declared a `permission-mode` select config option on the builtin coding driver, following the existing `thinking-level` pattern (persisted per lane, live-patches running Pi sessions via `setApprovalModeForSession`)
- **Zero renderer changes**: the generic config-option channel (`setLaneConfigOption` → `CodingComposerConfigControls`) renders the new select as a dropdown automatically
- Cowork keeps its existing two-tier UI (ask / allowAll), mapped onto the new enum; scheduled tasks pinned to `AllowAll` as before
- New i18n keys in both zh and en (`src/main/i18n.ts`)

## Verification

- 218 targeted tests pass (`taskService`, `builtinCodingDriver`, `codingRoomService`, `piRuntimeAdapter`, `piScheduledTaskExecutor`, `imCoworkHandler`), including new cases for the auto tier and driver live-patch wiring
- `npm run compile:electron` clean; `npm run lint` 0 warnings / 0 errors

## Notes

- Electron-specific: main-process only changes; no IPC schema changes (config options flow through the existing generic channel)
- A plan (read-only) tier was considered but deliberately excluded — it has no existing foundation in the Pi runtime and would need separate design