### PR TITLE
feat: 扩展自动化快捷操作与技能联动

### DIFF
--- a/public/quick-actions-i18n.json
+++ b/public/quick-actions-i18n.json
@@ -99,6 +99,33 @@
           "prompt": "帮我做一个客户满意度调查问卷网页。\n\n问卷标题:「您的反馈对我们很重要」\n\n问卷内容:\n- 基本信息:姓名(选填)、联系方式(选填);\n- 单选题:整体满意度(非常满意/满意/一般/不满意/非常不满意);\n- 单选题:您是否愿意推荐给朋友(1-10分评分滑块);\n- 多选题:您最看重的方面(产品质量/服务态度/响应速度/性价比/售后保障);\n- 单选题:使用频率(每天/每周/每月/偶尔);\n- 文本题:您的建议或意见(大文本框);\n- 提交按钮,提交后显示感谢页面。\n\n设计目标:\n让填写过程轻松、可信且适合手机操作，清晰呈现进度和反馈状态。请根据这一任务选择克制而有辨识度的设计系统；不要默认使用白底蓝绿色问卷模板。"
         }
       }
+    },
+    "deep-research": {
+      "label": "深度调研",
+      "prompts": {
+        "research-industry": { "label": "行业趋势", "description": "梳理行业现状与发展方向", "prompt": "请对我指定的行业进行深度调研，梳理市场规模、主要参与者、关键趋势、机会与风险，并给出有来源依据的结论。" },
+        "research-competitors": { "label": "竞品分析", "description": "比较竞品能力与市场定位", "prompt": "请完成一份竞品分析，比较主要产品的定位、目标用户、核心功能、价格、优势短板和差异化机会，并用表格总结。" },
+        "research-policy": { "label": "政策分析", "description": "解读政策影响与执行要点", "prompt": "请分析我提供的政策或法规，提炼核心要求、适用范围、时间节点、对业务的影响和落地建议，标注不确定信息。" },
+        "research-literature": { "label": "文献综述", "description": "整理研究脉络与关键观点", "prompt": "请围绕指定主题撰写文献综述框架，归纳主要研究观点、方法、共识、争议与研究空白，并提出后续研究问题。" }
+      }
+    },
+    "academic-research": {
+      "label": "学术研究",
+      "prompts": {
+        "academic-outline": { "label": "论文大纲", "description": "搭建清晰的论文结构", "prompt": "请根据我的研究主题设计一份学术论文大纲，包含研究问题、理论框架、方法、结果与讨论，并说明各部分写作重点。" },
+        "academic-review": { "label": "文献整理", "description": "提炼文献并建立研究脉络", "prompt": "请整理我提供的文献，按主题、方法和结论分类，提炼关键观点并指出相互支持、矛盾和可引用之处。" },
+        "academic-method": { "label": "研究方法", "description": "选择合适的方法与实验方案", "prompt": "请根据研究目标和可用数据，比较可选研究方法，给出推荐方案、变量设计、样本要求、实施步骤和潜在局限。" },
+        "academic-polish": { "label": "学术润色", "description": "提升表达的准确性与连贯性", "prompt": "请将我提供的论文段落润色为规范、清晰、严谨的学术中文，保留原意，并列出关键修改理由。" }
+      }
+    },
+    "docs": {
+      "label": "文档",
+      "prompts": {
+        "docs-meeting": { "label": "会议纪要", "description": "整理讨论内容与行动项", "prompt": "请把我提供的会议记录整理成正式会议纪要，包含议题、关键结论、待办事项、负责人和截止时间。" },
+        "docs-report": { "label": "工作报告", "description": "生成结构清晰的正式报告", "prompt": "请根据我提供的材料撰写一份正式工作报告，包含背景、进展、数据、问题、建议和下一步计划。" },
+        "docs-summary": { "label": "文档摘要", "description": "快速提炼长文档重点", "prompt": "请阅读我提供的文档，输出简明摘要、关键事实、重要结论、风险点和需要进一步确认的问题。" },
+        "docs-polish": { "label": "文档润色", "description": "改善语句与整体表达", "prompt": "请润色我提供的文档，改善语法、措辞、结构和正式程度，保留原有事实与意图，并给出修改后的完整版本。" }
+      }
     }
   },
   "en": {
@@ -200,6 +227,33 @@
           "description": "Online form and questionnaire collection page",
           "prompt": "Help me create a customer satisfaction survey questionnaire webpage.\n\nQuestionnaire title: \"Your Feedback is Important to Us\"\n\nQuestionnaire content:\n- Basic information: Name (optional), Contact (optional)\n- Single choice: Overall satisfaction (Very satisfied/Satisfied/Neutral/Dissatisfied/Very dissatisfied)\n- Single choice: Would you recommend to friends (1-10 rating slider)\n- Multiple choice: What aspects do you value most (Product quality/Service attitude/Response speed/Value for money/After-sales support)\n- Single choice: Usage frequency (Daily/Weekly/Monthly/Occasionally)\n- Text question: Your suggestions or opinions (large text box)\n- Submit button, show thank you page after submission\n\nDesign goal:\nMake completion easy, trustworthy, and mobile-friendly with clear progress and feedback states. Choose a restrained but distinctive system for this task; do not default to a white-and-teal survey template."
         }
