### PR TITLE
build(electron): omit source maps from production output

### DIFF
--- a/electron-tsconfig.json
+++ b/electron-tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "strict": false,
-    "sourceMap": true,
+    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "dist-electron",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary\n- disable source maps in the production Electron TypeScript output\n- keep the runtime dependency gate green and avoid shipping source maps in installers\n\n## Verification\n- npm test -- --run src/main/enterpriseExtension\n- bun run build\n- bun run check:electron-runtime-dependencies\n\nThis PR does not contain enterprise extension source, License signer code, or private keys.