### PR TITLE
fix(memory): recall manually added memories

### DIFF
--- a/src/main/memory/repository.test.ts
+++ b/src/main/memory/repository.test.ts
@@ -236,6 +236,39 @@ test('reads local metadata for a confirmed memory link', () => {
   }
 });
 
+test('keeps manually added Personal memories recallable without extractor metadata', () => {
+  const db = new Database(':memory:');
+  const repository = new MemoryRepository(db);
+
+  try {
+    repository.createLink({
+      id: 'manual-personal-link',
+      memoryId: 9,
+      projectId: 'personal://zhiyuan-agent/user',
+      scope: MemoryScope.Personal,
+      sessionId: 'personal:settings-memory',
+      sourceKind: MemorySourceKind.Explicit,
+      title: 'Email address',
+      content: 'user@example.com',
+      kind: MemoryKind.Preference,
+      metadata: { manual: true },
+    });
+
+    expect(
+      repository.filterRecallableMemoryIds({
+        projectId: 'personal://zhiyuan-agent/user',
+        memoryIds: [9],
+        scope: MemoryScope.Personal,
+      }),
+    ).toEqual(new Set([9]));
+    expect(
+      repository.isCurrentSemanticMemoryLink('manual-personal-link', MemoryScope.Personal),
+    ).toBe(true);
+  } finally {
+    db.close();
+  }
+});
+
 test('deleting a candidate also cancels its pending outbox delivery', () => {
   const db = new Database(':memory:');
   const repository = new MemoryRepository(db);

--- a/src/main/memory/repository.ts
+++ b/src/main/memory/repository.ts
@@ -919,6 +919,7 @@ function isCurrentSemanticSessionMetadata(metadata: Record<string, unknown>): bo
 }
 
 function isCurrentAtomicMetadata(metadata: Record<string, unknown>): boolean {
+  if (metadata.manual === true) return true;
   const candidate =
     metadata.extractorKind === MemoryExtractorKind.Atomic ? metadata : metadata.extraction;
   return Boolean(


### PR DESCRIPTION
## Summary

- allow confirmed manually added Project and Personal memories to participate in recall
- preserve the existing atomic-extractor gate for automatically extracted memories
- add a regression test for manually added Personal memory links

## Root Cause

Manual memories are stored with `metadata.manual = true`, while recall authorization only accepted atomic extractor metadata. The Engram observation could remain active, but the local `memory_links` projection rejected its ID before results were returned to the agent.

## Behavior

`manual: true` is now treated as valid non-session memory metadata. This covers existing manual memory links and all future manual memories created through the managed memory flow. Session summaries remain subject to their separate semantic summary validation.

## Validation

- `npm test -- repository memory` (25 test files, 153 tests passed)
- `npm run compile:electron`
- `npm run lint`
- `git diff --check`

`oxfmt --check` still reports pre-existing formatting differences in `src/main/memory/repository.ts`; no unrelated formatting changes are included in this PR.