### PR TITLE
feat(模型设置): 新增切换API兼容时的自动检测模型

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -63,6 +63,7 @@ import {
   ModelConnectionStatus,
   useModelConnectionStatus,
 } from './settings/useModelConnectionStatus';
+import { shouldAutoDetectProviderModels } from './settings/providerModelAutoDetection';
 import { APP_ID, EXPORT_FORMAT_TYPE, EXPORT_PASSWORD } from '../constants/app';
 import { getProviderIcon } from '../providers/uiRegistry';
 import { apiService } from '../services/api';
@@ -1432,6 +1433,27 @@ const Settings: React.FC<SettingsProps> = ({
   const handleProviderConfigChange = (provider: ProviderType, field: string, value: string) => {
     if (field === 'apiKey' || field === 'baseUrl' || field === 'apiFormat') {
       invalidateProviderModelConnectionStatuses(provider);
+    }
+    if (field === 'apiFormat') {
+      const currentProviderConfig = providers[provider];
+      const nextApiFormat = getEffectiveApiFormat(provider, value);
+      const nextBaseUrl = shouldAutoSwitchProviderBaseUrl(provider, currentProviderConfig.baseUrl)
+        ? getProviderDefaultBaseUrl(provider, nextApiFormat) || currentProviderConfig.baseUrl
+        : currentProviderConfig.baseUrl;
+      if (
+        shouldAutoDetectProviderModels({
+          providerId: provider,
+          baseUrl: nextBaseUrl,
+          apiKey: currentProviderConfig.apiKey,
+          authType: currentProviderConfig.authType,
+          requiresApiKey: providerRequiresApiKey(provider),
+        })
+      ) {
+        setAutoDetectRequest({
+          provider,
+          requestId: ++autoDetectRequestIdRef.current,
+        });
+      }
     }
     setProviders(prev => {
       if (field === 'apiFormat') {

--- a/src/renderer/components/settings/providerModelAutoDetection.test.ts
+++ b/src/renderer/components/settings/providerModelAutoDetection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+
+import { AuthType, ProviderName } from '../../../shared/providers';
+import { shouldAutoDetectProviderModels } from './providerModelAutoDetection';
+
+const defaultInput = {
+  providerId: ProviderName.DeepSeek,
+  baseUrl: 'https://api.example.com/v1',
+  apiKey: 'test-key',
+  requiresApiKey: true,
+};
+
+describe('shouldAutoDetectProviderModels', () => {
+  test('allows a provider with the required API key and base URL', () => {
+    expect(shouldAutoDetectProviderModels(defaultInput)).toBe(true);
+  });
+
+  test('rejects a provider without a base URL', () => {
+    expect(shouldAutoDetectProviderModels({ ...defaultInput, baseUrl: '  ' })).toBe(false);
+  });
+
+  test('rejects a provider missing a required API key', () => {
+    expect(shouldAutoDetectProviderModels({ ...defaultInput, apiKey: '' })).toBe(false);
+  });
+
+  test('allows OAuth and optional API key providers without an API key', () => {
+    expect(
+      shouldAutoDetectProviderModels({ ...defaultInput, apiKey: '', authType: AuthType.OAuth }),
+    ).toBe(true);
+    expect(
+      shouldAutoDetectProviderModels({ ...defaultInput, apiKey: '', requiresApiKey: false }),
+    ).toBe(true);
+  });
+
+  test('rejects the local inference provider', () => {
+    expect(
+      shouldAutoDetectProviderModels({ ...defaultInput, providerId: ProviderName.LlamaCpp }),
+    ).toBe(false);
+  });
+});

--- a/src/renderer/components/settings/providerModelAutoDetection.ts
+++ b/src/renderer/components/settings/providerModelAutoDetection.ts
@@ -1,0 +1,23 @@
+import { AuthType, ProviderName } from '../../../shared/providers';
+
+interface ProviderModelAutoDetectionInput {
+  providerId: string;
+  baseUrl: string;
+  apiKey: string;
+  authType?: string;
+  requiresApiKey: boolean;
+}
+
+export function shouldAutoDetectProviderModels(
+  input: ProviderModelAutoDetectionInput,
+): boolean {
+  if (input.providerId === ProviderName.LlamaCpp || !input.baseUrl.trim()) {
+    return false;
+  }
+
+  return (
+    !input.requiresApiKey ||
+    input.authType === AuthType.OAuth ||
+    Boolean(input.apiKey.trim())
+  );
+}


### PR DESCRIPTION
## 概要

  优化设置-模型页面的模型配置、自动检测、连接测试与本地模型刷新流程，降低自定义模型和本地模型的配置成本。

  本次补充：切换 API 兼容格式后，满足 URL 与鉴权条件时自动检测模型列表。

  ## 关联 Issue

  暂无关联 Issue。

  ## 变更内容

  - 切换 OpenAI 兼容、Anthropic 兼容等 API 格式后，自动按新格式请求模型列表。
  - 优化模型设置界面：统一模型卡片样式、精简自定义配置说明、完善 API Key 清除与模型删除确认交互。
  - 本地模型列表新增刷新能力，通过主进程同步当前运行模型绑定。
  - 调整设置弹窗退出行为，避免点击外部区域或回车导致未保存配置丢失。
  - 补充模型连接、API 地址处理、格式切换自动检测及本地模型绑定刷新的测试覆盖。

  ## 变更类型

  - [x] 缺陷修复（不破坏现有功能）
  - [x] 新功能（不破坏现有功能）
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## 测试

  - [x] 已在本地执行自动化验证
  - [x] 已新增测试
  - [x] 已更新现有测试
  - [ ] 未进行 Electron 人工界面测试

  已执行：

  - npx vitest run src/renderer/components/settings/providerModelAutoDetection.test.ts src/renderer/services/providerModelDiscovery.test.ts src/main/libs/
    providerModelDiscovery.test.ts：19 项通过。

  - npx vitest run src/main/ipcHandlers/llamacpp.test.ts：29 项通过。
  - TypeScript 编译：通过。
  - bun run build:vite：通过。
  - bun run test:bundle-budget：通过。
  - bun install --frozen-lockfile --ignore-scripts：通过。
  - npm run lint：通过。
  - git diff --check：通过。

  ## 截图

  暂无。未启动 Electron 进行人工界面验证。

  ## 检查清单

  - [x] 代码遵循现有项目风格和组件规范
  - [x] 已完成自查
  - [x] 已为新增自动检测条件补充单元测试
  - [ ] 未修改项目文档
  - [x] 全量 lint 通过
  - [x] 已添加测试验证关键逻辑
  - [ ] 未执行完整单元测试集

  ## Electron 专项变更

  - [x] 修改主进程：新增本地运行模型绑定刷新处理。
  - [x] 修改预加载脚本：暴露本地模型绑定刷新接口。
  - [x] 修改 IPC 通信：新增本地模型绑定刷新通道。
  - [ ] 未修改窗口管理。
  - [ ] 不适用。

  ## 补充说明

  本 PR 涉及设置页面 UI、模型发现流程与 Electron IPC。建议合并前在桌面端验证：

  - 用户自定义模型的自动检测与连接测试；
  - 切换 API 兼容格式后的自动检测；
  - API Key 清除确认与模型删除确认；
  - 本地模型列表刷新。