### PR TITLE
fix(workbench): align and bound timeline connectors

### DIFF
--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineChapter.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineChapter.tsx
@@ -98,7 +98,7 @@ export function TimelineChapter({
     <>
       <span
         aria-hidden="true"
-        className="absolute top-0 left-0 flex size-7 items-center justify-center rounded-full border border-border bg-background"
+        className="absolute top-0 left-0 z-10 flex size-7 items-center justify-center rounded-full border border-border bg-background"
       >
         <StatusIcon
           className={cn(

--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineEntries.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/TimelineEntries.tsx
@@ -113,7 +113,10 @@ function EntryMarker({ className }: { className?: string }) {
   return (
     <span
       aria-hidden="true"
-      className={cn('absolute top-[9px] left-[10px] size-2 rounded-full', className)}
+      className={cn(
+        'absolute top-[9px] left-[10px] z-10 size-2 rounded-full ring-2 ring-background',
+        className,
+      )}
     />
   );
 }
@@ -309,7 +312,10 @@ function PendingApprovalEntry({
 
   return (
     <li className="relative pl-10">
-      <span aria-hidden="true" className="absolute top-[9px] left-[10px] flex size-2">
+      <span
+        aria-hidden="true"
+        className="absolute top-[9px] left-[10px] z-10 flex size-2 rounded-full ring-2 ring-background"
+      >
         {!reducedMotion && (
           <motion.span
             className="absolute inline-flex size-full rounded-full bg-primary"

--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
@@ -63,12 +63,12 @@ export function WorkbenchTimeline({
                 <>
                   <span
                     aria-hidden="true"
-                    className="pointer-events-none absolute top-7 left-3.5 h-[calc(100%-0.75rem)] w-px bg-border"
+                    className="pointer-events-none absolute top-7 left-3.5 z-0 h-[calc(100%-0.75rem)] w-px bg-border"
                   />
                   {!reducedMotion && (
                     <motion.span
                       aria-hidden="true"
-                      className="pointer-events-none absolute top-7 left-3.5 h-[calc(100%-0.75rem)] w-px origin-top bg-primary/40"
+                      className="pointer-events-none absolute top-7 left-3.5 z-0 h-[calc(100%-0.75rem)] w-px origin-top bg-primary/40"
                       initial={{ scaleY: 0 }}
                       animate={{ scaleY: 1 }}
                       transition={{ duration: 0.8, ease: TIMELINE_EASE }}

--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
@@ -63,12 +63,12 @@ export function WorkbenchTimeline({
                 <>
                   <span
                     aria-hidden="true"
-                    className="pointer-events-none absolute top-3.5 left-3.5 h-[calc(100%+1rem)] w-px bg-border"
+                    className="pointer-events-none absolute top-7 left-3.5 h-[calc(100%-0.75rem)] w-px bg-border"
                   />
                   {!reducedMotion && (
                     <motion.span
                       aria-hidden="true"
-                      className="pointer-events-none absolute top-3.5 left-3.5 h-[calc(100%+1rem)] w-px origin-top bg-primary/40"
+                      className="pointer-events-none absolute top-7 left-3.5 h-[calc(100%-0.75rem)] w-px origin-top bg-primary/40"
                       initial={{ scaleY: 0 }}
                       animate={{ scaleY: 1 }}
                       transition={{ duration: 0.8, ease: TIMELINE_EASE }}

--- a/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
+++ b/src/renderer/components/cowork/workbenchTaskAudit/timeline/WorkbenchTimeline.tsx
@@ -45,37 +45,47 @@ export function WorkbenchTimeline({
 
   return (
     <div className="relative pb-10">
-      <span aria-hidden="true" className="absolute inset-y-0 left-3.5 w-px bg-border" />
-      {!reducedMotion && (
-        <motion.span
-          aria-hidden="true"
-          className="absolute inset-y-0 left-3.5 w-px origin-top bg-primary/40"
-          initial={{ scaleY: 0 }}
-          animate={{ scaleY: 1 }}
-          transition={{ duration: 0.8, ease: TIMELINE_EASE }}
-        />
-      )}
       <motion.ol
         className="relative flex flex-col gap-4"
         variants={reducedMotion ? undefined : chapterListVariants}
         initial={reducedMotion ? false : 'hidden'}
         animate={reducedMotion ? undefined : 'show'}
       >
-        {chapters.map(chapter => (
-          <motion.li
-            key={chapter.run.id}
-            className="relative"
-            variants={reducedMotion ? undefined : chapterItemVariants}
-          >
-            <TimelineChapter
-              chapter={chapter}
-              runs={detail.runs}
-              defaultOpen={chapter.run.id === defaultOpenRunId}
-              busy={busy}
-              onRespondToApproval={onRespondToApproval}
-            />
-          </motion.li>
-        ))}
+        {chapters.map((chapter, index) => {
+          const hasNextChapter = index < chapters.length - 1;
+          return (
+            <motion.li
+              key={chapter.run.id}
+              className="relative"
+              variants={reducedMotion ? undefined : chapterItemVariants}
+            >
+              {hasNextChapter && (
+                <>
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute top-3.5 left-3.5 h-[calc(100%+1rem)] w-px bg-border"
+                  />
+                  {!reducedMotion && (
+                    <motion.span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute top-3.5 left-3.5 h-[calc(100%+1rem)] w-px origin-top bg-primary/40"
+                      initial={{ scaleY: 0 }}
+                      animate={{ scaleY: 1 }}
+                      transition={{ duration: 0.8, ease: TIMELINE_EASE }}
+                    />
+                  )}
+                </>
+              )}
+              <TimelineChapter
+                chapter={chapter}
+                runs={detail.runs}
+                defaultOpen={chapter.run.id === defaultOpenRunId}
+                busy={busy}
+                onRespondToApproval={onRespondToApproval}
+              />
+            </motion.li>
+          );
+        })}
       </motion.ol>
     </div>
   );


### PR DESCRIPTION
## Summary

Fix connector rendering between Workbench task audit timeline chapters.

## Changes

- Render connector segments only when a following chapter exists.
- Bound each segment from the current chapter node edge to the next chapter node.
- Keep chapter and expanded event markers above the connector so the line does not paint through them.
- Preserve the existing expand/collapse behavior and timeline data flow.

## Scope

This PR only changes timeline connector and marker presentation in the Workbench task audit.

## Verification

- `npm test -- WorkbenchTaskAuditView TimelineEntries timelineModel`
- `npm run lint`
- `npm run build`
- Captured expanded and collapsed timeline previews.
