### PR TITLE
fix(runtime): add official PyPI fallback for uv

### DIFF
--- a/src/main/libs/coworkUtil.ts
+++ b/src/main/libs/coworkUtil.ts
@@ -25,12 +25,12 @@ import {
   extractApiErrorSnippet,
 } from './coworkModelApi';
 import type { OpenAICompatProxyTarget } from './coworkOpenAICompatProxy';
+import { applyUvPackageIndexDefaults, PythonPackageIndexUrl } from './pythonPackageIndexes';
 import { appendPythonRuntimeToEnv } from './pythonRuntime';
 import { findSharedSkillPythonExecutable } from './skillPythonRuntime';
 import { isSystemProxyEnabled, resolveSystemProxyUrlForTargets } from './systemProxy';
 import { appendUvRuntimeToEnv, configureUvForManagedPython } from './uvRuntime';
 
-const DOMESTIC_PYPI_INDEX_URL = 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple';
 const DOMESTIC_NPM_REGISTRY_URL = 'https://registry.npmmirror.com';
 
 type EnhancedEnvOptions = {
@@ -1095,11 +1095,9 @@ function ensureWindowsBashUtf8InitScript(): string | null {
 
 function applyDomesticPackageMirrorDefaults(env: Record<string, string | undefined>): void {
   if (!env.PIP_INDEX_URL) {
-    env.PIP_INDEX_URL = DOMESTIC_PYPI_INDEX_URL;
+    env.PIP_INDEX_URL = PythonPackageIndexUrl.Tsinghua;
   }
-  if (!env.UV_DEFAULT_INDEX) {
-    env.UV_DEFAULT_INDEX = DOMESTIC_PYPI_INDEX_URL;
-  }
+  applyUvPackageIndexDefaults(env);
 
   const hasNpmRegistry = Boolean(env.npm_config_registry || env.NPM_CONFIG_REGISTRY);
   if (!hasNpmRegistry) {

--- a/src/main/libs/pythonPackageIndexes.test.ts
+++ b/src/main/libs/pythonPackageIndexes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  applyUvPackageIndexDefaults,
+  MANAGED_UV_CONFIG,
+  PythonPackageIndexUrl,
+} from './pythonPackageIndexes';
+
+describe('managed uv package indexes', () => {
+  test('uses Tsinghua first and the official PyPI index as fallback', () => {
+    const tsinghuaIndex = MANAGED_UV_CONFIG.indexOf(PythonPackageIndexUrl.Tsinghua);
+    const officialIndex = MANAGED_UV_CONFIG.indexOf(PythonPackageIndexUrl.Official);
+
+    expect(tsinghuaIndex).toBeGreaterThan(-1);
+    expect(officialIndex).toBeGreaterThan(tsinghuaIndex);
+    expect(MANAGED_UV_CONFIG.slice(officialIndex)).toContain('default = true');
+  });
+
+  test('sets missing uv index environment variables', () => {
+    const env: Record<string, string | undefined> = {};
+
+    applyUvPackageIndexDefaults(env);
+
+    expect(env.UV_INDEX).toBe(PythonPackageIndexUrl.Tsinghua);
+    expect(env.UV_DEFAULT_INDEX).toBe(PythonPackageIndexUrl.Official);
+  });
+
+  test('can replace inherited uv index environment variables', () => {
+    const env = {
+      UV_INDEX: 'https://example.com/simple',
+      UV_DEFAULT_INDEX: 'https://example.org/simple',
+    };
+
+    applyUvPackageIndexDefaults(env, { overwrite: true });
+
+    expect(env.UV_INDEX).toBe(PythonPackageIndexUrl.Tsinghua);
+    expect(env.UV_DEFAULT_INDEX).toBe(PythonPackageIndexUrl.Official);
+  });
+});

--- a/src/main/libs/pythonPackageIndexes.ts
+++ b/src/main/libs/pythonPackageIndexes.ts
@@ -1,0 +1,28 @@
+export const PythonPackageIndexUrl = {
+  Tsinghua: 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple',
+  Official: 'https://pypi.org/simple',
+} as const;
+
+export const MANAGED_UV_CONFIG = [
+  '[[index]]',
+  "name = 'tsinghua'",
+  `url = '${PythonPackageIndexUrl.Tsinghua}'`,
+  '',
+  '[[index]]',
+  "name = 'pypi'",
+  `url = '${PythonPackageIndexUrl.Official}'`,
+  'default = true',
+  '',
+].join('\n');
+
+export function applyUvPackageIndexDefaults(
+  env: Record<string, string | undefined>,
+  options: { overwrite?: boolean } = {},
+): void {
+  if (options.overwrite || !env.UV_INDEX) {
+    env.UV_INDEX = PythonPackageIndexUrl.Tsinghua;
+  }
+  if (options.overwrite || !env.UV_DEFAULT_INDEX) {
+    env.UV_DEFAULT_INDEX = PythonPackageIndexUrl.Official;
+  }
+}

--- a/src/main/libs/uvRuntime.ts
+++ b/src/main/libs/uvRuntime.ts
@@ -2,19 +2,13 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
+import { applyUvPackageIndexDefaults, MANAGED_UV_CONFIG } from './pythonPackageIndexes';
 import { getManagedPythonExecutable } from './pythonRuntime';
 
 const UV_RUNTIME_DIR_NAME =
   process.platform === 'darwin' ? 'uv-mac' : process.platform === 'linux' ? 'uv-linux' : 'uv-win';
 const UV_CONFIG_DIR_NAME = 'uv';
 const UV_CONFIG_FILE_NAME = 'uv.toml';
-const DOMESTIC_PYPI_INDEX_URL = 'https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple';
-const MANAGED_UV_CONFIG = [
-  '[[index]]',
-  `url = '${DOMESTIC_PYPI_INDEX_URL}'`,
-  'default = true',
-  '',
-].join('\n');
 const IS_WINDOWS = process.platform === 'win32';
 type UvExecutableName = 'uv.exe' | 'uvx.exe' | 'uv' | 'uvx';
 
@@ -169,9 +163,9 @@ export function configureUvForManagedPython(
   const configPath = ensureManagedUvConfig();
   if (configPath) {
     env.UV_CONFIG_FILE = configPath;
-    // An inherited UV_DEFAULT_INDEX has higher priority than uv.toml. Pin this
-    // process to the app's mirror so external shell configuration cannot change it.
-    env.UV_DEFAULT_INDEX = DOMESTIC_PYPI_INDEX_URL;
+    // Environment variables have higher priority than uv.toml. Pin both indexes
+    // so external shell configuration cannot disable the official fallback.
+    applyUvPackageIndexDefaults(env, { overwrite: true });
   }
   env.ZHIYUAN_PYTHON_BIN = python;
   return env;


### PR DESCRIPTION
## Summary

- keep the Tsinghua PyPI mirror as uv's first package index
- use the official PyPI index as the low-priority default fallback
- centralize managed uv index configuration and cover both config and environment behavior with unit tests

## Behavior

uv keeps its default `first-index` strategy, so packages are resolved from Tsinghua when available and the official index is consulted when the package is absent there. Managed runtime environment variables are pinned to the same ordering so inherited shell settings cannot remove the fallback.

Transport failures from the first index are still surfaced by uv itself; this fallback covers package availability rather than suppressing mirror connection errors.

## Validation

- `npm test -- pythonPackageIndexes`
- `npx vitest run src/main/libs/pythonPackageIndexes.test.ts`
- `npm run compile:electron`
- `npm run lint`
- `bunx oxfmt --check src/main/libs/pythonPackageIndexes.ts src/main/libs/pythonPackageIndexes.test.ts`