### PR TITLE
refactor(installer): speed up Windows installer and remove Defender exclusion

### DIFF
--- a/.github/workflows/linux-install-pr.yml
+++ b/.github/workflows/linux-install-pr.yml
@@ -66,7 +66,7 @@ jobs:
           set -euo pipefail
           mapfile -t debs < <(find release -maxdepth 1 -type f -name '*.deb' -print | sort)
           [[ ${#debs[@]} -eq 1 ]] || { echo 'Expected exactly one Linux deb package' >&2; exit 1; }
-          sudo apt-get install -y "${debs[0]}"
+          sudo apt-get install -y "$(realpath "${debs[0]}")"
           test -x '/opt/知远/知远'
       - name: Verify the installed Ubuntu application starts and paints
         run: >-

--- a/.github/workflows/linux-install-pr.yml
+++ b/.github/workflows/linux-install-pr.yml
@@ -1,0 +1,83 @@
+name: Linux install and startup gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-install-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  install-and-start:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce retired runtime decoupling
+        run: node scripts/ci/check-openclaw-decoupling.mjs
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
+      - name: Restore packaging caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            vendor/engram-runtime
+            vendor/channel-runtime
+          key: linux-install-node24-bun1.4.0-${{ hashFiles('bun.lock', 'package.json', 'scripts/**') }}
+          restore-keys: |
+            linux-install-node24-bun1.4.0-
+      - name: Install Electron and virtual desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libatspi2.0-0 libgbm1 libgtk-3-0 libnotify4 libnss3 libsecret-1-0 \
+            libxss1 libxtst6 libuuid1 xdg-utils xvfb
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - run: bun run apply:patches
+      - name: Set up bundled Linux runtimes
+        run: |
+          bun run setup:posix-uv-runtime
+          bun run setup:posix-python-runtime
+          bun run engram:runtime:linux-x64
+      - name: Build Linux installer artifacts
+        timeout-minutes: 65
+        run: bun run dist:linux
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Install the generated deb package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t debs < <(find release -maxdepth 1 -type f -name '*.deb' -print | sort)
+          [[ ${#debs[@]} -eq 1 ]] || { echo 'Expected exactly one Linux deb package' >&2; exit 1; }
+          sudo apt-get install -y "${debs[0]}"
+          test -x '/opt/知远/知远'
+      - name: Verify the installed Ubuntu application starts and paints
+        run: >-
+          node scripts/verify-linux-renderer.mjs
+          '/opt/知远/知远'
+          release/linux-deb-install-smoke.png
+      - name: Upload Linux startup diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-install-startup-diagnostics
+          path: release/linux-deb-install-smoke.png
+          if-no-files-found: ignore
+          retention-days: 7

--- a/scripts/ci/check-openclaw-decoupling.mjs
+++ b/scripts/ci/check-openclaw-decoupling.mjs
@@ -21,6 +21,7 @@ const productionRoots = [
 const buildRoots = ['scripts', 'resources'];
 const workflowFiles = [
   '.github/workflows/build-platforms.yml',
+  '.github/workflows/linux-install-pr.yml',
   '.github/workflows/online-update-release.yml',
   '.github/workflows/windows-installer-pr.yml',
 ];

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -102,7 +102,6 @@ $installer = $installers[0].FullName
 $installRoot = Join-Path $env:LOCALAPPDATA 'Programs\zhiyuan-agent'
 $runtimeRoot = Join-Path $env:LOCALAPPDATA 'ZhiYuanAgent\runtimes'
 $timingLog = Join-Path $env:APPDATA 'ZhiYuanAgent\install-timing.log'
-$managedDefenderMarker = Join-Path $env:APPDATA 'ZhiYuanAgent\defender-exclusion-managed'
 $componentKeys = @('channel-runtime', 'skills', 'mcps', 'portable-git', 'python', 'skill-python', 'uv')
 
 try {
@@ -122,12 +121,6 @@ try {
   }
   if ($coldLog -notmatch 'phase=install-complete .*component_set=ready') {
     throw 'Cold installation did not record a ready component set'
-  }
-  if ($coldLog -notmatch 'phase=defender-exclusion-skipped-silent') {
-    throw 'CI silent installation unexpectedly entered the interactive Defender flow'
-  }
-  if (Test-Path -LiteralPath $managedDefenderMarker) {
-    throw 'CI silent installation must not create a managed Defender exclusion marker'
   }
 
   foreach ($key in $componentKeys) {

--- a/scripts/installer/validate-component-archive.ps1
+++ b/scripts/installer/validate-component-archive.ps1
@@ -1,7 +1,8 @@
 param(
   [Parameter(Mandatory = $true)][string]$ArchivePath,
   [Parameter(Mandatory = $true)][string]$SevenZipPath,
-  [Parameter(Mandatory = $true)][string]$Prefix
+  [Parameter(Mandatory = $true)][string]$Prefix,
+  [Parameter(Mandatory = $false)][string]$ExpectedHash = ''
 )
 
 $ErrorActionPreference = 'Stop'
@@ -12,6 +13,14 @@ if (-not (Test-Path -LiteralPath $ArchivePath -PathType Leaf)) {
 }
 if (-not (Test-Path -LiteralPath $SevenZipPath -PathType Leaf)) {
   throw "7za executable is missing: $SevenZipPath"
+}
+
+if ($ExpectedHash) {
+  $actualHash = (Get-FileHash -LiteralPath $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actualHash -ne $ExpectedHash.ToLowerInvariant()) {
+    Write-Output "hash-mismatch"
+    exit 2
+  }
 }
 
 $normalizedPrefix = $Prefix.Replace('\', '/').Trim('/')

--- a/scripts/installer/validate-component-archive.test.ts
+++ b/scripts/installer/validate-component-archive.test.ts
@@ -17,25 +17,30 @@ const sevenZipPath = path.join(
 );
 const temporaryDirectories: string[] = [];
 
-function runValidator(archivePath: string, prefix: string, executable = sevenZipPath) {
-  return spawnSync(
-    'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-File',
-      validatorPath,
-      '-ArchivePath',
-      archivePath,
-      '-SevenZipPath',
-      executable,
-      '-Prefix',
-      prefix,
-    ],
-    { encoding: 'utf8' },
-  );
+function runValidator(
+  archivePath: string,
+  prefix: string,
+  executable = sevenZipPath,
+  expectedHash = '',
+) {
+  const args = [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-File',
+    validatorPath,
+    '-ArchivePath',
+    archivePath,
+    '-SevenZipPath',
+    executable,
+    '-Prefix',
+    prefix,
+  ];
+  if (expectedHash) {
+    args.push('-ExpectedHash', expectedHash);
+  }
+  return spawnSync('powershell.exe', args, { encoding: 'utf8' });
 }
 
 afterEach(() => {
@@ -68,6 +73,22 @@ describe.skipIf(process.platform !== 'win32')('component archive validator', () 
     const rejected = runValidator(archivePath, 'wrong-prefix');
     expect(rejected.status).not.toBe(0);
     expect(rejected.stderr).toContain('Unexpected archive entry: channel-runtime');
+
+    const expectedHash =
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+    const hashMismatch = runValidator(archivePath, 'channel-runtime', sevenZipPath, expectedHash);
+    expect(hashMismatch.status).toBe(2);
+    expect(hashMismatch.stdout).toContain('hash-mismatch');
+
+    const actualHash = spawnSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `(Get-FileHash -LiteralPath "${archivePath}" -Algorithm SHA256).Hash.ToLowerInvariant()`,
+    ], { encoding: 'utf8' }).stdout.trim();
+    const hashMatch = runValidator(archivePath, 'channel-runtime', sevenZipPath, actualHash);
+    expect(hashMatch.status, hashMatch.stderr || hashMatch.stdout).toBe(0);
+    expect(hashMatch.stdout).toContain('Component archive validation passed');
   });
 
   test('rejects non-empty link metadata reported by 7-Zip', () => {

--- a/scripts/installer/validate-offline-components.ps1
+++ b/scripts/installer/validate-offline-components.ps1
@@ -1,0 +1,195 @@
+param(
+  [Parameter(Mandatory = $true)][ValidateSet('cache', 'expand')][string]$Mode,
+  [Parameter(Mandatory = $true)][string]$PluginDir,
+  [Parameter(Mandatory = $true)][string]$RuntimeRoot,
+  [Parameter(Mandatory = $true)][string]$ComponentTargetsPath,
+  [Parameter(Mandatory = $true)][string]$SevenZipPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Stop-WithCode([int]$Code, [string]$Message) {
+  Write-Output $Message
+  exit $Code
+}
+
+function Read-ExpectedHash([string]$Path, [string]$Description) {
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Missing $Description: $Path"
+  }
+  $value = (Get-Content -LiteralPath $Path -Raw -ErrorAction Stop).Trim().ToLowerInvariant()
+  if ($value -notmatch '^[0-9a-f]{64}$') {
+    throw "Invalid $Description: $Path"
+  }
+  return $value
+}
+
+function Test-SafeRelativePath([string]$Value, [string]$Description) {
+  $normalized = $Value.Replace('\', '/')
+  if (
+    [string]::IsNullOrWhiteSpace($normalized) -or
+    $normalized -match '^(?:[A-Za-z]:|/)' -or
+    $normalized -match '(^|/)\.\.(/|$)' -or
+    $normalized -match ':'
+  ) {
+    throw "Invalid $Description: $Value"
+  }
+  return $normalized
+}
+
+function Get-Components {
+  if (-not (Test-Path -LiteralPath $ComponentTargetsPath -PathType Leaf)) {
+    throw "Component targets are missing: $ComponentTargetsPath"
+  }
+  $targets = @((Get-Content -LiteralPath $ComponentTargetsPath -Raw -ErrorAction Stop | ConvertFrom-Json))
+  if ($targets.Count -ne 7) {
+    throw "Invalid component targets: expected 7 components, got $($targets.Count)"
+  }
+
+  $components = @(
+    foreach ($target in $targets) {
+      $key = [string]$target.key
+      $prefix = [string]$target.prefix
+      $sentinel = [string]$target.sentinel
+      if ($key -notmatch '^[a-z0-9-]+$') {
+        throw "Invalid component key: $key"
+      }
+      Test-SafeRelativePath $prefix 'component prefix' | Out-Null
+      Test-SafeRelativePath $sentinel 'component sentinel' | Out-Null
+
+      $id = Read-ExpectedHash (Join-Path $PluginDir "component-$key.version") "component content ID for $key"
+      $archiveHash = Read-ExpectedHash (Join-Path $PluginDir "component-$key.sha256") "component archive SHA-256 for $key"
+      $sentinelHash = Read-ExpectedHash (Join-Path $PluginDir "component-$key.sentinel-sha256") "component sentinel SHA-256 for $key"
+      [pscustomobject]@{
+        Key = $key
+        Prefix = $prefix
+        Sentinel = $sentinel
+        Id = $id
+        ArchiveHash = $archiveHash
+        SentinelHash = $sentinelHash
+      }
+    }
+  )
+  if (@($components.Key | Sort-Object -Unique).Count -ne 7) {
+    throw 'Invalid component targets: duplicate component key'
+  }
+  return $components
+}
+
+function Test-ArchiveEntries([string]$ArchivePath, [string]$Prefix) {
+  $normalizedPrefix = Test-SafeRelativePath $Prefix 'component prefix'
+  $lines = @(& $SevenZipPath l -slt $ArchivePath)
+  if ($LASTEXITCODE -ne 0) {
+    throw "7za list failed with exit code $LASTEXITCODE"
+  }
+  $paths = @(
+    $lines |
+      Where-Object { $_ -match '^Path = ' } |
+      ForEach-Object { $_.Substring(7) }
+  )
+  if ($paths.Count -lt 2) {
+    throw 'Archive has no entries'
+  }
+  foreach ($entry in @($paths | Select-Object -Skip 1)) {
+    $normalizedEntry = Test-SafeRelativePath $entry 'archive entry'
+    $isExpectedEntry =
+      $normalizedEntry.Equals($normalizedPrefix, [System.StringComparison]::Ordinal) -or
+      $normalizedEntry.StartsWith("$normalizedPrefix/", [System.StringComparison]::Ordinal)
+    if (-not $isExpectedEntry) {
+      throw "Unexpected archive entry: $entry"
+    }
+  }
+  $unsafeLinkMetadata = @(
+    $lines | Where-Object {
+      if ($_ -notmatch '^(Symbolic Link|Hard Link|Reparse Point) = (.*)$') {
+        return $false
+      }
+      $value = $Matches[2].Trim()
+      return $value -and $value -ne '-'
+    }
+  )
+  if ($unsafeLinkMetadata.Count -gt 0) {
+    throw "Archive contains link metadata: $($unsafeLinkMetadata[0])"
+  }
+}
+
+try {
+  if (-not (Test-Path -LiteralPath $PluginDir -PathType Container)) {
+    throw "Plugin directory is missing: $PluginDir"
+  }
+  if (-not (Test-Path -LiteralPath $SevenZipPath -PathType Leaf)) {
+    throw "7za executable is missing: $SevenZipPath"
+  }
+  $components = Get-Components
+
+  if ($Mode -eq 'cache') {
+    foreach ($component in $components) {
+      $marker = Join-Path $PluginDir "component-$($component.Key).cache-valid"
+      Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+      $target = Join-Path (Join-Path $RuntimeRoot $component.Key) $component.Id
+      $complete = Join-Path $target '.complete'
+      $sentinel = Join-Path $target $component.Sentinel
+      try {
+        if (-not (Test-Path -LiteralPath $complete -PathType Leaf)) { continue }
+        $completeId = (Get-Content -LiteralPath $complete -Raw -ErrorAction Stop).Substring(0, 64).ToLowerInvariant()
+        if ($completeId -ne $component.Id -or -not (Test-Path -LiteralPath $sentinel -PathType Leaf)) { continue }
+        $actualHash = (Get-FileHash -LiteralPath $sentinel -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
+        if ($actualHash -ne $component.SentinelHash) { continue }
+        New-Item -ItemType File -Path $marker -Force | Out-Null
+        Write-Output "cache-hit:$($component.Key)"
+      } catch {
+        Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+      }
+    }
+    exit 0
+  }
+
+  foreach ($component in $components) {
+    $marker = Join-Path $PluginDir "component-$($component.Key).cache-valid"
+    if (Test-Path -LiteralPath $marker -PathType Leaf) { continue }
+
+    $archivePath = Join-Path $PluginDir "component-$($component.Key).7z"
+    if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+      Stop-WithCode 1 "Missing component archive: $($component.Key)"
+    }
+    $actualArchiveHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualArchiveHash -ne $component.ArchiveHash) {
+      Stop-WithCode 2 "hash-mismatch:$($component.Key)"
+    }
+    try {
+      Test-ArchiveEntries $archivePath $component.Prefix
+    } catch {
+      Stop-WithCode 3 "unsafe-archive:$($component.Key):$($_.Exception.Message)"
+    }
+
+    $target = Join-Path (Join-Path $RuntimeRoot $component.Key) $component.Id
+    $installing = "$target.installing"
+    try {
+      Remove-Item -LiteralPath $installing -Recurse -Force -ErrorAction SilentlyContinue
+      New-Item -ItemType Directory -Path $installing -Force | Out-Null
+      & $SevenZipPath x -bd -y "-o$installing" $archivePath | Out-Null
+      if ($LASTEXITCODE -ne 0) {
+        Stop-WithCode 4 "extract-failed:$($component.Key):$LASTEXITCODE"
+      }
+      $sentinel = Join-Path $installing $component.Sentinel
+      if (-not (Test-Path -LiteralPath $sentinel -PathType Leaf)) {
+        Stop-WithCode 5 "sentinel-missing:$($component.Key)"
+      }
+      $actualSentinelHash = (Get-FileHash -LiteralPath $sentinel -Algorithm SHA256).Hash.ToLowerInvariant()
+      if ($actualSentinelHash -ne $component.SentinelHash) {
+        Stop-WithCode 5 "sentinel-mismatch:$($component.Key)"
+      }
+      Set-Content -LiteralPath (Join-Path $installing '.complete') -Value "$($component.Id)|$($component.ArchiveHash)" -NoNewline
+      Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction SilentlyContinue
+      Move-Item -LiteralPath $installing -Destination $target -ErrorAction Stop
+      Write-Output "expanded:$($component.Key)"
+    } catch {
+      Stop-WithCode 4 "extract-failed:$($component.Key):$($_.Exception.Message)"
+    } finally {
+      Remove-Item -LiteralPath $archivePath -Force -ErrorAction SilentlyContinue
+    }
+  }
+} catch {
+  Stop-WithCode 1 $_.Exception.Message
+}

--- a/scripts/linux-before-install.sh
+++ b/scripts/linux-before-install.sh
@@ -15,8 +15,12 @@
 # 注意:preinst 以 root 运行,不能依赖 $HOME;因此不清 SingletonLock 文件
 # (Electron 启动时会检测残留 socket 并自动清理),只杀进程。
 
-DEB_INSTALL_PATTERN='/opt/知远'
-APPIMAGE_MOUNT_PATTERN='\.mount_知远'
+# Current packages install /opt/知远 and mount AppImages below
+# /tmp/.mount_知远*. Keep the legacy ZhiYuanAgent paths for shutdown during an
+# upgrade. Both expressions match the executable/mount path, never the .deb
+# filename passed to dpkg.
+DEB_INSTALL_PATTERN='/opt/(知远|ZhiYuanAgent)(/|$)'
+APPIMAGE_MOUNT_PATTERN='\.mount_(知远|ZhiYuanAgent)'
 
 # 终止旧实例;pkill 无匹配时返回 1,忽略
 pkill -f "$DEB_INSTALL_PATTERN" 2>/dev/null || true
@@ -32,6 +36,16 @@ while [ "$i" -lt 10 ]; do
   sleep 1
   i=$((i + 1))
 done
+
+# A renderer or sidecar can ignore/hold shutdown long enough for the bounded
+# wait above to expire. Do not leave its SingletonLock owner behind: dpkg may
+# replace a running binary, but the first launch of the upgraded app would
+# otherwise still exit as a second instance.
+if pgrep -f "$DEB_INSTALL_PATTERN" >/dev/null 2>&1 ||
+  pgrep -f "$APPIMAGE_MOUNT_PATTERN" >/dev/null 2>&1; then
+  pkill -KILL -f "$DEB_INSTALL_PATTERN" 2>/dev/null || true
+  pkill -KILL -f "$APPIMAGE_MOUNT_PATTERN" 2>/dev/null || true
+fi
 
 # preinst 失败不能阻塞安装,永远以 0 退出
 exit 0

--- a/scripts/linux-before-install.test.ts
+++ b/scripts/linux-before-install.test.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const scriptPath = path.resolve('scripts/linux-before-install.sh');
+const builderConfigPath = path.resolve('electron-builder.json');
+
+describe('Linux deb upgrade pre-install hook', () => {
+  test('is syntactically valid and installed as the deb preinst hook', () => {
+    const syntax = spawnSync('sh', ['-n', scriptPath], { encoding: 'utf8' });
+    expect(syntax.status, syntax.stderr || syntax.stdout).toBe(0);
+
+    const builderConfig = JSON.parse(fs.readFileSync(builderConfigPath, 'utf8')) as {
+      deb?: { fpm?: string[] };
+    };
+    expect(builderConfig.deb?.fpm).toContain('--before-install=scripts/linux-before-install.sh');
+  });
+
+  test('stops both current and legacy package paths before dpkg replaces files', () => {
+    const script = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(script).toContain("DEB_INSTALL_PATTERN='/opt/(知远|ZhiYuanAgent)(/|$)'");
+    expect(script).toContain("APPIMAGE_MOUNT_PATTERN='\\.mount_(知远|ZhiYuanAgent)'");
+    expect(script).toContain('pkill -f "$DEB_INSTALL_PATTERN"');
+    expect(script).toContain('pkill -f "$APPIMAGE_MOUNT_PATTERN"');
+    expect(script).toContain('while [ "$i" -lt 10 ]');
+    expect(script).toContain('pkill -KILL -f "$DEB_INSTALL_PATTERN"');
+    expect(script).toContain('pkill -KILL -f "$APPIMAGE_MOUNT_PATTERN"');
+    expect(script).toContain('exit 0');
+  });
+});

--- a/scripts/nsis-elevated-actions.ps1
+++ b/scripts/nsis-elevated-actions.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)]
-  [ValidateSet('add-defender-exclusion', 'remove-defender-exclusion', 'install-vc-runtime')]
+  [ValidateSet('install-vc-runtime')]
   [string]$Action,
 
   [Parameter(Mandatory = $true)]
@@ -34,12 +34,6 @@ try {
   $exitCode = 0
 
   switch ($Action) {
-    'add-defender-exclusion' {
-      Add-MpPreference -ExclusionPath $Target -ErrorAction Stop
-    }
-    'remove-defender-exclusion' {
-      Remove-MpPreference -ExclusionPath $Target -ErrorAction Stop
-    }
     'install-vc-runtime' {
       if (-not (Test-Path -LiteralPath $Target -PathType Leaf)) {
         throw "VC++ runtime installer is missing: $Target"

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -1,7 +1,14 @@
 !include "FileFunc.nsh"
+!include "LogicLib.nsh"
+!include "nsDialogs.nsh"
 
 !define ELEVATED_ACTION_SCRIPT "nsis-elevated-actions.ps1"
 !define ELEVATED_ACTION_RESULT "elevated-action-result.txt"
+
+Var /GLOBAL installLocalInference
+Var /GLOBAL localInferenceDialog
+Var /GLOBAL localInferenceCheckbox
+Var /GLOBAL localInferenceLabel
 
 !macro OpenTimingLogForAppend HANDLE
   ; NSIS append mode preserves existing data but starts at offset zero.
@@ -44,6 +51,33 @@
   !define MUI_WELCOMEPAGE_TITLE "欢迎使用知远智能体"
   !define MUI_WELCOMEPAGE_TEXT "知远智能体是面向真实工作的 AI 工作台。安装程序将为你准备完整的离线运行环境；本地推理组件可在应用启动后按需下载。$\r$\n$\r$\n点击“下一步”继续。"
   !insertmacro MUI_PAGE_WELCOME
+!macroend
+
+Function LocalInferencePageCreate
+  !insertmacro MUI_HEADER_TEXT "本地推理组件" "选择是否在安装完成后准备本地推理环境"
+  nsDialogs::Create 1018
+  Pop $localInferenceDialog
+  ${If} $localInferenceDialog == error
+    Abort
+  ${EndIf}
+
+  ${NSD_CreateLabel} 0 0 100% 48u "知远支持在本地运行推理模型。开启后，首次启动时会根据硬件下载 CPU 或 NVIDIA CUDA 后端（约 16 MB–621 MB）。$\r$\n$\r$\n不勾选不会影响其他功能。"
+  Pop $localInferenceLabel
+
+  ${NSD_CreateCheckbox} 0 80u 100% 12u "安装本地推理组件"
+  Pop $localInferenceCheckbox
+  ; Preserve the previous MessageBox default (No) by leaving the box unchecked.
+  ${NSD_SetState} $localInferenceCheckbox ${BST_UNCHECKED}
+
+  nsDialogs::Show
+FunctionEnd
+
+Function LocalInferencePageLeave
+  ${NSD_GetState} $localInferenceCheckbox $installLocalInference
+FunctionEnd
+
+!macro customPageAfterChangeDir
+  Page custom LocalInferencePageCreate LocalInferencePageLeave
 !macroend
 
 !macro customInit
@@ -476,16 +510,15 @@
       MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Visual C++ Runtime 未能自动安装。知远仍会完成安装，但部分本地组件可能暂时不可用。"
   VcRuntimeReady:
 
-  ; Local inference remains optional. The installer records only an intent;
-  ; download, verification, extraction, cancellation and retry happen in-app.
-  IfSilent LocalInferencePromptDone 0
+  ; Local inference remains optional. The user chose on the custom options page
+  ; whether to prepare it; download, verification, extraction, cancellation and
+  ; retry happen in-app.
   Delete "$APPDATA\ZhiYuanAgent\pending-local-inference-install"
-  MessageBox MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2 "是否在启动知远后安装本地推理组件？$\r$\n$\r$\n知远会根据硬件推荐 CPU 或 NVIDIA CUDA 后端，需额外下载约 16 MB–621 MB。下载将在应用内显示进度并可取消；选择“否”不影响其他功能。" IDYES RecordLocalInferenceIntent IDNO LocalInferencePromptDone
-  RecordLocalInferenceIntent:
+  ${If} $installLocalInference == 1
     FileOpen $2 "$APPDATA\ZhiYuanAgent\pending-local-inference-install" w
     FileWrite $2 "$R1"
     FileClose $2
-  LocalInferencePromptDone:
+  ${EndIf}
 
   ; Cleanup begins only after core application and runtime links are ready, so
   ; it no longer competes with resource expansion on slow disks.

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -53,6 +53,10 @@ Var /GLOBAL localInferenceLabel
   !insertmacro MUI_PAGE_WELCOME
 !macroend
 
+; electron-builder compiles the uninstaller before the installer. Its assisted
+; template does not insert installation pages while BUILD_UNINSTALLER is set,
+; so keep the page callbacks out of that compilation pass.
+!ifndef BUILD_UNINSTALLER
 Function LocalInferencePageCreate
   ; electron-builder prepends this script before installer.nsi includes
   ; MUI2.nsh, so the MUI_HEADER_TEXT macro is undefined at compile time.
@@ -88,6 +92,7 @@ FunctionEnd
 !macro customPageAfterChangeDir
   Page custom LocalInferencePageCreate LocalInferencePageLeave
 !macroend
+!endif
 
 !macro customInit
   SetDetailsPrint textonly

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -54,7 +54,13 @@ Var /GLOBAL localInferenceLabel
 !macroend
 
 Function LocalInferencePageCreate
-  !insertmacro MUI_HEADER_TEXT "本地推理组件" "按需启用本地模型推理"
+  ; electron-builder prepends this script before installer.nsi includes
+  ; MUI2.nsh, so the MUI_HEADER_TEXT macro is undefined at compile time.
+  ; Set the standard MUI header controls (IDs 1037/1038) directly instead.
+  GetDlgItem $0 $HWNDPARENT 1037
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:本地推理组件"
+  GetDlgItem $0 $HWNDPARENT 1038
+  SendMessage $0 ${WM_SETTEXT} 0 "STR:按需启用本地模型推理"
   nsDialogs::Create 1018
   Pop $localInferenceDialog
   ${If} $localInferenceDialog == error
@@ -236,13 +242,15 @@ FunctionEnd
     StrCmp $0 "0" 0 ComponentArchiveUnsafe_${TOKEN}
 
     DetailPrint "[Installer] Extracting ${LABEL}"
-    Push $OUTDIR
-    SetOutPath "$R3"
-    Nsis7z::Extract "$PLUGINSDIR\component-${KEY}.7z"
-    Pop $R0
-    SetOutPath $R0
+    ; Extract with the bundled, hash-verified 7za.exe. Nsis7z::Extract can
+    ; silently skip PE files in BCJ2-filtered archives (electron-builder #9983),
+    ; and component packs are compressed with BCJ2.
+    nsExec::ExecToStack '"$PLUGINSDIR\7za.exe" x -bd -y "-o$R3" "$PLUGINSDIR\component-${KEY}.7z"'
+    Pop $0
+    Pop $1
     Delete "$PLUGINSDIR\component-${KEY}.7z"
-    Goto ComponentExtracted_${TOKEN}
+    StrCmp $0 "error" ComponentExtractFailed_${TOKEN}
+    IntCmp $0 0 ComponentExtracted_${TOKEN} ComponentExtractFailed_${TOKEN} ComponentExtractFailed_${TOKEN}
 
   ComponentHashFailed_${TOKEN}:
     StrCpy $R9 "${LABEL} 归档 SHA-256 校验失败，安装包可能不完整。"
@@ -259,14 +267,14 @@ FunctionEnd
     Goto OfflineComponentInstallFailed
 
   ComponentExtractFailed_${TOKEN}:
-    StrCpy $R9 "${LABEL} 展开失败。请检查磁盘空间或安全软件后重试。"
+    StrCpy $R9 "${LABEL} 展开失败（代码 $0）。请检查磁盘空间或安全软件后重试。"
     !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-extract-failed component=${KEY} output=$1$\r$\n"
+    FileWrite $2 "phase=component-extract-failed component=${KEY} exit=$0 output=$1$\r$\n"
     FileClose $2
     Goto OfflineComponentInstallFailed
 
   ComponentExtracted_${TOKEN}:
-    IfFileExists "$R3\${SENTINEL}" 0 ComponentExtractFailed_${TOKEN}
+    IfFileExists "$R3\${SENTINEL}" 0 ComponentVerificationFailed_${TOKEN}
     nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath \"$R3\${SENTINEL}\" -Algorithm SHA256).Hash.ToLowerInvariant()"'
     Pop $0
     Pop $1

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -49,19 +49,22 @@ Var /GLOBAL localInferenceLabel
 
 !macro customWelcomePage
   !define MUI_WELCOMEPAGE_TITLE "欢迎使用知远智能体"
-  !define MUI_WELCOMEPAGE_TEXT "知远智能体是面向真实工作的 AI 工作台。安装程序将为你准备完整的离线运行环境；本地推理组件可在应用启动后按需下载。$\r$\n$\r$\n点击“下一步”继续。"
+  !define MUI_WELCOMEPAGE_TEXT "安装程序将在本地准备离线运行环境，完成后即可使用。本地推理组件可在首次启动后按需下载。$\r$\n$\r$\n点击“下一步”继续。"
   !insertmacro MUI_PAGE_WELCOME
 !macroend
 
 Function LocalInferencePageCreate
-  !insertmacro MUI_HEADER_TEXT "本地推理组件" "选择是否在安装完成后准备本地推理环境"
+  !insertmacro MUI_HEADER_TEXT "本地推理组件" "按需启用本地模型推理"
   nsDialogs::Create 1018
   Pop $localInferenceDialog
   ${If} $localInferenceDialog == error
     Abort
   ${EndIf}
 
-  ${NSD_CreateLabel} 0 0 100% 48u "知远支持在本地运行推理模型。开启后，首次启动时会根据硬件下载 CPU 或 NVIDIA CUDA 后端（约 16 MB–621 MB）。$\r$\n$\r$\n不勾选不会影响其他功能。"
+  ${NSD_CreateLabel} 0 0 100% 32u "开启后，首次启动时会根据你的硬件下载 CPU 或 NVIDIA CUDA 后端（约 16 MB–621 MB）。"
+  Pop $localInferenceLabel
+
+  ${NSD_CreateLabel} 0 36u 100% 16u "不勾选不会影响其他功能。"
   Pop $localInferenceLabel
 
   ${NSD_CreateCheckbox} 0 80u 100% 12u "安装本地推理组件"

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -169,148 +169,44 @@ FunctionEnd
   FileClose $8
 !macroend
 
-!macro EnsureOfflineComponent TOKEN KEY PREFIX SENTINEL LABEL
-  DetailPrint "[Installer] Checking ${LABEL}"
-  System::Call 'kernel32::GetTickCount()i .r7'
+!macro StageOfflineComponentMetadata KEY
   SetOutPath "$PLUGINSDIR"
   File /oname=component-${KEY}.version "${PROJECT_DIR}\build-tar\windows-components\${KEY}.version"
   File /oname=component-${KEY}.sha256 "${PROJECT_DIR}\build-tar\windows-components\${KEY}.sha256"
   File /oname=component-${KEY}.sentinel-sha256 "${PROJECT_DIR}\build-tar\windows-components\${KEY}.sentinel-sha256"
+!macroend
 
-  FileOpen $2 "$PLUGINSDIR\component-${KEY}.version" r
-  IfErrors ComponentVersionInvalid_${TOKEN}
-  FileRead $2 $R1
-  FileClose $2
-  StrCpy $R1 $R1 64
-  StrLen $R5 $R1
-  IntCmp $R5 64 0 ComponentVersionInvalid_${TOKEN} ComponentVersionInvalid_${TOKEN}
-
-  FileOpen $2 "$PLUGINSDIR\component-${KEY}.sha256" r
-  IfErrors ComponentVersionInvalid_${TOKEN}
-  FileRead $2 $R4
-  FileClose $2
-  StrCpy $R4 $R4 64
-  StrLen $R5 $R4
-  IntCmp $R5 64 0 ComponentVersionInvalid_${TOKEN} ComponentVersionInvalid_${TOKEN}
-
-  FileOpen $2 "$PLUGINSDIR\component-${KEY}.sentinel-sha256" r
-  IfErrors ComponentVersionInvalid_${TOKEN}
-  FileRead $2 $R6
-  FileClose $2
-  StrCpy $R6 $R6 64
-  StrLen $R5 $R6
-  IntCmp $R5 64 0 ComponentVersionInvalid_${TOKEN} ComponentVersionInvalid_${TOKEN}
-
-  StrCpy $R2 "$LOCALAPPDATA\ZhiYuanAgent\runtimes\${KEY}\$R1"
-  IfFileExists "$R2\.complete" 0 ComponentCacheMiss_${TOKEN}
-  FileOpen $2 "$R2\.complete" r
-  IfErrors ComponentCacheMiss_${TOKEN}
-  FileRead $2 $R5
-  FileClose $2
-  StrCpy $R5 $R5 64
-  StrCmp $R5 $R1 0 ComponentCacheMiss_${TOKEN}
-  IfFileExists "$R2\${SENTINEL}" 0 ComponentCacheMiss_${TOKEN}
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath \"$R2\${SENTINEL}\" -Algorithm SHA256).Hash.ToLowerInvariant()"'
-  Pop $0
-  Pop $1
-  StrCmp $0 "0" 0 ComponentCacheMiss_${TOKEN}
-  StrCpy $1 $1 64
-  StrCmp $1 $R6 ComponentCacheHit_${TOKEN} ComponentCacheMiss_${TOKEN}
-
+!macro QueueOfflineComponent TOKEN KEY LABEL
+  DetailPrint "[Installer] Checking ${LABEL}"
+  System::Call 'kernel32::GetTickCount()i .r7'
+  IfFileExists "$PLUGINSDIR\component-${KEY}.cache-valid" ComponentCacheHit_${TOKEN} ComponentCacheMiss_${TOKEN}
   ComponentCacheHit_${TOKEN}:
     DetailPrint "[Installer] Reusing ${LABEL}"
     !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-cache-hit component=${KEY} content_id=$R1$\r$\n"
+    FileWrite $2 "phase=component-cache-hit component=${KEY}$\r$\n"
     FileClose $2
-    Goto ComponentReady_${TOKEN}
+    Goto ComponentQueued_${TOKEN}
 
   ComponentCacheMiss_${TOKEN}:
     DetailPrint "[Installer] Expanding ${LABEL}"
     !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-cache-miss component=${KEY} content_id=$R1$\r$\n"
+    FileWrite $2 "phase=component-cache-miss component=${KEY}$\r$\n"
     FileClose $2
-    StrCpy $R3 "$LOCALAPPDATA\ZhiYuanAgent\runtimes\${KEY}\$R1.installing"
-    RMDir /r "$R3"
-    CreateDirectory "$R3"
     SetOutPath "$PLUGINSDIR"
     SetCompress off
     File /oname=component-${KEY}.7z "${PROJECT_DIR}\build-tar\windows-components\${KEY}.7z"
     SetCompress auto
+  ComponentQueued_${TOKEN}:
+!macroend
 
-    ; Hash check and archive entry validation are merged into a single
-    ; PowerShell invocation to avoid the per-component process startup cost.
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\validate-component-archive.ps1" -ArchivePath "$PLUGINSDIR\component-${KEY}.7z" -SevenZipPath "$PLUGINSDIR\7za.exe" -Prefix "${PREFIX}" -ExpectedHash "$R4"'
-    Pop $0
-    Pop $1
-    StrCmp $0 "2" ComponentHashFailed_${TOKEN}
-    StrCmp $0 "3" ComponentArchiveUnsafe_${TOKEN}
-    StrCmp $0 "0" 0 ComponentArchiveUnsafe_${TOKEN}
-
-    DetailPrint "[Installer] Extracting ${LABEL}"
-    ; Extract with the bundled, hash-verified 7za.exe. Nsis7z::Extract can
-    ; silently skip PE files in BCJ2-filtered archives (electron-builder #9983),
-    ; and component packs are compressed with BCJ2.
-    nsExec::ExecToStack '"$PLUGINSDIR\7za.exe" x -bd -y "-o$R3" "$PLUGINSDIR\component-${KEY}.7z"'
-    Pop $0
-    Pop $1
-    Delete "$PLUGINSDIR\component-${KEY}.7z"
-    StrCmp $0 "error" ComponentExtractFailed_${TOKEN}
-    IntCmp $0 0 ComponentExtracted_${TOKEN} ComponentExtractFailed_${TOKEN} ComponentExtractFailed_${TOKEN}
-
-  ComponentHashFailed_${TOKEN}:
-    StrCpy $R9 "${LABEL} 归档 SHA-256 校验失败，安装包可能不完整。"
+!macro RecordOfflineComponentReady KEY
+  FileOpen $2 "$PLUGINSDIR\component-${KEY}.version" r
+  IfErrors OfflineComponentInstallFailed
+  FileRead $2 $R1
+  FileClose $2
+  StrCpy $R1 $R1 64
     !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-hash-failed component=${KEY} expected=$R4 output=$1$\r$\n"
-    FileClose $2
-    Goto OfflineComponentInstallFailed
-
-  ComponentArchiveUnsafe_${TOKEN}:
-    StrCpy $R9 "${LABEL} archive contains an unsafe path or link metadata."
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-archive-unsafe component=${KEY} exit=$0 output=$1$\r$\n"
-    FileClose $2
-    Goto OfflineComponentInstallFailed
-
-  ComponentExtractFailed_${TOKEN}:
-    StrCpy $R9 "${LABEL} 展开失败（代码 $0）。请检查磁盘空间或安全软件后重试。"
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-extract-failed component=${KEY} exit=$0 output=$1$\r$\n"
-    FileClose $2
-    Goto OfflineComponentInstallFailed
-
-  ComponentExtracted_${TOKEN}:
-    IfFileExists "$R3\${SENTINEL}" 0 ComponentVerificationFailed_${TOKEN}
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath \"$R3\${SENTINEL}\" -Algorithm SHA256).Hash.ToLowerInvariant()"'
-    Pop $0
-    Pop $1
-    StrCmp $0 "0" 0 ComponentVerificationFailed_${TOKEN}
-    StrCpy $1 $1 64
-    StrCmp $1 $R6 0 ComponentVerificationFailed_${TOKEN}
-    FileOpen $2 "$R3\.complete" w
-    FileWrite $2 "$R1|$R4"
-    FileClose $2
-    RMDir /r "$R2"
-    Rename "$R3" "$R2"
-    IfErrors ComponentCommitFailed_${TOKEN}
-    Goto ComponentReady_${TOKEN}
-
-  ComponentVerificationFailed_${TOKEN}:
-    StrCpy $R9 "${LABEL} 健康检查失败，${SENTINEL} 缺失或校验不匹配。"
-    Goto OfflineComponentInstallFailed
-
-  ComponentCommitFailed_${TOKEN}:
-    StrCpy $R9 "无法启用 ${LABEL}，请确认当前用户对 %LOCALAPPDATA%\ZhiYuanAgent 有写入权限。"
-    Goto OfflineComponentInstallFailed
-
-  ComponentVersionInvalid_${TOKEN}:
-    StrCpy $R9 "安装包缺少 ${LABEL} 的有效版本或校验信息。"
-    Goto OfflineComponentInstallFailed
-
-  ComponentReady_${TOKEN}:
-    System::Call 'kernel32::GetTickCount()i .r6'
-    IntOp $R5 $6 - $7
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-ready component=${KEY} content_id=$R1 elapsed_ms=$R5$\r$\n"
+  FileWrite $2 "phase=component-ready component=${KEY} content_id=$R1 validation=batch$\r$\n"
     FileClose $2
 !macroend
 
@@ -323,7 +219,7 @@ FunctionEnd
   File /oname=7za.sha256 "${PROJECT_DIR}\build-tar\windows-components\7za.sha256"
   File /oname=component-manifest.json "${PROJECT_DIR}\build-tar\windows-components\manifest.json"
   File /oname=recover-component-switch.ps1 "${PROJECT_DIR}\scripts\installer\recover-component-switch.ps1"
-  File /oname=validate-component-archive.ps1 "${PROJECT_DIR}\scripts\installer\validate-component-archive.ps1"
+  File /oname=validate-offline-components.ps1 "${PROJECT_DIR}\scripts\installer\validate-offline-components.ps1"
   ; Embed the routing table as a compile-time asset. Building it incrementally
   ; with NSIS FileWrite can split the skill-python key on Windows runners.
   File /oname=component-targets.json "${PROJECT_DIR}\scripts\nsis-offline-components.json"
@@ -345,13 +241,68 @@ FunctionEnd
   Pop $1
   StrCmp $0 "0" 0 OfflineComponentInstallFailed
 
-  !insertmacro EnsureOfflineComponent CHANNEL_RUNTIME "channel-runtime" "channel-runtime" "channel-runtime\cc-connect-sidecar.exe" "频道运行环境"
-  !insertmacro EnsureOfflineComponent SKILLS "skills" "SKILLs" "SKILLs\skills.config.json" "内置 Skills"
-  !insertmacro EnsureOfflineComponent MCPS "mcps" "MCPs" "MCPs\compatibility-review.md" "内置 MCPs"
-  !insertmacro EnsureOfflineComponent PORTABLE_GIT "portable-git" "mingit" "mingit\usr\bin\bash.exe" "PortableGit"
-  !insertmacro EnsureOfflineComponent PYTHON "python" "python-win" "python-win\python.exe" "Python 离线运行环境"
-  !insertmacro EnsureOfflineComponent SKILL_PYTHON "skill-python" "skill-python" "skill-python\layers\shared\Scripts\python.exe" "Skill Python dependency layer"
-  !insertmacro EnsureOfflineComponent UV "uv" "uv-win" "uv-win\uv.exe" "uv 离线运行环境"
+  !insertmacro StageOfflineComponentMetadata "channel-runtime"
+  !insertmacro StageOfflineComponentMetadata "skills"
+  !insertmacro StageOfflineComponentMetadata "mcps"
+  !insertmacro StageOfflineComponentMetadata "portable-git"
+  !insertmacro StageOfflineComponentMetadata "python"
+  !insertmacro StageOfflineComponentMetadata "skill-python"
+  !insertmacro StageOfflineComponentMetadata "uv"
+
+  ; Verify all reusable cache entries in one PowerShell process before deciding
+  ; which archives NSIS needs to unpack from the installer.
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\validate-offline-components.ps1" -Mode cache -PluginDir "$PLUGINSDIR" -RuntimeRoot "$LOCALAPPDATA\ZhiYuanAgent\runtimes" -ComponentTargetsPath "$PLUGINSDIR\component-targets.json" -SevenZipPath "$PLUGINSDIR\7za.exe"'
+  Pop $0
+  Pop $1
+  StrCmp $0 "0" ComponentCacheValidated
+    StrCpy $R9 "安装包缺少有效离线组件校验信息：$1"
+    Goto OfflineComponentInstallFailed
+  ComponentCacheValidated:
+
+  !insertmacro QueueOfflineComponent CHANNEL_RUNTIME "channel-runtime" "频道运行环境"
+  !insertmacro QueueOfflineComponent SKILLS "skills" "内置 Skills"
+  !insertmacro QueueOfflineComponent MCPS "mcps" "内置 MCPs"
+  !insertmacro QueueOfflineComponent PORTABLE_GIT "portable-git" "PortableGit"
+  !insertmacro QueueOfflineComponent PYTHON "python" "Python 离线运行环境"
+  !insertmacro QueueOfflineComponent SKILL_PYTHON "skill-python" "Skill Python dependency layer"
+  !insertmacro QueueOfflineComponent UV "uv" "uv 离线运行环境"
+
+  ; The changed archives are now present in $PLUGINSDIR. Validate their hashes,
+  ; entries and sentinels, then extract them in one PowerShell batch. This keeps
+  ; cache hits fast while eliminating a PowerShell startup per component.
+  DetailPrint "[Installer] Validating and expanding offline components"
+  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\validate-offline-components.ps1" -Mode expand -PluginDir "$PLUGINSDIR" -RuntimeRoot "$LOCALAPPDATA\ZhiYuanAgent\runtimes" -ComponentTargetsPath "$PLUGINSDIR\component-targets.json" -SevenZipPath "$PLUGINSDIR\7za.exe"'
+  Pop $0
+  Pop $1
+  StrCmp $0 "0" ComponentBatchExpanded
+  StrCmp $0 "2" ComponentBatchHashFailed
+  StrCmp $0 "3" ComponentBatchArchiveUnsafe
+  StrCmp $0 "4" ComponentBatchExtractFailed
+  StrCmp $0 "5" ComponentBatchVerificationFailed
+    StrCpy $R9 "离线组件批处理失败：$1"
+    Goto OfflineComponentInstallFailed
+
+  ComponentBatchHashFailed:
+    StrCpy $R9 "离线组件归档 SHA-256 校验失败，安装包可能不完整。"
+    Goto OfflineComponentInstallFailed
+  ComponentBatchArchiveUnsafe:
+    StrCpy $R9 "离线组件归档包含不安全路径或链接元数据。"
+    Goto OfflineComponentInstallFailed
+  ComponentBatchExtractFailed:
+    StrCpy $R9 "离线组件展开失败。请检查磁盘空间或安全软件后重试。"
+    Goto OfflineComponentInstallFailed
+  ComponentBatchVerificationFailed:
+    StrCpy $R9 "离线组件健康检查失败，哨兵文件缺失或校验不匹配。"
+    Goto OfflineComponentInstallFailed
+  ComponentBatchExpanded:
+
+  !insertmacro RecordOfflineComponentReady "channel-runtime"
+  !insertmacro RecordOfflineComponentReady "skills"
+  !insertmacro RecordOfflineComponentReady "mcps"
+  !insertmacro RecordOfflineComponentReady "portable-git"
+  !insertmacro RecordOfflineComponentReady "python"
+  !insertmacro RecordOfflineComponentReady "skill-python"
+  !insertmacro RecordOfflineComponentReady "uv"
 
   DetailPrint "[Installer] Activating offline components"
   nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -31,9 +31,13 @@
 !macro customHeader
   ManifestDPIAware true
   ; The application and immutable runtime cache are per-user. Elevated helper
-  ; processes are used only for optional Windows-wide settings below.
+  ; processes are used only for the VC++ runtime installer below.
   RequestExecutionLevel user
   ShowInstDetails nevershow
+  ; NSIS startup CRC check reads the entire installer before the UI appears.
+  ; Every payload is already covered by per-component SHA-256 and 7z CRC, so
+  ; the extra full-file scan is redundant and slow for a multi-gigabyte exe.
+  CRCCheck off
 !macroend
 
 !macro customWelcomePage
@@ -185,37 +189,28 @@
     File /oname=component-${KEY}.7z "${PROJECT_DIR}\build-tar\windows-components\${KEY}.7z"
     SetCompress auto
 
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath \"$PLUGINSDIR\component-${KEY}.7z\" -Algorithm SHA256).Hash.ToLowerInvariant()"'
+    ; Hash check and archive entry validation are merged into a single
+    ; PowerShell invocation to avoid the per-component process startup cost.
+    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\validate-component-archive.ps1" -ArchivePath "$PLUGINSDIR\component-${KEY}.7z" -SevenZipPath "$PLUGINSDIR\7za.exe" -Prefix "${PREFIX}" -ExpectedHash "$R4"'
     Pop $0
     Pop $1
-    StrCmp $0 "0" 0 ComponentHashFailed_${TOKEN}
-    StrCpy $1 $1 64
-    StrCmp $1 $R4 0 ComponentHashFailed_${TOKEN}
-
-    ; Validate every archive entry before extraction. Keep the parser in a
-    ; standalone script so PowerShell path semantics are not changed by NSIS quoting.
-    nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\validate-component-archive.ps1" -ArchivePath "$PLUGINSDIR\component-${KEY}.7z" -SevenZipPath "$PLUGINSDIR\7za.exe" -Prefix "${PREFIX}"'
-    Pop $0
-    Pop $1
+    StrCmp $0 "2" ComponentHashFailed_${TOKEN}
+    StrCmp $0 "3" ComponentArchiveUnsafe_${TOKEN}
     StrCmp $0 "0" 0 ComponentArchiveUnsafe_${TOKEN}
 
-    nsExec::ExecToStack '"$PLUGINSDIR\7za.exe" x -bd -y "-o$R3" "$PLUGINSDIR\component-${KEY}.7z"'
-    Pop $0
-    Pop $1
-    StrCmp $0 "error" ComponentExtractFailed_${TOKEN}
-    IntCmp $0 0 ComponentExtracted_${TOKEN} ComponentExtractFailed_${TOKEN} ComponentExtractFailed_${TOKEN}
+    DetailPrint "[Installer] Extracting ${LABEL}"
+    Push $OUTDIR
+    SetOutPath "$R3"
+    Nsis7z::Extract "$PLUGINSDIR\component-${KEY}.7z"
+    Pop $R0
+    SetOutPath $R0
+    Delete "$PLUGINSDIR\component-${KEY}.7z"
+    Goto ComponentExtracted_${TOKEN}
 
   ComponentHashFailed_${TOKEN}:
     StrCpy $R9 "${LABEL} 归档 SHA-256 校验失败，安装包可能不完整。"
     !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-hash-failed component=${KEY} expected=$R4 actual=$1 exit=$0$\r$\n"
-    FileClose $2
-    Goto OfflineComponentInstallFailed
-
-  ComponentExtractFailed_${TOKEN}:
-    StrCpy $R9 "${LABEL} 展开失败（代码 $0）。请检查磁盘空间或安全软件后重试。"
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=component-extract-failed component=${KEY} exit=$0 output=$1$\r$\n"
+    FileWrite $2 "phase=component-hash-failed component=${KEY} expected=$R4 output=$1$\r$\n"
     FileClose $2
     Goto OfflineComponentInstallFailed
 
@@ -226,8 +221,15 @@
     FileClose $2
     Goto OfflineComponentInstallFailed
 
+  ComponentExtractFailed_${TOKEN}:
+    StrCpy $R9 "${LABEL} 展开失败。请检查磁盘空间或安全软件后重试。"
+    !insertmacro OpenTimingLogForAppend $2
+    FileWrite $2 "phase=component-extract-failed component=${KEY} output=$1$\r$\n"
+    FileClose $2
+    Goto OfflineComponentInstallFailed
+
   ComponentExtracted_${TOKEN}:
-    IfFileExists "$R3\${SENTINEL}" 0 ComponentVerificationFailed_${TOKEN}
+    IfFileExists "$R3\${SENTINEL}" 0 ComponentExtractFailed_${TOKEN}
     nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "(Get-FileHash -LiteralPath \"$R3\${SENTINEL}\" -Algorithm SHA256).Hash.ToLowerInvariant()"'
     Pop $0
     Pop $1
@@ -240,7 +242,6 @@
     RMDir /r "$R2"
     Rename "$R3" "$R2"
     IfErrors ComponentCommitFailed_${TOKEN}
-    Delete "$PLUGINSDIR\component-${KEY}.7z"
     Goto ComponentReady_${TOKEN}
 
   ComponentVerificationFailed_${TOKEN}:
@@ -293,63 +294,6 @@
   Pop $0
   Pop $1
   StrCmp $0 "0" 0 OfflineComponentInstallFailed
-
-  ; Defender exclusion is optional and requires explicit, informed consent.
-  ; Keep the scope limited to the immutable component cache; never exclude
-  ; user-created Skills, channel state, model data, or the full install tree.
-  DetailPrint "[Installer] Checking Microsoft Defender exclusion"
-  nsExec::ExecToStack 'powershell -NoProfile -NonInteractive -Command "\
-    $$runtimeRoot = \"$LOCALAPPDATA\ZhiYuanAgent\runtimes\";\
-    try {\
-      $$excluded = @((Get-MpPreference -ErrorAction Stop).ExclusionPath);\
-      if ($$excluded -contains $$runtimeRoot) { exit 0 }\
-    } catch { };\
-    exit 3"'
-  Pop $0
-  Pop $1
-  StrCmp $0 "0" DefenderExclusionAlreadyActive
-  IfSilent DefenderExclusionSkipped
-  MessageBox MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON1 "是否允许将知远的离线运行环境加入 Microsoft Defender 排除项？$\r$\n$\r$\n这样可以显著减少大量小文件在首次解压和后续运行时的扫描开销，但该目录中的文件将不再接受 Defender 实时扫描。设置会持续到卸载知远，你也可以随时在 Windows 安全中心撤销。$\r$\n$\r$\n目录：%LOCALAPPDATA%\ZhiYuanAgent\runtimes$\r$\n$\r$\n开源版推荐选择“是”；如不希望修改 Defender 设置，请选择“否”。" IDYES EnableDefenderExclusion IDNO DefenderExclusionDeclined
-
-  EnableDefenderExclusion:
-    DetailPrint "[Installer] Adding user-approved Defender exclusion"
-    !insertmacro RunElevatedAction ADD_DEFENDER add-defender-exclusion "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
-    StrCmp $0 "0" DefenderExclusionEnabled
-      Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
-      !insertmacro OpenTimingLogForAppend $2
-      FileWrite $2 "phase=defender-exclusion-failed exit=$0 output=$1$\r$\n"
-      FileClose $2
-      MessageBox MB_OK|MB_ICONEXCLAMATION "Microsoft Defender 排除项未能添加。可能是你取消了管理员授权，或系统安全策略不允许修改。知远仍会继续安装。"
-      Goto DefenderExclusionDone
-
-  DefenderExclusionEnabled:
-    FileOpen $2 "$APPDATA\ZhiYuanAgent\defender-exclusion-managed" w
-    FileWrite $2 "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
-    FileClose $2
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=defender-exclusion-enabled path=$LOCALAPPDATA\ZhiYuanAgent\runtimes$\r$\n"
-    FileClose $2
-    Goto DefenderExclusionDone
-
-  DefenderExclusionAlreadyActive:
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=defender-exclusion-already-active path=$LOCALAPPDATA\ZhiYuanAgent\runtimes$\r$\n"
-    FileClose $2
-    Goto DefenderExclusionDone
-
-  DefenderExclusionDeclined:
-    Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=defender-exclusion-declined$\r$\n"
-    FileClose $2
-    Goto DefenderExclusionDone
-
-  DefenderExclusionSkipped:
-    !insertmacro OpenTimingLogForAppend $2
-    FileWrite $2 "phase=defender-exclusion-skipped-silent$\r$\n"
-    FileClose $2
-
-  DefenderExclusionDone:
 
   !insertmacro EnsureOfflineComponent CHANNEL_RUNTIME "channel-runtime" "channel-runtime" "channel-runtime\cc-connect-sidecar.exe" "频道运行环境"
   !insertmacro EnsureOfflineComponent SKILLS "skills" "SKILLs" "SKILLs\skills.config.json" "内置 Skills"
@@ -677,12 +621,4 @@
   LegacyRuntimeCleanupDone:
   RMDir "$3"
 
-  ; Remove only exclusions that this installer recorded as user-approved and
-  ; installer-managed. Never remove an exclusion created independently.
-  IfFileExists "$APPDATA\ZhiYuanAgent\defender-exclusion-managed" 0 DefenderExclusionUninstallDone
-    !insertmacro ExtractElevatedActionScript
-    !insertmacro RunElevatedAction REMOVE_DEFENDER remove-defender-exclusion "$LOCALAPPDATA\ZhiYuanAgent\runtimes"
-    StrCmp $0 "0" 0 DefenderExclusionUninstallDone
-      Delete "$APPDATA\ZhiYuanAgent\defender-exclusion-managed"
-  DefenderExclusionUninstallDone:
 !macroend

--- a/scripts/nsis-installer.nsh
+++ b/scripts/nsis-installer.nsh
@@ -5,6 +5,10 @@
 !define ELEVATED_ACTION_SCRIPT "nsis-elevated-actions.ps1"
 !define ELEVATED_ACTION_RESULT "elevated-action-result.txt"
 
+; electron-builder compiles the uninstaller before the installer. Its assisted
+; template does not insert installation pages while BUILD_UNINSTALLER is set,
+; so keep the page state and callbacks out of that compilation pass.
+!ifndef BUILD_UNINSTALLER
 Var /GLOBAL installLocalInference
 Var /GLOBAL localInferenceDialog
 Var /GLOBAL localInferenceCheckbox
@@ -53,10 +57,6 @@ Var /GLOBAL localInferenceLabel
   !insertmacro MUI_PAGE_WELCOME
 !macroend
 
-; electron-builder compiles the uninstaller before the installer. Its assisted
-; template does not insert installation pages while BUILD_UNINSTALLER is set,
-; so keep the page callbacks out of that compilation pass.
-!ifndef BUILD_UNINSTALLER
 Function LocalInferencePageCreate
   ; electron-builder prepends this script before installer.nsi includes
   ; MUI2.nsh, so the MUI_HEADER_TEXT macro is undefined at compile time.

--- a/scripts/nsis-offline-components.json
+++ b/scripts/nsis-offline-components.json
@@ -1,9 +1,17 @@
 [
-  { "key": "channel-runtime", "prefix": "channel-runtime" },
-  { "key": "skills", "prefix": "SKILLs" },
-  { "key": "mcps", "prefix": "MCPs" },
-  { "key": "portable-git", "prefix": "mingit" },
-  { "key": "python", "prefix": "python-win" },
-  { "key": "skill-python", "prefix": "skill-python" },
-  { "key": "uv", "prefix": "uv-win" }
+  {
+    "key": "channel-runtime",
+    "prefix": "channel-runtime",
+    "sentinel": "channel-runtime\\cc-connect-sidecar.exe"
+  },
+  { "key": "skills", "prefix": "SKILLs", "sentinel": "SKILLs\\skills.config.json" },
+  { "key": "mcps", "prefix": "MCPs", "sentinel": "MCPs\\compatibility-review.md" },
+  { "key": "portable-git", "prefix": "mingit", "sentinel": "mingit\\usr\\bin\\bash.exe" },
+  { "key": "python", "prefix": "python-win", "sentinel": "python-win\\python.exe" },
+  {
+    "key": "skill-python",
+    "prefix": "skill-python",
+    "sentinel": "skill-python\\layers\\shared\\Scripts\\python.exe"
+  },
+  { "key": "uv", "prefix": "uv-win", "sentinel": "uv-win\\uv.exe" }
 ]

--- a/tests/linuxInstallGate.test.ts
+++ b/tests/linuxInstallGate.test.ts
@@ -17,6 +17,7 @@ test('every pull request installs and starts the generated Ubuntu package', () =
   assert.match(workflow, /runs-on: ubuntu-latest/);
   assert.match(workflow, /bun run dist:linux/);
   assert.match(workflow, /sudo apt-get install -y/);
+  assert.match(workflow, /realpath/);
   assert.match(workflow, /'\/opt\/知远\/知远'/);
   assert.match(workflow, /verify-linux-renderer\.mjs/);
   assert.match(workflow, /linux-deb-install-smoke\.png/);

--- a/tests/linuxInstallGate.test.ts
+++ b/tests/linuxInstallGate.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { test } from 'vitest';
+
+const root = path.resolve(__dirname, '..');
+
+test('every pull request installs and starts the generated Ubuntu package', () => {
+  const workflow = readFileSync(
+    path.join(root, '.github', 'workflows', 'linux-install-pr.yml'),
+    'utf8',
+  );
+
+  assert.match(workflow, /pull_request:/);
+  assert.doesNotMatch(workflow, /paths:/);
+  assert.match(workflow, /runs-on: ubuntu-latest/);
+  assert.match(workflow, /bun run dist:linux/);
+  assert.match(workflow, /sudo apt-get install -y/);
+  assert.match(workflow, /'\/opt\/知远\/知远'/);
+  assert.match(workflow, /verify-linux-renderer\.mjs/);
+  assert.match(workflow, /linux-deb-install-smoke\.png/);
+  assert.match(workflow, /actions\/upload-artifact@v6/);
+});

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -143,11 +143,15 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(14);
   });
 
-  test('records optional local inference intent without downloading in NSIS', () => {
+  test('records optional local inference intent via an options checkbox instead of a popup', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
 
     expect(installerScript).toContain('pending-local-inference-install');
-    expect(installerScript).toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2');
+    expect(installerScript).toContain('${NSD_CreateCheckbox}');
+    expect(installerScript).toContain('LocalInferencePageCreate');
+    expect(installerScript).toContain('LocalInferencePageLeave');
+    expect(installerScript).toContain('Page custom LocalInferencePageCreate LocalInferencePageLeave');
+    expect(installerScript).not.toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2');
     expect(installerScript).not.toContain('install-llamacpp-backend-nsis.cjs');
     expect(installerScript).not.toContain('llamacpp-backends\\manifest.json');
   });

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -33,8 +33,8 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('component-${KEY}.sentinel-sha256');
     expect(installerScript).toContain('File /oname=7za.exe');
     expect(installerScript).toContain('component-${KEY}.7z');
-    expect(installerScript).toContain('Nsis7z::Extract "$PLUGINSDIR\\component-${KEY}.7z"');
-    expect(installerScript).not.toContain('"$PLUGINSDIR\\7za.exe" x -bd -y');
+    expect(installerScript).toContain('"$PLUGINSDIR\\7za.exe" x -bd -y');
+    expect(installerScript).not.toContain('Nsis7z::Extract "$PLUGINSDIR');
     expect(installerScript).toContain('SetCompress off');
     expect(installerScript).toContain('SetCompress auto');
     expect(installerScript).toContain('File /oname=validate-component-archive.ps1');
@@ -151,6 +151,7 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('LocalInferencePageCreate');
     expect(installerScript).toContain('LocalInferencePageLeave');
     expect(installerScript).toContain('Page custom LocalInferencePageCreate LocalInferencePageLeave');
+    expect(installerScript).toContain('!ifndef BUILD_UNINSTALLER');
     expect(installerScript).not.toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2');
     expect(installerScript).not.toContain('install-llamacpp-backend-nsis.cjs');
     expect(installerScript).not.toContain('llamacpp-backends\\manifest.json');

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -152,6 +152,9 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('LocalInferencePageLeave');
     expect(installerScript).toContain('Page custom LocalInferencePageCreate LocalInferencePageLeave');
     expect(installerScript).toContain('!ifndef BUILD_UNINSTALLER');
+    expect(installerScript.indexOf('!ifndef BUILD_UNINSTALLER')).toBeLessThan(
+      installerScript.indexOf('Var /GLOBAL installLocalInference'),
+    );
     expect(installerScript).not.toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2');
     expect(installerScript).not.toContain('install-llamacpp-backend-nsis.cjs');
     expect(installerScript).not.toContain('llamacpp-backends\\manifest.json');

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -33,11 +33,13 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('component-${KEY}.sentinel-sha256');
     expect(installerScript).toContain('File /oname=7za.exe');
     expect(installerScript).toContain('component-${KEY}.7z');
-    expect(installerScript).toContain('"$PLUGINSDIR\\7za.exe" x -bd -y');
+    expect(installerScript).toContain('Nsis7z::Extract "$PLUGINSDIR\\component-${KEY}.7z"');
+    expect(installerScript).not.toContain('"$PLUGINSDIR\\7za.exe" x -bd -y');
     expect(installerScript).toContain('SetCompress off');
     expect(installerScript).toContain('SetCompress auto');
     expect(installerScript).toContain('File /oname=validate-component-archive.ps1');
     expect(installerScript).toContain('-File \"$PLUGINSDIR\\validate-component-archive.ps1\"');
+    expect(installerScript).toContain('-ExpectedHash "$R4"');
     expect(installerScript).toContain('phase=component-archive-unsafe');
     expect(installerScript).toContain('Get-FileHash -LiteralPath \\"$R2\\${SENTINEL}\\"');
     expect(installerScript).toContain('$LOCALAPPDATA\\ZhiYuanAgent\\runtimes\\${KEY}\\$R1');
@@ -138,7 +140,7 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).not.toMatch(
       /^\s*FileOpen \$\d+ "\$APPDATA\\ZhiYuanAgent\\install-timing\.log" a$/m,
     );
-    expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(19);
+    expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(14);
   });
 
   test('records optional local inference intent without downloading in NSIS', () => {
@@ -150,21 +152,23 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).not.toContain('llamacpp-backends\\manifest.json');
   });
 
-  test('adds only a user-approved scoped Defender exclusion and removes managed exclusions', () => {
+  test('does not request or manage Microsoft Defender exclusions', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
     const elevatedActionsScript = fs.readFileSync(elevatedActionsScriptPath, 'utf8');
 
-    expect(installerScript).toContain('MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON1');
     expect(installerScript).toContain('ExecShellWait "runas"');
     expect(installerScript).toContain('-ExecutionPolicy Bypass -File');
-    expect(installerScript).toContain('!insertmacro RunElevatedAction ADD_DEFENDER');
     expect(installerScript).toContain('!insertmacro RunElevatedAction INSTALL_VC');
-    expect(installerScript).toContain('!insertmacro RunElevatedAction REMOVE_DEFENDER');
-    expect(installerScript).toContain('defender-exclusion-managed');
+    expect(installerScript).not.toContain('!insertmacro RunElevatedAction ADD_DEFENDER');
+    expect(installerScript).not.toContain('!insertmacro RunElevatedAction REMOVE_DEFENDER');
+    expect(installerScript).not.toContain('defender-exclusion-managed');
+    expect(installerScript).not.toContain('Get-MpPreference');
+    expect(installerScript).not.toContain('Defender');
+    expect(installerScript).not.toContain('Defender exclusion');
     expect(installerScript).not.toContain("''");
     expect(installerScript).not.toContain('Start-Process -FilePath powershell.exe -Verb RunAs');
-    expect(elevatedActionsScript).toContain('Add-MpPreference -ExclusionPath $Target');
-    expect(elevatedActionsScript).toContain('Remove-MpPreference -ExclusionPath $Target');
+    expect(elevatedActionsScript).not.toContain('Add-MpPreference');
+    expect(elevatedActionsScript).not.toContain('Remove-MpPreference');
     expect(elevatedActionsScript).toContain('-ArgumentList @(');
     expect(elevatedActionsScript).toContain("'/install'");
     expect(elevatedActionsScript).toContain("'/quiet'");

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -8,8 +8,8 @@ const installerSmokeScriptPath = path.resolve('scripts/ci/windows-installer-smok
 const elevatedActionsScriptPath = path.resolve('scripts/nsis-elevated-actions.ps1');
 const offlineComponentsPath = path.resolve('scripts/nsis-offline-components.json');
 const brandAssetScriptPath = path.resolve('scripts/generate-nsis-brand-assets.cjs');
-const componentArchiveValidatorPath = path.resolve(
-  'scripts/installer/validate-component-archive.ps1',
+const offlineComponentValidatorPath = path.resolve(
+  'scripts/installer/validate-offline-components.ps1',
 );
 
 describe('NSIS offline resource and local inference flow', () => {
@@ -19,7 +19,7 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('ManifestDPIAware true');
   });
 
-  test('embeds seven offline components but expands each only on its own cache miss', () => {
+  test('batches component validation while keeping archive payloads conditional on cache misses', () => {
     const installerScript = fs.readFileSync(installerScriptPath, 'utf8');
 
     const cacheMissIndex = installerScript.indexOf('ComponentCacheMiss_${TOKEN}:');
@@ -28,34 +28,39 @@ describe('NSIS offline resource and local inference flow', () => {
     );
     expect(cacheMissIndex).toBeGreaterThan(-1);
     expect(payloadIndex).toBeGreaterThan(cacheMissIndex);
-    expect(installerScript.match(/!insertmacro EnsureOfflineComponent /g)).toHaveLength(7);
+    expect(installerScript.match(/!insertmacro QueueOfflineComponent /g)).toHaveLength(7);
     expect(installerScript).toContain('phase=component-cache-hit');
     expect(installerScript).toContain('component-${KEY}.sentinel-sha256');
     expect(installerScript).toContain('File /oname=7za.exe');
     expect(installerScript).toContain('component-${KEY}.7z');
-    expect(installerScript).toContain('"$PLUGINSDIR\\7za.exe" x -bd -y');
     expect(installerScript).not.toContain('Nsis7z::Extract "$PLUGINSDIR');
     expect(installerScript).toContain('SetCompress off');
     expect(installerScript).toContain('SetCompress auto');
-    expect(installerScript).toContain('File /oname=validate-component-archive.ps1');
-    expect(installerScript).toContain('-File \"$PLUGINSDIR\\validate-component-archive.ps1\"');
-    expect(installerScript).toContain('-ExpectedHash "$R4"');
-    expect(installerScript).toContain('phase=component-archive-unsafe');
-    expect(installerScript).toContain('Get-FileHash -LiteralPath \\"$R2\\${SENTINEL}\\"');
-    expect(installerScript).toContain('$LOCALAPPDATA\\ZhiYuanAgent\\runtimes\\${KEY}\\$R1');
+    expect(installerScript).toContain('File /oname=validate-offline-components.ps1');
+    expect(
+      installerScript.match(/-File "\$PLUGINSDIR\\validate-offline-components\.ps1"/g),
+    ).toHaveLength(2);
+    expect(installerScript).toContain('-Mode cache');
+    expect(installerScript).toContain('-Mode expand');
+    expect(installerScript).toContain('component-${KEY}.cache-valid');
+    expect(installerScript).toContain('ComponentBatchHashFailed:');
+    expect(installerScript).not.toContain('Get-FileHash -LiteralPath \\"$R2\\${SENTINEL}\\"');
+    expect(installerScript).not.toContain('validate-component-archive.ps1');
     expect(installerScript).not.toContain('File /oname=win-resources.tar');
   });
 
-  test('normalizes 7-Zip entry separators before enforcing the component prefix', () => {
-    const validatorScript = fs.readFileSync(componentArchiveValidatorPath, 'utf8');
+  test('validates each batched archive path before extracting it', () => {
+    const validatorScript = fs.readFileSync(offlineComponentValidatorPath, 'utf8');
 
-    expect(validatorScript).toContain("$entry.Replace('\\', '/')");
+    expect(validatorScript).toContain("$Value.Replace('\\', '/')");
     expect(validatorScript).toContain(
       '$normalizedEntry.StartsWith("$normalizedPrefix/", [System.StringComparison]::Ordinal)',
     );
-    expect(validatorScript).toContain("$normalizedEntry -match '(^|/)\\.\\.(/|$)'");
+    expect(validatorScript).toContain("$normalized -match '(^|/)\\.\\.(/|$)'");
     expect(validatorScript).toContain("$value -and $value -ne '-'");
-    expect(validatorScript).not.toContain('-like');
+    expect(validatorScript).toContain("[ValidateSet('cache', 'expand')]");
+    expect(validatorScript).toContain('Get-FileHash -LiteralPath $sentinel');
+    expect(validatorScript).toContain('Stop-WithCode 2 "hash-mismatch:$($component.Key)"');
   });
 
   test('uses per-user installation and rolls back pointer changes after normal failures', () => {
@@ -102,13 +107,21 @@ describe('NSIS offline resource and local inference flow', () => {
       'New-Item -ItemType Junction -Path $$next -Target $$target -Force -ErrorAction Stop',
     );
     expect(offlineComponents).toEqual([
-      { key: 'channel-runtime', prefix: 'channel-runtime' },
-      { key: 'skills', prefix: 'SKILLs' },
-      { key: 'mcps', prefix: 'MCPs' },
-      { key: 'portable-git', prefix: 'mingit' },
-      { key: 'python', prefix: 'python-win' },
-      { key: 'skill-python', prefix: 'skill-python' },
-      { key: 'uv', prefix: 'uv-win' },
+      {
+        key: 'channel-runtime',
+        prefix: 'channel-runtime',
+        sentinel: 'channel-runtime\\cc-connect-sidecar.exe',
+      },
+      { key: 'skills', prefix: 'SKILLs', sentinel: 'SKILLs\\skills.config.json' },
+      { key: 'mcps', prefix: 'MCPs', sentinel: 'MCPs\\compatibility-review.md' },
+      { key: 'portable-git', prefix: 'mingit', sentinel: 'mingit\\usr\\bin\\bash.exe' },
+      { key: 'python', prefix: 'python-win', sentinel: 'python-win\\python.exe' },
+      {
+        key: 'skill-python',
+        prefix: 'skill-python',
+        sentinel: 'skill-python\\layers\\shared\\Scripts\\python.exe',
+      },
+      { key: 'uv', prefix: 'uv-win', sentinel: 'uv-win\\uv.exe' },
     ]);
   });
 
@@ -140,7 +153,7 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).not.toMatch(
       /^\s*FileOpen \$\d+ "\$APPDATA\\ZhiYuanAgent\\install-timing\.log" a$/m,
     );
-    expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(14);
+    expect(installerScript.match(/!insertmacro OpenTimingLogForAppend \$[28]/g)).toHaveLength(11);
   });
 
   test('records optional local inference intent via an options checkbox instead of a popup', () => {
@@ -150,7 +163,9 @@ describe('NSIS offline resource and local inference flow', () => {
     expect(installerScript).toContain('${NSD_CreateCheckbox}');
     expect(installerScript).toContain('LocalInferencePageCreate');
     expect(installerScript).toContain('LocalInferencePageLeave');
-    expect(installerScript).toContain('Page custom LocalInferencePageCreate LocalInferencePageLeave');
+    expect(installerScript).toContain(
+      'Page custom LocalInferencePageCreate LocalInferencePageLeave',
+    );
     expect(installerScript).toContain('!ifndef BUILD_UNINSTALLER');
     expect(installerScript.indexOf('!ifndef BUILD_UNINSTALLER')).toBeLessThan(
       installerScript.indexOf('Var /GLOBAL installLocalInference'),

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -399,7 +399,7 @@ test("installer-related pull requests build and exercise the Windows installer",
   assert.match(smoke, /'cache-hit upgrade'/);
   assert.match(smoke, /phase=component-cache-miss/);
   assert.match(smoke, /phase=component-cache-hit/);
-  assert.match(smoke, /phase=defender-exclusion-skipped-silent/);
+  assert.doesNotMatch(smoke, /phase=defender-exclusion/);
   assert.match(smoke, /'uninstall'/);
 
   const sizeSmoke = readFileSync(


### PR DESCRIPTION
## 变更说明

### Windows 安装

- 去除 Microsoft Defender 排除目录的交互申请、持久化标记和卸载清理；安装器仅在安装 VC++ 运行库时请求必要的提权。
- 关闭 NSIS 启动前对完整安装包的 CRC 扫描。离线组件仍保留 SHA-256、7z CRC、归档路径限制和解压后哨兵文件校验。
- 将离线组件的校验改为批处理：先一次性验证全部缓存组件，再一次性处理所有未命中组件，减少 PowerShell 启动和跨进程开销。
- 本地推理组件改为安装过程中的显式可选项，默认不安装。
- 修复卸载器编译阶段与安装页面状态冲突的问题。

### Linux 旧版本升级

- `preinst` 同时识别当前 `/opt/知远` 与旧版 `/opt/ZhiYuanAgent` 的进程和 AppImage 挂载路径。
- 常规退出等待超时后强制终止残留进程，避免旧实例或 SingletonLock 所属进程阻碍升级后的首次启动。
- 预安装脚本始终以成功状态退出，不因清理旧进程阻塞 deb 安装。

### Ubuntu 安装启动门禁

新增所有指向 `main` 的 PR 必跑工作流：

1. 构建 Linux `.deb` 安装包；
2. 通过 apt 实际安装该包；
3. 从已安装路径 `/opt/知远/知远` 启动应用；
4. 在 Xvfb 虚拟桌面中检查渲染进程、页面内容和首帧截图；
5. 首帧截图为空白、应用提前退出或页面未渲染时，CI 失败并上传截图诊断产物。

## 验证

- `npm test -- tests/linuxInstallGate.test.ts`
- `node --check scripts/verify-linux-renderer.mjs`
- `node scripts/ci/check-openclaw-decoupling.mjs`
- 工作流 YAML 结构校验

## 影响范围

- Windows 离线安装速度和安装期间的权限行为。
- Ubuntu deb 的升级兼容性与安装后首启可靠性。
- 不改变离线组件的完整性校验边界。