### PR TITLE
fix(scheduler): disable user questions in unattended runs

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -236,6 +236,7 @@ vi.mock('../coworkUtil', async importOriginal => {
 
 import { PiRuntimeAdapter } from './piRuntimeAdapter';
 import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
+import { PiUnattendedSystemPrompt } from './piUnattendedPolicy';
 import { DeclareArtifactSystemPrompt } from '../../declareArtifact/tool';
 import { PiAgentLoopAction, PiAgentLoopMode, PiAgentLoopToolName } from './piAgentLoop';
 import { CoworkErrorKind, type CoworkError } from '../../../common/coworkError';
@@ -2079,6 +2080,59 @@ describe('PiRuntimeAdapter', () => {
       if (process.platform === 'win32') {
         expect(appended.some(entry => entry.includes('## Bash execution contract'))).toBe(true);
       }
+    });
+
+    it('removes AskUserQuestion and adds autonomous guidance for unattended runs', async () => {
+      await adapter.startSession('unattended', 'Run the scheduled task', { unattended: true });
+
+      const sessionOptions = mockCreateAgentSession.mock.calls[0]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(sessionOptions.customTools?.map(tool => tool.name) ?? []).not.toContain(
+        'AskUserQuestion',
+      );
+
+      const loaderOptions = mockDefaultResourceLoader.mock.calls[0]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      const appended = loaderOptions.appendSystemPromptOverride();
+      expect(appended).not.toContain(PiAskUserQuestionSystemPrompt);
+      expect(appended).toContain(PiUnattendedSystemPrompt);
+    });
+
+    it('recreates the Pi session when unattended mode changes', async () => {
+      await adapter.startSession('mode-switch', 'Start in the foreground');
+      await adapter.continueSession('mode-switch', 'Run on schedule', { unattended: true });
+
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(2);
+      const unattendedOptions = mockCreateAgentSession.mock.calls[1]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(unattendedOptions.customTools?.map(tool => tool.name) ?? []).not.toContain(
+        'AskUserQuestion',
+      );
+      const unattendedLoaderOptions = mockDefaultResourceLoader.mock.calls[1]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      expect(unattendedLoaderOptions.appendSystemPromptOverride()).toContain(
+        PiUnattendedSystemPrompt,
+      );
+
+      await adapter.continueSession('mode-switch', 'Return to the foreground');
+
+      expect(mockCreateAgentSession).toHaveBeenCalledTimes(3);
+      const attendedOptions = mockCreateAgentSession.mock.calls[2]?.[0] as {
+        customTools?: Array<{ name: string }>;
+      };
+      expect(attendedOptions.customTools?.map(tool => tool.name) ?? []).toContain(
+        'AskUserQuestion',
+      );
+      const attendedLoaderOptions = mockDefaultResourceLoader.mock.calls[2]?.[0] as {
+        appendSystemPromptOverride: () => string[];
+      };
+      const attendedPrompt = attendedLoaderOptions.appendSystemPromptOverride();
+      expect(attendedPrompt).toContain(PiAskUserQuestionSystemPrompt);
+      expect(attendedPrompt).not.toContain(PiUnattendedSystemPrompt);
     });
 
     it('guards Windows Bash calls against cmd and PowerShell syntax', async () => {

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -144,6 +144,7 @@ import { PiThinkingLifecycle } from './piThinkingLifecycle';
 import { PiStreamAccumulator } from './piStreamAccumulator';
 import { PiAssistantEventType } from './piStreamConstants';
 import { PiPendingMessageQueue } from './piPendingMessageQueue';
+import { shouldExposeAskUserQuestionTool } from './piUnattendedPolicy';
 import { createPiWorkLoop } from './piWorkLoop';
 import { PiWriteTokenLimitRecovery } from './piWriteTokenLimit';
 import { collectPiSystemPromptContributions } from './piSystemPromptContributions';
@@ -307,6 +308,7 @@ interface ActivePiSession {
   workspaceRoot: string;
   settingsManager: PiSettingsManager | null;
   approvalMode: WorkbenchApprovalMode;
+  unattended: boolean;
   /** True while Pi is executing the current Work/Chat turn. */
   isRunning: boolean;
   /** True when the current turn settled with an unrecoverable Pi error. */
@@ -363,6 +365,7 @@ interface PiResourceState {
   skillIds: string[] | undefined;
   maxOutputTokens: number;
   fileToolsEnabled: boolean;
+  unattended: boolean;
   /** Bundled preset skill dirs for the session's experts (file-sourced, live). */
   expertSkillDirs: string[];
 }
@@ -732,6 +735,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: normalizeSkillIds(options.skillIds),
         maxOutputTokens: DEFAULT_PI_LOCAL_MAX_TOKENS,
         fileToolsEnabled: options.confirmationMode !== 'text',
+        unattended: options.unattended === true,
         expertSkillDirs: this.resolveExpertPresetSkillDirs(options.expertIds),
       };
 
@@ -850,11 +854,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // sequential execution mode cannot block another session.
       const customTools: Record<string, unknown>[] = [];
 
-      customTools.push(
-        createPiAskUserQuestionTool((toolCallId, input, signal) =>
-          this.requestAskUserQuestion(sessionId, toolCallId, input, signal),
-        ),
-      );
+      if (shouldExposeAskUserQuestionTool(resourceState.unattended)) {
+        customTools.push(
+          createPiAskUserQuestionTool((toolCallId, input, signal) =>
+            this.requestAskUserQuestion(sessionId, toolCallId, input, signal),
+          ),
+        );
+      }
       if (this.projectMemoryService) {
         customTools.push(
           buildPiProjectMemoryTool({
@@ -1007,6 +1013,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
               skillIds,
               maxOutputTokens,
               fileToolsEnabled: true,
+              unattended: resourceState.unattended,
               expertSkillDirs: [],
             },
             {
@@ -1149,6 +1156,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         workspaceRoot,
         settingsManager,
         approvalMode: options.approvalMode ?? WorkbenchApprovalMode.Ask,
+        unattended: resourceState.unattended,
         isRunning: true,
         turnFailed: false,
         queueFlushInFlight: false,
@@ -1236,6 +1244,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
     options: PiContinueOptions = {},
   ): Promise<void> {
     const explicitExpertIds = normalizeSingleExpertIds(options.expertIds);
+    const nextUnattended = options.unattended === true;
     const active = this.activeSessions.get(sessionId);
     if (!active || active.aborted) {
       if (active?.aborted) {
@@ -1261,6 +1270,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         agentId: options.agentId ?? storedSession?.agentId,
         modelOverride: options.modelOverride ?? storedSession?.modelOverride,
         goalMode: options.goalMode ?? active?.goalMode,
+        unattended: nextUnattended,
         _piPromptOverride: piPrompt,
       });
     }
@@ -1302,10 +1312,12 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       productionControlsAvailable !== active.productionControlsAvailable;
     const mcpToolTopologyChanged =
       active.mcpToolManifestGeneration !== this.mcpToolManifestGeneration;
+    const unattendedTopologyChanged = nextUnattended !== active.unattended;
     if (
       !haveSameStringList(requestedExpertIds, active.requestedExpertIds) ||
       productionWorkflowTopologyChanged ||
-      mcpToolTopologyChanged
+      mcpToolTopologyChanged ||
+      unattendedTopologyChanged
     ) {
       const history = this.store?.getSession(sessionId)?.messages ?? [];
       if (mcpToolTopologyChanged) {
@@ -1319,6 +1331,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
         goalMode: nextGoalMode,
+        unattended: nextUnattended,
         _piPromptOverride: buildPiConversationPrompt(history, prompt, {
           maxChars: calculatePiConversationHistoryCharLimit(
             typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
@@ -1347,6 +1360,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
         skillIds: requestedSkillIds,
         expertIds: requestedExpertIds,
         goalMode: nextGoalMode,
+        unattended: nextUnattended,
         _piPromptOverride: buildPiConversationPrompt(history, prompt, {
           maxChars: calculatePiConversationHistoryCharLimit(
             typeof active.model.contextWindow === 'number' ? active.model.contextWindow : undefined,
@@ -2110,6 +2124,7 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
           fileToolsEnabled: resourceState.fileToolsEnabled,
           maxOutputTokens: resourceState.maxOutputTokens,
           platform: process.platform,
+          unattended: resourceState.unattended,
           mcpToolManifest: this.mcpServerManager?.toolManifest ?? [],
           mcpServerStatuses: this.mcpServerManager?.serverStatuses ?? [],
         }),

--- a/src/main/libs/agentEngine/piRuntimeTypes.ts
+++ b/src/main/libs/agentEngine/piRuntimeTypes.ts
@@ -82,6 +82,8 @@ export type PiStartOptions = {
   skillIds?: string[];
   systemPrompt?: string;
   approvalMode?: WorkbenchApprovalMode;
+  /** No foreground user is available to answer questions during this run. */
+  unattended?: boolean;
   workspaceRoot?: string;
   confirmationMode?: 'modal' | 'text';
   /** UI session mode, used to apply Work-only execution controls. */
@@ -123,6 +125,8 @@ export type PiContinueOptions = {
   thinkingLevel?: PiThinkingLevel;
   /** Forwarded to startSession when the runtime has to recreate the session. */
   approvalMode?: WorkbenchApprovalMode;
+  /** No foreground user is available to answer questions during this run. */
+  unattended?: boolean;
   /** Internal: run already created by an explicit Resume/Retry action. */
   _workbenchRunId?: string;
   /** Internal: the owning task already has a controlled production workflow. */

--- a/src/main/libs/agentEngine/piSystemPromptContributions.test.ts
+++ b/src/main/libs/agentEngine/piSystemPromptContributions.test.ts
@@ -12,6 +12,7 @@ import { PiAskUserQuestionSystemPrompt } from './piAskUserQuestion';
 import { createPiBashToolSystemPrompt } from './piBashToolGuidelines';
 import { PiBuiltinFileToolSystemPrompt } from './piBuiltinToolGuidelines';
 import { PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
+import { PiUnattendedSystemPrompt } from './piUnattendedPolicy';
 import {
   collectPiSystemPromptContributions,
   PiSystemPromptContributions,
@@ -20,6 +21,7 @@ import { calculatePiWriteChunkCharacterLimit } from './piWriteTokenLimit';
 
 const FULL_CONTEXT = { fileToolsEnabled: true, maxOutputTokens: 8000 } as const;
 const TEXT_CONTEXT = { fileToolsEnabled: false, maxOutputTokens: 8000 } as const;
+const UNATTENDED_CONTEXT = { ...FULL_CONTEXT, unattended: true } as const;
 const MCP_CONTEXT = {
   ...FULL_CONTEXT,
   mcpToolManifest: [
@@ -51,7 +53,13 @@ describe('piSystemPromptContributions', () => {
 
   it('produces a non-empty prompt for every contribution in both tool modes', () => {
     for (const contribution of PiSystemPromptContributions) {
-      for (const context of [FULL_CONTEXT, TEXT_CONTEXT, MCP_CONTEXT, FAILED_MCP_CONTEXT]) {
+      for (const context of [
+        FULL_CONTEXT,
+        TEXT_CONTEXT,
+        UNATTENDED_CONTEXT,
+        MCP_CONTEXT,
+        FAILED_MCP_CONTEXT,
+      ]) {
         if (contribution.enabled && !contribution.enabled(context)) continue;
         const prompt =
           typeof contribution.prompt === 'function'
@@ -78,6 +86,7 @@ describe('piSystemPromptContributions', () => {
     );
     for (const policy of [
       PiAskUserQuestionSystemPrompt,
+      PiUnattendedSystemPrompt,
       PiDocumentReaderSystemPrompt,
       PiBuiltinFileToolSystemPrompt,
       DeclareArtifactSystemPrompt,
@@ -97,6 +106,16 @@ describe('piSystemPromptContributions', () => {
     // Tool-agnostic policies stay present in both modes.
     expect(text).toContain(PiAskUserQuestionSystemPrompt);
     expect(text).toContain(DeclareArtifactSystemPrompt);
+  });
+
+  it('replaces the user-question policy with autonomous guidance when unattended', () => {
+    const attended = collectPiSystemPromptContributions(FULL_CONTEXT);
+    const unattended = collectPiSystemPromptContributions(UNATTENDED_CONTEXT);
+
+    expect(attended).toContain(PiAskUserQuestionSystemPrompt);
+    expect(attended).not.toContain(PiUnattendedSystemPrompt);
+    expect(unattended).not.toContain(PiAskUserQuestionSystemPrompt);
+    expect(unattended).toContain(PiUnattendedSystemPrompt);
   });
 
   it('renders the large-file-write policy from the session token budget', () => {

--- a/src/main/libs/agentEngine/piSystemPromptContributions.ts
+++ b/src/main/libs/agentEngine/piSystemPromptContributions.ts
@@ -15,6 +15,7 @@ import { createPiBashToolSystemPrompt } from './piBashToolGuidelines';
 import { PiBuiltinFileToolSystemPrompt } from './piBuiltinToolGuidelines';
 import { PiDocumentReaderSystemPrompt } from './piDocumentReaderTool';
 import { buildPiMcpCapabilityPrompt } from './piMcpCapabilityPrompt';
+import { PiUnattendedSystemPrompt } from './piUnattendedPolicy';
 import { createPiLargeFileWriteSystemPrompt } from './piWriteTokenLimit';
 
 export interface PiSystemPromptContext {
@@ -24,6 +25,8 @@ export interface PiSystemPromptContext {
   maxOutputTokens: number;
   /** Runtime platform, used for platform-specific tool contracts. */
   platform?: NodeJS.Platform;
+  /** Whether the current run has no foreground user interaction. */
+  unattended?: boolean;
   /** Concrete MCP capabilities discovered before this session was created. */
   mcpToolManifest?: McpToolManifestEntry[];
   /** Configured MCP servers, including connection and discovery failures. */
@@ -43,7 +46,16 @@ export interface PiSystemPromptContribution {
 
 // Order matters: entries are appended to the system prompt in this sequence.
 export const PiSystemPromptContributions: ReadonlyArray<PiSystemPromptContribution> = [
-  { id: 'ask-user-question', prompt: PiAskUserQuestionSystemPrompt },
+  {
+    id: 'ask-user-question',
+    enabled: context => context.unattended !== true,
+    prompt: PiAskUserQuestionSystemPrompt,
+  },
+  {
+    id: 'unattended-execution',
+    enabled: context => context.unattended === true,
+    prompt: PiUnattendedSystemPrompt,
+  },
   {
     id: 'bash-tool',
     requiresFileTools: true,

--- a/src/main/libs/agentEngine/piUnattendedPolicy.test.ts
+++ b/src/main/libs/agentEngine/piUnattendedPolicy.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest';
+
+import { PiUnattendedSystemPrompt, shouldExposeAskUserQuestionTool } from './piUnattendedPolicy';
+
+test('defines an autonomous policy for unattended runs', () => {
+  expect(PiUnattendedSystemPrompt).toContain('No user interaction is available');
+  expect(PiUnattendedSystemPrompt).toContain('Make reasonable assumptions');
+  expect(PiUnattendedSystemPrompt).toContain('safest viable next action');
+  expect(PiUnattendedSystemPrompt).toContain('external credentials or authorization');
+});
+
+test('exposes AskUserQuestion only for attended runs', () => {
+  expect(shouldExposeAskUserQuestionTool(false)).toBe(true);
+  expect(shouldExposeAskUserQuestionTool(true)).toBe(false);
+});

--- a/src/main/libs/agentEngine/piUnattendedPolicy.ts
+++ b/src/main/libs/agentEngine/piUnattendedPolicy.ts
@@ -1,0 +1,11 @@
+export const PiUnattendedSystemPrompt = [
+  '## Unattended execution',
+  '- No user interaction is available during this run. Do not ask the user questions or wait for input.',
+  '- Make reasonable assumptions from the task and existing context.',
+  '- Choose and execute the safest viable next action when details are ambiguous.',
+  '- Stop only when external credentials or authorization are required and no progress is possible; report the blocker clearly.',
+].join('\n');
+
+export function shouldExposeAskUserQuestionTool(unattended: boolean): boolean {
+  return !unattended;
+}

--- a/src/scheduledTask/piScheduledTaskExecutor.test.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.test.ts
@@ -126,6 +126,7 @@ test('runs a canonical task in its workspace and waits for complete', async () =
     'run',
     expect.objectContaining({
       approvalMode: WorkbenchApprovalMode.AllowAll,
+      unattended: true,
       skillIds: session.activeSkillIds,
       modelOverride: session.modelOverride,
     }),
@@ -213,7 +214,10 @@ test('reuses one stable dedicated session for every run of a task-bound task', a
   expect(runtime.continueSession).toHaveBeenCalledWith(
     `scheduled-task:${task.id}`,
     'run',
-    expect.anything(),
+    expect.objectContaining({
+      approvalMode: WorkbenchApprovalMode.AllowAll,
+      unattended: true,
+    }),
   );
 });
 

--- a/src/scheduledTask/piScheduledTaskExecutor.ts
+++ b/src/scheduledTask/piScheduledTaskExecutor.ts
@@ -60,6 +60,7 @@ export class PiScheduledTaskExecutor {
       // Scheduled runs have no foreground permission UI. Their creator opted
       // into unattended execution, so tools must follow that run policy.
       approvalMode: WorkbenchApprovalMode.AllowAll,
+      unattended: true,
     };
     try {
       const execution = this.runtime.isSessionActive(session.id)


### PR DESCRIPTION
## Summary

- add an explicit unattended Pi runtime mode for scheduled work
- remove `AskUserQuestion` from unattended tool topology and replace its prompt policy with autonomous decision guidance
- recreate Pi sessions when switching between foreground and unattended execution

## Problem

Scheduled runs already use `AllowAll`, but `AskUserQuestion` is a separate custom tool. It remained available and could emit a permission request that waited up to ten minutes for a foreground response that would never arrive.

## Behavior

- scheduled starts and continuations pass `unattended: true`
- unattended sessions cannot invoke `AskUserQuestion`
- unattended prompts direct the agent to make reasonable assumptions and execute the safest viable next action
- external credentials or authorization remain valid blockers when no further progress is possible
- foreground-to-scheduled and scheduled-to-foreground transitions rebuild the session so the exposed tools and system policy always match the current run mode
- subagent resource loaders inherit the same unattended prompt policy

## Testing

- `npx vitest run src/main/libs/agentEngine/piUnattendedPolicy.test.ts src/main/libs/agentEngine/piSystemPromptContributions.test.ts src/scheduledTask/piScheduledTaskExecutor.test.ts`
- `npx vitest run src/main/libs/agentEngine/piRuntimeAdapter.test.ts -t "removes AskUserQuestion|recreates the Pi session when unattended mode changes"`
- `npm run lint`
- `npx tsc -p electron-tsconfig.json --noEmit`
- `npm run build`

The unfiltered runtime adapter suite reaches 109 passing tests locally; 13 existing SQLite-backed tests cannot start because the installed `better-sqlite3` binary targets Electron ABI 143 while the local Node test process requires ABI 137.
