### PR TITLE
feat(删除确认): 回退删除确认界面

### DIFF
--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -5504,7 +5504,6 @@ const Settings: React.FC<SettingsProps> = ({
           description={i18nService.t('clearApiKeyConfirmDescription')}
           cancelLabel={i18nService.t('cancel')}
           confirmLabel={i18nService.t('clear')}
-          cancelVariant="outline"
           confirmVariant="outline"
           onCancel={() => setPendingApiKeyClearProvider(null)}
           onConfirm={confirmApiKeyClear}
@@ -5518,7 +5517,6 @@ const Settings: React.FC<SettingsProps> = ({
           }
           cancelLabel={i18nService.t('cancel')}
           confirmLabel={i18nService.t('delete')}
-          cancelVariant="outline"
           confirmVariant="outline"
           onCancel={() => setPendingDeleteModel(null)}
           onConfirm={confirmDeleteModel}

--- a/src/renderer/components/agentSidebar/AgentTaskRow.tsx
+++ b/src/renderer/components/agentSidebar/AgentTaskRow.tsx
@@ -255,7 +255,6 @@ const AgentTaskRow: React.FC<AgentTaskRowProps> = ({
         description={i18nService.t('deleteTaskConfirmMessage')}
         cancelLabel={i18nService.t('cancel')}
         confirmLabel={i18nService.t('deleteSession')}
-        cancelVariant="outline"
         confirmVariant="outline"
         onCancel={() => setShowConfirmDelete(false)}
         onConfirm={() => {

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -326,7 +326,6 @@ export const CodingWorkspaceSidebar = ({
         description={i18nService.t('codingWorkspaceRemoveConfirm')}
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingWorkspaceRemove')}
-        cancelVariant="outline"
         confirmVariant="outline"
         onCancel={() => setRemovingWorkspace(null)}
         onConfirm={() => void removeWorkspace()}
@@ -337,7 +336,6 @@ export const CodingWorkspaceSidebar = ({
         description={i18nService.t('codingSessionRemoveConfirm')}
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingSessionRemove')}
-        cancelVariant="outline"
         confirmVariant="outline"
         onCancel={() => setRemovingSession(null)}
         onConfirm={() => void removeSession()}

--- a/src/renderer/components/cowork/CoworkSessionItem.tsx
+++ b/src/renderer/components/cowork/CoworkSessionItem.tsx
@@ -396,7 +396,6 @@ const CoworkSessionItem: React.FC<CoworkSessionItemProps> = ({
         description={i18nService.t('deleteTaskConfirmMessage')}
         cancelLabel={i18nService.t('cancel')}
         confirmLabel={i18nService.t('deleteSession')}
-        cancelVariant="outline"
         confirmVariant="outline"
         onCancel={handleCancelDelete}
         onConfirm={handleConfirmDelete}

--- a/src/shared/components/ui/destructive-confirm-dialog.tsx
+++ b/src/shared/components/ui/destructive-confirm-dialog.tsx
@@ -7,7 +7,6 @@ import {
 } from '@shared/components/ui/dialog';
 import { type VariantProps } from 'class-variance-authority';
 import { cn } from '@shared/lib/utils';
-import { AlertTriangle } from 'lucide-react';
 
 type ButtonVariant = NonNullable<VariantProps<typeof buttonVariants>['variant']>;
 
@@ -21,7 +20,6 @@ type DestructiveConfirmDialogProps = {
   onConfirm: () => void;
   confirmDisabled?: boolean;
   isConfirming?: boolean;
-  cancelVariant?: ButtonVariant;
   confirmVariant?: ButtonVariant;
   /** Optional lesser-emphasis danger action rendered between cancel and confirm. */
   secondaryConfirmLabel?: string;
@@ -39,7 +37,6 @@ function DestructiveConfirmDialog({
   onConfirm,
   confirmDisabled = false,
   isConfirming = false,
-  cancelVariant = 'ghost',
   confirmVariant = 'destructive',
   secondaryConfirmLabel,
   onSecondaryConfirm,
@@ -55,37 +52,25 @@ function DestructiveConfirmDialog({
       <DialogContent
         showCloseButton={false}
         className={cn(
-          'w-full max-w-sm rounded-xl border border-border bg-surface p-0 shadow-modal',
+          'w-full max-w-sm rounded-2xl border border-border bg-surface p-0 shadow-2xl',
           className,
         )}
       >
         <div className="flex w-full min-w-0 flex-col gap-5 p-6">
-          <div className="flex min-w-0 items-start gap-3">
-            <span
-              aria-hidden="true"
-              className="flex size-5 shrink-0 items-center justify-center text-destructive"
+          <div className="flex min-w-0 flex-col gap-2">
+            <DialogTitle className="text-base font-semibold text-foreground">{title}</DialogTitle>
+            <DialogDescription
+              className="min-w-0 truncate text-sm leading-6 text-muted-foreground"
+              title={description}
             >
-              <AlertTriangle className="size-4" />
-            </span>
-            <div className="flex min-w-0 flex-col gap-2">
-              <DialogTitle className="text-base font-semibold text-foreground">{title}</DialogTitle>
-              <DialogDescription
-                className="min-w-0 truncate text-sm leading-6 text-muted-foreground"
-                title={description}
-              >
-                {description}
-              </DialogDescription>
-            </div>
+              {description}
+            </DialogDescription>
           </div>
-          <div className="-mx-6 -mb-6 flex min-w-0 flex-wrap items-center justify-end gap-2 rounded-b-xl border-t border-border-subtle bg-muted/50 px-6 py-4">
+          <div className="flex min-w-0 items-center justify-end gap-2">
             <Button
               type="button"
-              variant={cancelVariant}
-              className={cn(
-                'h-8 min-w-16 cursor-pointer px-3 shadow-none',
-                cancelVariant === 'ghost' &&
-                  '!border-0 text-muted-foreground hover:bg-surface-raised hover:text-foreground',
-              )}
+              variant="ghost"
+              className="h-8 min-w-16 cursor-pointer !border-0 px-3 text-muted-foreground shadow-none hover:bg-surface-raised hover:text-foreground"
               data-destructive-confirm-cancel-button="true"
               disabled={isConfirming}
               onClick={onCancel}


### PR DESCRIPTION
## 概要

  回退删除确认弹窗至较早的简洁布局，并统一取消按钮的无边框样式。

  ## 变更内容

  - 移除删除确认标题区的危险操作图标。
  - 移除带背景、顶边框的独立底部操作栏，恢复正文内按钮布局。
  - 恢复弹窗 rounded-2xl 与 shadow-2xl 样式。
  - 取消按钮固定使用无边框 ghost 样式，仅悬停时显示背景。
  - 移除任务、设置、会话与编码工作区中对取消按钮的 outline 覆盖。

  ## 验证

  - npm run lint：通过。
  - git diff --check：通过，仅输出 Windows 换行符提示。