### PR TITLE
fix(memory): hide inactive embedding settings

### DIFF
--- a/src/renderer/components/Settings.memory.test.ts
+++ b/src/renderer/components/Settings.memory.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(fileURLToPath(new URL('./Settings.tsx', import.meta.url)), 'utf8');
+
+test('hides embedding controls until semantic recall is implemented', () => {
+  const memorySettingsStart = source.indexOf("case 'coworkMemory':");
+  const memorySettingsEnd = source.indexOf("case 'model':", memorySettingsStart);
+  const memorySettingsSource = source.slice(memorySettingsStart, memorySettingsEnd);
+
+  expect(memorySettingsStart).toBeGreaterThanOrEqual(0);
+  expect(memorySettingsEnd).toBeGreaterThan(memorySettingsStart);
+  expect(memorySettingsSource).toContain('<ManagedMemorySettings');
+  expect(memorySettingsSource).not.toContain('<EmbeddingSettingsSection');
+  expect(source).not.toContain(
+    "import EmbeddingSettingsSection from './cowork/EmbeddingSettingsSection'",
+  );
+});

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -86,7 +86,6 @@ import { themeService } from '../services/theme';
 import { selectCoworkConfig } from '../store/selectors/coworkSelectors';
 import Modal from './common/Modal';
 import { DestructiveConfirmDialog } from '@shared/components/ui/destructive-confirm-dialog';
-import EmbeddingSettingsSection from './cowork/EmbeddingSettingsSection';
 import ErrorMessage from './ErrorMessage';
 import { GitHubCopilotIcon } from './icons/providers';
 import {
@@ -3257,27 +3256,7 @@ const Settings: React.FC<SettingsProps> = ({
         return null;
 
       case 'coworkMemory':
-        return (
-          <div className="flex flex-col gap-6">
-            <ManagedMemorySettings workingDirectory={coworkConfig.workingDirectory} />
-
-            {/* Section 3: Embedding / Vector Memory Search */}
-            <EmbeddingSettingsSection
-              embeddingEnabled={embeddingEnabled}
-              embeddingProvider={embeddingProvider}
-              embeddingModel={embeddingModel}
-              embeddingVectorWeight={embeddingVectorWeight}
-              embeddingRemoteBaseUrl={embeddingRemoteBaseUrl}
-              embeddingRemoteApiKey={embeddingRemoteApiKey}
-              onEmbeddingEnabledChange={setEmbeddingEnabled}
-              onEmbeddingProviderChange={setEmbeddingProvider}
-              onEmbeddingModelChange={setEmbeddingModel}
-              onEmbeddingVectorWeightChange={setEmbeddingVectorWeight}
-              onEmbeddingRemoteBaseUrlChange={setEmbeddingRemoteBaseUrl}
-              onEmbeddingRemoteApiKeyChange={setEmbeddingRemoteApiKey}
-            />
-          </div>
-        );
+        return <ManagedMemorySettings workingDirectory={coworkConfig.workingDirectory} />;
 
       case 'model':
         return (


### PR DESCRIPTION
## Summary

- hide the inactive Embedding semantic-search controls from Memory settings
- preserve the existing Embedding configuration schema and stored values for future implementation
- add a source-structure regression test that keeps managed memory visible without mounting the inactive controls

## Behavior

| Area | Behavior |
| --- | --- |
| Memory settings | Shows the managed long-term memory and workspace-scoped session summary views without the Embedding card |
| Existing Embedding configuration | Remains stored and unchanged; this PR only removes the renderer entry point |
| Memory recall | Unchanged; the existing lexical recall path continues to operate as before |

## Validation

- `npm run lint`
- `npm test -- Settings.memory` (1 test passed)
- `npx oxfmt --check src/renderer/components/Settings.memory.test.ts`
- `git diff --check`
- `npm run electron:dev` (application and renderer started successfully)

## Screenshots

Not attached. This is a removal-only change: the nonfunctional Embedding card no longer appears below the existing memory cards.

## Electron Impact

Renderer-only UI change. No IPC channels, storage schema, stored configuration, memory runtime, or recall behavior changed.
