### PR TITLE
feat: 优化侧边栏与定时任务控件

### DIFF
--- a/src/renderer/components/PageHeader.tsx
+++ b/src/renderer/components/PageHeader.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@shared/components/ui/button';
 import { cn } from '@shared/lib/utils';
-import { PanelLeftOpen } from 'lucide-react';
 import React from 'react';
 
 import { i18nService } from '../services/i18n';
 import { SidebarAnimatedMessageCirclePlusIcon } from './icons/SidebarAnimatedMessageCirclePlusIcon';
+import { SidebarAnimatedPanelLeftCloseIcon } from './icons/SidebarAnimatedPanelLeftCloseIcon';
 import WindowTitleBar from './window/WindowTitleBar';
 
 /**
@@ -65,7 +65,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
                   title={i18nService.t('expand')}
                   className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised hover:text-foreground"
                 >
-                  <PanelLeftOpen className="h-4 w-4" />
+                  <SidebarAnimatedPanelLeftCloseIcon direction="right" />
                 </Button>
               )}
               {onNewChat && (

--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -2,7 +2,6 @@ import { Button } from '@shared/components/ui/button';
 import { Switch } from '@shared/components/ui/switch';
 import { cn } from '@shared/lib/utils';
 import { useReducedMotion } from 'motion/react';
-import { ListTodo } from 'lucide-react';
 import { type RefObject, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
@@ -37,6 +36,10 @@ import {
   SidebarAnimatedTerminalIcon,
   type SidebarAnimatedTerminalIconHandle,
 } from './icons/SidebarAnimatedTerminalIcon';
+import {
+  SidebarAnimatedTodoIcon,
+  type SidebarAnimatedTodoIconHandle,
+} from './icons/SidebarAnimatedTodoIcon';
 
 export type SidebarActiveView =
   | 'cowork'
@@ -100,6 +103,7 @@ export const SidebarNavigationControls = ({
   const localInferenceIconRef = useRef<SidebarAnimatedBotIconHandle>(null);
   const expertIconRef = useRef<SidebarAnimatedUsersIconHandle>(null);
   const codingIconRef = useRef<SidebarAnimatedTerminalIconHandle>(null);
+  const todoIconRef = useRef<SidebarAnimatedTodoIconHandle>(null);
   const prefersReducedMotion = useReducedMotion();
   const isNewConversationActive =
     activeView === 'cowork' && (workMode !== WorkMode.Chat || activeSkillIds.length === 0);
@@ -214,8 +218,12 @@ export const SidebarNavigationControls = ({
           type="button"
           variant="ghost"
           onClick={onShowTodo}
-          onMouseEnter={() => onPrefetchView?.('todo')}
+          onMouseEnter={() => {
+            startIconAnimation(todoIconRef);
+            onPrefetchView?.('todo');
+          }}
           onFocus={() => onPrefetchView?.('todo')}
+          onMouseLeave={() => todoIconRef.current?.stopAnimation()}
           className={
             activeView === 'todo'
               ? activeSidebarViewNavItemClassName
@@ -223,7 +231,7 @@ export const SidebarNavigationControls = ({
           }
           aria-current={activeView === 'todo' ? 'page' : undefined}
         >
-          <ListTodo className="size-4" />
+          <SidebarAnimatedTodoIcon ref={todoIconRef} />
           {i18nService.t('todoTitle')}
         </Button>
       )}

--- a/src/renderer/components/icons/SidebarAnimatedTerminalIcon.tsx
+++ b/src/renderer/components/icons/SidebarAnimatedTerminalIcon.tsx
@@ -17,8 +17,7 @@ const LINE_VARIANTS: Variants = {
   [TerminalIconAnimationState.Animate]: {
     opacity: [1, 0, 1],
     transition: {
-      duration: 0.8,
-      repeat: Number.POSITIVE_INFINITY,
+      duration: 0.35,
       ease: 'linear',
     },
   },

--- a/src/renderer/components/icons/SidebarAnimatedTodoIcon.tsx
+++ b/src/renderer/components/icons/SidebarAnimatedTodoIcon.tsx
@@ -1,33 +1,31 @@
-import { motion, useAnimation, useReducedMotion, type Transition, type Variants } from 'motion/react';
+import { motion, useAnimation, useReducedMotion, type Variants } from 'motion/react';
 import type { HTMLAttributes, MouseEvent } from 'react';
 import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 
 import { cn } from '@shared/lib/utils';
 
-export interface SidebarAnimatedPanelLeftCloseIconHandle {
+export interface SidebarAnimatedTodoIconHandle {
   startAnimation: () => void;
   stopAnimation: () => void;
 }
 
-interface SidebarAnimatedPanelLeftCloseIconProps extends HTMLAttributes<HTMLDivElement> {
+interface SidebarAnimatedTodoIconProps extends HTMLAttributes<HTMLDivElement> {
   size?: number;
-  direction?: 'left' | 'right';
 }
 
-const DEFAULT_TRANSITION: Transition = {
-  times: [0, 0.4, 1],
-  duration: 0.5,
+const VARIANTS: Variants = {
+  normal: { y: 0, rotate: 0, transition: { duration: 0.3, ease: 'easeOut' } },
+  animate: {
+    y: [0, -2, 0],
+    rotate: [0, -3, 0],
+    transition: { duration: 0.55, ease: 'easeInOut', times: [0, 0.45, 1] },
+  },
 };
 
-const PATH_VARIANTS: Variants = {
-  normal: { x: 0 },
-  animate: { x: [0, -1.5, 0] },
-};
-
-export const SidebarAnimatedPanelLeftCloseIcon = forwardRef<
-  SidebarAnimatedPanelLeftCloseIconHandle,
-  SidebarAnimatedPanelLeftCloseIconProps
->(({ onMouseEnter, onMouseLeave, className, size = 16, direction = 'left', ...props }, ref) => {
+export const SidebarAnimatedTodoIcon = forwardRef<
+  SidebarAnimatedTodoIconHandle,
+  SidebarAnimatedTodoIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 16, ...props }, ref) => {
   const controls = useAnimation();
   const isControlledRef = useRef(false);
   const prefersReducedMotion = useReducedMotion();
@@ -61,33 +59,35 @@ export const SidebarAnimatedPanelLeftCloseIcon = forwardRef<
   return (
     <div
       aria-hidden="true"
-      className={cn('sidebar-animated-panel-left-close-icon size-4 shrink-0', className)}
+      className={cn('sidebar-animated-todo-icon size-4 shrink-0', className)}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       {...props}
     >
-      <svg
+      <motion.svg
+        animate={controls}
         fill="none"
         height={size}
+        initial="normal"
         stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth="2"
+        style={{ transformOrigin: '12px 12px' }}
+        variants={VARIANTS}
         viewBox="0 0 24 24"
         width={size}
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect height="18" rx="2" width="18" x="3" y="3" />
-        <path d="M9 3v18" />
-        <motion.path
-          animate={controls}
-          d={direction === 'right' ? 'm13 9 3 3-3 3' : 'm16 15-3-3 3-3'}
-          transition={DEFAULT_TRANSITION}
-          variants={PATH_VARIANTS}
-        />
-      </svg>
+        <path d="M9 6h11" />
+        <path d="M9 12h11" />
+        <path d="M9 18h11" />
+        <path d="m3 6 1 1 2-2" />
+        <path d="m3 12 1 1 2-2" />
+        <path d="m3 18 1 1 2-2" />
+      </motion.svg>
     </div>
   );
 });
 
-SidebarAnimatedPanelLeftCloseIcon.displayName = 'SidebarAnimatedPanelLeftCloseIcon';
+SidebarAnimatedTodoIcon.displayName = 'SidebarAnimatedTodoIcon';

--- a/src/renderer/components/im/ChannelWorkspaceField.test.tsx
+++ b/src/renderer/components/im/ChannelWorkspaceField.test.tsx
@@ -4,63 +4,31 @@ import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import { describe, expect, test, vi } from 'vitest';
-
 import type { Workspace } from '@shared/workspace';
-
 import { ChannelWorkspaceField } from './ChannelWorkspaceField';
 
 const workspaces: Workspace[] = [
-  {
-    id: 'ws-main',
-    name: '主工作区',
-    path: 'C:/main',
-    isHidden: false,
-    pinned: false,
-    createdAt: 1,
-    updatedAt: 1,
-  },
-  {
-    id: 'ws-sandbox',
-    name: '沙盒',
-    path: 'C:/sandbox',
-    isHidden: true,
-    pinned: false,
-    createdAt: 1,
-    updatedAt: 1,
-  },
-  {
-    id: 'ws-proj',
-    name: '项目 A',
-    path: 'C:/proj',
-    isHidden: false,
-    pinned: false,
-    createdAt: 1,
-    updatedAt: 1,
-  },
+  { id: 'ws-main', name: '主工作区', path: 'C:/main', isHidden: false, pinned: false, createdAt: 1, updatedAt: 1 },
+  { id: 'ws-sandbox', name: '沙盒', path: 'C:/sandbox', isHidden: true, pinned: false, createdAt: 1, updatedAt: 1 },
+  { id: 'ws-proj', name: '项目 A', path: 'C:/proj', isHidden: false, pinned: false, createdAt: 1, updatedAt: 1 },
 ];
 
 function renderField(workspaceId: string, onChange = vi.fn()) {
   render(
-    <ChannelWorkspaceField
-      accountId="acc-1"
-      workspaceId={workspaceId}
-      workspaces={workspaces}
-      onChange={onChange}
-    />,
+    <ChannelWorkspaceField accountId="acc-1" workspaceId={workspaceId} workspaces={workspaces} onChange={onChange} />,
   );
   return onChange;
 }
 
 describe('ChannelWorkspaceField', () => {
-  test('shows the workspace name for a preconfigured selection instead of the id', () => {
+  test('shows folder name instead of workspace id', () => {
     renderField('ws-proj');
     expect(screen.getByRole('combobox')).toHaveTextContent('项目 A');
     expect(screen.getByRole('combobox')).not.toHaveTextContent('ws-proj');
   });
 
-  test('shows the name of the workspace picked from the popup', async () => {
+  test('shows picked folder name', async () => {
     const user = userEvent.setup();
-    // Mirror the real flow: the parent (redux) updates the controlled value.
     function ControlledField() {
       const [currentId, setCurrentId] = React.useState('ws-main');
       return (

--- a/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
+++ b/src/renderer/components/scheduledTasks/ScheduledTasksView.tsx
@@ -197,7 +197,16 @@ const ScheduledTasksView: React.FC<ScheduledTasksViewProps> = ({
       </div>
 
       {/* Create-task modal */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+      <Dialog
