### PR TITLE
fix(coding): stop overflow clipping of git panel card footers

### DIFF
--- a/src/renderer/components/coding/CodingGitPanel.tsx
+++ b/src/renderer/components/coding/CodingGitPanel.tsx
@@ -316,7 +316,7 @@ export const CodingGitPanel = ({
                     </span>
                   </div>
                 </CardContent>
-                <CardFooter className="-mx-3 -mb-3 justify-between gap-3 px-3 py-2">
+                <CardFooter className="-mx-3 justify-between gap-3 px-3 py-2">
                   <span className="text-xs text-muted-foreground">
                     {formatCount('codingGitChangesSummary', status.files.length)}
                   </span>
@@ -420,7 +420,7 @@ export const CodingGitPanel = ({
                     </Field>
                   </FieldGroup>
                 </CardContent>
-                <CardFooter className="-mx-3 -mb-3 justify-end gap-2 px-3 py-2">
+                <CardFooter className="-mx-3 justify-end gap-2 px-3 py-2">
                   <Button
                     type="button"
                     variant="outline"


### PR DESCRIPTION
## Summary
Fixes component misalignment/overflow clipping in the coding-mode git panel (`CodingGitPanel`).

## Problem
The environment card and the commit card use `CardFooter` with `-mx-3 -mb-3`. Because the `Card` is `size="sm"` and has a footer slot, it applies `has-data-[slot=card-footer]:pb-0` and `overflow-hidden`. The `-mb-3` (-12px) pushes the footer 12px below the card's content edge, so the card's `overflow-hidden` **clips the bottom 12px of the footer** — cutting into the footer content (the push/commit buttons and the additions/deletions summary). This shows up as misplaced/occluded content.

## Change
Remove `-mb-3` from both footers while keeping `-mx-3`. With `pb-0` the footer already sits flush with the card's bottom edge; `-mx-3` preserves the edge-flush horizontal look (and the existing `px-3` keeps the content aligned), so nothing is pushed below the clip boundary anymore.

## Verification
- `npm run lint`: 0 warnings, 0 errors.
- `tsc -p tsconfig.json`: 0 errors.
- `npm test -- coding`: 25 test files / 160 cases passed.
- Recommendation: `npm run electron:dev` → open the git panel in coding mode and confirm the footer content is no longer clipped.