### PR TITLE
feat(sidebar): 添加 Coding 入口图标动画

### DIFF
--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { Switch } from '@shared/components/ui/switch';
 import { cn } from '@shared/lib/utils';
-import { Code2 } from 'lucide-react';
 import { useReducedMotion } from 'motion/react';
 import { type RefObject, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -33,6 +32,10 @@ import {
   SidebarAnimatedUsersIcon,
   type SidebarAnimatedUsersIconHandle,
 } from './icons/SidebarAnimatedUsersIcon';
+import {
+  SidebarAnimatedTerminalIcon,
+  type SidebarAnimatedTerminalIconHandle,
+} from './icons/SidebarAnimatedTerminalIcon';
 
 export type SidebarActiveView =
   | 'cowork'
@@ -92,6 +95,7 @@ export const SidebarNavigationControls = ({
   const newConversationIconRef = useRef<SidebarAnimatedMessageCirclePlusIconHandle>(null);
   const localInferenceIconRef = useRef<SidebarAnimatedBotIconHandle>(null);
   const expertIconRef = useRef<SidebarAnimatedUsersIconHandle>(null);
+  const codingIconRef = useRef<SidebarAnimatedTerminalIconHandle>(null);
   const prefersReducedMotion = useReducedMotion();
   const isNewConversationActive =
     activeView === 'cowork' && (workMode !== WorkMode.Chat || activeSkillIds.length === 0);
@@ -187,12 +191,16 @@ export const SidebarNavigationControls = ({
           type="button"
           variant="ghost"
           onClick={onShowCoding}
+          onMouseEnter={() => startIconAnimation(codingIconRef)}
+          onMouseLeave={() => codingIconRef.current?.stopAnimation()}
           className={
-            activeView === 'coding' ? activeSidebarViewNavItemClassName : sidebarViewNavItemClassName
+            activeView === 'coding'
+              ? activeSidebarViewNavItemClassName
+              : sidebarViewNavItemClassName
           }
           aria-current={activeView === 'coding' ? 'page' : undefined}
         >
-          <Code2 className="size-4" />
+          <SidebarAnimatedTerminalIcon ref={codingIconRef} />
           {i18nService.t('codingAgent')}
         </Button>
       )}

--- a/src/renderer/components/icons/SidebarAnimatedTerminalIcon.tsx
+++ b/src/renderer/components/icons/SidebarAnimatedTerminalIcon.tsx
@@ -1,0 +1,106 @@
+import { motion, useAnimation, type Variants } from 'motion/react';
+import type { HTMLAttributes, MouseEvent } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
+
+import { cn } from '@shared/lib/utils';
+
+const TerminalIconAnimationState = {
+  Normal: 'normal',
+  Animate: 'animate',
+} as const;
+
+type TerminalIconAnimationState =
+  (typeof TerminalIconAnimationState)[keyof typeof TerminalIconAnimationState];
+
+const LINE_VARIANTS: Variants = {
+  [TerminalIconAnimationState.Normal]: { opacity: 1 },
+  [TerminalIconAnimationState.Animate]: {
+    opacity: [1, 0, 1],
+    transition: {
+      duration: 0.8,
+      repeat: Number.POSITIVE_INFINITY,
+      ease: 'linear',
+    },
+  },
+};
+
+export interface SidebarAnimatedTerminalIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SidebarAnimatedTerminalIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+export const SidebarAnimatedTerminalIcon = forwardRef<
+  SidebarAnimatedTerminalIconHandle,
+  SidebarAnimatedTerminalIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  const stopAnimation = useCallback(() => {
+    controls.stop();
+    void controls.start(TerminalIconAnimationState.Normal);
+  }, [controls]);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+    return {
+      startAnimation: () => void controls.start(TerminalIconAnimationState.Animate),
+      stopAnimation,
+    };
+  }, [controls, stopAnimation]);
+
+  const handleMouseEnter = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseEnter?.(event);
+      else void controls.start(TerminalIconAnimationState.Animate);
+    },
+    [controls, onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) onMouseLeave?.(event);
+      else stopAnimation();
+    },
+    [onMouseLeave, stopAnimation],
+  );
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn('size-4 shrink-0', className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <svg
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <polyline points="4 17 10 11 4 5" />
+        <motion.line
+          animate={controls}
+          initial={TerminalIconAnimationState.Normal}
+          variants={LINE_VARIANTS}
+          x1="12"
+          x2="20"
+          y1="19"
+          y2="19"
+        />
+      </svg>
+    </div>
+  );
+});
+
+SidebarAnimatedTerminalIcon.displayName = 'SidebarAnimatedTerminalIcon';


### PR DESCRIPTION
## 概要

为侧边栏 Coding 入口增加与其他导航项一致的终端图标和悬停动画，提升导航反馈的一致性。

## 关联 Issue

无。

## 变更内容

- 新增可复用的 SidebarAnimatedTerminalIcon 组件。
- Coding 入口接入图标 hover 开始和结束动画。
- 遵循 reduced-motion 设置，减少动态效果偏好下不播放动画。
- 保持现有导航点击、选中态和国际化文案不变。

## 变更类型

- [ ] Bug 修复（非破坏性变更）
- [x] 新功能（非破坏性变更）
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化
- [ ] 其他

## 测试

- [x] 定向 lint 检查通过
- [x] git diff --check 通过
- [ ] 新增测试
- [ ] 手动测试

## 截图

不适用。

## 检查清单

- [x] 遵循项目代码风格
- [x] 已完成自检
- [ ] 新增或更新文档
- [ ] 已添加测试
- [ ] 全量单元测试通过

## Electron 专项变更

- [ ] 主进程变更
- [ ] preload 变更
- [ ] IPC 变更
- [ ] 窗口管理变更
- [x] 无

## 补充说明

分支已 rebase 到最新 origin/main，过程无冲突。