### PR TITLE
feat(模型设置): 优化模型上下文长度检测逻辑

### DIFF
--- a/src/main/ipcHandlers/llamacpp.test.ts
+++ b/src/main/ipcHandlers/llamacpp.test.ts
@@ -6,6 +6,7 @@ import {
   LlamaCppRuntimeCudaMajor,
   LlamaCppMemoryPolicy,
 } from '../../shared/llamacpp';
+import { ModelCapabilityStatus } from '../../shared/providers';
 import type { LlamaCppManager } from '../libs/llamacppManager';
 import {
   enforceLlamaCppParallelTwo,
@@ -15,10 +16,49 @@ import {
   getTotalFreeVramMiB,
   hasRecoveredVram,
   sanitizeLlamaCppServiceConfig,
+  sanitizeLlamaCppModelPreference,
   waitForLlamaCppModelUnloadConfirmation,
   waitForLlamaCppStartupModelBindings,
   registerLlamaCppIpcHandlers,
 } from './llamacpp';
+
+test('sanitizeLlamaCppModelPreference retains every supported capability field', () => {
+  expect(
+    sanitizeLlamaCppModelPreference({
+      ctxSize: '65536',
+      maxTokens: '8192',
+      capabilities: {
+        toolCalling: ModelCapabilityStatus.Supported,
+        imageInput: ModelCapabilityStatus.Unsupported,
+        videoInput: ModelCapabilityStatus.Unknown,
+        audioInput: ModelCapabilityStatus.Supported,
+        documentInput: ModelCapabilityStatus.Unsupported,
+        reasoning: ModelCapabilityStatus.Supported,
+        ignored: ModelCapabilityStatus.Supported,
+      },
+    }),
+  ).toEqual({
+    ctxSize: 65536,
+    maxTokens: 8192,
+    capabilities: {
+      toolCalling: ModelCapabilityStatus.Supported,
+      imageInput: ModelCapabilityStatus.Unsupported,
+      videoInput: ModelCapabilityStatus.Unknown,
+      audioInput: ModelCapabilityStatus.Supported,
+      documentInput: ModelCapabilityStatus.Unsupported,
+      reasoning: ModelCapabilityStatus.Supported,
+    },
+  });
+});
+
+test('sanitizeLlamaCppModelPreference drops invalid maximum output and capability values', () => {
+  expect(
+    sanitizeLlamaCppModelPreference({
+      maxTokens: 0,
+      capabilities: { toolCalling: 'yes' },
+    }),
+  ).toBeNull();
+});
 
 const electronMocks = vi.hoisted(() => ({
   handlers: new Map<string, (...args: unknown[]) => unknown>(),

--- a/src/main/ipcHandlers/llamacpp.ts
+++ b/src/main/ipcHandlers/llamacpp.ts
@@ -88,6 +88,14 @@ const LLAMACPP_UNLOAD_CONFIRM_POLL_INTERVAL_MS = 400;
 const LLAMACPP_UNLOAD_CONFIRM_STABLE_MISSING_POLLS = 2;
 const LLAMACPP_STARTUP_BINDING_SYNC_ATTEMPTS = 30;
 const LLAMACPP_STARTUP_BINDING_SYNC_INTERVAL_MS = 1_000;
+const LLAMACPP_MODEL_PREFERENCE_CAPABILITY_KEYS = [
+  'toolCalling',
+  'imageInput',
+  'videoInput',
+  'audioInput',
+  'documentInput',
+  'reasoning',
+] as const satisfies ReadonlyArray<keyof ModelCapabilities>;
 
 const LlamaCppServiceStatus = {
   Running: 'running',
@@ -298,7 +306,8 @@ export function registerLlamaCppIpcHandlers(
           } catch {
             // Runtime metadata is optional; context and loaded state remain usable.
           }
-          const preferenceCapabilities = modelPreferences[model.id]?.capabilities;
+          const preference = modelPreferences[model.id];
+          const preferenceCapabilities = preference?.capabilities;
           const capabilities = {
             ...detectedCapabilities,
             ...(runningModel.supportsThinkingToggle === true
@@ -306,7 +315,12 @@ export function registerLlamaCppIpcHandlers(
               : {}),
             ...(preferenceCapabilities ?? {}),
           };
-          return Object.keys(capabilities).length ? { ...model, capabilities } : model;
+          return {
+            ...model,
+            ...(preference?.ctxSize ? { contextWindow: preference.ctxSize } : {}),
+            ...(preference?.maxTokens ? { maxTokens: preference.maxTokens } : {}),
+            ...(Object.keys(capabilities).length ? { capabilities } : {}),
+          };
         }),
       )
     ).filter((model): model is NonNullable<typeof model> => Boolean(model));
@@ -1059,12 +1073,18 @@ function sanitizeUpdatedModelPreferences(
   };
 }
 
-function sanitizeLlamaCppModelPreference(preference: unknown): LlamaCppModelPreference | null {
+export function sanitizeLlamaCppModelPreference(
+  preference: unknown,
+): LlamaCppModelPreference | null {
   if (!preference || typeof preference !== 'object') {
     return null;
   }
 
-  const candidate = preference as { ctxSize?: unknown; capabilities?: { toolCalling?: unknown } };
+  const candidate = preference as {
+    ctxSize?: unknown;
+    maxTokens?: unknown;
+    capabilities?: Record<string, unknown>;
+  };
   const parsedCtxSize =
     typeof candidate.ctxSize === 'number'
       ? candidate.ctxSize
@@ -1081,16 +1101,35 @@ function sanitizeLlamaCppModelPreference(preference: unknown): LlamaCppModelPref
     parsedCtxSize <= ctxSizeRange.max
       ? parsedCtxSize
       : undefined;
-  const toolCalling = candidate.capabilities?.toolCalling;
-  const capabilities =
-    toolCalling === ModelCapabilityStatus.Supported ||
-    toolCalling === ModelCapabilityStatus.Unsupported ||
-    toolCalling === ModelCapabilityStatus.Unknown
-      ? { toolCalling }
+  const parsedMaxTokens =
+    typeof candidate.maxTokens === 'number'
+      ? candidate.maxTokens
+      : typeof candidate.maxTokens === 'string'
+        ? Number.parseInt(candidate.maxTokens, 10)
+        : undefined;
+  const maxTokens =
+    typeof parsedMaxTokens === 'number' &&
+    Number.isSafeInteger(parsedMaxTokens) &&
+    parsedMaxTokens > 0
+      ? parsedMaxTokens
       : undefined;
+  const capabilities = Object.fromEntries(
+    LLAMACPP_MODEL_PREFERENCE_CAPABILITY_KEYS.flatMap(key => {
+      const status = candidate.capabilities?.[key];
+      return status === ModelCapabilityStatus.Supported ||
+        status === ModelCapabilityStatus.Unsupported ||
+        status === ModelCapabilityStatus.Unknown
+        ? [[key, status]]
+        : [];
+    }),
+  ) as Partial<ModelCapabilities>;
 
-  return ctxSize || capabilities
-    ? { ...(ctxSize ? { ctxSize } : {}), ...(capabilities ? { capabilities } : {}) }
+  return ctxSize || maxTokens || Object.keys(capabilities).length > 0
+    ? {
+        ...(ctxSize ? { ctxSize } : {}),
+        ...(maxTokens ? { maxTokens } : {}),
+        ...(Object.keys(capabilities).length > 0 ? { capabilities } : {}),
+      }
     : null;
 }
 

--- a/src/main/ipcHandlers/ollama.ts
+++ b/src/main/ipcHandlers/ollama.ts
@@ -9,6 +9,10 @@ import type {
   OllamaStatusSnapshot,
 } from '../../shared/ollama';
 import { OllamaIpcChannel } from '../../shared/ollama';
+import {
+  updateOllamaRuntimeModelCapabilities,
+  updateOllamaRuntimeModels,
+} from '../libs/claudeSettings';
 import { OllamaManager } from '../libs/ollamaManager';
 import type { SqliteStore } from '../sqliteStore';
 
@@ -68,7 +72,9 @@ export function registerOllamaIpcHandlers(
   });
   ipcMain.handle(OllamaIpcChannel.ListRunningModels, async () => {
     const client = await manager.client();
-    return await client.runningModels();
+    const runningModels = await client.runningModels();
+    updateOllamaRuntimeModels(runningModels);
+    return runningModels;
   });
   ipcMain.handle(OllamaIpcChannel.DeleteModel, async (_event, name: string) => {
     const client = await manager.client();
@@ -77,7 +83,9 @@ export function registerOllamaIpcHandlers(
   });
   ipcMain.handle(OllamaIpcChannel.ShowModel, async (_event, name: string) => {
     const client = await manager.client();
-    return await client.showModel(name);
+    const model = await client.showModel(name);
+    updateOllamaRuntimeModelCapabilities(name, model);
+    return model;
   });
   ipcMain.handle(OllamaIpcChannel.CreateModel, async (_event, name: string, modelfile: string) => {
     const client = await manager.client();
@@ -88,14 +96,18 @@ export function registerOllamaIpcHandlers(
     const modelName = input.model.trim();
     if (!modelName) throw new Error('Model name is required');
     const client = await manager.client();
-    return await client.preloadModel({ ...input, model: modelName });
+    const result = await client.preloadModel({ ...input, model: modelName });
+    updateOllamaRuntimeModels(result.runningModels);
+    return result;
   });
   ipcMain.handle(OllamaIpcChannel.UnloadModel, async (_event, name: string) => {
     const modelName = name.trim();
     if (!modelName) throw new Error('Model name is required');
     const client = await manager.client();
     await client.unloadModel(modelName);
-    return { success: true, runningModels: await client.runningModels() };
+    const runningModels = await client.runningModels();
+    updateOllamaRuntimeModels(runningModels);
+    return { success: true, runningModels };
   });
   ipcMain.handle(OllamaIpcChannel.PullModel, async (_event, name: string) => {
     const modelName = name.trim();

--- a/src/main/libs/providerModelDiscovery.test.ts
+++ b/src/main/libs/providerModelDiscovery.test.ts
@@ -90,6 +90,19 @@ describe('parseProviderModelsResponse', () => {
     ]);
   });
 
+  test('reads llama.cpp context metadata from the OpenAI-compatible model response', () => {
+    expect(
+      parseProviderModelsResponse({
+        data: [
+          {
+            id: 'qwen-local',
+            meta: { n_ctx: 262_144, n_ctx_train: 262_144 },
+          },
+        ],
+      }),
+    ).toEqual([{ id: 'qwen-local', contextWindow: 262_144 }]);
+  });
+
   test('rejects unsupported payloads', () => {
     expect(() => parseProviderModelsResponse({ items: [] })).toThrowError(
       expect.objectContaining<Partial<ProviderModelDiscoveryError>>({

--- a/src/main/libs/providerModelDiscovery.ts
+++ b/src/main/libs/providerModelDiscovery.ts
@@ -192,26 +192,31 @@ function modelCapabilities(item: Record<string, unknown>): Partial<ModelCapabili
     : undefined;
 }
 
-function modelMetadata(item: Record<string, unknown>): Pick<DiscoveredProviderModel, 'contextWindow' | 'maxTokens' | 'capabilities'> {
+function modelMetadata(
+  item: Record<string, unknown>,
+): Pick<DiscoveredProviderModel, 'contextWindow' | 'maxTokens' | 'capabilities'> {
   const topProvider = nestedRecord(item.top_provider);
+  const meta = nestedRecord(item.meta);
   const contextWindow = firstPositiveInteger(
-      item.contextWindow,
-      item.context_window,
-      item.contextLength,
-      item.context_length,
-      item.max_context_length,
-      item.input_context_length,
-      topProvider?.context_length,
-    );
+    item.contextWindow,
+    item.context_window,
+    item.contextLength,
+    item.context_length,
+    item.max_context_length,
+    item.input_context_length,
+    meta?.n_ctx,
+    meta?.context_length,
+    topProvider?.context_length,
+  );
   const maxTokens = firstPositiveInteger(
-      item.maxTokens,
-      item.max_tokens,
-      item.maxOutputTokens,
-      item.max_output_tokens,
-      item.max_completion_tokens,
-      item.output_token_limit,
-      topProvider?.max_completion_tokens,
-    );
+    item.maxTokens,
+    item.max_tokens,
+    item.maxOutputTokens,
+    item.max_output_tokens,
+    item.max_completion_tokens,
+    item.output_token_limit,
+    topProvider?.max_completion_tokens,
+  );
   const capabilities = modelCapabilities(item);
   return {
     ...(contextWindow !== undefined ? { contextWindow } : {}),

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@shared/components/ui/button';
-import { Checkbox } from '@shared/components/ui/checkbox';
 import { FluidTabs } from '@shared/components/ui/fluid-tabs';
 import { Input } from '@shared/components/ui/input';
 import { RadioGroup, RadioGroupItem } from '@shared/components/ui/radio-group';
@@ -11,7 +10,6 @@ import {
   SelectValue,
 } from '@shared/components/ui/select';
 import { Switch } from '@shared/components/ui/switch';
-import { Tabs, TabsContent } from '@shared/components/ui/tabs';
 import { Textarea } from '@shared/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@shared/components/ui/tooltip';
 import { cn } from '@shared/lib/utils';
@@ -43,7 +41,6 @@ import {
   ProviderName,
   ProviderRegistry,
 } from '../../shared/providers';
-import type { LlamaCppModelPreference } from '../../shared/llamacpp';
 import { type AppUpdateRuntimeState, AppUpdateStatus } from '../../shared/appUpdate/constants';
 import {
   type AppConfig,
@@ -55,8 +52,6 @@ import {
 import { SettingsToggleRow } from './common/SettingsToggleRow';
 import {
   MODEL_CAPABILITY_FIELDS,
-  ModelCapabilitiesFields,
-  type ModelCapabilityKey,
 } from './settings/ModelCapabilitiesFields';
 import { ProviderModelDiscoveryButton } from './settings/ProviderModelDiscoveryButton';
 import {
@@ -130,7 +125,14 @@ import IMSettings from './im/IMSettings';
 import { EmailSettingsPage } from './settings/email/EmailSettingsPage';
 import { ManagedMemorySettings } from './settings/memory/ManagedMemorySettings';
 import { GeneralLanguageField } from './settings/general/GeneralLanguageField';
-import { ModelCapabilitySettingsModal } from './localInference/components/ModelCapabilitySettingsModal';
+import {
+  ProviderModelEditorDialog,
+  type ProviderModelEditorDraft,
+} from './settings/ProviderModelEditorDialog';
+import {
+  resolveDiscoveredModelContext,
+  resolveOllamaRunningModelContext,
+} from './settings/ollamaRuntimeMetadata';
 import { localInferenceCompactButtonClass } from './localInference/constants';
 import type { EmailSettingsHandle } from './settings/email/types';
 import type { EnterpriseRendererSettingsPage } from '../../shared/enterpriseRenderer';
@@ -227,15 +229,6 @@ const DEFAULT_CUSTOM_MODEL_CAPABILITIES: Partial<ModelCapabilities> = {
   documentInput: ModelCapabilityStatus.Unknown,
   reasoning: ModelCapabilityStatus.Unknown,
 };
-
-const CUSTOM_MODEL_CAPABILITY_KEYS: readonly ModelCapabilityKey[] = [
-  'toolCalling',
-  'imageInput',
-  'videoInput',
-  'audioInput',
-  'documentInput',
-  'reasoning',
-];
 
 const TOKENS_PER_K = 1024;
 const LOCAL_MODEL_REFRESH_MIN_LOADING_DURATION_MS = 1_000;
@@ -853,11 +846,6 @@ const Settings: React.FC<SettingsProps> = ({
     ProviderModelPiRuntimeConfig | undefined
   >(undefined);
   const [modelFormError, setModelFormError] = useState<string | null>(null);
-  const [modelDialogTab, setModelDialogTab] = useState<'basic' | 'capabilities'>('basic');
-  const [llamaCapabilityModel, setLlamaCapabilityModel] = useState<Model | null>(null);
-  const [llamaCapabilityPreference, setLlamaCapabilityPreference] =
-    useState<LlamaCppModelPreference>();
-  const [ollamaCapabilityModel, setOllamaCapabilityModel] = useState<Model | null>(null);
 
   // About tab
   const [appVersion, setAppVersion] = useState('');
@@ -2236,23 +2224,7 @@ const Settings: React.FC<SettingsProps> = ({
     setPendingDeleteModel(null);
   };
 
-  const handleSaveLlamaCapability = async (
-    model: Model,
-    toolCalling: ModelCapabilityStatus,
-  ): Promise<void> => {
-    const preferences = await window.electron.llamacpp.getModelPreferences();
-    await window.electron.llamacpp.setModelPreference({
-      modelName: model.id,
-      preference: {
-        ...preferences[model.id],
-        capabilities: { toolCalling },
-      },
-    });
-    window.dispatchEvent(new CustomEvent(LLAMACPP_RUNNING_MODELS_CHANGED_EVENT));
-    setLlamaCapabilityModel(null);
-  };
-
-  const handleSaveNewModel = () => {
+  const handleSaveNewModel = async (): Promise<void> => {
     const modelId = newModelId.trim();
 
     if (activeProvider === 'ollama') {
@@ -2287,6 +2259,20 @@ const Settings: React.FC<SettingsProps> = ({
       return;
     }
 
+    if (activeProvider === ProviderName.LlamaCpp) {
+      await window.electron.llamacpp.setModelPreference({
+        modelName: modelId,
+        preference: {
+          ...(contextWindow ? { ctxSize: contextWindow } : {}),
+          ...(maxTokens ? { maxTokens } : {}),
+          capabilities: newModelCapabilities,
+        },
+      });
+      window.dispatchEvent(new CustomEvent(LLAMACPP_RUNNING_MODELS_CHANGED_EVENT));
+      handleCancelModelEdit();
+      return;
+    }
+
     const currentModels = providers[activeProvider].models ?? [];
     const duplicateModel = currentModels.find(
       model => model.id === modelId && (!isEditingModel || model.id !== editingModelId),
@@ -2306,7 +2292,9 @@ const Settings: React.FC<SettingsProps> = ({
       ),
       ...(contextWindow ? { contextWindow } : {}),
       ...(maxTokens ? { maxTokens } : {}),
-      ...(isCustomProvider(activeProvider) ? { capabilities: newModelCapabilities } : {}),
+      ...(isCustomProvider(activeProvider) || activeProvider === ProviderName.Ollama
+        ? { capabilities: newModelCapabilities }
+        : {}),
       ...(isCustomProvider(activeProvider) && newModelPiRuntime
         ? { piRuntime: newModelPiRuntime }
         : {}),
@@ -2347,18 +2335,6 @@ const Settings: React.FC<SettingsProps> = ({
     setNewModelCapabilities(DEFAULT_CUSTOM_MODEL_CAPABILITIES);
     setNewModelPiRuntime(undefined);
     setModelFormError(null);
-  };
-
-  const handleModelDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      handleCancelModelEdit();
-      return;
-    }
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      handleSaveNewModel();
-    }
   };
 
   const showConnectionTestNotification = (
@@ -3537,7 +3513,7 @@ const Settings: React.FC<SettingsProps> = ({
                       <div className="flex items-center justify-between mb-1">
                         <label
                           htmlFor="minimax-apiKey"
-                          className="block text-xs font-medium text-foreground"
+                          className="block text-sm font-medium text-foreground"
                         >
                           {i18nService.t('apiKey')}
                           <span className="text-destructive ml-0.5">*</span>
@@ -3566,7 +3542,7 @@ const Settings: React.FC<SettingsProps> = ({
                           onChange={e =>
                             handleProviderConfigChange('minimax', 'apiKey', e.target.value)
                           }
-                          className="pr-20 text-xs"
+                          className="pr-20 text-sm"
                           placeholder={i18nService.t('apiKeyPlaceholder')}
                         />
                         <div className="absolute right-2 inset-y-0 flex items-center gap-1">
@@ -3651,7 +3627,7 @@ const Settings: React.FC<SettingsProps> = ({
                       {minimaxOAuthPhase.kind === 'idle' && !providers.minimax.oauthAccessToken && (
                         <div className="space-y-2">
                           <div>
-                            <label className="block text-xs font-medium text-foreground mb-1">
+                            <label className="block text-sm font-medium text-foreground mb-1">
                               {i18nService.t('minimaxOAuthRegionLabel')}
                             </label>
                             <FluidTabs<MiniMaxRegion>
@@ -3667,7 +3643,7 @@ const Settings: React.FC<SettingsProps> = ({
                           <Button
                             type="button"
                             onClick={() => handleMiniMaxDeviceLogin(minimaxOAuthRegion)}
-                            className="w-full py-2 text-xs h-auto"
+                            className="w-full py-2 text-sm h-auto"
                           >
                             {i18nService.t('minimaxOAuthLogin')}
                           </Button>
@@ -4803,18 +4779,11 @@ const Settings: React.FC<SettingsProps> = ({
                                 </div>
                               ) : null}
                               {isCustomProvider(activeProvider) &&
-                                (model.contextWindow ||
-                                  model.maxTokens ||
+                                (model.maxTokens ||
                                   Object.values(model.capabilities ?? {}).some(
                                     status => status === ModelCapabilityStatus.Supported,
                                   )) && (
                                   <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                    {model.contextWindow && (
-                                      <span>
-                                        {i18nService.t('modelContextWindowShort')}:{' '}
-                                        {formatDetectedTokenLimit(model.contextWindow)}
-                                      </span>
-                                    )}
                                     {model.maxTokens && (
                                       <span>
                                         {i18nService.t('modelMaxOutputTokensShort')}:{' '}
@@ -4851,26 +4820,62 @@ const Settings: React.FC<SettingsProps> = ({
                                   variant="ghost"
                                   size="icon-xs"
                                   onClick={() => {
-                                    if (activeProvider === ProviderName.Ollama) {
-                                      setOllamaCapabilityModel(model);
+                                    const openEditor = (runtimeContextWindow?: number) =>
+                                      handleEditModel(
+                                        model.id,
+                                        model.name,
+                                        model.supportsImage,
+                                        model.capabilities,
+                                        model.piRuntime,
+                                        runtimeContextWindow ?? model.contextWindow,
+                                        model.maxTokens,
+                                      );
+                                    if (activeProvider !== ProviderName.Ollama) {
+                                      openEditor();
                                       return;
                                     }
-                                    handleEditModel(
-                                      model.id,
-                                      model.name,
-                                      model.supportsImage,
-                                      model.capabilities,
-                                      model.piRuntime,
-                                      model.contextWindow,
-                                      model.maxTokens,
+                                    const providerConfig = providers[activeProvider];
+                                    const apiFormat = getEffectiveApiFormat(
+                                      activeProvider,
+                                      providerConfig.apiFormat,
                                     );
+                                    const openWithLocalRuntimeFallback = () => {
+                                      void window.electron.ollama
+                                        .listRunningModels()
+                                        .then(runningModels =>
+                                          openEditor(
+                                            resolveOllamaRunningModelContext(
+                                              model.id,
+                                              runningModels,
+                                            ),
+                                          ),
+                                        )
+                                        .catch(() => openEditor());
+                                    };
+                                    void window.electron.api
+                                      .fetchModels({
+                                        baseUrl: resolveBaseUrl(
+                                          activeProvider,
+                                          providerConfig.baseUrl,
+                                          apiFormat,
+                                        ),
+                                        apiKey: providerConfig.apiKey,
+                                        apiFormat,
+                                      })
+                                      .then(result => {
+                                        const contextWindow = result.success
+                                          ? resolveDiscoveredModelContext(model.id, result.models)
+                                          : undefined;
+                                        if (contextWindow !== undefined) {
+                                          openEditor(contextWindow);
+                                          return;
+                                        }
+                                        openWithLocalRuntimeFallback();
+                                      })
+                                      .catch(openWithLocalRuntimeFallback);
                                   }}
-                                  aria-label={`${i18nService.t(activeProvider === ProviderName.Ollama ? 'modelCapabilities' : 'editModel')} ${model.name}`}
-                                  title={i18nService.t(
-                                    activeProvider === ProviderName.Ollama
-                                      ? 'modelCapabilities'
-                                      : 'editModel',
-                                  )}
+                                  aria-label={`${i18nService.t('editModel')} ${model.name}`}
+                                  title={i18nService.t('editModel')}
                                   className="size-5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground [&_svg]:size-3.5"
                                 >
                                   <Pencil />
@@ -4894,15 +4899,21 @@ const Settings: React.FC<SettingsProps> = ({
                                 variant="ghost"
                                 size="icon-xs"
                                 onClick={() => {
-                                  void window.electron.llamacpp
-                                    .getModelPreferences()
-                                    .then(preferences => {
-                                      setLlamaCapabilityPreference(preferences[model.id]);
-                                      setLlamaCapabilityModel(model);
-                                    });
+                                  void window.electron.llamacpp.getModelPreferences().then(preferences => {
+                                    const preference = preferences[model.id];
+                                    handleEditModel(
+                                      model.id,
+                                      model.name,
+                                      model.supportsImage,
+                                      { ...model.capabilities, ...preference?.capabilities },
+                                      undefined,
+                                      preference?.ctxSize ?? model.contextWindow,
+                                      preference?.maxTokens ?? model.maxTokens,
+                                    );
+                                  });
                                 }}
-                                aria-label={`${i18nService.t('modelCapabilities')} ${model.name}`}
-                                title={i18nService.t('modelCapabilities')}
+                                aria-label={`${i18nService.t('editModel')} ${model.name}`}
+                                title={i18nService.t('editModel')}
                                 className="size-5 text-muted-foreground hover:text-foreground [&_svg]:size-3.5"
                               >
                                 <Pencil />
@@ -5534,222 +5545,32 @@ const Settings: React.FC<SettingsProps> = ({
           onConfirm={confirmDeleteModel}
         />
 
-        {(isAddingModel || isEditingModel) && (
-          <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/35 px-4 rounded-2xl">
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-label={
-                isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')
-              }
-              onClick={e => e.stopPropagation()}
-              onKeyDown={handleModelDialogKeyDown}
-              className="w-full max-w-md rounded-2xl bg-background border-border border shadow-modal p-4"
-            >
-              <div className="flex items-center justify-between mb-3">
-                <h4 className="text-sm font-semibold text-foreground">
-                  {isEditingModel ? i18nService.t('editModel') : i18nService.t('addNewModel')}
-                </h4>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleCancelModelEdit}
-                  className="p-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-surface-raised"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-
-              {modelFormError && <p className="mb-3 text-xs text-destructive">{modelFormError}</p>}
-
-              <Tabs
-                value={modelDialogTab}
-                onValueChange={value => setModelDialogTab(value as 'basic' | 'capabilities')}
-                className="gap-4"
-                >
-                  {isCustomProvider(activeProvider) && (
-                  <FluidTabs
-                    aria-label={i18nService.t(isEditingModel ? 'editModel' : 'addNewModel')}
-                    items={[
-                      { value: 'basic', label: i18nService.t('modelName') },
-                      { value: 'capabilities', label: i18nService.t('modelCapabilities') },
-                    ]}
-                    value={modelDialogTab}
-                    onValueChange={setModelDialogTab}
-                  />
-                )}
-                <TabsContent value="basic" className="mt-0">
-                  <div className="space-y-3">
-                    {activeProvider === 'ollama' ? (
-                      <>
-                        <div>
-                          <label className="block text-xs font-medium text-muted-foreground mb-1">
-                            {i18nService.t('ollamaModelName')}
-                            <span className="text-destructive ml-0.5">*</span>
-                          </label>
-                          <Input
-                            autoFocus
-                            type="text"
-                            value={newModelId}
-                            onChange={e => {
-                              setNewModelId(e.target.value);
-                              if (!newModelName || newModelName === newModelId) {
-                                setNewModelName(e.target.value);
-                              }
-                              if (modelFormError) {
-                                setModelFormError(null);
-                              }
-                            }}
-                            className="text-xs"
-                            placeholder={i18nService.t('ollamaModelNamePlaceholder')}
-                          />
-                          <p className="mt-1 text-[11px] text-muted">
-                            {i18nService.t('ollamaModelNameHint')}
-                          </p>
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-muted-foreground mb-1">
-                            {i18nService.t('ollamaDisplayName')}
-                          </label>
-                          <Input
-                            type="text"
-                            value={newModelName === newModelId ? '' : newModelName}
-                            onChange={e => {
-                              setNewModelName(e.target.value || newModelId);
-                              if (modelFormError) {
-                                setModelFormError(null);
-                              }
-                            }}
-                            className="text-xs"
-                            placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
-                          />
-                          <p className="mt-1 text-[11px] text-muted">
-                            {i18nService.t('ollamaDisplayNameHint')}
-                          </p>
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <div>
-                          <label className="block text-xs font-medium text-muted-foreground mb-1">
-                            {i18nService.t('modelName')}
-                            <span className="text-destructive ml-0.5">*</span>
-                          </label>
-                          <Input
-                            autoFocus
-                            type="text"
-                            value={newModelName}
-                            onChange={e => {
-                              setNewModelName(e.target.value);
-                              if (modelFormError) {
-                                setModelFormError(null);
-                              }
-                            }}
-                            className="text-xs"
-                            placeholder="GPT-4"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-muted-foreground mb-1">
-                            {i18nService.t('modelId')}
-                            <span className="text-destructive ml-0.5">*</span>
-                          </label>
-                          <Input
-                            type="text"
-                            value={newModelId}
-                            onChange={e => {
-                              setNewModelId(e.target.value);
-                              if (modelFormError) {
-                                setModelFormError(null);
-                              }
-                            }}
-                            className="text-xs"
-                            placeholder="gpt-4"
-                          />
-                        </div>
-                      </>
-                    )}
-                    {!isCustomProvider(activeProvider) && (
-                      <div className="flex items-center space-x-2">
-                        <Checkbox
-                          id={`${activeProvider}-supportsImage`}
-                          checked={
-                            newModelCapabilities.imageInput === ModelCapabilityStatus.Supported
-                          }
-                          onCheckedChange={checked =>
-                            setNewModelCapabilities(current => ({
-                              ...current,
-                              imageInput:
-                                checked === true
-                                  ? ModelCapabilityStatus.Supported
-                                  : ModelCapabilityStatus.Unsupported,
-                            }))
-                          }
-                        />
-                        <label
-                          htmlFor={`${activeProvider}-supportsImage`}
-                          className="text-xs text-muted-foreground"
-                        >
-                          {i18nService.t('supportsImageInput')}
-                        </label>
-                      </div>
-                    )}
-                  </div>
-                </TabsContent>
-                {isCustomProvider(activeProvider) && (
-                  <>
-                    <TabsContent value="capabilities" className="mt-0">
-                      <ModelCapabilitiesFields
-                        capabilities={newModelCapabilities}
-                        contextWindow={newModelContextWindow}
-                        maxTokens={newModelMaxTokens}
-                        visibleCapabilities={CUSTOM_MODEL_CAPABILITY_KEYS}
-                        onContextWindowChange={setNewModelContextWindow}
-                        onMaxTokensChange={setNewModelMaxTokens}
-                        onCapabilityChange={(key, value) =>
-                          setNewModelCapabilities(current => ({ ...current, [key]: value }))
-                        }
-                      />
-                    </TabsContent>
-                  </>
-                )}
-              </Tabs>
-
-              <div className="flex justify-end space-x-2 mt-4">
-                <Button type="button" variant="outline" size="sm" onClick={handleCancelModelEdit}>
-                  {i18nService.t('cancel')}
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={handleSaveNewModel}>
-                  {i18nService.t('save')}
-                </Button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <ModelCapabilitySettingsModal
-          isOpen={Boolean(llamaCapabilityModel)}
-          model={llamaCapabilityModel}
-          provider={ProviderName.LlamaCpp}
-          preference={llamaCapabilityPreference}
-          onClose={() => {
-            setLlamaCapabilityModel(null);
-            setLlamaCapabilityPreference(undefined);
+        <ProviderModelEditorDialog
+          isOpen={isAddingModel || isEditingModel}
+          isEditing={isEditingModel}
+          providerName={activeProvider}
+          draft={{
+            id: newModelId,
+            name: newModelName,
+            contextWindow: newModelContextWindow,
+            maxTokens: newModelMaxTokens,
+            capabilities: newModelCapabilities,
+            piRuntime: newModelPiRuntime,
+          } satisfies ProviderModelEditorDraft}
+          error={modelFormError}
+          onDraftChange={patch => {
+            if (patch.id !== undefined) setNewModelId(patch.id);
+            if (patch.name !== undefined) setNewModelName(patch.name);
+            if (patch.contextWindow !== undefined) setNewModelContextWindow(patch.contextWindow);
+            if (patch.maxTokens !== undefined) setNewModelMaxTokens(patch.maxTokens);
+            if (patch.capabilities !== undefined) setNewModelCapabilities(patch.capabilities);
+            if ('piRuntime' in patch) setNewModelPiRuntime(patch.piRuntime);
+            if (modelFormError) setModelFormError(null);
           }}
-          onSave={toolCalling => {
-            if (llamaCapabilityModel) {
-              void handleSaveLlamaCapability(llamaCapabilityModel, toolCalling);
-            }
-          }}
+          onClose={handleCancelModelEdit}
+          onSave={handleSaveNewModel}
         />
 
-        <ModelCapabilitySettingsModal
-          isOpen={Boolean(ollamaCapabilityModel)}
-          model={ollamaCapabilityModel}
-          provider={ProviderName.Ollama}
-          onClose={() => setOllamaCapabilityModel(null)}
-        />
       </div>
     </Modal>
   );

--- a/src/renderer/components/settings/ModelCapabilitiesFields.tsx
+++ b/src/renderer/components/settings/ModelCapabilitiesFields.tsx
@@ -60,10 +60,6 @@ export function ModelCapabilitiesFields({
 
   return (
     <div className="rounded-lg border border-border bg-surface-raised p-3">
-      <p className="mb-2 text-xs font-medium text-foreground">{i18nService.t('modelCapabilities')}</p>
-      <p className="mb-3 text-[11px] leading-4 text-muted-foreground">
-        {i18nService.t('modelCapabilitiesHint')}
-      </p>
       <div className="mb-3 grid grid-cols-2 gap-3">
         <label className="flex flex-col gap-1 text-sm text-foreground">
           <span>{i18nService.t('modelContextWindowK')}</span>
@@ -107,7 +103,7 @@ export function ModelCapabilitiesFields({
                 <SelectTrigger className="w-full">
                   <SelectValue>{statusLabel(status)}</SelectValue>
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent alignItemWithTrigger={false} sideOffset={4}>
                   <SelectItem value={ModelCapabilityStatus.Supported}>
                     {i18nService.t('capabilitySupported')}
                   </SelectItem>

--- a/src/renderer/components/settings/ProviderModelEditorDialog.tsx
+++ b/src/renderer/components/settings/ProviderModelEditorDialog.tsx
@@ -1,0 +1,201 @@
+import { Button } from '@shared/components/ui/button';
+import { FluidTabs } from '@shared/components/ui/fluid-tabs';
+import { Input } from '@shared/components/ui/input';
+import { Tabs, TabsContent } from '@shared/components/ui/tabs';
+import { X } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  type ModelCapabilities,
+  type ProviderModelPiRuntimeConfig,
+  ProviderName,
+} from '../../../shared/providers';
+import { i18nService } from '../../services/i18n';
+import { ModelCapabilitiesFields } from './ModelCapabilitiesFields';
+
+const ModelEditorTab = {
+  Basic: 'basic',
+  Capabilities: 'capabilities',
+} as const;
+
+type ModelEditorTab = (typeof ModelEditorTab)[keyof typeof ModelEditorTab];
+
+export type ProviderModelEditorDraft = {
+  id: string;
+  name: string;
+  contextWindow: string;
+  maxTokens: string;
+  capabilities: Partial<ModelCapabilities>;
+  piRuntime?: ProviderModelPiRuntimeConfig;
+};
+
+type ProviderModelEditorDialogProps = {
+  isOpen: boolean;
+  isEditing: boolean;
+  providerName: string;
+  draft: ProviderModelEditorDraft;
+  error: string | null;
+  onDraftChange: (patch: Partial<ProviderModelEditorDraft>) => void;
+  onClose: () => void;
+  onSave: () => void | Promise<void>;
+};
+
+export function ProviderModelEditorDialog({
+  isOpen,
+  isEditing,
+  providerName,
+  draft,
+  error,
+  onDraftChange,
+  onClose,
+  onSave,
+}: ProviderModelEditorDialogProps) {
+  const [tab, setTab] = useState<ModelEditorTab>(ModelEditorTab.Basic);
+  const isOllama = providerName === ProviderName.Ollama;
+  const isLocalModel = providerName === ProviderName.LlamaCpp;
+
+  if (!isOpen) return null;
+
+  const updateModelId = (id: string) => {
+    onDraftChange({
+      id,
+      ...(isOllama && (!draft.name || draft.name === draft.id) ? { name: id } : {}),
+    });
+  };
+
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center rounded-2xl bg-black/35 px-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={i18nService.t(isEditing ? 'editModel' : 'addNewModel')}
+        onClick={event => event.stopPropagation()}
+        onKeyDown={event => {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            onClose();
+          }
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            void onSave();
+          }
+        }}
+        className="w-full max-w-md rounded-xl border border-border bg-background p-4 shadow-xl"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-foreground">
+            {i18nService.t(isEditing ? 'editModel' : 'addNewModel')}
+          </h4>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label={i18nService.t('cancel')}
+          >
+            <X />
+          </Button>
+        </div>
+
+        {error && <p className="mb-3 text-xs text-destructive">{error}</p>}
+
+        <Tabs value={tab} onValueChange={value => setTab(value as ModelEditorTab)} className="gap-4">
+          <FluidTabs
+            aria-label={i18nService.t(isEditing ? 'editModel' : 'addNewModel')}
+            items={[
+              { value: ModelEditorTab.Basic, label: i18nService.t('modelName') },
+              { value: ModelEditorTab.Capabilities, label: i18nService.t('modelCapabilities') },
+            ]}
+            value={tab}
+            onValueChange={value => setTab(value as ModelEditorTab)}
+          />
+          <TabsContent value={ModelEditorTab.Basic} className="mt-0">
+            <div className="flex flex-col gap-3">
+              {isOllama ? (
+                <>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+                    <span>
+                      {i18nService.t('ollamaModelName')}
+                      <span className="ml-0.5 text-destructive">*</span>
+                    </span>
+                    <Input
+                      autoFocus
+                      type="text"
+                      value={draft.id}
+                      disabled={isLocalModel}
+                      onChange={event => updateModelId(event.target.value)}
+                      placeholder={i18nService.t('ollamaModelNamePlaceholder')}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+                    <span>{i18nService.t('ollamaDisplayName')}</span>
+                    <Input
+                      type="text"
+                      value={draft.name === draft.id ? '' : draft.name}
+                      disabled={isLocalModel}
+                      onChange={event => onDraftChange({ name: event.target.value || draft.id })}
+                      placeholder={i18nService.t('ollamaDisplayNamePlaceholder')}
+                    />
+                  </label>
+                </>
+              ) : (
+                <>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+                    <span>
+                      {i18nService.t('modelName')}
+                      <span className="ml-0.5 text-destructive">*</span>
+                    </span>
+                    <Input
+                      autoFocus
+                      type="text"
+                      value={draft.name}
+                      disabled={isLocalModel}
+                      onChange={event => onDraftChange({ name: event.target.value })}
+                      placeholder="GPT-4"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+                    <span>
+                      {i18nService.t('modelId')}
+                      <span className="ml-0.5 text-destructive">*</span>
+                    </span>
+                    <Input
+                      type="text"
+                      value={draft.id}
+                      disabled={isLocalModel}
+                      onChange={event => updateModelId(event.target.value)}
+                      placeholder="gpt-4"
+                    />
+                  </label>
+                </>
+              )}
+            </div>
+          </TabsContent>
+          <TabsContent value={ModelEditorTab.Capabilities} className="mt-0">
+            <div className="flex flex-col gap-3">
+              <ModelCapabilitiesFields
+                capabilities={draft.capabilities}
+                contextWindow={draft.contextWindow}
+                maxTokens={draft.maxTokens}
+                onContextWindowChange={contextWindow => onDraftChange({ contextWindow })}
+                onMaxTokensChange={maxTokens => onDraftChange({ maxTokens })}
+                onCapabilityChange={(key, value) =>
+                  onDraftChange({ capabilities: { ...draft.capabilities, [key]: value } })
+                }
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        <div className="mt-4 flex justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onClose}>
+            {i18nService.t('cancel')}
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={() => void onSave()}>
+            {i18nService.t('save')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/settings/ollamaRuntimeMetadata.test.ts
+++ b/src/renderer/components/settings/ollamaRuntimeMetadata.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+
+import {
+  resolveDiscoveredModelContext,
+  resolveOllamaRunningModelContext,
+} from './ollamaRuntimeMetadata';
+
+test('uses the context length of the matching running Ollama model', () => {
+  expect(
+    resolveOllamaRunningModelContext('Qwen3:32B', [
+      { name: 'qwen3:8b', context_length: 131_072 },
+      { model: 'qwen3:32b', context_length: 262_144 },
+    ]),
+  ).toBe(262_144);
+});
+
+test('ignores invalid or non-matching runtime context lengths', () => {
+  expect(
+    resolveOllamaRunningModelContext('qwen3:32b', [
+      { name: 'qwen3:32b', context_length: 0 },
+      { name: 'qwen3:8b', context_length: 262_144 },
+    ]),
+  ).toBeUndefined();
+});
+
+test('uses the configured provider discovery context for a matching model', () => {
+  expect(
+    resolveDiscoveredModelContext('qwen3:32b', [
+      { id: 'qwen3:32b', contextWindow: 262_144 },
+    ]),
+  ).toBe(262_144);
+});

--- a/src/renderer/components/settings/ollamaRuntimeMetadata.ts
+++ b/src/renderer/components/settings/ollamaRuntimeMetadata.ts
@@ -1,0 +1,41 @@
+import type { DiscoveredProviderModel } from '../../../shared/providers';
+
+type OllamaRuntimeModel = {
+  name?: string;
+  model?: string;
+  id?: string;
+  context_length?: number;
+};
+
+export function resolveOllamaRunningModelContext(
+  modelId: string,
+  runningModels: readonly OllamaRuntimeModel[],
+): number | undefined {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  if (!normalizedModelId) return undefined;
+
+  const runningModel = runningModels.find(model =>
+    [model.name, model.model, model.id].some(
+      candidate => candidate?.trim().toLowerCase() === normalizedModelId,
+    ),
+  );
+  const contextLength = runningModel?.context_length;
+  return typeof contextLength === 'number' && Number.isFinite(contextLength) && contextLength > 0
+    ? contextLength
+    : undefined;
+}
+
+export function resolveDiscoveredModelContext(
+  modelId: string,
+  discoveredModels: readonly DiscoveredProviderModel[],
+): number | undefined {
+  const normalizedModelId = modelId.trim().toLowerCase();
+  if (!normalizedModelId) return undefined;
+
+  const contextWindow = discoveredModels.find(
+    model => model.id.trim().toLowerCase() === normalizedModelId,
+  )?.contextWindow;
+  return typeof contextWindow === 'number' && Number.isFinite(contextWindow) && contextWindow > 0
+    ? contextWindow
+    : undefined;
+}

--- a/src/renderer/services/availableModels.test.ts
+++ b/src/renderer/services/availableModels.test.ts
@@ -4,7 +4,11 @@ import { ModelCapabilityStatus, ProviderName } from '../../shared/providers';
 import { ManagedProviderAccessMode } from '../../shared/managedProviders';
 import type { AppConfig } from '../config';
 import { defaultConfig } from '../config';
-import { buildConfiguredAvailableModels, collectAvailableModels } from './availableModels';
+import {
+  buildConfiguredAvailableModels,
+  buildLlamaCppRunningModels,
+  collectAvailableModels,
+} from './availableModels';
 
 function createConfig(): AppConfig {
   return {
@@ -146,6 +150,36 @@ test('collectAvailableModels merges running llama.cpp model metadata', async () 
     trainedContextWindow: 32768,
   });
   expect(llamaCppModel?.supportsThinkingToggle).toBe(true);
+});
+
+test('uses saved llama.cpp preferences for the model capability metadata', () => {
+  const models = buildLlamaCppRunningModels(
+    [{ name: 'qwen-local', runtime_context_length: 8192 }],
+    {
+      'qwen-local': {
+        ctxSize: 65_536,
+        maxTokens: 8192,
+        capabilities: {
+          toolCalling: ModelCapabilityStatus.Supported,
+          imageInput: ModelCapabilityStatus.Unsupported,
+          reasoning: ModelCapabilityStatus.Supported,
+        },
+      },
+    },
+  );
+
+  expect(models).toEqual([
+    expect.objectContaining({
+      id: 'qwen-local',
+      maxTokens: 8192,
+      llamaCppRuntimeContextWindow: 65_536,
+      capabilities: {
+        toolCalling: ModelCapabilityStatus.Supported,
+        imageInput: ModelCapabilityStatus.Unsupported,
+        reasoning: ModelCapabilityStatus.Supported,
+      },
+    }),
+  ]);
 });
 
 test('preserves contextTokens for custom cloud models', () => {

--- a/src/renderer/services/availableModels.ts
+++ b/src/renderer/services/availableModels.ts
@@ -109,9 +109,10 @@ export function buildLlamaCppRunningModels(
       agentProviderId: ProviderRegistry.getAgentProviderId(ProviderName.LlamaCpp),
       supportsImage: false,
       capabilities: preferences[name]?.capabilities,
+      ...(preferences[name]?.maxTokens ? { maxTokens: preferences[name]?.maxTokens } : {}),
       supportsThinkingToggle: model.supportsThinkingToggle,
       llamaCppAgentEligibility: eligibility,
-      llamaCppRuntimeContextWindow: eligibility.runtimeContextWindow,
+      llamaCppRuntimeContextWindow: preferences[name]?.ctxSize ?? eligibility.runtimeContextWindow,
       llamaCppTrainedContextWindow: eligibility.trainedContextWindow,
     });
   });

--- a/src/renderer/services/providerModelDiscovery.test.ts
+++ b/src/renderer/services/providerModelDiscovery.test.ts
@@ -47,7 +47,7 @@ describe('mergeDiscoveredProviderModels', () => {
     ).toEqual([...latestDraft, { id: 'model-b', name: 'Remote B' }]);
   });
 
-  test('fills missing metadata without overwriting explicit user values', () => {
+  test('updates an existing context length from explicit discovery metadata', () => {
     const existing = [
       {
         id: 'model-a',
@@ -74,7 +74,7 @@ describe('mergeDiscoveredProviderModels', () => {
       {
         id: 'model-a',
         name: 'Model A',
-        contextWindow: 8192,
+        contextWindow: 32768,
         maxTokens: 4096,
         supportsImage: true,
         capabilities: {

--- a/src/renderer/services/providerModelDiscovery.ts
+++ b/src/renderer/services/providerModelDiscovery.ts
@@ -32,7 +32,10 @@ function applyDiscoveredMetadata(
   let changed = false;
   const next: ProviderModel = { ...current };
 
-  if (next.contextWindow === undefined && discovered.contextWindow !== undefined) {
+  if (
+    discovered.contextWindow !== undefined &&
+    next.contextWindow !== discovered.contextWindow
+  ) {
     next.contextWindow = discovered.contextWindow;
     changed = true;
   }

--- a/src/shared/ipc/schemas.test.ts
+++ b/src/shared/ipc/schemas.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
 import { CoworkPermissionMode } from '../cowork/constants';
-import { CoworkSessionContinueSchema, CoworkSessionStartSchema } from './schemas';
+import { ModelCapabilityStatus } from '../providers';
+import {
+  CoworkSessionContinueSchema,
+  CoworkSessionStartSchema,
+  ProviderModelDiscoverySchema,
+} from './schemas';
 
 describe('CoworkSessionStartSchema permissionMode', () => {
   const baseInput = { prompt: 'hello' };
@@ -62,5 +67,39 @@ describe.each([
 
   test('rejects multiple experts', () => {
     expect(() => schema.parse({ ...baseInput, expertIds: ['expert-a', 'expert-b'] })).toThrow();
+  });
+});
+
+test('preserves discovered model metadata in the IPC response', () => {
+  expect(
+    ProviderModelDiscoverySchema.output.parse({
+      success: true,
+      models: [
+        {
+          id: 'Qwen3.6-35B-A3B-APEX-I-Compact',
+          contextWindow: 262_144,
+          maxTokens: 16_384,
+          capabilities: {
+            toolCalling: ModelCapabilityStatus.Supported,
+            imageInput: ModelCapabilityStatus.Unsupported,
+            reasoning: ModelCapabilityStatus.Supported,
+          },
+        },
+      ],
+    }),
+  ).toEqual({
+    success: true,
+    models: [
+      {
+        id: 'Qwen3.6-35B-A3B-APEX-I-Compact',
+        contextWindow: 262_144,
+        maxTokens: 16_384,
+        capabilities: {
+          toolCalling: ModelCapabilityStatus.Supported,
+          imageInput: ModelCapabilityStatus.Unsupported,
+          reasoning: ModelCapabilityStatus.Supported,
+        },
+      },
+    ],
   });
 });

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -17,7 +17,7 @@ import {
   CoworkToolActivityEventType,
   CoworkToolActivityPhase,
 } from '../cowork/toolActivity';
-import { ApiFormat, ProviderModelDiscoveryErrorCode } from '../providers';
+import { ApiFormat, ModelCapabilityStatus, ProviderModelDiscoveryErrorCode } from '../providers';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -139,6 +139,54 @@ export const ProviderModelDiscoverySchema = {
           id: z.string().min(1),
           displayName: z.string().optional(),
           ownedBy: z.string().optional(),
+          contextWindow: z.number().int().positive().optional(),
+          maxTokens: z.number().int().positive().optional(),
+          capabilities: z
+            .object({
+              toolCalling: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+              imageInput: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+              videoInput: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+              audioInput: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+              documentInput: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+              reasoning: z
+                .enum([
+                  ModelCapabilityStatus.Supported,
+                  ModelCapabilityStatus.Unsupported,
+                  ModelCapabilityStatus.Unknown,
+                ])
+                .optional(),
+            })
+            .optional(),
         }),
       ),
     }),

--- a/src/shared/llamacpp/types.ts
+++ b/src/shared/llamacpp/types.ts
@@ -344,7 +344,8 @@ export type LlamaCppCancelInstallResult = {
 
 export type LlamaCppModelPreference = {
   ctxSize?: number;
-  capabilities?: Pick<ModelCapabilities, 'toolCalling'>;
+  maxTokens?: number;
+  capabilities?: Partial<ModelCapabilities>;
 };
 
 export type LlamaCppModelPreferences = Record<string, LlamaCppModelPreference>;


### PR DESCRIPTION
## 概要

  优化模型上下文长度检测与本地模型配置流程，确保 API 返回的模型元数据能够正确传递并显示。

  ## 关联 Issue

  暂无关联 Issue。

  ## 变更内容

  - 支持从模型接口返回的 meta.n_ctx、meta.context_length 等字段读取上下文长度。
  - 修复模型发现结果通过 IPC 时，上下文窗口、最大输出 token 和模型能力字段被裁剪的问题。
  - Ollama 模型编辑时优先读取远程模型接口的上下文信息，失败时回退到本地运行时信息。
  - 本地模型配置支持保存上下文窗口、最大输出 token 和模型能力。
  - 统一用户自定义、Ollama 和本地模型的模型编辑界面。
  - 优化模型能力字段的合并和覆盖逻辑，检测到新上下文长度时更新旧值。
  - 用户自定义模型卡片不再显示上下文窗口信息。
  - 调整模型能力下拉框位置，避免菜单遮挡当前选择内容。
  - 调整 MiniMax 页面主要控件字号，使其与其他模型页面保持一致。
  - 删除模型编辑界面中的运行时 API 和兼容参数配置区域。
  - 增加模型元数据、IPC schema、本地模型配置和上下文解析测试。

  ## 变更类型

  - [x] 缺陷修复
  - [x] 新功能
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## 测试

  - [x] 已执行相关自动化测试
  - [x] 已新增或更新测试
  - [x] 已进行界面人工验证
  - [ ] 未执行完整测试集

  已执行：

  - 模型发现、IPC schema、上下文解析及 Ollama 元数据测试：28 项通过。
  - npm run build:tsc：通过。
  - npm run lint：通过。
  - git diff --check：通过。

  ## 截图

  暂无。

  ## 检查清单

  - [x] 代码遵循现有项目风格
  - [x] 已完成自查
  - [x] 已补充关键逻辑测试
  - [x] 已进行界面验证
  - [ ] 未修改项目文档
  - [x] 类型检查通过
  - [x] lint 检查通过
  - [ ] 未执行完整单元测试集

  ## Electron 专项变更

  - [x] 修改主进程模型发现和本地模型绑定逻辑
  - [x] 修改预加载接口类型
  - [x] 修改 IPC 模型元数据返回 schema
  - [ ] 未修改窗口管理

  ## 补充说明

  本次内容对应提交 ba7b4eef 相对于上一提交 ed68e0eb 的修改，重点是模型上下文长度检测、元数据传递和本地模型编辑流程。 