+      }
+    },
+    "deep-research": {
+      "label": "Deep Research",
+      "prompts": {
+        "research-industry": { "label": "Industry Trends", "description": "Map the market and its direction", "prompt": "Conduct deep research on the industry I specify, covering market size, key players, trends, opportunities, risks, and source-backed conclusions." },
+        "research-competitors": { "label": "Competitor Analysis", "description": "Compare positioning and capabilities", "prompt": "Prepare a competitor analysis comparing positioning, users, features, pricing, strengths, weaknesses, and differentiation opportunities in a table." },
+        "research-policy": { "label": "Policy Analysis", "description": "Explain impact and requirements", "prompt": "Analyze the policy or regulation I provide, extracting requirements, scope, dates, business impact, and implementation advice while flagging uncertainty." },
+        "research-literature": { "label": "Literature Review", "description": "Organize the research landscape", "prompt": "Create a literature review framework for the topic, summarizing methods, consensus, disagreements, gaps, and follow-up research questions." }
+      }
+    },
+    "academic-research": {
+      "label": "Academic Research",
+      "prompts": {
+        "academic-outline": { "label": "Paper Outline", "description": "Build a clear paper structure", "prompt": "Design an academic paper outline for my topic with research questions, framework, methods, results, and discussion, including writing guidance for each section." },
+        "academic-review": { "label": "Literature Notes", "description": "Extract and connect key studies", "prompt": "Organize the literature I provide by topic, method, and conclusion; extract key claims and identify support, contradictions, and useful citations." },
+        "academic-method": { "label": "Research Method", "description": "Choose a suitable study design", "prompt": "Compare research methods for my objective and data, then recommend a design with variables, sample needs, steps, and limitations." },
+        "academic-polish": { "label": "Academic Editing", "description": "Improve rigor and clarity", "prompt": "Edit the paper passage I provide into precise, coherent academic English while preserving meaning, and list the key revisions." }
+      }
+    },
+    "docs": {
+      "label": "Documents",
+      "prompts": {
+        "docs-meeting": { "label": "Meeting Minutes", "description": "Turn discussion into action items", "prompt": "Turn my meeting notes into formal minutes with agenda, decisions, action items, owners, and due dates." },
+        "docs-report": { "label": "Work Report", "description": "Create a structured formal report", "prompt": "Write a formal work report from my materials covering background, progress, data, issues, recommendations, and next steps." },
+        "docs-summary": { "label": "Document Summary", "description": "Extract the essentials quickly", "prompt": "Read the document I provide and return a concise summary, key facts, conclusions, risks, and questions requiring confirmation." },
+        "docs-polish": { "label": "Document Editing", "description": "Improve language and structure", "prompt": "Edit my document for grammar, wording, structure, and appropriate formality while preserving facts and intent, then provide the complete revised version." }
       }
     }
   }

