### PR TITLE
feat(模型设置): 使用Agent润色模型设置的页面呈现

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -3281,9 +3281,9 @@ const Settings: React.FC<SettingsProps> = ({
 
       case 'model':
         return (
-          <div className="flex h-full">
-            {/* Provider List - Left Side */}
-            <div className="w-2/5 border-r border-border px-2 space-y-1.5 overflow-y-auto">
+            <div className="flex h-full flex-col md:flex-row">
+              {/* Provider List - Left Side */}
+            <div className="min-h-0 max-h-56 w-full shrink-0 space-y-1.5 overflow-y-auto border-b border-border px-2 md:max-h-none md:w-2/5 md:border-b-0 md:border-r">
               <div className="flex items-center justify-between mb-2 px-1">
                 <h3 className="text-sm font-medium text-foreground">
                   {i18nService.t('modelProviders')}
@@ -3406,7 +3406,7 @@ const Settings: React.FC<SettingsProps> = ({
             </div>
 
             {/* Provider Settings - Right Side */}
-            <div className="w-3/5 pl-4 pr-2 space-y-4 overflow-y-auto scrollbar-gutter-stable flex flex-col">
+            <div className="min-h-0 w-full min-w-0 flex-1 space-y-4 overflow-y-auto pl-4 pr-2 scrollbar-gutter-stable md:w-3/5 md:flex-none">
               {activeProvider !== ProviderName.LlamaCpp &&
                 (() => {
                   return (
@@ -3942,21 +3942,11 @@ const Settings: React.FC<SettingsProps> = ({
                         <div className="flex items-center justify-between mb-1">
                           <label
                             htmlFor={`${activeProvider}-apiKey`}
-                            className={cn(
-                              'block font-medium',
-                              isCustomProvider(activeProvider)
-                                ? 'text-sm text-foreground'
-                               : 'text-sm dark:text-claude-darkText text-claude-text',
-                            )}
+                            className="block text-sm font-medium text-foreground"
                           >
                             {i18nService.t('apiKey')}
                             {providerRequiresApiKey(activeProvider) && (
                               <span className="text-red-500 dark:text-red-400 ml-0.5">*</span>
-                            )}
-                            {isCustomProvider(activeProvider) && (
-                              <span className="ml-1.5 inline-flex items-center rounded-full bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                                {i18nService.t('customFieldOptional')}
-                              </span>
                             )}
                           </label>
                           {ProviderRegistry.get(activeProvider)?.apiKeyUrl && (
@@ -4257,9 +4247,6 @@ const Settings: React.FC<SettingsProps> = ({
                     className="mb-1 block text-sm font-medium text-foreground"
                   >
                     {i18nService.t('customDisplayName')}
-                    <span className="ml-1.5 inline-flex items-center rounded-full bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                      {i18nService.t('customFieldOptional')}
-                    </span>
                   </label>
                   <Input
                     type="text"
@@ -4287,9 +4274,7 @@ const Settings: React.FC<SettingsProps> = ({
                       {i18nService.t('baseUrl')}
                     </span>
                     {isCustomProvider(activeProvider) && (
-                      <span className="ml-1.5 inline-flex items-center rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-normal text-destructive">
-                        {i18nService.t('customFieldRequired')}
-                      </span>
+                      <span className="ml-0.5 text-destructive">*</span>
                     )}
                   </label>
                   <div className="relative">
@@ -4730,13 +4715,14 @@ const Settings: React.FC<SettingsProps> = ({
                       )}
                       </div>
 
-                    <div
-                      className="max-h-60 space-y-1.5 overflow-y-auto p-2"
-                    >
+                    <div className="max-h-60 divide-y divide-border overflow-y-auto">
                     {(providers[activeProvider].models ?? []).map(model => (
                       <div
                         key={model.id}
-                        className="group cursor-pointer rounded-xl border border-border bg-surface p-2 transition-[background-color,transform] duration-150 ease-out hover:border-primary active:translate-y-px"
+                        role="button"
+                        tabIndex={0}
+                        aria-label={`${i18nService.t('testConnection')} ${model.name}`}
+                        className="flex min-h-12 cursor-pointer items-center px-3 py-2 transition-colors duration-150 ease-out hover:bg-surface-raised focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 active:translate-y-px"
                         onClick={event => {
                           if (event.target instanceof Element && event.target.closest('button')) {
                             return;
@@ -4744,8 +4730,15 @@ const Settings: React.FC<SettingsProps> = ({
                           setSelectedModelId(model.id);
                           void handleTestConnection(model.id);
                         }}
+                        onKeyDown={event => {
+                          if (event.target !== event.currentTarget) return;
+                          if (event.key !== 'Enter' && event.key !== ' ') return;
+                          event.preventDefault();
+                          setSelectedModelId(model.id);
+                          void handleTestConnection(model.id);
+                        }}
                       >
-                        <div className="flex min-w-0 items-center justify-between gap-2">
+                        <div className="flex w-full min-w-0 items-center justify-between gap-2">
                           <div className="flex min-w-0 flex-1 items-center gap-1.5">
                             <div
                               className={cn(
@@ -4802,7 +4795,7 @@ const Settings: React.FC<SettingsProps> = ({
                                 )}
                             </div>
                           </div>
-                          <div className="flex items-center shrink-0 space-x-1">
+                          <div className="ml-auto flex shrink-0 items-center justify-end gap-1">
                             {model.supportsImage && (
                               <span
                                 className={cn(
@@ -4876,7 +4869,7 @@ const Settings: React.FC<SettingsProps> = ({
                                   }}
                                   aria-label={`${i18nService.t('editModel')} ${model.name}`}
                                   title={i18nService.t('editModel')}
-                                  className="size-5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground [&_svg]:size-3.5"
+                                  className="text-muted-foreground hover:text-foreground"
                                 >
                                   <Pencil />
                                 </Button>
@@ -4887,7 +4880,7 @@ const Settings: React.FC<SettingsProps> = ({
                                   onClick={() => handleDeleteModel(model.id)}
                                   aria-label={`${i18nService.t('delete')} ${model.name}`}
                                   title={i18nService.t('delete')}
-                                  className="size-5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-destructive [&_svg]:size-3.5"
+                                  className="text-muted-foreground hover:text-destructive"
                                 >
                                   <Trash2 />
                                 </Button>

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -255,6 +255,8 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
         description={i18nService.t('deleteTaskConfirmMessage')}
         cancelLabel={i18nService.t('cancel')}
         confirmLabel={i18nService.t('deleteSession')}
+        cancelVariant="outline"
+        confirmVariant="outline"
         onCancel={() => setShowConfirmDelete(false)}
         onConfirm={() => {
           setShowConfirmDelete(false);

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -326,6 +326,8 @@ export const CodingWorkspaceSidebar = ({
         description={i18nService.t('codingWorkspaceRemoveConfirm')}
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingWorkspaceRemove')}
+        cancelVariant="outline"
+        confirmVariant="outline"
         onCancel={() => setRemovingWorkspace(null)}
         onConfirm={() => void removeWorkspace()}
       />
@@ -335,6 +337,8 @@ export const CodingWorkspaceSidebar = ({
         description={i18nService.t('codingSessionRemoveConfirm')}
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingSessionRemove')}
+        cancelVariant="outline"
+        confirmVariant="outline"
         onCancel={() => setRemovingSession(null)}
         onConfirm={() => void removeSession()}
       />

--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -396,6 +396,8 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
         description={i18nService.t('deleteTaskConfirmMessage')}
         cancelLabel={i18nService.t('cancel')}
         confirmLabel={i18nService.t('deleteSession')}
+        cancelVariant="outline"
+        confirmVariant="outline"
         onCancel={handleCancelDelete}
         onConfirm={handleConfirmDelete}
       />

--- a/src/renderer/components/settings/ModelCapabilitiesFields.tsx
+++ b/src/renderer/components/settings/ModelCapabilitiesFields.tsx
@@ -60,7 +60,7 @@ export function ModelCapabilitiesFields({
 
   return (
     <div className="rounded-lg border border-border bg-surface-raised p-3">
-      <div className="mb-3 grid grid-cols-2 gap-3">
+      <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
         <label className="flex flex-col gap-1 text-sm text-foreground">
           <span>{i18nService.t('modelContextWindowK')}</span>
           <Input
@@ -84,7 +84,7 @@ export function ModelCapabilitiesFields({
           />
         </label>
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         {fields.map(field => {
           const status = capabilities[field.key] ?? ModelCapabilityStatus.Unknown;
           const editable = editableCapabilities


### PR DESCRIPTION
 ## 概要

  优化模型设置页面的布局、字体层级、模型卡片操作区域及删除确认交互，提升不同窗口尺寸下的可读性和操作一致性。

  ## 关联 Issue

  暂无关联 Issue。

  ## 变更内容

  - 模型设置页面增加窄窗口响应式布局，桌面端保持左右双栏。
  - 统一 API Key 字段的字体和颜色样式，移除旧主题颜色类。
  - 必填字段统一使用红色 *，移除“必填”和“可选”标签。
  - 模型列表由多层卡片边框调整为单层分隔行，减少视觉堆叠。
  - 模型卡片中的编辑、删除按钮固定在最右侧，并将删除按钮改为常显。
  - 模型卡片支持键盘聚焦、Enter 和 Space 键触发连接测试。
  - 模型能力字段在窄窗口下自动切换为单列布局。
  - 默认对话、Cowork 会话和 Project 会话的删除确认按钮统一为设置页的 outline 样式。

  ## 变更类型

  - [x] 缺陷修复（界面布局和交互一致性）
  - [x] 新功能（模型卡片支持键盘触发连接测试）
  - [ ] 破坏性变更
  - [ ] 代码重构
  - [ ] 文档更新
  - [ ] 性能优化
  - [ ] 其他

  ## 测试

  - [x] 已在本地执行自动化验证
  - [ ] 已新增测试
  - [ ] 已更新现有测试
  - [ ] Electron 人工界面测试

  已执行：

  - npm run lint：通过。
  - npm run build:tsc：通过。
  - git diff --check：通过，仅有 Windows 换行符提示。

  ## 截图

  暂无。尚未启动 Electron 进行人工界面验证。

  ## 检查清单

  - [x] 代码遵循现有项目风格和组件规范
  - [x] 已完成自查
  - [ ] 未新增测试
  - [ ] 未修改项目文档
  - [x] lint 未发现新增问题
  - [ ] 未执行完整单元测试集

  ## Electron 专项变更

  - [ ] 修改主进程
  - [ ] 修改预加载脚本
  - [ ] 修改 IPC 通信
  - [ ] 修改窗口管理
  - [x] 不适用

  ## 补充说明

  本次提交仅涉及渲染进程界面与交互样式，未修改模型检测、连接测试、保存或删除业务逻辑。建议合并前在桌面端验证：

  - 不同窗口宽度下的模型设置布局；
  - 模型卡片右侧编辑、删除按钮位置；
  - 删除确认弹窗按钮样式；
  - 键盘触发模型连接测试。