### PR TITLE
fix(scheduled-task): 持久化定时任务投递消息

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1240,6 +1240,7 @@ const getCanonicalScheduledTaskService = (): CanonicalScheduledTaskService => {
     deferredCcConnectCronClient = new DeferredCcConnectCronClient();
     ccConnectDeliveryTransport = new CcConnectDeliveryTransport(
       new IMStore(getStore().getDatabase()),
+      getCoworkStore(),
     );
     const executor = new PiScheduledTaskExecutor(getPiRuntimeAdapter(), getCoworkStore());
     activityService ??= new ActivityService(getStore().getDatabase());

--- a/src/renderer/components/scheduledTasks/taskFormState.ts
+++ b/src/renderer/components/scheduledTasks/taskFormState.ts
@@ -299,6 +299,6 @@ export function getNotifyConversationLabel(conversation: Pick<ScheduledTaskConve
   // Connectors may return opaque user/session IDs for direct chats. They are
   // routing keys, not human-facing names, so never expose them in the form.
   return conversationId
-    ? `${i18nService.t('scheduledTasksFormNotifyDirectMessage')} · ${conversationId.slice(-4)}`
+    ? i18nService.t('scheduledTasksFormNotifyDirectMessage')
     : i18nService.t('scheduledTasksFormNotifyConversationUnknown');
 }

--- a/src/scheduledTask/ccConnectDeliveryTransport.ts
+++ b/src/scheduledTask/ccConnectDeliveryTransport.ts
@@ -1,5 +1,6 @@
 import type { IMStore } from "../main/im/imStore";
 import { tryParseCcConnectScopedConversationId } from "../main/im/ccConnectConversationId";
+import type { CoworkStore } from "../main/coworkStore";
 
 import type { CcConnectDeliveryClient } from "./ccConnectDeliveryClient";
 import type { SchedulerDeliveryTransport } from "./deliveryDispatcher";
@@ -16,6 +17,7 @@ export class CcConnectDeliveryTransport implements SchedulerDeliveryTransport {
 
   constructor(
     private readonly imStore: Pick<IMStore, "getCcConnectSessionKey" | "listSessionMappings">,
+    private readonly coworkStore?: Pick<CoworkStore, "addMessage">,
   ) {}
 
   attach(accountId: string, client: DeliveryClient): void {
@@ -53,7 +55,39 @@ export class CcConnectDeliveryTransport implements SchedulerDeliveryTransport {
       );
     }
     await client.send({ accountId, platform, sessionKey, content: input.content });
+    try {
+      this.persistAssistantMessage(platform, accountId, conversationId, input.content);
+    } catch (error) {
+      // Delivery has already succeeded. Do not turn an outbound notification
+      // into a failed delivery merely because its local context projection
+      // could not be persisted.
+      console.warn('[CcConnectDelivery] failed to persist assistant context:', error);
+    }
     return {};
+  }
+
+  private persistAssistantMessage(
+    platform: string,
+    accountId: string,
+    conversationId: string,
+    content: string,
+  ): void {
+    if (!this.coworkStore || !content.trim()) return;
+    const scopedConversationId = JSON.stringify([accountId, conversationId]);
+    const mapping = this.imStore.listSessionMappings().find(item => {
+      const parsed = tryParseCcConnectScopedConversationId(item.imConversationId);
+      return (
+        normalizePlatform(item.platform) === platform &&
+        parsed?.[0] === accountId &&
+        parsed?.[1] === conversationId
+      );
+    });
+    if (!mapping) return;
+    this.coworkStore.addMessage(mapping.coworkSessionId, {
+      type: 'assistant',
+      content,
+      metadata: { source: 'scheduled_task_delivery', scopedConversationId },
+    });
   }
 
   private resolveAccountId(platform: string, conversationId: string, configuredAccountId?: string): string {


### PR DESCRIPTION
## 概要

补充定时任务通知投递后的本地上下文持久化，并优化通知会话名称展示。

## 关联 Issue

无。

## 变更内容

- 定时任务投递成功后，将助手消息写入对应的 Cowork 会话。
- 持久化失败不影响已经成功的外部消息投递，并记录警告日志。
- 通过现有会话映射定位目标 Cowork 会话，保存渠道、账户和会话范围信息。
- 对无法区分路由或缺少映射的情况保持明确失败行为。
- 隐藏不必要的私聊会话 ID 尾缀，避免表单展示内部路由信息。

## 变更类型

- [x] Bug 修复（非破坏性变更）
- [ ] 新功能
- [ ] 破坏性变更
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化
- [ ] 其他

## 测试

- [ ] 本地完整测试
- [x] 定向 lint 检查通过
- [x] git diff --check 通过
- [ ] 新增测试
- [ ] 手动测试

说明：compile:electron 未完成，因本机 better-sqlite3.node 文件被占用，electron-rebuild 删除文件时返回 EPERM；不是源码编译错误。

## 截图

不适用。

## 检查清单

- [x] 遵循项目代码风格
- [x] 已完成自检
- [ ] 新增或更新文档
- [ ] 新增测试证明修复有效
- [ ] 全量单元测试通过

## Electron 专项变更

- [x] 主进程变更
- [ ] preload 变更
- [ ] IPC 变更
- [ ] 窗口管理变更
- [ ] 无

## 补充说明

分支已 rebase 到最新 origin/main，过程无冲突。