+        open={createOpen}
+        onOpenChange={open => {
+          setCreateOpen(open);
+          if (!open) {
+            setCreatePrefill(undefined);
+            setCreateFormKey(key => key + 1);
+          }
+        }}
+      >
         <DialogContent className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-2xl">
           <DialogHeader className="sr-only">
             <DialogTitle>{i18nService.t('scheduledTasksNewTask')}</DialogTitle>

--- a/src/renderer/components/scheduledTasks/TaskForm.tsx
+++ b/src/renderer/components/scheduledTasks/TaskForm.tsx
@@ -27,8 +27,10 @@ import type {
   ScheduledTaskConversationOption,
   ScheduledTaskInput,
 } from '../../../scheduledTask/types';
+import type { Workspace } from '../../../shared/workspace';
 import { CoworkSessionSource } from '../../../shared/cowork/constants';
 import { i18nService } from '../../services/i18n';
+import { getLastPathSegment } from '../../utils/path';
 import { coworkService } from '../../services/cowork';
 import { scheduledTaskService } from '../../services/scheduledTask';
 import { RootState } from '../../store';
@@ -68,6 +70,21 @@ interface TaskFormProps {
   onDirtyChange?: (dirty: boolean) => void;
 }
 
+const createInitialFormState = (
+  mode: TaskFormProps['mode'],
+  task: ScheduledTask | undefined,
+  prefill: TaskTemplateValues | undefined,
+): FormState => {
+  if (mode === 'create' && !prefill) {
+    return { ...createFormState(), planType: 'daily' };
+  }
+  return createFormState(task, prefill);
+};
+
+const getWorkspaceFolderName = (workspace: Workspace): string => {
+  return getLastPathSegment(workspace.path) || workspace.name;
+};
+
 const TaskForm: React.FC<TaskFormProps> = ({
   mode,
   task,
@@ -76,9 +93,11 @@ const TaskForm: React.FC<TaskFormProps> = ({
   onSaved,
   onDirtyChange,
 }) => {
-  const [form, setForm] = useState<FormState>(() => createFormState(task, prefill));
+  const [form, setForm] = useState<FormState>(() => createInitialFormState(mode, task, prefill));
   // Snapshot of the pristine form for the dirty check (shallow compare, no stringify).
-  const [initialForm, setInitialForm] = useState<FormState>(() => createFormState(task, prefill));
+  const [initialForm, setInitialForm] = useState<FormState>(() =>
+    createInitialFormState(mode, task, prefill),
+  );
   const availableModels = useSelector((state: RootState) => state.model.availableModels);
   const defaultSelectedModel = useSelector((state: RootState) => state.model.defaultSelectedModel);
   const workspaces = useSelector((state: RootState) => state.workspace.workspaces);
@@ -117,10 +136,10 @@ const TaskForm: React.FC<TaskFormProps> = ({
   );
 
   useEffect(() => {
-    const nextForm = createFormState(task, prefill);
+    const nextForm = createInitialFormState(mode, task, prefill);
     setInitialForm(nextForm);
     setForm(nextForm);
-  }, [task, prefill]);
+  }, [mode, task, prefill]);
 
   useEffect(() => {
     if (form.workspaceId) return;
@@ -290,10 +309,24 @@ const TaskForm: React.FC<TaskFormProps> = ({
     [availableModels],
   );
   const workspaceOptions = useMemo(
-    () =>
-      workspaces
-        .filter(workspace => !workspace.isHidden)
-        .map(workspace => ({ value: workspace.id, label: workspace.name })),
+    () => {
+      const visible = workspaces.filter(workspace => !workspace.isHidden);
+      const counts = new Map<string, number>();
+      for (const workspace of visible) {
+        const folderName = getWorkspaceFolderName(workspace);
+        counts.set(folderName, (counts.get(folderName) ?? 0) + 1);
+      }
+      return visible.map(workspace => {
+        const folderName = getWorkspaceFolderName(workspace);
+        return {
+          value: workspace.id,
+          label:
+            (counts.get(folderName) ?? 0) > 1
+              ? `${folderName} (${workspace.name})`
+              : folderName,
+        };
+      });
+    },
     [workspaces],
   );
 
@@ -780,7 +813,7 @@ const TaskForm: React.FC<TaskFormProps> = ({
         </Alert>
       )}
 
-      <div className="shrink-0 flex items-center justify-end gap-2 py-2.5 border-t border-border">
+      <div className="shrink-0 flex items-center justify-end gap-2 py-2.5">
         <Button type="button" variant="outline" onClick={onCancel}>
           {i18nService.t('cancel')}
         </Button>

--- a/src/renderer/components/scheduledTasks/TaskFormBody.tsx
+++ b/src/renderer/components/scheduledTasks/TaskFormBody.tsx
@@ -129,7 +129,11 @@ const TaskFormBody: React.FC<TaskFormBodyProps> = React.memo(
             {i18nService.t('scheduledTasksFormWorkspace')}
             <span className="text-destructive">*</span>
           </FieldLabel>
-          <Select value={workspaceId} onValueChange={value => onWorkspaceChange(value ?? '')}>
+          <Select
+            items={Object.fromEntries(workspaceOptions.map(option => [option.value, option.label]))}
+            value={workspaceId}
+            onValueChange={value => onWorkspaceChange(value ?? '')}
+          >
             <SelectTrigger
               id="scheduled-task-workspace"
               className="w-full"
@@ -158,6 +162,11 @@ const TaskFormBody: React.FC<TaskFormBodyProps> = React.memo(
             {i18nService.t('scheduledTasksFormSessionBinding')}
           </FieldLabel>
           <Select
+            items={{
+              [SessionBindingStrategy.PerRun]: i18nService.t('scheduledTasksFormSessionBindingPerRun'),
+              [SessionBindingStrategy.Task]: i18nService.t('scheduledTasksFormSessionBindingTask'),
+              [SessionBindingStrategy.Existing]: i18nService.t('scheduledTasksFormSessionBindingExisting'),
+            }}
             value={sessionBinding}
             onValueChange={value => onSessionBindingChange(value as SessionBindingStrategyType)}
           >

--- a/src/renderer/components/scheduledTasks/taskFormState.test.ts
+++ b/src/renderer/components/scheduledTasks/taskFormState.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'vitest';
+
+import { createFormState } from './taskFormState';
+
+describe('createFormState', () => {
+  test('defaults a blank task to a daily schedule', () => {
+    expect(createFormState().planType).toBe('daily');
+  });
+});


### PR DESCRIPTION
## Summary

优化侧边栏导航图标、IM 工作区选择和定时任务表单交互，提升不同布局下的可用性。

## Related Issue

暂无直接关联 issue，本 PR 不关闭 issue。

## Changes Made

- 为待办导航和侧边栏收起按钮增加动画图标及方向支持
- 调整终端图标动画节奏，避免持续闪烁
- 优化 IM 工作区字段展示和相关测试
- 优化定时任务弹窗关闭后的表单状态重置
- 使用工作区文件夹名作为定时任务选项显示名称，并处理重名场景
- 为定时任务下拉选择补充选项映射和默认状态测试

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed

验证结果：
- `npm run lint` 通过
- `npx vitest run src/renderer/components/im/ChannelWorkspaceField.test.tsx src/renderer/components/scheduledTasks/taskFormState.test.ts` 通过，5 个测试全部通过
- `git diff --check` 通过

## Screenshots (if applicable)

不适用。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

本次 PR 已基于最新 `origin/main` 完成 rebase。`bun.lock` 和未跟踪的外部 skill 文件未包含在本 PR 中。