### PR TITLE
feat(memory): select workspace for managed memories

### DIFF
--- a/src/main/memory/projectMemoryService.test.ts
+++ b/src/main/memory/projectMemoryService.test.ts
@@ -112,6 +112,22 @@ test('always recalls with the current project identity', async () => {
   expect(recall.mock.calls[1][0]).toMatchObject({ project: 'project-beta' });
 });
 
+test('filters managed memories to the selected workspace while retaining personal memories', () => {
+  const memories = [
+    { id: 'project-alpha', scope: MemoryScope.Project, projectId: 'project-alpha' },
+    { id: 'project-beta', scope: MemoryScope.Project, projectId: 'project-beta' },
+    { id: 'session-alpha', scope: MemoryScope.Session, projectId: 'project-alpha' },
+    { id: 'personal', scope: MemoryScope.Personal, projectId: PERSONAL_MEMORY_PROJECT_ID },
+  ];
+  const listManaged = vi.fn(() => memories);
+  const service = new ProjectMemoryService({ listManaged } as never, {} as never, identityFor);
+
+  expect(
+    service.listManagedMemories({ workingDirectory: 'alpha' }).map(memory => memory.id),
+  ).toEqual(['project-alpha', 'session-alpha', 'personal']);
+  expect(listManaged).toHaveBeenCalledWith({ workingDirectory: 'alpha' });
+});
+
 test('returns referenced memory only when it is recallable in the current boundary', () => {
   const findLinkByMemoryId = vi.fn((memoryId: number) => ({
     memoryId,
@@ -308,7 +324,9 @@ test('edits active manual memory by confirming a superseding candidate', async (
     createPersonalCandidate: vi.fn(() => replacement.id),
   };
   const service = new ProjectMemoryService(repository as never, {} as never, identityFor);
-  const confirm = vi.spyOn(service, 'confirmMemoryCandidate').mockResolvedValue(replacement.memoryId);
+  const confirm = vi
+    .spyOn(service, 'confirmMemoryCandidate')
+    .mockResolvedValue(replacement.memoryId);
 
   await expect(
     service.updateManualMemory({

--- a/src/main/memory/projectMemoryService.ts
+++ b/src/main/memory/projectMemoryService.ts
@@ -128,8 +128,7 @@ export class ProjectMemoryService {
     const project = this.resolveIdentity(input.workingDirectory);
     const replacementId = this.repository.createPersonalCandidate({
       projectId: current.scope === MemoryScope.Personal ? PERSONAL_MEMORY_PROJECT_ID : project.id,
-      projectRoot:
-        current.scope === MemoryScope.Personal ? this.personalDirectory : project.root,
+      projectRoot: current.scope === MemoryScope.Personal ? this.personalDirectory : project.root,
       scope: current.scope,
       sessionId: MANUAL_MEMORY_SESSION_ID,
       sourceKind: MemorySourceKind.Explicit,
@@ -148,7 +147,9 @@ export class ProjectMemoryService {
     id: string;
     title: string;
     content: string;
-    sourceKind: typeof MemorySourceKind.LegacyFileImport | typeof MemorySourceKind.LegacySqliteImport;
+    sourceKind:
+      | typeof MemorySourceKind.LegacyFileImport
+      | typeof MemorySourceKind.LegacySqliteImport;
     metadata: Record<string, unknown>;
   }): boolean {
     if (
@@ -563,11 +564,7 @@ export class ProjectMemoryService {
     record: Pick<MemoryMigrationRecord, 'storageKind'> & { memory: { id: string } },
     metadata: Record<string, unknown>,
   ): void {
-    this.repository.updateMigrationRecordMetadata(
-      record.memory.id,
-      record.storageKind,
-      metadata,
-    );
+    this.repository.updateMigrationRecordMetadata(record.memory.id, record.storageKind, metadata);
   }
 
   deleteMigrationCandidate(id: string): void {
@@ -575,7 +572,18 @@ export class ProjectMemoryService {
   }
 
   listManagedMemories(input: ManagedMemoryListInput = {}): ManagedMemoryRecord[] {
-    return this.repository.listManaged(input);
+    const records = this.repository.listManaged(input);
+    const workingDirectory = input.workingDirectory?.trim();
+    if (!workingDirectory) return records;
+
+    const projectId = this.resolveIdentity(workingDirectory).id;
+    return records.filter(
+      memory =>
+        (memory.scope === MemoryScope.Personal &&
+          memory.projectId === PERSONAL_MEMORY_PROJECT_ID) ||
+        ((memory.scope === MemoryScope.Project || memory.scope === MemoryScope.Session) &&
+          memory.projectId === projectId),
+    );
   }
 
   archiveMemory(id: string): void {
@@ -637,10 +645,7 @@ export class ProjectMemoryService {
     return memory;
   }
 
-  private assertManualMemoryBoundary(
-    memory: ManagedMemoryRecord,
-    workingDirectory: string,
-  ): void {
+  private assertManualMemoryBoundary(memory: ManagedMemoryRecord, workingDirectory: string): void {
     if (memory.scope === MemoryScope.Session) {
       throw new Error('Session summaries cannot be edited manually.');
     }

--- a/src/renderer/components/settings/memory/ManagedMemorySettings.tsx
+++ b/src/renderer/components/settings/memory/ManagedMemorySettings.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus, RefreshCw } from 'lucide-react';
+import { useSelector } from 'react-redux';
 import { toast } from 'sonner';
 
 import { Button } from '@shared/components/ui/button';
@@ -43,6 +44,7 @@ import {
 } from '../../../../shared/memory';
 import { i18nService } from '../../../services/i18n';
 import { memoryService } from '../../../services/memory';
+import type { RootState } from '../../../store';
 import { MemoryRecordList } from './MemoryRecordList';
 import { collectMemorySourceSessionIds } from './memoryViewModel';
 
@@ -79,6 +81,21 @@ const emptyDraft = (): MemoryDraft => ({
 });
 
 export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySettingsProps) {
+  const workspaces = useSelector((state: RootState) => state.workspace.workspaces);
+  const currentWorkspaceId = useSelector((state: RootState) => state.workspace.currentWorkspaceId);
+  const currentWorkspace = workspaces.find(workspace => workspace.id === currentWorkspaceId);
+  const workspaceOptions = useMemo(() => {
+    const options = workspaces
+      .filter(workspace => !workspace.isHidden)
+      .map(workspace => ({ id: workspace.id, name: workspace.name, path: workspace.path }));
+    const configuredPath = workingDirectory.trim();
+    if (configuredPath && !options.some(option => option.path === configuredPath)) {
+      options.push({ id: configuredPath, name: configuredPath, path: configuredPath });
+    }
+    return options;
+  }, [workspaces, workingDirectory]);
+  const defaultWorkspacePath = currentWorkspace?.path || workingDirectory.trim();
+  const [selectedWorkspacePath, setSelectedWorkspacePath] = useState(defaultWorkspacePath);
   const [records, setRecords] = useState<ManagedMemoryRecord[]>([]);
   const [sessionTitles, setSessionTitles] = useState<ReadonlyMap<string, string>>(new Map());
   const [loading, setLoading] = useState(true);
@@ -86,10 +103,21 @@ export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySetting
   const [editor, setEditor] = useState<MemoryEditor | null>(null);
   const [forgetTarget, setForgetTarget] = useState<ForgetTarget | null>(null);
 
+  useEffect(() => {
+    const nextPath = currentWorkspace?.path || workingDirectory.trim();
+    if (nextPath) setSelectedWorkspacePath(nextPath);
+  }, [currentWorkspace?.path, workingDirectory]);
+
+  useEffect(() => {
+    if (!selectedWorkspacePath && defaultWorkspacePath) {
+      setSelectedWorkspacePath(defaultWorkspacePath);
+    }
+  }, [defaultWorkspacePath, selectedWorkspacePath]);
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const nextRecords = await memoryService.list();
+      const nextRecords = await memoryService.list({ workingDirectory: selectedWorkspacePath });
       const sourceSessionIds = collectMemorySourceSessionIds(nextRecords);
       try {
         const resolvedTitles = sourceSessionIds.length
@@ -109,7 +137,7 @@ export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySetting
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [selectedWorkspacePath]);
 
   useEffect(() => {
     void load();
@@ -190,7 +218,7 @@ export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySetting
       if (editor.record) {
         await memoryService.updateManual({
           id: editor.record.id,
-          workingDirectory,
+          workingDirectory: selectedWorkspacePath,
           title,
           content,
           kind: editor.draft.kind,
@@ -199,7 +227,7 @@ export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySetting
         toast.success(i18nService.t('managedMemoryUpdated'));
       } else {
         await memoryService.createManual({
-          workingDirectory,
+          workingDirectory: selectedWorkspacePath,
           scope: editor.draft.scope,
           title,
           content,
@@ -224,7 +252,31 @@ export function ManagedMemorySettings({ workingDirectory }: ManagedMemorySetting
         <CardTitle>{i18nService.t('managedMemoryTitle')}</CardTitle>
         <CardDescription>{i18nService.t('managedMemoryDescription')}</CardDescription>
         <CardAction className="col-start-1 row-start-3 row-span-1 justify-self-start pt-2 sm:col-start-2 sm:row-start-1 sm:row-span-2 sm:justify-self-end sm:pt-0">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-muted-foreground">
+              {i18nService.t('managedMemoryWorkspaceLabel')}
+            </span>
+            <Select
+              value={selectedWorkspacePath}
+              onValueChange={value => value && setSelectedWorkspacePath(value)}
+              disabled={workspaceOptions.length === 0}
+            >
+              <SelectTrigger
+                className="w-52"
+                aria-label={i18nService.t('managedMemoryWorkspaceLabel')}
+              >
+                <SelectValue placeholder={i18nService.t('managedMemoryWorkspaceEmpty')} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {workspaceOptions.map(workspace => (
+                    <SelectItem key={workspace.id} value={workspace.path}>
+                      {workspace.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
             {pendingCount > 0 && (
               <Button
                 type="button"

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1411,6 +1411,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkMemoryCrudDeleteFailed: '删除记忆条目失败',
     managedMemoryTitle: '受控长期记忆',
     managedMemoryDescription: '统一管理个人、项目和会话记忆，以及它们的来源和生命周期。',
+    managedMemoryWorkspaceLabel: '记忆工作区',
+    managedMemoryWorkspaceEmpty: '暂无可用工作区',
     managedMemoryCreate: '新增记忆',
     managedMemoryTabLongTerm: '长期记忆',
     managedMemoryTabSessions: '会话摘要',
@@ -4666,6 +4668,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     managedMemoryTitle: 'Controlled long-term memory',
     managedMemoryDescription:
       'Manage personal, workspace, and session memories with their sources and lifecycle.',
+    managedMemoryWorkspaceLabel: 'Memory workspace',
+    managedMemoryWorkspaceEmpty: 'No workspace available',
     managedMemoryCreate: 'Add memory',
     managedMemoryTabLongTerm: 'Long-term memory',
     managedMemoryTabSessions: 'Session summaries',

--- a/src/shared/memory/types.ts
+++ b/src/shared/memory/types.ts
@@ -40,6 +40,7 @@ export interface ManagedMemoryRecord {
 }
 
 export interface ManagedMemoryListInput {
+  workingDirectory?: string;
   scope?: MemoryScope;
   status?: MemoryLifecycleStatus;
   query?: string;


### PR DESCRIPTION
## Summary

- add an explicit workspace selector to controlled memory settings
- filter personal, project, and session records to the selected workspace
- use the selected workspace for manual memory creation and editing
- add regression coverage for workspace-scoped listing

## Verification

- `npm test -- --run src/main/memory/projectMemoryService.test.ts`
- `npm run lint`
- `npm run build`
- `npx oxfmt --check src/shared/memory/types.ts src/main/memory/projectMemoryService.ts src/main/memory/projectMemoryService.test.ts src/renderer/components/settings/memory/ManagedMemorySettings.tsx src/renderer/services/i18n.ts`

## Notes

The renderer reuses the existing workspace registry and shadcn Select. Personal memories remain visible across workspace selections; project and session memories are isolated by the normalized workspace identity.