--- a/public/quick-actions.json
+++ b/public/quick-actions.json
@@ -80,6 +80,42 @@
           "id": "web-survey"
         }
       ]
+    },
+    {
+      "id": "deep-research",
+      "icon": "Telescope",
+      "color": "#0F766E",
+      "skillMapping": "deep-research",
+      "prompts": [
+        { "id": "research-industry" },
+        { "id": "research-competitors" },
+        { "id": "research-policy" },
+        { "id": "research-literature" }
+      ]
+    },
+    {
+      "id": "academic-research",
+      "icon": "GraduationCap",
+      "color": "#7C3AED",
+      "skillMapping": "deli-autoresearch",
+      "prompts": [
+        { "id": "academic-outline" },
+        { "id": "academic-review" },
+        { "id": "academic-method" },
+        { "id": "academic-polish" }
+      ]
+    },
+    {
+      "id": "docs",
+      "icon": "FileText",
+      "color": "#B45309",
+      "skillMapping": "docx",
+      "prompts": [
+        { "id": "docs-meeting" },
+        { "id": "docs-report" },
+        { "id": "docs-summary" },
+        { "id": "docs-polish" }
+      ]
     }
   ]
 }

--- a/public/quick-actions.json
+++ b/public/quick-actions.json
@@ -86,6 +86,7 @@
       "icon": "Telescope",
       "color": "#0F766E",
       "skillMapping": "deep-research",
