### PR TITLE
fix(renderer): align Base UI trigger button semantics

### DIFF
--- a/src/renderer/components/baseUiTriggerSemantics.test.ts
+++ b/src/renderer/components/baseUiTriggerSemantics.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const NATIVE_BUTTON_TRIGGER_FILES = [
+  'cowork/PromptPlusMenu.tsx',
+  'cowork/PermissionModeMenu.tsx',
+  'cowork/CoworkModelPicker.tsx',
+  'cowork/ContextUsageIndicator.tsx',
+  'cowork/SessionExpertPicker.tsx',
+  'skills/SkillsPopover.tsx',
+  'scheduledTasks/TaskTimePicker.tsx',
+  'scheduledTasks/DateInput.tsx',
+] as const;
+
+describe('Base UI trigger semantics', () => {
+  test.each(NATIVE_BUTTON_TRIGGER_FILES)(
+    '%s declares its rendered button as native',
+    relativePath => {
+      const source = readFileSync(
+        resolve(process.cwd(), 'src/renderer/components', relativePath),
+        'utf8',
+      );
+
+      expect(source).toContain('nativeButton={true}');
+      expect(source).not.toContain('nativeButton={false}');
+    },
+  );
+});

--- a/src/renderer/components/cowork/ContextUsageIndicator.tsx
+++ b/src/renderer/components/cowork/ContextUsageIndicator.tsx
@@ -92,7 +92,7 @@ export function ContextUsageIndicator({
         <TooltipTrigger
           render={
             <PopoverTrigger
-              nativeButton={false}
+              nativeButton={true}
               render={
                 <Button type="button" variant="ghost" size="icon-sm" aria-label={summary}>
                   <span className="sr-only">{summary}</span>

--- a/src/renderer/components/cowork/CoworkModelPicker.tsx
+++ b/src/renderer/components/cowork/CoworkModelPicker.tsx
@@ -62,7 +62,7 @@ export function CoworkModelPicker({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
-        nativeButton={false}
+        nativeButton={true}
         render={
           <PromptInputButton className="max-w-[200px] gap-1 px-2 text-sm hover:bg-surface-raised">
             {displayedSelectedModel ? (

--- a/src/renderer/components/cowork/PermissionModeMenu.tsx
+++ b/src/renderer/components/cowork/PermissionModeMenu.tsx
@@ -37,7 +37,7 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        nativeButton={false}
+        nativeButton={true}
         disabled={disabled}
         render={
           <PromptInputButton

--- a/src/renderer/components/cowork/PromptPlusMenu.tsx
+++ b/src/renderer/components/cowork/PromptPlusMenu.tsx
@@ -222,7 +222,7 @@ const PromptPlusMenu: React.FC<PromptPlusMenuProps> = ({
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
-        nativeButton={false}
+        nativeButton={true}
         disabled={disabled}
         render={
           <PromptInputButton

--- a/src/renderer/components/cowork/SessionExpertPicker.tsx
+++ b/src/renderer/components/cowork/SessionExpertPicker.tsx
@@ -61,7 +61,7 @@ const SessionExpertPicker: React.FC<SessionExpertPickerProps> = ({
     <>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
-          nativeButton={false}
+          nativeButton={true}
           render={
             <PromptInputButton
               type="button"

--- a/src/renderer/components/scheduledTasks/DateInput.tsx
+++ b/src/renderer/components/scheduledTasks/DateInput.tsx
@@ -115,7 +115,7 @@ const DateInput: React.FC<DateInputProps> = ({ value, onChange, min, max, placeh
     <Popover open={open} onOpenChange={setOpen}>
       <div className="relative inline-flex">
         <PopoverTrigger
-          nativeButton={false}
+          nativeButton={true}
           render={
             <Button
               type="button"

--- a/src/renderer/components/scheduledTasks/TaskTimePicker.tsx
+++ b/src/renderer/components/scheduledTasks/TaskTimePicker.tsx
@@ -63,7 +63,7 @@ const TaskTimePicker: React.FC<TaskTimePickerProps> = ({ hour, minute, second, o
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
-        nativeButton={false}
+        nativeButton={true}
         render={
           <Button type="button" variant="outline" className="flex-1 min-w-0 justify-between">
             <span>{timeLabel}</span>

--- a/src/renderer/components/skills/SkillsPopover.tsx
+++ b/src/renderer/components/skills/SkillsPopover.tsx
@@ -88,7 +88,7 @@ const SkillsPopover: React.FC<SkillsPopoverProps> = ({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger nativeButton={false} render={children as React.ReactElement} />
+      <PopoverTrigger nativeButton={true} render={children as React.ReactElement} />
       <PopoverContent
         side="top"
         align="start"


### PR DESCRIPTION
## Summary

- declare native button semantics for Base UI menu and popover triggers that render shared buttons
- cover Cowork toolbar controls, the skills popover, and scheduled-task date/time pickers
- add a regression test for every corrected trigger

## Problem

These triggers passed `nativeButton={false}` while their `render` prop resolved to the shared `Button` or `PromptInputButton`, both of which render a native `<button>`. Base UI therefore applied non-native button behavior to a native button and repeatedly emitted a development warning.

## Solution

Set `nativeButton={true}` on each affected trigger so Base UI uses the element's actual semantics. The rendered elements, styling classes, state, callbacks, and popup placement remain unchanged.

## Visual impact

No visual changes. This only corrects semantics and event/ARIA handling for the existing native buttons.

## Validation

- `npm test -- baseUiTriggerSemantics`
- `npm run lint`
- `npm run build`
- `git diff --check`

Screenshots are not applicable because the patch does not change layout or styling.
