### PR TITLE
fix(artifacts): defer file loading until preview

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/ui/button';
 import { FluidTabs } from '@shared/components/ui/fluid-tabs';
+import { Skeleton } from '@shared/components/ui/skeleton';
 import { ArrowLeft, Copy, Expand, Filter, Maximize2, Minimize2, Shrink } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -37,10 +38,19 @@ import { toLocalFileUrl } from './artifactFileUrl';
 import FileDirectoryView from './FileDirectoryView';
 import ArtifactPanelResizeHandle from './ArtifactPanelResizeHandle';
 import CodeRenderer from './renderers/CodeRenderer';
+import { invalidateArtifactFile, loadArtifactFile } from '@/services/artifactFileLoader';
 
 const t = (key: string) => i18nService.t(key);
 
 const BROWSER_OPENABLE_TYPES = new Set<ArtifactType>(['html', 'svg', 'mermaid']);
+const PANEL_LOADED_ARTIFACT_TYPES = new Set<ArtifactType>([
+  'mermaid',
+  'svg',
+  'image',
+  'code',
+  'markdown',
+  'text',
+]);
 
 function isDelimitedArtifact(artifact: Artifact): boolean {
   const name = (artifact.fileName || artifact.filePath || artifact.title || '').toLowerCase();
@@ -70,6 +80,7 @@ function escapeHtml(str: string): string {
 
 interface ArtifactPanelProps {
   sessionId: string | null;
+  cwd?: string | null;
   artifacts: Artifact[];
   panelWidth: number;
   minPanelWidth?: number;
@@ -80,6 +91,7 @@ interface ArtifactPanelProps {
 
 const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
   sessionId,
+  cwd,
   artifacts,
   panelWidth,
   minPanelWidth = MIN_PANEL_WIDTH,
@@ -101,6 +113,8 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
   const toggleBtnRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [loadingArtifactId, setLoadingArtifactId] = useState<string | null>(null);
+  const [artifactLoadError, setArtifactLoadError] = useState<string | null>(null);
   const isMac = window.electron.platform === 'darwin';
   const isTopLevelPanel = layoutMode === ArtifactLayoutMode.Workspace || isFullscreen;
 
@@ -122,6 +136,51 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
   const displayedTab = availableTabs.includes(activeTab) ? activeTab : availableTabs[0];
   const isCodeView = displayedTab === 'code';
   const hasLocalFilePreview = Boolean(selectedArtifact?.filePath) && !isCodeView;
+
+  useEffect(() => {
+    if (
+      panelView !== ArtifactPanelView.Preview ||
+      !selectedArtifact ||
+      selectedArtifact.content ||
+      !selectedArtifact.filePath ||
+      (!PANEL_LOADED_ARTIFACT_TYPES.has(selectedArtifact.type) &&
+        !(isCodeView && selectedArtifact.type === 'html'))
+    ) {
+      setLoadingArtifactId(null);
+      setArtifactLoadError(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const artifactId = selectedArtifact.id;
+    setLoadingArtifactId(artifactId);
+    setArtifactLoadError(null);
+
+    loadArtifactFile(selectedArtifact, cwd)
+      .then(loaded => {
+        if (cancelled) return;
+        if (!loaded) {
+          setArtifactLoadError(artifactId);
+          return;
+        }
+        dispatch(
+          addArtifact({
+            sessionId: selectedArtifact.sessionId,
+            artifact: { ...selectedArtifact, content: loaded.content, filePath: loaded.filePath },
+          }),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setArtifactLoadError(artifactId);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingArtifactId(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd, dispatch, isCodeView, panelView, selectedArtifact]);
 
   const intermediateToggle = (
     <Button
@@ -278,6 +337,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
 
   const handleRefresh = useCallback(async () => {
     if (!selectedArtifact?.filePath) return;
+    invalidateArtifactFile(selectedArtifact.filePath);
     try {
       const result = await window.electron.dialog.readFileAsDataUrl(selectedArtifact.filePath);
       if (result?.success && result.dataUrl) {
@@ -509,7 +569,15 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
 
             {/* Render area */}
             <div key={`${selectedArtifact.id}-${displayedTab}`} className="flex-1 min-h-0 overflow-hidden animate-fade-in">
-              {displayedTab === 'preview' ? (
+              {loadingArtifactId === selectedArtifact.id ? (
+                <div className="h-full min-h-0 p-4" aria-busy="true">
+                  <Skeleton className="h-full w-full rounded-lg" />
+                </div>
+              ) : artifactLoadError && artifactLoadError === selectedArtifact.id ? (
+                <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+                  {t('artifactDocumentError')}
+                </div>
+              ) : displayedTab === 'preview' ? (
                 <ArtifactRenderer
                   artifact={
                     isDelimitedArtifact(selectedArtifact)

--- a/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelFrame.tsx
@@ -14,6 +14,7 @@ import { clampArtifactPanelWidth } from './artifactPanelResize';
 
 interface ArtifactPanelFrameProps {
   sessionId: string | null;
+  cwd?: string | null;
   artifacts: Artifact[];
   isOpen: boolean;
   isVisible: boolean;
@@ -25,6 +26,7 @@ interface ArtifactPanelFrameProps {
 
 const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
   sessionId,
+  cwd,
   artifacts,
   isOpen,
   isVisible,
@@ -86,6 +88,7 @@ const ArtifactPanelFrame: React.FC<ArtifactPanelFrameProps> = ({
       <div className="relative flex h-full w-full">
         <ArtifactPanel
           sessionId={sessionId}
+          cwd={cwd}
           artifacts={artifacts}
           panelWidth={panelWidth}
           minPanelWidth={minPanelWidth}

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -300,15 +300,10 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const service = new ArtifactDetectionService(
       detected => {
         for (const { artifact } of detected) {
-          // Keep path-backed artifacts visible while their file contents load.
-          // Renderers can use filePath directly when the read is unavailable.
+          // Keep path-backed artifacts visible while their file contents remain deferred.
           dispatch(addArtifact({ sessionId, artifact }));
         }
       },
-      artifact => {
-        dispatch(addArtifact({ sessionId, artifact }));
-      },
-      absPath => window.electron.dialog.readFileAsDataUrl(absPath),
     );
     artifactDetectionServiceRef.current = service;
 
@@ -448,9 +443,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
         dispatch(addArtifact({ sessionId, artifact }));
       }
       // The async useEffect pass below will also call processMessages.
-      // addArtifact is idempotent (merges by id / filePath), so the only
-      // side-effect of the second pass is loadFiles — which fills in the
-      // content of already-painted artifact cards.
+      // addArtifact is idempotent (merges by id / filePath).
     }
   }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -461,7 +454,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
     const service = artifactDetectionServiceRef.current;
     if (!service) return;
 
-    service.processMessages(currentSession.messages, sessionId, currentSession.cwd).catch(err => {
+    service.processMessages(currentSession.messages, sessionId).catch(err => {
       console.error('[ArtifactDetection] failed:', err);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- message count and updatedAt cover message additions and content updates
@@ -1576,6 +1569,7 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             >
               <ArtifactPanelFrame
                 sessionId={previewSessionId}
+                cwd={currentSession?.cwd}
                 artifacts={previewArtifacts}
                 isOpen={isPanelOpen}
                 isVisible={isArtifactPanelVisible}

--- a/src/renderer/services/artifactDetectionService.test.ts
+++ b/src/renderer/services/artifactDetectionService.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { ArtifactRole, type Artifact } from '../types/artifact';
+import { ArtifactRole } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
 import { ArtifactDetectionService } from './artifactDetectionService';
 import type {
@@ -40,10 +40,7 @@ describe('ArtifactDetectionService', () => {
 
   test('reprocesses when a declare_artifact tool call arrives after thinking is done', async () => {
     const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
-    const service = new ArtifactDetectionService(
-      detected => detectedArtifacts.push(...detected),
-      () => {},
-    );
+    const service = new ArtifactDetectionService(detected => detectedArtifacts.push(...detected));
     const messageId = 'assistant-message';
     const toolMessageId = 'tool-declare';
     const sessionId = 'session-1';
@@ -96,16 +93,9 @@ describe('ArtifactDetectionService', () => {
     });
   });
 
-  test('loads UTF-8 CSV files as text for the table preview', async () => {
-    const loadedArtifacts: Artifact[] = [];
-    const service = new ArtifactDetectionService(
-      () => {},
-      artifact => loadedArtifacts.push(artifact),
-      async () => ({
-        success: true,
-        dataUrl: `data:text/csv;base64,${Buffer.from('姓名,分数\n王浩哲,100', 'utf8').toString('base64')}`,
-      }),
-    );
+  test('does not read CSV files while detecting artifacts', async () => {
+    const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
+    const service = new ArtifactDetectionService(detected => detectedArtifacts.push(...detected));
 
     await service.processMessages(
       [
@@ -121,25 +111,39 @@ describe('ArtifactDetectionService', () => {
         },
       ],
       'session-csv',
-      'C:/workspace',
     );
 
-    expect(loadedArtifacts).toHaveLength(1);
-    expect(loadedArtifacts[0]).toMatchObject({
-      type: 'document',
-      filePath: 'C:/workspace/scores.csv',
-      content: '姓名,分数\n王浩哲,100',
-    });
+    expect(detectedArtifacts).toHaveLength(1);
+    expect(detectedArtifacts[0].artifact.content).toBe('');
   });
 
-  test('keeps XLS files base64-encoded for the spreadsheet renderer', async () => {
-    const loadedArtifacts: Artifact[] = [];
-    const dataUrl = 'data:application/vnd.ms-excel;base64,AAEC';
-    const service = new ArtifactDetectionService(
-      () => {},
-      artifact => loadedArtifacts.push(artifact),
-      async () => ({ success: true, dataUrl }),
+  test('keeps binary artifact loading out of detection', async () => {
+    const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
+    const service = new ArtifactDetectionService(detected => detectedArtifacts.push(...detected));
+
+    await service.processMessages(
+      [
+        {
+          id: 'write-model',
+          type: 'tool_use',
+          content: '',
+          timestamp: 1,
+          metadata: {
+            toolName: 'write',
+            toolInput: { path: 'C:/workspace/model.stl' },
+          },
+        },
+      ],
+      'session-model',
     );
+
+    expect(detectedArtifacts).toHaveLength(1);
+    expect(detectedArtifacts[0].artifact).toMatchObject({ type: 'model', content: '' });
+  });
+
+  test('does not preload declared document files', async () => {
+    const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
+    const service = new ArtifactDetectionService(detected => detectedArtifacts.push(...detected));
 
     await service.processMessages(
       [
@@ -155,10 +159,40 @@ describe('ArtifactDetectionService', () => {
         },
       ],
       'session-xls',
-      'C:/workspace',
     );
 
-    expect(loadedArtifacts).toHaveLength(1);
-    expect(loadedArtifacts[0].content).toBe(dataUrl);
+    expect(detectedArtifacts).toHaveLength(1);
+    expect(detectedArtifacts[0].artifact).toMatchObject({ type: 'document', content: '' });
+  });
+
+  test('keeps declared artifact metadata available before preview', async () => {
+    const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
+    const service = new ArtifactDetectionService(
+      detected => detectedArtifacts.push(...detected),
+    );
+
+    await service.processMessages(
+      [
+        {
+          id: 'declare-model',
+          type: 'tool_use',
+          content: '',
+          timestamp: 1,
+          metadata: {
+            toolName: 'declare_artifact',
+            toolInput: {
+              filePath: 'C:/workspace/model.stl',
+              role: 'deliverable',
+            },
+          },
+        },
+      ],
+      'session-model',
+    );
+
+    expect(detectedArtifacts[0]?.artifact).toMatchObject({
+      type: 'model',
+      filePath: 'C:/workspace/model.stl',
+    });
   });
 });

--- a/src/renderer/services/artifactDetectionService.ts
+++ b/src/renderer/services/artifactDetectionService.ts
@@ -1,6 +1,5 @@
 import type { Artifact } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
-import { isBinaryArtifactFile } from '../../shared/cowork/artifactPreview';
 import type {
   ArtifactDetectionWorkerRequest,
   ArtifactDetectionWorkerResponse,
@@ -53,14 +52,9 @@ export class ArtifactDetectionService {
   private pending = new Map<number, (result: ArtifactDetectionResult[]) => void>();
   private seq = 0;
   private processedMessages = new Map<string, ProcessedMessageSnapshot>();
-  private loadedFileIds = new Set<string>();
 
   constructor(
     private onDetected: (artifacts: ArtifactDetectionResult[]) => void,
-    private onFileLoaded: (artifact: Artifact) => void,
-    private readFile?: (
-      absPath: string,
-    ) => Promise<{ success: boolean; dataUrl?: string } | null | undefined>,
   ) {}
 
   private ensureWorker(): Worker {
@@ -103,7 +97,6 @@ export class ArtifactDetectionService {
   async processMessages(
     messages: CoworkMessage[],
     sessionId: string,
-    cwd?: string | null,
   ): Promise<void> {
     const snapshots = messages.map(message => ({
       id: message.id,
@@ -122,12 +115,10 @@ export class ArtifactDetectionService {
     if (detected.length === 0) return;
 
     this.onDetected(detected);
-    await this.loadFiles(detected, cwd);
   }
 
   reset(): void {
     this.processedMessages.clear();
-    this.loadedFileIds.clear();
   }
 
   private detect(messages: CoworkMessage[], sessionId: string): Promise<ArtifactDetectionResult[]> {
@@ -142,56 +133,4 @@ export class ArtifactDetectionService {
     });
   }
 
-  private async loadFiles(detected: ArtifactDetectionResult[], cwd?: string | null): Promise<void> {
-    if (!this.readFile) return;
-    const toLoad = detected.filter(
-      d =>
-        d.needsFileLoad &&
-        d.artifact.type !== 'unsupported' &&
-        d.artifact.filePath &&
-        !this.loadedFileIds.has(d.artifact.id),
-    );
-    if (toLoad.length === 0) return;
-
-    for (const { artifact } of toLoad) {
-      let rawPath = artifact.filePath!;
-      rawPath = this.toAbsolutePath(rawPath);
-      const absPath = rawPath.startsWith('/')
-        ? rawPath
-        : /^[A-Za-z]:/.test(rawPath)
-          ? rawPath
-          : `${cwd ?? ''}/${rawPath}`;
-      try {
-        const result = await this.readFile(absPath);
-        if (result?.success && result.dataUrl) {
-          const isTextType = !isBinaryArtifactFile(absPath);
-          let content = result.dataUrl;
-          if (isTextType) {
-            try {
-              const base64 = result.dataUrl.split(',')[1] || '';
-              const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
-              content = new TextDecoder('utf-8').decode(bytes);
-            } catch {
-              content = result.dataUrl;
-            }
-          }
-          this.loadedFileIds.add(artifact.id);
-          this.onFileLoaded({ ...artifact, content, filePath: absPath });
-        } else {
-          this.loadedFileIds.add(artifact.id);
-        }
-      } catch {
-        this.loadedFileIds.add(artifact.id);
-      }
-    }
-  }
-
-  private toAbsolutePath(rawPath: string): string {
-    let p = rawPath;
-    if (p.startsWith('file:///')) p = p.slice(7);
-    else if (p.startsWith('file://')) p = p.slice(7);
-    else if (p.startsWith('file:/')) p = p.slice(5);
-    if (/^\/[A-Za-z]:/.test(p)) p = p.slice(1);
-    return p;
-  }
 }

--- a/src/renderer/services/artifactFileLoader.ts
+++ b/src/renderer/services/artifactFileLoader.ts
@@ -1,0 +1,74 @@
+import { isBinaryArtifactFile } from '../../shared/cowork/artifactPreview';
+import type { Artifact } from '../types/artifact';
+
+export type LoadedArtifactFile = {
+  content: string;
+  filePath: string;
+};
+
+const pendingLoads = new Map<string, Promise<LoadedArtifactFile | null>>();
+
+function normalizeFilePath(rawPath: string): string {
+  let filePath = rawPath;
+  if (filePath.startsWith('file:///')) filePath = filePath.slice(7);
+  else if (filePath.startsWith('file://')) filePath = filePath.slice(7);
+  else if (filePath.startsWith('file:/')) filePath = filePath.slice(5);
+  if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.slice(1);
+  return filePath;
+}
+
+function resolveFilePath(rawPath: string, cwd?: string | null): string {
+  const filePath = normalizeFilePath(rawPath);
+  if (filePath.startsWith('/') || /^[A-Za-z]:/.test(filePath)) return filePath;
+  return `${cwd ?? ''}/${filePath}`.replace(/\\/g, '/');
+}
+
+function decodeTextDataUrl(dataUrl: string): string {
+  const base64 = dataUrl.split(',')[1] || '';
+  const bytes = Uint8Array.from(atob(base64), character => character.charCodeAt(0));
+  return new TextDecoder('utf-8').decode(bytes);
+}
+
+/** Loads a path-backed artifact only when its preview is opened. */
+export function loadArtifactFile(
+  artifact: Artifact,
+  cwd?: string | null,
+): Promise<LoadedArtifactFile | null> {
+  if (artifact.content || !artifact.filePath) {
+    return Promise.resolve(null);
+  }
+
+  const filePath = resolveFilePath(artifact.filePath, cwd);
+  const cached = pendingLoads.get(filePath);
+  if (cached) return cached;
+
+  const load = (async (): Promise<LoadedArtifactFile | null> => {
+    const readFile = window.electron?.dialog?.readFileAsDataUrl;
+    if (typeof readFile !== 'function') return null;
+
+    const result = await readFile(filePath);
+    if (!result?.success || !result.dataUrl) {
+      throw new Error(result?.error || 'Failed to read artifact file');
+    }
+
+    const content = isBinaryArtifactFile(filePath)
+      ? result.dataUrl
+      : decodeTextDataUrl(result.dataUrl);
+    return { content, filePath };
+  })();
+
+  pendingLoads.set(filePath, load);
+  void load.then(
+    () => {
+      if (pendingLoads.get(filePath) === load) pendingLoads.delete(filePath);
+    },
+    () => {
+      if (pendingLoads.get(filePath) === load) pendingLoads.delete(filePath);
+    },
+  );
+  return load;
+}
+
+export function invalidateArtifactFile(filePath: string): void {
+  pendingLoads.delete(normalizeFilePath(filePath));
+}


### PR DESCRIPTION
## Problem

Switching sessions triggered background reads of every path-backed artifact after detection. Large 3D models, images, and documents could therefore block the renderer or amplify memory and I/O pressure before the user opened a preview.

## Root Cause

`ArtifactDetectionService` loaded every detected file as a data URL during message processing. This happened after the first paint but still on every session load.

## Solution

- Keep artifact detection limited to metadata and file paths.
- Load SVG, image, code, Markdown, text, and Mermaid files from `ArtifactPanel` only when the preview or source view is opened.
- Resolve relative paths against the session working directory and decode text data URLs before storing content.
- Deduplicate concurrent reads and release the in-flight cache when each request settles.
- Preserve existing renderer-owned lazy loading for HTML, office documents, and 3D models.
- Ignore stale results when the user switches artifacts while a read is pending.

## Behavior Change

Session switching no longer reads artifact file bodies. The first preview interaction performs the existing `dialog:readFileAsDataUrl` IPC read, then stores the result in artifact state for renderer reuse.

## Testing

- `npm test -- artifactDetectionService` (5 tests passed)
- `npm run lint` passed
- `npm run build:tsc` passed
- `git diff --check` passed
- Full `npm run build` reached the Vite output successfully; the repository Electron runtime dependency manifest check failed on generated/working-tree files outside this change.

## Electron-Specific Note

No new IPC channel was introduced. Preview-time reads continue through the existing `dialog:readFileAsDataUrl` preload bridge, so the 20 MB main-process safety limit remains in effect.
