### PR TITLE
fix: 优化窄窗口下的输入区域布局

### DIFF
--- a/src/renderer/components/artifacts/artifactPanelResize.test.ts
+++ b/src/renderer/components/artifacts/artifactPanelResize.test.ts
@@ -27,11 +27,10 @@ describe('artifact panel resize', () => {
     expect(clampArtifactPanelWidth(1536, 180, 1720)).toBe(1536);
   });
 
-  test('caps the drag maximum so the conversation column keeps its space', () => {
+  test('caps the drag maximum at half the content width and preserves chat space', () => {
     const contentWidth = 2031;
-    expect(resolveArtifactPanelMaxWidth(contentWidth, 180)).toBe(
-      contentWidth - ARTIFACT_PANEL_CHAT_RESERVE,
-    );
+    expect(resolveArtifactPanelMaxWidth(contentWidth, 180)).toBe(contentWidth * 0.5);
+    expect(resolveArtifactPanelMaxWidth(600, 180)).toBe(600 - ARTIFACT_PANEL_CHAT_RESERVE);
     // Never below the panel minimum, whatever the row width is.
     expect(resolveArtifactPanelMaxWidth(320, 180)).toBe(180);
   });

--- a/src/renderer/components/artifacts/artifactPanelResize.ts
+++ b/src/renderer/components/artifacts/artifactPanelResize.ts
@@ -3,18 +3,21 @@ export const ARTIFACT_PANEL_KEYBOARD_RESIZE_STEP = 32;
 /** Minimum width the conversation column keeps when the artifact panel is at
  * its drag maximum — the panel must never swallow the chat area. */
 export const ARTIFACT_PANEL_CHAT_RESERVE = 360;
+const ARTIFACT_PANEL_MAX_CONTENT_RATIO = 0.5;
 
 export function clampArtifactPanelWidth(value: number, minWidth: number, maxWidth: number): number {
   return Math.min(Math.max(value, minWidth), Math.max(minWidth, maxWidth));
 }
 
-/** Panel drag maximum: the content row minus the chat column's reserved
- * minimum, so a fully-dragged panel still leaves a usable conversation. */
+/** Panel drag maximum: never consume more than half the row, and always keep
+ * the chat column's reserved minimum when the row is especially narrow. */
 export function resolveArtifactPanelMaxWidth(
   contentWidth: number,
   minPanelWidth: number,
 ): number {
-  return Math.max(minPanelWidth, contentWidth - ARTIFACT_PANEL_CHAT_RESERVE);
+  const chatReserveMaximum = contentWidth - ARTIFACT_PANEL_CHAT_RESERVE;
+  const halfContentMaximum = contentWidth * ARTIFACT_PANEL_MAX_CONTENT_RATIO;
+  return Math.max(minPanelWidth, Math.min(chatReserveMaximum, halfContentMaximum));
 }
 
 export function resolveArtifactPanelPointerWidth(

--- a/src/renderer/components/coding/CodingComposer.test.ts
+++ b/src/renderer/components/coding/CodingComposer.test.ts
@@ -162,3 +162,37 @@ test('steers a running agent with Control S', () => {
 
   expect(onSteer).toHaveBeenCalledOnce();
 });
+
+test('uses a settings menu for configuration controls in a tight toolbar', () => {
+  const ResizeObserver = class {
+    observe() {}
+    disconnect() {}
+  };
+  vi.stubGlobal('ResizeObserver', ResizeObserver);
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(640);
+
+  render(
+    createElement(CodingComposer, {
+      availableCommands: [],
+      configOptions: [
+        {
+          id: 'model',
+          name: 'Model',
+          type: 'select',
+          currentValue: 'default',
+          options: [{ value: 'default', name: 'Default' }],
+        },
+      ],
+      disabled: false,
+      isRunning: false,
+      prompt: '',
+      recipientName: 'Codex',
+      onChange: vi.fn(),
+      onConfigOptionChange: vi.fn(),
+      onSend: vi.fn(),
+      onStop: vi.fn(),
+    }),
+  );
+
+  expect(screen.getByRole('button', { name: i18nService.t('settings') })).toBeTruthy();
+});

--- a/src/renderer/components/coding/CodingComposer.tsx
+++ b/src/renderer/components/coding/CodingComposer.tsx
@@ -34,7 +34,10 @@ interface CodingComposerProps {
   leadingTools?: ReactNode;
   statusNotice?: ReactNode;
   sessionId?: string;
-  queueService?: Pick<typeof coworkQueueService, 'subscribe' | 'load' | 'update' | 'remove' | 'steer' | 'followUp'>;
+  queueService?: Pick<
+    typeof coworkQueueService,
+    'subscribe' | 'load' | 'update' | 'remove' | 'steer' | 'followUp'
+  >;
   onChange: (value: string) => void;
   onConfigOptionChange: (optionId: string, value: string | boolean) => void;
   onSend: () => void;
@@ -122,7 +125,11 @@ export const CodingComposer = ({
       <div className="relative mx-auto max-w-5xl">
         {statusNotice}
         {sessionId ? (
-          <PendingMessageQueue sessionId={sessionId} isStreaming={isRunning} queueService={queueService} />
+          <PendingMessageQueue
+            sessionId={sessionId}
+            isStreaming={isRunning}
+            queueService={queueService}
+          />
         ) : null}
         {commandMenuOpen ? (
           <CodingSlashCommandMenu
@@ -217,6 +224,7 @@ export const CodingComposer = ({
               <CodingComposerConfigControls
                 options={configOptions}
                 onChange={onConfigOptionChange}
+                compact={isTightToolbar}
               />
             </PromptInputTools>
             <PromptInputSubmit

--- a/src/renderer/components/coding/CodingComposer.tsx
+++ b/src/renderer/components/coding/CodingComposer.tsx
@@ -7,7 +7,7 @@ import {
   PromptInputTools,
 } from '@shared/components/ai-elements/prompt-input';
 import { Bot } from 'lucide-react';
-import { type ReactNode, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 import type {
   CodingAgentAvailableCommand,
@@ -64,6 +64,8 @@ export const CodingComposer = ({
   supportsSteerShortcut = false,
   onStop,
 }: CodingComposerProps) => {
+  const composerRootRef = useRef<HTMLDivElement | null>(null);
+  const [isTightToolbar, setIsTightToolbar] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [commandSelection, setCommandSelection] = useState<{
     query: string | null;
@@ -81,6 +83,16 @@ export const CodingComposer = ({
     query !== null &&
     availableCommands.length > 0 &&
     dismissedPrompt !== prompt;
+
+  useEffect(() => {
+    const element = composerRootRef.current;
+    if (!element || typeof ResizeObserver === 'undefined') return;
+    const updateToolbarDensity = () => setIsTightToolbar(element.clientWidth <= 760);
+    updateToolbarDensity();
+    const observer = new ResizeObserver(updateToolbarDensity);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
 
   const selectCommand = (command: CodingAgentAvailableCommand) => {
     const nextPrompt = slashCommandPrompt(command);
@@ -106,7 +118,7 @@ export const CodingComposer = ({
   };
 
   return (
-    <div className="px-4 pt-2 pb-4">
+    <div ref={composerRootRef} className="px-4 pt-2 pb-4">
       <div className="relative mx-auto max-w-5xl">
         {statusNotice}
         {sessionId ? (
@@ -190,13 +202,15 @@ export const CodingComposer = ({
               className="max-h-48 min-h-20"
             />
           </PromptInputBody>
-          <PromptInputFooter className="flex-wrap">
-            <PromptInputTools className="flex-1 flex-wrap">
+          <PromptInputFooter className="flex-nowrap">
+            <PromptInputTools className="min-w-0 flex-1 flex-nowrap overflow-hidden">
               {leadingTools}
               {showRecipient ? (
                 <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
                   <Bot className="size-3.5 shrink-0" />
-                  <span className="shrink-0">{i18nService.t('codingAgentSendTo')}</span>
+                  {!isTightToolbar && (
+                    <span className="shrink-0">{i18nService.t('codingAgentSendTo')}</span>
+                  )}
                   <span className="truncate font-medium text-foreground">{recipientName}</span>
                 </div>
               ) : null}

--- a/src/renderer/components/coding/CodingComposerConfigControls.tsx
+++ b/src/renderer/components/coding/CodingComposerConfigControls.tsx
@@ -1,18 +1,24 @@
 import { PromptInputButton } from '@shared/components/ai-elements/prompt-input';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, SlidersHorizontal } from 'lucide-react';
 
 import type { CodingAgentConfigOption } from '../../../shared/codingAgent';
+import { i18nService } from '../../services/i18n';
 
 interface CodingComposerConfigControlsProps {
   options: CodingAgentConfigOption[];
   onChange: (optionId: string, value: string | boolean) => void;
+  compact?: boolean;
 }
 
 const selectedOptionLabel = (option: CodingAgentConfigOption): string => {
@@ -25,8 +31,55 @@ const selectedOptionLabel = (option: CodingAgentConfigOption): string => {
 export const CodingComposerConfigControls = ({
   options,
   onChange,
-}: CodingComposerConfigControlsProps) =>
-  options.map(option =>
+  compact = false,
+}: CodingComposerConfigControlsProps) => {
+  if (compact) {
+    if (options.length === 0) return null;
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          nativeButton
+          render={
+            <PromptInputButton aria-label={i18nService.t('settings')}>
+              <SlidersHorizontal />
+            </PromptInputButton>
+          }
+        />
+        <DropdownMenuContent align="end" side="top" className="min-w-48">
+          {options.map(option =>
+            option.type === 'select' ? (
+              <DropdownMenuSub key={option.id}>
+                <DropdownMenuSubTrigger>{option.name}</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent side="top" align="end" className="min-w-40">
+                  <DropdownMenuRadioGroup
+                    value={typeof option.currentValue === 'string' ? option.currentValue : ''}
+                    onValueChange={value => onChange(option.id, value)}
+                  >
+                    {option.options?.map(value => (
+                      <DropdownMenuRadioItem key={value.value} value={value.value}>
+                        {value.name}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ) : (
+              <DropdownMenuCheckboxItem
+                key={option.id}
+                checked={option.currentValue === true}
+                onCheckedChange={checked => onChange(option.id, checked === true)}
+              >
+                {option.name}
+              </DropdownMenuCheckboxItem>
+            ),
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  return options.map(option =>
     option.type === 'select' ? (
       <DropdownMenu key={option.id}>
         <DropdownMenuTrigger
@@ -68,3 +121,4 @@ export const CodingComposerConfigControls = ({
       </PromptInputButton>
     ),
   );
+};

--- a/src/renderer/components/cowork/ActiveExpertBadge.tsx
+++ b/src/renderer/components/cowork/ActiveExpertBadge.tsx
@@ -10,16 +10,26 @@ import { ExpertAvatar } from '../expert/expertAvatars';
 
 interface ActiveExpertBadgeProps {
   expertId?: string;
+  expertName?: string;
   onRemove: () => void;
+  compact?: boolean;
   className?: string;
 }
 
-const ActiveExpertBadge: React.FC<ActiveExpertBadgeProps> = ({ expertId, onRemove, className }) => {
+const ActiveExpertBadge: React.FC<ActiveExpertBadgeProps> = ({
+  expertId,
+  expertName,
+  onRemove,
+  compact = false,
+  className,
+}) => {
   const expert = useSelector((state: RootState) =>
     state.agent.agents.find(agent => agent.id === expertId),
   );
 
-  if (!expert) return null;
+  if (!expertId) return null;
+  const displayName = expert?.name ?? expertName ?? expertId;
+  const avatarName = expert?.presetId || expert?.id || expertId;
 
   return (
     <span
@@ -27,7 +37,7 @@ const ActiveExpertBadge: React.FC<ActiveExpertBadgeProps> = ({ expertId, onRemov
         'sidebar-interactive-surface inline-flex h-7 max-w-48 items-center gap-1.5 rounded-full bg-transparent px-2 text-sm font-medium text-foreground transition-colors',
         className,
       )}
-      title={expert.name}
+      title={displayName}
     >
       <Button
         type="button"
@@ -39,13 +49,13 @@ const ActiveExpertBadge: React.FC<ActiveExpertBadgeProps> = ({ expertId, onRemov
         className="group/expert relative size-4 rounded-full p-0 hover:bg-transparent"
       >
         <ExpertAvatar
-          name={expert.presetId || expert.id}
-          label={expert.name}
+          name={avatarName}
+          label={displayName}
           className="size-4 rounded-full border-0 transition-opacity group-hover/expert:opacity-0"
         />
         <X className="absolute size-4 text-primary opacity-0 transition-opacity group-hover/expert:opacity-100" />
       </Button>
-      <span className="truncate">{expert.name}</span>
+      {!compact && <span className="truncate">{displayName}</span>}
     </span>
   );
 };

--- a/src/renderer/components/cowork/CoworkModelPicker.tsx
+++ b/src/renderer/components/cowork/CoworkModelPicker.tsx
@@ -1,6 +1,4 @@
-import {
-  ModelSelectorName,
-} from '@shared/components/ai-elements/model-selector';
+import { ModelSelectorName } from '@shared/components/ai-elements/model-selector';
 import { PromptInputButton } from '@shared/components/ai-elements/prompt-input';
 import {
   Command,
@@ -24,6 +22,7 @@ type CoworkModelPickerProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSelect: (model: Model) => void;
+  compact?: boolean;
 };
 
 function ModelProviderIcon({ provider }: { provider: string }) {
@@ -36,6 +35,7 @@ export function CoworkModelPicker({
   open,
   onOpenChange,
   onSelect,
+  compact = false,
 }: CoworkModelPickerProps) {
   const displayedSelectedModel = models.length > 0 ? selectedModel : null;
   const [searchQuery, setSearchQuery] = useState('');
@@ -64,18 +64,25 @@ export function CoworkModelPicker({
       <PopoverTrigger
         nativeButton={true}
         render={
-          <PromptInputButton className="max-w-[200px] gap-1 px-2 text-sm hover:bg-surface-raised">
+          <PromptInputButton
+            className={compact ? 'gap-1 px-2' : 'max-w-[200px] gap-1 px-2 text-sm'}
+            aria-label={displayedSelectedModel?.name ?? i18nService.t('selectModel')}
+          >
             {displayedSelectedModel ? (
               <>
                 <ModelProviderIcon
                   provider={
-                    displayedSelectedModel.providerKey || displayedSelectedModel.provider || 'openai'
+                    displayedSelectedModel.providerKey ||
+                    displayedSelectedModel.provider ||
+                    'openai'
                   }
                 />
-                <ModelSelectorName>{displayedSelectedModel.name}</ModelSelectorName>
+                {!compact && <ModelSelectorName>{displayedSelectedModel.name}</ModelSelectorName>}
               </>
             ) : (
-              <span className="text-muted-foreground">{i18nService.t('selectModel')}</span>
+              !compact && (
+                <span className="text-muted-foreground">{i18nService.t('selectModel')}</span>
+              )
             )}
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           </PromptInputButton>

--- a/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkPromptInput.structure.test.ts
@@ -64,6 +64,17 @@ test('keeps the session permission selector available during an active run', () 
   expect(permissionMenu).not.toContain('disabled={disabled || isStreaming}');
 });
 
+test('keeps model, thinking, and permission controls reachable in compact toolbars', () => {
+  const compactControlsStart = source.lastIndexOf('<div className="flex items-center gap-1.5">');
+  const compactControls = source.slice(compactControlsStart);
+
+  expect(compactControlsStart).toBeGreaterThanOrEqual(0);
+  expect(compactControls).toContain('compact={isCompactToolbar}');
+  expect(compactControls).toContain('isCompactToolbar && isWorkVariant');
+  expect(compactControls).toContain('<PermissionModeMenu');
+  expect(compactControls).toContain('showModelSelector');
+});
+
 test('places the active expert identity between permissions and MCP controls', () => {
   const permissionMenu = source.indexOf('<PermissionModeMenu');
   const expertBadge = source.lastIndexOf('<ActiveExpertBadge');

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -71,10 +71,17 @@ import { usePersistAgentModelSelection } from './usePersistAgentModelSelection';
 // so that attachment state survives view switches (cowork ↔ skills, etc.)
 type CoworkAttachment = DraftAttachment;
 
-const GoalModeChip: React.FC<{ onRemove: () => void }> = ({ onRemove }) => (
-  <span className="inline-flex h-6 items-center gap-1.5 rounded-full px-1.5 text-xs font-medium text-(--zy-skill-blue-foreground) transition-colors hover:bg-(--zy-skill-blue-background)">
-    <Target className="size-3.5" />
-    <span className="max-w-24 truncate">{i18nService.t('goalMode')}</span>
+const GoalModeChip: React.FC<{ onRemove: () => void; compact?: boolean }> = ({
+  onRemove,
+  compact = false,
+}) => (
+  <span
+    className={cn(
+      'inline-flex h-6 items-center gap-1.5 rounded-full px-1.5 text-xs font-medium text-(--zy-skill-blue-foreground) transition-colors hover:bg-(--zy-skill-blue-background)',
+      compact && 'px-1',
+    )}
+    title={i18nService.t('goalMode')}
+  >
     <Button
       type="button"
       variant="ghost"
@@ -82,10 +89,12 @@ const GoalModeChip: React.FC<{ onRemove: () => void }> = ({ onRemove }) => (
       onClick={onRemove}
       aria-label={i18nService.t('clearGoalMode')}
       title={i18nService.t('clearGoalMode')}
-      className="ml-0.5 size-4 rounded-full hover:bg-(--zy-skill-blue-foreground)/10"
+      className="group/goal relative ml-0.5 size-4 rounded-full p-0 hover:bg-transparent"
     >
-      <X />
+      <Target className="size-3.5 transition-opacity group-hover/goal:opacity-0" />
+      <X className="absolute size-3.5 opacity-0 transition-opacity group-hover/goal:opacity-100" />
     </Button>
+    {!compact && <span className="max-w-24 truncate">{i18nService.t('goalMode')}</span>}
   </span>
 );
 
@@ -150,6 +159,10 @@ const buildInlinedSkillPrompt = (skill: Skill): string => {
 };
 
 const isMacPlatform = navigator.platform.includes('Mac');
+// Only collapse secondary controls when the chat column is genuinely narrow.
+// A split pane around 700px still has room for the full permission/model row.
+const COMPACT_TOOLBAR_MAX_WIDTH = 480;
+const TIGHT_TOOLBAR_MAX_WIDTH = 760;
 
 export interface CoworkPromptInputRef {
   /** 设置输入框值 */
@@ -305,8 +318,11 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
     const [imageVisionHint, setImageVisionHint] = useState(false);
     const [isPatchingModel, setIsPatchingModel] = useState(false);
     const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
+    const [isCompactToolbar, setIsCompactToolbar] = useState(false);
+    const [isTightToolbar, setIsTightToolbar] = useState(false);
 
     const textareaRef = useRef<HTMLDivElement>(null);
+    const promptRootRef = useRef<HTMLDivElement>(null);
     const dragDepthRef = useRef(0);
     const warningTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const modelPatchRequestIdRef = useRef(0);
@@ -491,6 +507,20 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       modelPatchRequestIdRef.current += 1;
       setIsPatchingModel(false);
     }, [sessionId]);
+
+    useEffect(() => {
+      const element = promptRootRef.current;
+      if (!element || typeof ResizeObserver === 'undefined') return;
+      const updateCompactState = () => {
+        const width = element.clientWidth;
+        setIsCompactToolbar(width <= COMPACT_TOOLBAR_MAX_WIDTH);
+        setIsTightToolbar(width <= TIGHT_TOOLBAR_MAX_WIDTH);
+      };
+      updateCompactState();
+      const observer = new ResizeObserver(updateCompactState);
+      observer.observe(element);
+      return () => observer.disconnect();
+    }, []);
 
     // Sync value from draft when sessionId changes
     useEffect(() => {
@@ -1130,7 +1160,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
     const isPlusToolbar = !remoteManaged;
     const isWorkVariant = showFolderSelector || showPermissionModeSelector;
     return (
-      <div className="relative">
+      <div ref={promptRootRef} className="relative">
         {imageVisionHint && (
           <div className="mb-2 flex items-start gap-1.5 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-2.5 py-1.5 text-xs text-amber-700 dark:text-amber-400">
             <TriangleAlert className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -1187,16 +1217,16 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
               className={size === 'large' ? 'max-h-48 overflow-y-auto' : undefined}
             />
           </PromptInputBody>
-          <PromptInputFooter className="flex-wrap">
+          <PromptInputFooter className="flex-nowrap">
             <PromptInputTools
               className={cn(
-                'min-w-0 flex-1 flex-wrap',
+                'min-w-0 flex-1 flex-nowrap overflow-hidden',
                 sessionContextPending && 'pointer-events-none opacity-50',
               )}
               aria-disabled={sessionContextPending}
               inert={sessionContextPending ? true : undefined}
             >
-              {!isPlusToolbar && showModelSelector && (
+              {!isCompactToolbar && !isPlusToolbar && showModelSelector && (
                 <>
                   <ContextUsageIndicator
                     usage={contextUsage}
@@ -1219,7 +1249,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                   />
                 </>
               )}
-              {!isPlusToolbar && (
+              {!isCompactToolbar && !isPlusToolbar && (
                 <LocalThinkingToggle
                   model={effectiveSelectedModel}
                   visible={showLocalThinkingToggle}
@@ -1247,7 +1277,7 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                     onProductionLoopModeChange={setProductionLoopMode}
                     disabled={disabled || isStreaming || isAddingFile}
                   />
-                  {isWorkVariant && (
+                  {!isCompactToolbar && isWorkVariant && (
                     <PermissionModeMenu
                       value={permissionMode ?? CoworkPermissionMode.Ask}
                       onChange={mode => onPermissionModeChange?.(mode)}
@@ -1257,17 +1287,23 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                   {isWorkVariant && (
                     <ActiveExpertBadge
                       expertId={selectedExpertIds[0]}
+                      expertName={
+                        currentSession?.experts?.find(
+                          expert => expert.expertId === selectedExpertIds[0],
+                        )?.expertName
+                      }
                       onRemove={() => setSelectedExpertIds([])}
+                      compact={isTightToolbar}
                     />
                   )}
                   {isWorkVariant && goalMode && (
-                    <GoalModeChip onRemove={() => setGoalMode(false)} />
+                    <GoalModeChip compact={isTightToolbar} onRemove={() => setGoalMode(false)} />
                   )}
                   <ActiveMcpBadge />
                 </>
               )}
             </PromptInputTools>
-            {isPlusToolbar && (showLocalThinkingToggle || showModelSelector) && (
+            {!isCompactToolbar && isPlusToolbar && (showLocalThinkingToggle || showModelSelector) && (
               <div className="flex items-center gap-1.5">
                 {!isWorkVariant && (
                   <LocalThinkingToggle

--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -1303,42 +1303,57 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
                 </>
               )}
             </PromptInputTools>
-            {!isCompactToolbar && isPlusToolbar && (showLocalThinkingToggle || showModelSelector) && (
-              <div className="flex items-center gap-1.5">
-                {!isWorkVariant && (
-                  <LocalThinkingToggle
-                    model={effectiveSelectedModel}
-                    visible={showLocalThinkingToggle}
-                    enabled={localThinkingEnabled}
-                    disabled={disabled || isStreaming}
-                    onEnabledChange={onLocalThinkingEnabledChange}
-                  />
-                )}
-                {showModelSelector && (
-                  <>
-                    <ContextUsageIndicator
-                      usage={contextUsage}
-                      messageUsage={contextMessage?.metadata?.usage}
-                      modelId={contextMessage?.metadata?.model}
-                      modelProviderKey={contextMessage?.metadata?.modelProviderKey}
-                      selectedModelId={effectiveSelectedModel?.id}
-                      selectedModelProviderKey={effectiveSelectedModel?.providerKey}
-                      messages={currentSession?.messages}
-                      systemPrompt={currentSession?.systemPrompt}
+            {isPlusToolbar &&
+              (showLocalThinkingToggle ||
+                showModelSelector ||
+                (isCompactToolbar && isWorkVariant)) && (
+                <div className="flex items-center gap-1.5">
+                  {!isWorkVariant && showLocalThinkingToggle && (
+                    <LocalThinkingToggle
+                      model={effectiveSelectedModel}
+                      visible={showLocalThinkingToggle}
+                      enabled={localThinkingEnabled}
+                      disabled={disabled || isStreaming}
+                      onEnabledChange={onLocalThinkingEnabledChange}
+                      compact={isCompactToolbar}
                     />
-                    <CoworkModelPicker
-                      models={availableModels}
-                      selectedModel={effectiveSelectedModel}
-                      open={modelSelectorOpen}
-                      onOpenChange={setModelSelectorOpen}
-                      onSelect={model => {
-                        void handleModelSelect(model);
-                      }}
+                  )}
+                  {showModelSelector && (
+                    <>
+                      {!isCompactToolbar && (
+                        <ContextUsageIndicator
+                          usage={contextUsage}
+                          messageUsage={contextMessage?.metadata?.usage}
+                          modelId={contextMessage?.metadata?.model}
+                          modelProviderKey={contextMessage?.metadata?.modelProviderKey}
+                          selectedModelId={effectiveSelectedModel?.id}
+                          selectedModelProviderKey={effectiveSelectedModel?.providerKey}
+                          messages={currentSession?.messages}
+                          systemPrompt={currentSession?.systemPrompt}
+                        />
+                      )}
+                      <CoworkModelPicker
+                        models={availableModels}
+                        selectedModel={effectiveSelectedModel}
+                        open={modelSelectorOpen}
+                        onOpenChange={setModelSelectorOpen}
+                        onSelect={model => {
+                          void handleModelSelect(model);
+                        }}
+                        compact={isCompactToolbar}
+                      />
+                    </>
+                  )}
+                  {isCompactToolbar && isWorkVariant && (
+                    <PermissionModeMenu
+                      value={permissionMode ?? CoworkPermissionMode.Ask}
+                      onChange={mode => onPermissionModeChange?.(mode)}
+                      disabled={disabled}
+                      compact
                     />
-                  </>
-                )}
-              </div>
-            )}
+                  )}
+                </div>
+              )}
             <PromptInputSubmit
               disabled={sessionContextPending}
               status={isStreaming ? 'streaming' : 'ready'}

--- a/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
+++ b/src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts
@@ -43,7 +43,7 @@ test('lets the conversation fill the pane behind the floating composer', () => {
   const overlayClose = source.indexOf('{!isSessionSwitching && inlinePermission', overlay);
   expect(overlayClose).toBeGreaterThan(scrollContainer);
   expect(source.slice(overlay, promptInput)).toContain(
-    'className="pointer-events-auto relative col-start-1 row-start-1 self-end rounded-t-3xl bg-background pb-4"',
+    'className="pointer-events-auto relative col-start-1 row-start-1 min-w-0 self-end rounded-t-3xl bg-background pb-4"',
   );
   expect(turnBlockSource).toContain('className="mx-auto w-full max-w-5xl min-w-[320px] pl-4"');
   expect(turnBlockSource).toContain('className="flex min-w-0 flex-1 flex-col gap-3 py-3"');

--- a/src/renderer/components/cowork/CoworkSessionDetail.tsx
+++ b/src/renderer/components/cowork/CoworkSessionDetail.tsx
@@ -1488,8 +1488,8 @@ const CoworkSessionDetail: React.FC<CoworkSessionDetailProps> = ({
             ref={composerOverlayRef}
             className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-4"
           >
-            <div className="mx-auto grid w-full max-w-5xl min-w-[320px] pl-4">
-              <div className="pointer-events-auto relative col-start-1 row-start-1 self-end rounded-t-3xl bg-background pb-4">
+            <div className="mx-auto grid w-full max-w-5xl min-w-[320px] grid-cols-[minmax(0,1fr)] pl-4">
+              <div className="pointer-events-auto relative col-start-1 row-start-1 min-w-0 self-end rounded-t-3xl bg-background pb-4">
                 <CoworkPromptInput
                   ref={promptInputRef}
                   topAccessory={

--- a/src/renderer/components/cowork/LocalThinkingToggle.tsx
+++ b/src/renderer/components/cowork/LocalThinkingToggle.tsx
@@ -13,6 +13,7 @@ type LocalThinkingToggleProps = {
   enabled?: boolean;
   disabled: boolean;
   onEnabledChange?: (enabled: boolean | undefined) => void;
+  compact?: boolean;
 };
 
 export function LocalThinkingToggle({
@@ -21,6 +22,7 @@ export function LocalThinkingToggle({
   enabled,
   disabled,
   onEnabledChange,
+  compact = false,
 }: LocalThinkingToggleProps) {
   const previousSupportedModelRef = useRef<string | undefined>(undefined);
   const modelIdentity = model
@@ -49,7 +51,7 @@ export function LocalThinkingToggle({
             size="sm"
           >
             <Brain data-icon="inline-start" />
-            <span>{i18nService.t('chatThinkingToggle')}</span>
+            {!compact && <span>{i18nService.t('chatThinkingToggle')}</span>}
           </Toggle>
         }
       />

--- a/src/renderer/components/cowork/PermissionModeMenu.tsx
+++ b/src/renderer/components/cowork/PermissionModeMenu.tsx
@@ -16,6 +16,7 @@ interface PermissionModeMenuProps {
   value: CoworkPermissionMode;
   onChange: (mode: CoworkPermissionMode) => void;
   disabled?: boolean;
+  compact?: boolean;
 }
 
 const PERMISSION_MODE_LABEL_KEYS = {
@@ -31,6 +32,7 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
   value,
   onChange,
   disabled = false,
+  compact = false,
 }) => {
   const TriggerIcon = value === CoworkPermissionMode.Ask ? ShieldCheck : ShieldAlert;
 
@@ -42,10 +44,11 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
         render={
           <PromptInputButton
             disabled={disabled}
-            className="sidebar-interactive-surface gap-1 px-2 text-sm hover:shadow-subtle data-popup-open:shadow-subtle"
+            aria-label={i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}
+            className={compact ? 'gap-1 px-2' : 'sidebar-interactive-surface gap-1 px-2 text-sm'}
           >
             <TriggerIcon className="size-4 text-foreground" />
-            <span>{i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}</span>
+            {!compact && <span>{i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}</span>}
             <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
           </PromptInputButton>
         }


### PR DESCRIPTION
## Summary

优化窄窗口和分栏场景下的对话输入区域布局，避免工具栏内容挤压和面板占用过多空间。

## Related Issue

暂无直接关联 issue，本 PR 不关闭 issue。

## Changes Made

- 限制 Artifacts 面板最大宽度，确保对话区域保留可用空间
- 根据输入区域宽度自适应收起次要工具栏控件
- 优化 Coding 和 Cowork 输入工具栏在窄布局下的排列方式
- 支持专家徽章在会话数据尚未加载时显示，并提供紧凑模式
- 更新相关结构测试和尺寸计算测试

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

验证结果：
- `npm run lint` 通过
- `npx vitest run src/renderer/components/artifacts/artifactPanelResize.test.ts src/renderer/components/cowork/CoworkSessionDetail.structure.test.ts` 通过，5 个测试全部通过
- `git diff --check` 通过

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

本次 PR 已基于最新 `origin/main` 完成 rebase。`bun.lock` 为本地未提交改动，未包含在本 PR 中。