### PR TITLE
fix(workbench): wrap verification check details

### DIFF
--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineChapter.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineChapter.tsx
@@ -247,7 +247,7 @@ function VerificationCheckRow({ check }: { check: WorkbenchVerificationCheck }) 
   const { icon: Icon, className } =
     checkIcons[check.status] ?? checkIcons[WorkbenchVerificationCheckStatus.Skipped];
   return (
-    <li className="flex items-start gap-2">
+    <li className="flex flex-wrap items-start gap-2">
       <Icon className={cn('mt-0.5 size-3.5 shrink-0', className)} />
       <span className="min-w-0 flex-1 break-all font-mono text-xs text-foreground">
         {check.name}


### PR DESCRIPTION
## Summary

Fix the artifact verification check layout in the Workbench task audit.

## Changes

- Allow verification check rows to wrap when a detail message needs a full row.
- Keep the check icon and check name readable instead of collapsing the name into a narrow column.

## Scope

This PR only changes the verification check row layout in `TimelineChapter.tsx`.

## Verification

- `npm test -- TimelineEntries`
- `npm run lint`
- `npm run build`
