### PR TITLE
fix(mcp): harden feishu connector installation

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1862,7 +1862,7 @@ const runFeishuCliCommand = (
     const env: Record<string, string | undefined> = { ...process.env };
     // lark-cli's generated launcher invokes `node` through PATH. Use the
     // application runtime here as well as for its initial npm installation.
-    applyApplicationRuntimeEnv(env);
+    applyApplicationRuntimeEnv(env, { includePackageMirrors: true });
     const child = spawn(command, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1833,8 +1833,10 @@ const ensureBuiltInMcpDefaultsDisabled = (): void => {
 };
 
 const FEISHU_CLI_TIMEOUT_MS = 120_000;
+const FEISHU_CLI_INSTALL_TIMEOUT_MS = 300_000;
 const FEISHU_CLI_AUTH_TIMEOUT_MS = 600_000;
 const FEISHU_MCP_REGISTRY_ID = 'feishu';
+const FEISHU_CLI_PACKAGE = '@larksuite/cli@1.0.93';
 
 const getFeishuCliRoot = (): string => path.join(app.getPath('userData'), 'MCPs', 'feishu', 'cli');
 
@@ -1927,25 +1929,49 @@ const findFeishuCliCommand = async (): Promise<string | null> => {
   return getLocalFeishuCliCommand();
 };
 
+const installFeishuCli = async (cliRoot: string, force = false): Promise<void> => {
+  const bundledNpm = resolveBundledNpmRuntime(NpmCli.Npm, [
+    'install',
+    '--prefix',
+    cliRoot,
+    '--no-save',
+    '--no-audit',
+    '--no-fund',
+    ...(force ? ['--force'] : []),
+    FEISHU_CLI_PACKAGE,
+  ]);
+  if (!bundledNpm)
+    throw new Error('Bundled npm runtime is unavailable. Please reinstall the application.');
+  await runFeishuCliCommand(
+    bundledNpm.command,
+    bundledNpm.args,
+    cliRoot,
+    FEISHU_CLI_INSTALL_TIMEOUT_MS,
+  );
+};
+
+const verifyFeishuCli = async (command: string, cliRoot: string): Promise<void> => {
+  await runFeishuCliCommand(command, ['--version'], cliRoot);
+};
+
 const prepareFeishuCli = async (): Promise<void> => {
   let cliCommand = await findFeishuCliCommand();
-  if (!cliCommand) {
-    const cliRoot = getFeishuCliRoot();
-    fs.mkdirSync(cliRoot, { recursive: true });
-    const bundledNpm = resolveBundledNpmRuntime(NpmCli.Npm, [
-      'install',
-      '--prefix',
-      cliRoot,
-      '--no-save',
-      '@larksuite/cli',
-    ]);
-    if (!bundledNpm)
-      throw new Error('Bundled npm runtime is unavailable. Please reinstall the application.');
-    await runFeishuCliCommand(bundledNpm.command, bundledNpm.args, cliRoot);
+  const cliRoot = getFeishuCliRoot();
+  fs.mkdirSync(cliRoot, { recursive: true });
+  if (cliCommand) {
+    try {
+      await verifyFeishuCli(cliCommand, cliRoot);
+    } catch (error) {
+      console.warn('[Feishu] CLI health check failed, reinstalling the pinned version:', error);
+      await installFeishuCli(cliRoot, true);
+      cliCommand = await findFeishuCliCommand();
+    }
+  } else {
+    await installFeishuCli(cliRoot);
     cliCommand = await findFeishuCliCommand();
   }
   if (!cliCommand) throw new Error('Feishu CLI installation did not provide lark-cli');
-  const cliRoot = getFeishuCliRoot();
+  await verifyFeishuCli(cliCommand, cliRoot);
 
   try {
     await runFeishuCliCommand(cliCommand, ['config', 'show'], cliRoot);

--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -586,7 +586,12 @@ const McpManager: React.FC<McpManagerProps> = ({
       setIsFeishuCliReady(true);
     } catch (error) {
       console.error('[MCP] Feishu connector installation failed:', error);
-      setActionError(i18nService.t('mcpFeishuInstallFailed'));
+      const detail = error instanceof Error ? error.message : '';
+      setActionError(
+        detail
+          ? `${i18nService.t('mcpFeishuInstallFailed')} ${detail}`
+          : i18nService.t('mcpFeishuInstallFailed'),
+      );
     } finally {
       setIsPreparingFeishuCli(false);
     }

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -2355,7 +2355,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpFeishuInstallTitle: '安装飞书连接器',
     mcpFeishuLoginTitle: '登录飞书账号',
     mcpFeishuSubtitle: '连接飞书，通过官方 CLI 授权调用日历、云文档、多维表格、聊天等能力。',
-    mcpFeishuInstallFailed: '飞书连接器安装失败，请检查网络和 Node.js 环境后重试。',
+    mcpFeishuInstallFailed: '飞书连接器安装失败，请检查网络后重试。错误详情：',
     mcpConfigureTitle: '配置 {name}',
     mcpGithubConfigureSubtitle: '连接 GitHub 以访问你授权的仓库、Issue 和 Pull Request。',
     mcpGithubPat: 'GitHub 个人访问令牌',
@@ -5727,7 +5727,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     mcpFeishuSubtitle:
       'Connect Feishu through its official CLI to use calendars, documents, Bitable, chat, and more.',
     mcpFeishuInstallFailed:
-      'Could not install the Feishu connector. Check your network and Node.js setup, then try again.',
+      'Could not install the Feishu connector. Check your network, then try again. Error details:',
     mcpConfigureTitle: 'Configure {name}',
     mcpGithubConfigureSubtitle:
       'Connect GitHub to access the repositories, issues, and pull requests you authorize.',

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -88,6 +88,16 @@ test("unpacks AnyDoc native bindings from the application archive", () => {
   );
 });
 
+test("unpacks npm for connector installation without a system Node.js runtime", () => {
+  const config = JSON.parse(
+    readFileSync(path.join(root, "electron-builder.json"), "utf8"),
+  ) as {
+    asarUnpack?: string[];
+  };
+
+  assert.ok(config.asarUnpack?.includes("node_modules/npm/**"));
+});
+
 test("unpacks ACP adapters without bundling external agent binaries", () => {
   const config = JSON.parse(
     readFileSync(path.join(root, "electron-builder.json"), "utf8"),


### PR DESCRIPTION
## 摘要

修复无系统 Node.js 环境下飞书连接器安装不稳定、错误不可诊断的问题。

## 关联 Issue

无。

## 改动内容

- 飞书 CLI 安装默认使用国内 npm 镜像，同时保留用户显式 registry。
- 固定 `@larksuite/cli@1.0.93`，安装超时调整为 5 分钟，关闭 audit/fund 请求。
- 对已存在 CLI 执行健康检查；检查失败时强制覆盖安装固定版本。
- 安装失败展示实际错误详情，不再提示用户安装 Node.js。
- 增加 npm 必须随安装包解包的回归测试。

## 变更类型

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## 验证

- [x] `npm run build:tsc`
- [x] `npm run lint`
- [x] `npm test -- runtimePackagingConfig`（15 passed）
- [ ] Windows 真实安装包、无系统 Node/PATH 清空的端到端冒烟

## Electron 影响

- [x] Main process：飞书 CLI 安装运行时及恢复逻辑。
- [ ] Preload / IPC / Window。

## 备注

当前验证覆盖代码、类型、lint 与安装包配置契约；Windows 真实安装包冒烟仍需在 CI 或目标机器补充。