+      "skillIds": ["deep-research", "web-search"],
       "prompts": [
         { "id": "research-industry" },
         { "id": "research-competitors" },
@@ -98,6 +99,7 @@
       "icon": "GraduationCap",
       "color": "#7C3AED",
       "skillMapping": "deli-autoresearch",
+      "skillIds": ["deli-autoresearch", "deep-research", "web-search"],
       "prompts": [
         { "id": "academic-outline" },
         { "id": "academic-review" },

--- a/src/main/activity/activityService.test.ts
+++ b/src/main/activity/activityService.test.ts
@@ -44,3 +44,21 @@ test('prunes only activity snapshots older than 180 days', async () => {
   expect(service.pruneExpired(now)).toBe(1);
   expect(service.list().map(run => run.id)).toEqual(['recent', 'boundary']);
 });
+
+test('recovers interrupted running snapshots during startup', async () => {
+  const { ActivityService } = await import('./activityService');
+  const service = new ActivityService(new Database(':memory:'));
+  service.upsert({ id: 'stale', source: ActivitySource.ScheduledTask, status: ActivityStatus.Running, updatedAt: 10 });
+  service.upsert({ id: 'done', source: ActivitySource.Channel, status: ActivityStatus.Completed, updatedAt: 11 });
+
+  expect(service.recoverInterruptedRuns(20)).toBe(1);
+  expect(service.list()).toEqual([
+    expect.objectContaining({
+      id: 'stale',
+      status: ActivityStatus.Failed,
+      updatedAt: 20,
+      errorMessage: 'Run was interrupted when the application closed.',
+    }),
+    expect.objectContaining({ id: 'done', status: ActivityStatus.Completed, updatedAt: 11 }),
+  ]);
+});

--- a/src/main/activity/activityService.ts
+++ b/src/main/activity/activityService.ts
@@ -1,7 +1,11 @@
 import { BrowserWindow } from 'electron';
 import type Database from 'better-sqlite3';
 
-import { ActivityIpc, ActivityRetention } from '../../shared/activity/constants';
+import {
+  ActivityIpc,
+  ActivityRetention,
+  ActivityStatus,
+} from '../../shared/activity/constants';
 import { shouldAcceptActivityUpdate } from '../../shared/activity/ordering';
 import type { ActivityRun, ActivityRunUpdate } from '../../shared/activity/types';
 
@@ -36,6 +40,26 @@ export class ActivityService {
     return this.db
       .prepare('DELETE FROM zhiyuan_activity_runs WHERE updated_at < ?')
       .run(cutoffMs).changes;
+  }
+
+  /**
+   * A force-closed app cannot emit a terminal event. Clear those stale
+   * in-progress projections during startup so the sidebar indicator reflects
+   * work that is actually running in this process.
+   */
+  recoverInterruptedRuns(nowMs = Date.now()): number {
+    return this.db
+      .prepare(
+        `UPDATE zhiyuan_activity_runs
+         SET status = ?, updated_at = ?, error_message = COALESCE(error_message, ?)
+         WHERE status = ?`,
+      )
+      .run(
+        ActivityStatus.Failed,
+        nowMs,
+        'Run was interrupted when the application closed.',
+        ActivityStatus.Running,
+      ).changes;
   }
 
   upsert(update: ActivityRunUpdate): ActivityRun {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7048,6 +7048,10 @@ if (!gotTheLock) {
       console.log(`[Main] Reset ${resetCount} stuck cowork session(s) from running -> idle`);
     }
     activityService ??= new ActivityService(getStore().getDatabase());
+    const recoveredActivityRuns = activityService.recoverInterruptedRuns();
+    if (recoveredActivityRuns > 0) {
+      console.warn(`[Activity] marked ${recoveredActivityRuns} interrupted activity run(s) as failed`);
+    }
     const prunedActivityRuns = activityService.pruneExpired();
     if (prunedActivityRuns > 0) {
       console.log(`[Activity] removed ${prunedActivityRuns} expired activity run(s)`);

--- a/src/renderer/components/chat/ChatSkillShortcuts.tsx
+++ b/src/renderer/components/chat/ChatSkillShortcuts.tsx
@@ -8,6 +8,7 @@ import { i18nService } from '../../services/i18n';
 import { RootState } from '../../store';
 import { selectIsStreaming } from '../../store/selectors/coworkSelectors';
 import { clearCurrentSession } from '../../store/slices/coworkSlice';
+import { selectAction } from '../../store/slices/quickActionSlice';
 import { setActiveSkillIds } from '../../store/slices/skillSlice';
 import {
   AnimatedFileTextIcon,
@@ -46,6 +47,7 @@ const ChatSkillShortcuts: React.FC = () => {
   const dispatch = useDispatch();
   const skills = useSelector((state: RootState) => state.skill.skills);
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
+  const quickActions = useSelector((state: RootState) => state.quickAction.actions);
   const isStreaming = useSelector(selectIsStreaming);
   const documentIconRef = React.useRef<AnimatedFileTextIconHandle>(null);
   const academicIconRef = React.useRef<AnimatedGraduationCapIconHandle>(null);
@@ -89,9 +91,23 @@ const ChatSkillShortcuts: React.FC = () => {
       return;
     }
     dispatch(setActiveSkillIds([...selectedSkillIds]));
+    const quickActionIdByShortcut: Record<string, string> = {
+      ppt: 'pptx',
+      sheets: 'data-analysis',
+      website: 'website',
+      docs: 'docs',
+      'deep-research': 'deep-research',
+      'academic-research': 'academic-research',
+    };
+    const quickActionId = quickActionIdByShortcut[entry.id];
+    dispatch(
+      selectAction(quickActions.some(action => action.id === quickActionId) ? quickActionId : null),
+    );
     dispatch(clearCurrentSession());
     window.setTimeout(() => {
-      window.dispatchEvent(new CustomEvent('cowork:focus-input', { detail: { clear: false } }));
+      // Switching shortcut skills starts a new prompt context. Clear the
+      // previous case text while preserving the conversation transcript.
+      window.dispatchEvent(new CustomEvent('cowork:focus-input', { detail: { clear: true } }));
     }, 0);
   };
 

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -51,7 +51,7 @@ import {
   updateSessionStatus,
 } from '../../store/slices/coworkSlice';
 import { clearSelection, selectAction, setActions } from '../../store/slices/quickActionSlice';
-import { setActiveSkillIds } from '../../store/slices/skillSlice';
+import { clearActiveSkills, setActiveSkillIds } from '../../store/slices/skillSlice';
 import { WorkMode } from '../../store/workMode/constants';
 import {
   CoworkSessionStatusValue,
@@ -71,7 +71,10 @@ import CoworkPromptInput, { type CoworkPromptInputRef } from './CoworkPromptInpu
 import CoworkSessionViewport from './CoworkSessionViewport';
 import { mergeDirectChatSnapshotMessages } from './directChatSnapshot';
 import SecurityStatusIndicator from './SecurityStatusIndicator';
-import { shouldClearQuickActionSelection } from '../quick-actions/quickActionSelection';
+import {
+  quickActionSkillIds,
+  shouldClearQuickActionSelection,
+} from '../quick-actions/quickActionSelection';
 import { useUnmanagedWorkingDirectory } from './useUnmanagedWorkingDirectory';
 import { useTaskResumeContext } from './hooks/useTaskResumeContext';
 
@@ -1429,18 +1432,27 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     // Skills can also be activated from the Chat sidebar or the skill badge.
     // In that path there is no quick-action selection event, so derive the
     // matching case panel from the active skill mapping.
-    return quickActions.find(action => activeSkillIds.includes(action.skillMapping));
+    return quickActions.find(action =>
+      quickActionSkillIds(action).every(skillId => activeSkillIds.includes(skillId)),
+    );
   }, [activeSkillIds, quickActions, selectedActionId]);
 
-  // Handle quick action button click and activate its mapped skill.
+  // Handle quick action button click and activate its complete Skill bundle.
   const handleActionSelect = (actionId: string) => {
     dispatch(selectAction(actionId));
     quickActionActivationRef.current = null;
     const action = quickActions.find(a => a.id === actionId);
-    const targetSkill = action && skills.find(s => s.id === action.skillMapping);
-    if (targetSkill) {
+    const skillIds = action ? quickActionSkillIds(action) : [];
+    const skillsAvailable = skillIds.every(skillId =>
+      skills.some(skill => skill.id === skillId && skill.enabled),
+    );
+    if (action && skillsAvailable) {
       quickActionActivationRef.current = actionId;
-      dispatch(setActiveSkillIds([targetSkill.id]));
+      dispatch(setActiveSkillIds(skillIds));
+    } else {
+      // Do not send a new quick-action prompt with skills left over from a
+      // previous action when the requested bundle is unavailable.
+      dispatch(clearActiveSkills());
     }
     window.setTimeout(() => {
       window.dispatchEvent(
@@ -1457,13 +1469,17 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       return;
     }
     const action = quickActions.find(a => a.id === selectedActionId);
-    const targetSkill = action && skills.find(s => s.id === action.skillMapping);
-    if (!action || !targetSkill) return;
+    if (!action) return;
+    const skillIds = quickActionSkillIds(action);
+    const skillsAvailable = skillIds.every(skillId =>
+      skills.some(skill => skill.id === skillId && skill.enabled),
+    );
+    if (!skillsAvailable) return;
 
     if (quickActionActivationRef.current !== selectedActionId) {
       quickActionActivationRef.current = selectedActionId;
-      if (!activeSkillIds.includes(targetSkill.id)) {
-        dispatch(setActiveSkillIds([targetSkill.id]));
+      if (!skillIds.every(skillId => activeSkillIds.includes(skillId))) {
+        dispatch(setActiveSkillIds(skillIds));
       }
       return;
     }

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -1423,8 +1423,14 @@ const CoworkView: React.FC<CoworkViewProps> = ({
 
   // Get selected quick action
   const selectedAction = React.useMemo(() => {
-    return quickActions.find(action => action.id === selectedActionId);
-  }, [quickActions, selectedActionId]);
+    const explicitlySelected = quickActions.find(action => action.id === selectedActionId);
+    if (explicitlySelected) return explicitlySelected;
+
+    // Skills can also be activated from the Chat sidebar or the skill badge.
+    // In that path there is no quick-action selection event, so derive the
+    // matching case panel from the active skill mapping.
+    return quickActions.find(action => activeSkillIds.includes(action.skillMapping));
+  }, [activeSkillIds, quickActions, selectedActionId]);
 
   // Handle quick action button click and activate its mapped skill.
   const handleActionSelect = (actionId: string) => {
@@ -1436,6 +1442,11 @@ const CoworkView: React.FC<CoworkViewProps> = ({
       quickActionActivationRef.current = actionId;
       dispatch(setActiveSkillIds([targetSkill.id]));
     }
+    window.setTimeout(() => {
+      window.dispatchEvent(
+        new CustomEvent('cowork:focus-input', { detail: { clear: true } }),
+      );
+    }, 0);
   };
 
   // Activate a mapped skill once it becomes available, and clear the quick action when

--- a/src/renderer/components/quick-actions/QuickActionBar.tsx
+++ b/src/renderer/components/quick-actions/QuickActionBar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@shared/components/ui/button';
-import { ChartColumn, Globe, GraduationCap, Presentation, Smartphone } from 'lucide-react';
+import { ChartColumn, FileText, Globe, GraduationCap, Presentation, Smartphone, Telescope } from 'lucide-react';
 import React from 'react';
 
 import type { LocalizedQuickAction } from '../../types/quickAction';
@@ -16,6 +16,8 @@ const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
   Smartphone,
   ChartColumn,
   GraduationCap,
+  Telescope,
+  FileText,
 };
 
 const QuickActionBar: React.FC<QuickActionBarProps> = ({ actions, onActionSelect }) => {

--- a/src/renderer/components/quick-actions/quickActionSelection.test.ts
+++ b/src/renderer/components/quick-actions/quickActionSelection.test.ts
@@ -1,6 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { expect, test } from 'vitest';
 
-import { shouldClearQuickActionSelection } from './quickActionSelection';
+import { quickActionSkillIds, shouldClearQuickActionSelection } from './quickActionSelection';
 
 const action = {
   id: 'education',
@@ -24,6 +26,13 @@ const skill = {
   skillPath: '',
 };
 
+const quickActionsConfig = JSON.parse(
+  readFileSync(
+    fileURLToPath(new URL('../../../../public/quick-actions.json', import.meta.url)),
+    'utf8',
+  ),
+) as { actions: Array<{ id: string; skillIds?: string[] }> };
+
 test('keeps a quick action selected when its mapped skill is unavailable', () => {
   expect(shouldClearQuickActionSelection(action, [], [])).toBe(false);
 });
@@ -34,4 +43,34 @@ test('clears a quick action when its available mapped skill is inactive', () => 
 
 test('keeps a quick action when its mapped skill is active', () => {
   expect(shouldClearQuickActionSelection(action, [skill], ['frontend-design'])).toBe(false);
+});
+
+test('requires every skill in a bundled quick action to remain active', () => {
+  const researchAction = {
+    ...action,
+    id: 'academic-research',
+    skillMapping: 'deli-autoresearch',
+    skillIds: ['deli-autoresearch', 'deep-research', 'web-search'],
+  };
+  const researchSkills = researchAction.skillIds.map(id => ({ ...skill, id }));
+
+  expect(quickActionSkillIds(researchAction)).toEqual(researchAction.skillIds);
+  expect(
+    shouldClearQuickActionSelection(researchAction, researchSkills, researchAction.skillIds),
+  ).toBe(false);
+  expect(
+    shouldClearQuickActionSelection(researchAction, researchSkills, ['deli-autoresearch']),
+  ).toBe(true);
+});
+
+test('declares the full research skill bundles in quick-action configuration', () => {
+  expect(quickActionsConfig.actions.find(action => action.id === 'deep-research')?.skillIds).toEqual([
+    'deep-research',
+    'web-search',
+  ]);
+  expect(quickActionsConfig.actions.find(action => action.id === 'academic-research')?.skillIds).toEqual([
+    'deli-autoresearch',
+    'deep-research',
+    'web-search',
+  ]);
 });

--- a/src/renderer/components/quick-actions/quickActionSelection.ts
+++ b/src/renderer/components/quick-actions/quickActionSelection.ts
@@ -1,14 +1,20 @@
 import type { LocalizedQuickAction } from '../../types/quickAction';
 import type { Skill } from '../../types/skill';
 
+export const quickActionSkillIds = (action: LocalizedQuickAction): string[] =>
+  action.skillIds?.length ? action.skillIds : [action.skillMapping];
+
 export function shouldClearQuickActionSelection(
   action: LocalizedQuickAction,
   skills: Skill[],
   activeSkillIds: string[],
 ): boolean {
-  const mappedSkillExists = skills.some(skill => skill.id === action.skillMapping);
+  const skillIds = quickActionSkillIds(action);
+  const allMappedSkillsExist = skillIds.every(skillId =>
+    skills.some(skill => skill.id === skillId),
+  );
 
   // Keep prompt-only quick actions available when the mapped skill is not
   // loaded in the current mode.
-  return mappedSkillExists && !activeSkillIds.includes(action.skillMapping);
+  return allMappedSkillsExist && !skillIds.every(skillId => activeSkillIds.includes(skillId));
 }

--- a/src/renderer/services/agent.test.ts
+++ b/src/renderer/services/agent.test.ts
@@ -7,13 +7,23 @@ const source = readFileSync(fileURLToPath(new URL('./agent.ts', import.meta.url)
 
 test('keeps expert package skills out of the visible active-skill selection', () => {
   const start = source.indexOf('switchAgent(agentId: string): void');
-  const end = source.indexOf('\n  }\n}', start);
-  const switchAgent = source.slice(start, end);
+  const switchAgent = source.slice(start);
 
   expect(start).toBeGreaterThanOrEqual(0);
-  expect(end).toBeGreaterThan(start);
   expect(switchAgent).toContain('agent?.source === CoworkSessionExpertSource.Package');
   expect(switchAgent).toContain('agent?.source === CoworkSessionExpertSource.Member');
   expect(switchAgent).toContain('agent?.skillIds?.length && !isExpertAgent');
   expect(switchAgent).toContain('dispatch(clearActiveSkills());');
+});
+
+test('does not overwrite temporary prompt skills when only the model changes', () => {
+  const start = source.indexOf('async updateAgent(');
+  const end = source.indexOf('\n  async deleteAgent', start);
+  const updateAgent = source.slice(start, end);
+
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  expect(updateAgent).toContain(
+    'id === store.getState().agent.currentAgentId && updates.skillIds !== undefined',
+  );
 });

--- a/src/renderer/services/agent.ts
+++ b/src/renderer/services/agent.ts
@@ -126,7 +126,7 @@ class AgentService {
         // to the runtime skill slice so new conversations pick up changes
         // immediately (switchAgent handles this on explicit switch, but
         // in-place editing without switching was missing the sync).
-        if (id === store.getState().agent.currentAgentId) {
+        if (id === store.getState().agent.currentAgentId && updates.skillIds !== undefined) {
           store.dispatch(setActiveSkillIds(agent.skillIds ?? []));
         }
         return agent;

--- a/src/renderer/services/cowork.ts
+++ b/src/renderer/services/cowork.ts
@@ -34,6 +34,7 @@ import {
   updateMessageContents,
   updateToolActivity,
   updateSessionPinned,
+  updateCurrentSessionModelOverride,
   updateSessionStatus,
   updateSessionTitle,
 } from '../store/slices/coworkSlice';
@@ -666,6 +667,7 @@ class CoworkService {
       if (result.session.agentId) {
         store.dispatch(setCurrentAgentId(result.session.agentId));
       }
+      const wasCurrentSession = store.getState().cowork.currentSessionId === sessionId;
       store.dispatch(setCurrentSession(result.session));
       // Only restore streaming for running sessions — never clear it here.
       // Clearing is the responsibility of complete/error stream events.
@@ -675,7 +677,9 @@ class CoworkService {
       // Session skills describe already-sent messages. Never reattach them to
       // the next prompt when reactive session loading runs during a stream.
       // Re-edit explicitly restores a message's skills in CoworkSessionDetail.
-      store.dispatch(clearActiveSkills());
+      if (!wasCurrentSession) {
+        store.dispatch(clearActiveSkills());
+      }
 
       const imResult = await cowork.remoteManaged(sessionId);
       if (requestId === this.latestLoadSessionRequestId) {
@@ -735,7 +739,15 @@ class CoworkService {
     if (result.success && result.session) {
       const currentSessionId = store.getState().cowork.currentSessionId;
       if (currentSessionId === sessionId) {
-        store.dispatch(setCurrentSession(result.session));
+        // Model updates return a metadata-only session snapshot. Patch just
+        // the model field so the in-memory transcript, draft and streaming
+        // state are not replaced while the user is switching models.
+        store.dispatch(
+          updateCurrentSessionModelOverride({
+            sessionId,
+            modelOverride: result.session.modelOverride,
+          }),
+        );
       }
       return result.session;
     }

--- a/src/renderer/types/quickAction.ts
+++ b/src/renderer/types/quickAction.ts
@@ -37,6 +37,8 @@ export interface QuickAction {
   color: string;
   /** 映射到 Skill ID */
   skillMapping: string;
+  /** 需要一并激活的 Skill ID；未配置时只激活 skillMapping。 */
+  skillIds?: string[];
   /** 预制提示词列表 */
   prompts: Prompt[];
 }
@@ -55,6 +57,8 @@ export interface LocalizedQuickAction {
   color: string;
   /** 映射到 Skill ID */
   skillMapping: string;
+  /** 需要一并激活的 Skill ID；未配置时只激活 skillMapping。 */
+  skillIds?: string[];
   /** 预制提示词列表（已本地化） */
   prompts: LocalizedPrompt[];
 }


### PR DESCRIPTION
## Summary

扩展自动化快捷操作，并完善技能快捷入口、Cowork 会话和 Agent 状态之间的联动。

## Related Issue

暂无直接关联 issue，本 PR 不关闭 issue。

## Changes Made

- 新增 Deep Research、Academic Research、Documents 快捷操作及中英文配置
- 增加快捷操作栏图标，并联动 Chat/Cowork 的 active skill 与输入状态
- 修复当前 Agent 编辑模型时覆盖临时技能的问题
- 应用启动时将残留的 running activity 标记为 failed，并补充测试
- 修复 Cowork 会话加载和模型切换时的状态覆盖问题

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

验证结果：
- `npm run lint` 通过
- `npx vitest run src/renderer/services/agent.test.ts` 通过
- `git diff --check` 通过
- activityService 测试受本机 better-sqlite3 Node ABI 不匹配影响，未能执行

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [x] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

本次提交已基于最新 `origin/main` 完成 rebase。Vitest 输出的 Vite config native loader warning 为现有配置提示，不是本次改动引入的错误。