### PR TITLE
perf(artifacts): incrementally sync detection worker

### DIFF
--- a/src/renderer/services/artifactDetection.constants.ts
+++ b/src/renderer/services/artifactDetection.constants.ts
@@ -1,0 +1,7 @@
+export const ArtifactDetectionRequestKind = {
+  Snapshot: 'snapshot',
+  Patch: 'patch',
+} as const;
+
+export type ArtifactDetectionRequestKind =
+  (typeof ArtifactDetectionRequestKind)[keyof typeof ArtifactDetectionRequestKind];

--- a/src/renderer/services/artifactDetection.worker.ts
+++ b/src/renderer/services/artifactDetection.worker.ts
@@ -1,11 +1,28 @@
 import type { CoworkMessage } from '../types/cowork';
+import { ArtifactDetectionRequestKind } from './artifactDetection.constants';
 import { detectArtifactsFromMessages, type DetectedArtifact } from './artifactParser';
 
-export interface ArtifactDetectionWorkerRequest {
-  messages: CoworkMessage[];
+interface ArtifactDetectionWorkerRequestBase {
   sessionId: string;
   seq: number;
 }
+
+export interface ArtifactDetectionSnapshotRequest extends ArtifactDetectionWorkerRequestBase {
+  kind: typeof ArtifactDetectionRequestKind.Snapshot;
+  messages: CoworkMessage[];
+}
+
+export interface ArtifactDetectionPatchRequest extends ArtifactDetectionWorkerRequestBase {
+  kind: typeof ArtifactDetectionRequestKind.Patch;
+  upserts: CoworkMessage[];
+  relatedMessages: CoworkMessage[];
+  removedMessageIds: string[];
+  messageOrder?: string[];
+}
+
+export type ArtifactDetectionWorkerRequest =
+  | ArtifactDetectionSnapshotRequest
+  | ArtifactDetectionPatchRequest;
 
 export interface ArtifactDetectionWorkerResponse {
   artifacts: DetectedArtifact[];
@@ -13,10 +30,65 @@ export interface ArtifactDetectionWorkerResponse {
   error?: string;
 }
 
+let activeSessionId: string | null = null;
+const messagesById = new Map<string, CoworkMessage>();
+let messageOrder: string[] = [];
+
+function resetSession(sessionId: string): void {
+  activeSessionId = sessionId;
+  messagesById.clear();
+  messageOrder = [];
+}
+
+function upsertMessages(messages: CoworkMessage[]): void {
+  const knownMessageIds = new Set(messageOrder);
+  for (const message of messages) {
+    messagesById.set(message.id, message);
+    if (!knownMessageIds.has(message.id)) {
+      messageOrder.push(message.id);
+      knownMessageIds.add(message.id);
+    }
+  }
+}
+
+function applySnapshot(request: ArtifactDetectionSnapshotRequest): void {
+  resetSession(request.sessionId);
+  for (const message of request.messages) messagesById.set(message.id, message);
+  messageOrder = request.messages.map(message => message.id);
+}
+
+function applyPatch(request: ArtifactDetectionPatchRequest): void {
+  if (activeSessionId !== request.sessionId) {
+    throw new Error('Artifact detection patch received before a session snapshot');
+  }
+
+  for (const messageId of request.removedMessageIds) {
+    messagesById.delete(messageId);
+  }
+  upsertMessages([...request.upserts, ...request.relatedMessages]);
+
+  if (request.messageOrder) {
+    messageOrder = request.messageOrder.filter(messageId => messagesById.has(messageId));
+  } else {
+    messageOrder = messageOrder.filter(messageId => messagesById.has(messageId));
+  }
+}
+
 self.onmessage = (event: MessageEvent<ArtifactDetectionWorkerRequest>) => {
-  const { messages, sessionId, seq } = event.data;
+  const request = event.data;
+  const { sessionId, seq } = request;
   try {
-    const artifacts = detectArtifactsFromMessages(messages, sessionId);
+    if (request.kind === ArtifactDetectionRequestKind.Snapshot) {
+      applySnapshot(request);
+    } else {
+      applyPatch(request);
+    }
+    const artifacts = detectArtifactsFromMessages(
+      messageOrder
+        .map(messageId => messagesById.get(messageId))
+        .filter((message): message is CoworkMessage => message !== undefined),
+      sessionId,
+    );
     self.postMessage({ artifacts, seq } satisfies ArtifactDetectionWorkerResponse);
   } catch (error) {
     self.postMessage({

--- a/src/renderer/services/artifactDetectionService.test.ts
+++ b/src/renderer/services/artifactDetectionService.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ArtifactRole } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
+import { ArtifactDetectionRequestKind } from './artifactDetection.constants';
 import { ArtifactDetectionService } from './artifactDetectionService';
 import type {
   ArtifactDetectionWorkerRequest,
@@ -11,16 +12,34 @@ import { detectArtifactsFromMessages } from './artifactParser';
 
 class FakeArtifactDetectionWorker {
   static requests: ArtifactDetectionWorkerRequest[] = [];
+  private messages = new Map<string, CoworkMessage>();
+  private messageOrder: string[] = [];
 
   onmessage: ((event: MessageEvent<ArtifactDetectionWorkerResponse>) => void) | null = null;
   onerror: ((event: ErrorEvent) => void) | null = null;
 
   postMessage(request: ArtifactDetectionWorkerRequest): void {
     FakeArtifactDetectionWorker.requests.push(request);
+    if (request.kind === ArtifactDetectionRequestKind.Snapshot) {
+      this.messages.clear();
+      this.messageOrder = request.messages.map(message => message.id);
+      for (const message of request.messages) this.messages.set(message.id, message);
+    } else {
+      for (const messageId of request.removedMessageIds) this.messages.delete(messageId);
+      for (const message of [...request.upserts, ...request.relatedMessages]) {
+        this.messages.set(message.id, message);
+        if (!this.messageOrder.includes(message.id)) this.messageOrder.push(message.id);
+      }
+      this.messageOrder = request.messageOrder ?? this.messageOrder;
+      this.messageOrder = this.messageOrder.filter(messageId => this.messages.has(messageId));
+    }
+    const messages = this.messageOrder
+      .map(messageId => this.messages.get(messageId))
+      .filter((message): message is CoworkMessage => message !== undefined);
     this.onmessage?.({
       data: {
         seq: request.seq,
-        artifacts: detectArtifactsFromMessages(request.messages, request.sessionId),
+        artifacts: detectArtifactsFromMessages(messages, request.sessionId),
       },
     } as MessageEvent<ArtifactDetectionWorkerResponse>);
   }
@@ -83,6 +102,15 @@ describe('ArtifactDetectionService', () => {
     await service.processMessages([finalAssistant, declareToolMessage], sessionId);
 
     expect(FakeArtifactDetectionWorker.requests).toHaveLength(2);
+    expect(FakeArtifactDetectionWorker.requests[0]?.kind).toBe(
+      ArtifactDetectionRequestKind.Snapshot,
+    );
+    const patchRequest = FakeArtifactDetectionWorker.requests[1];
+    expect(patchRequest?.kind).toBe(ArtifactDetectionRequestKind.Patch);
+    if (patchRequest?.kind === ArtifactDetectionRequestKind.Patch) {
+      expect(patchRequest.upserts.map(message => message.id)).toEqual([messageId, toolMessageId]);
+      expect(patchRequest).not.toHaveProperty('messages');
+    }
     // Only the declare_artifact tool call produces an artifact
     // (the assistant message content no longer triggers file path detection)
     expect(detectedArtifacts).toHaveLength(1);
@@ -91,6 +119,88 @@ describe('ArtifactDetectionService', () => {
       filePath: 'C:/workspace/presentation.pptx',
       role: ArtifactRole.Deliverable,
     });
+  });
+
+  test('sends only a changed tool result and its linked tool call', async () => {
+    const toolUse: CoworkMessage = {
+      id: 'tool-use',
+      type: 'tool_use',
+      content: '',
+      timestamp: 1,
+      metadata: {
+        toolName: 'write',
+        toolUseId: 'call-1',
+        toolInput: { path: 'C:/workspace/report.md' },
+      },
+    };
+    const assistant: CoworkMessage = {
+      id: 'assistant',
+      type: 'assistant',
+      content: 'Working',
+      timestamp: 2,
+      metadata: { isFinal: true },
+    };
+    const toolResult: CoworkMessage = {
+      id: 'tool-result',
+      type: 'tool_result',
+      content: 'written',
+      timestamp: 3,
+      metadata: { toolUseId: 'call-1' },
+    };
+    const service = new ArtifactDetectionService(() => {});
+
+    await service.processMessages([toolUse, assistant], 'session-2');
+    await service.processMessages([toolUse, assistant, toolResult], 'session-2');
+
+    const patchRequest = FakeArtifactDetectionWorker.requests[1];
+    expect(patchRequest?.kind).toBe(ArtifactDetectionRequestKind.Patch);
+    if (patchRequest?.kind !== ArtifactDetectionRequestKind.Patch) return;
+    expect(patchRequest.upserts.map(message => message.id)).toEqual(['tool-result']);
+    expect(patchRequest.relatedMessages.map(message => message.id)).toEqual(['tool-use']);
+    expect(patchRequest.messageOrder).toEqual(['tool-use', 'assistant', 'tool-result']);
+  });
+
+  test('reports removed message ids when history shrinks', async () => {
+    const message: CoworkMessage = {
+      id: 'removed-message',
+      type: 'assistant',
+      content: 'Temporary',
+      timestamp: 1,
+      metadata: { isFinal: true },
+    };
+    const service = new ArtifactDetectionService(() => {});
+
+    await service.processMessages([message], 'session-3');
+    await service.processMessages([], 'session-3');
+
+    const patchRequest = FakeArtifactDetectionWorker.requests[1];
+    expect(patchRequest?.kind).toBe(ArtifactDetectionRequestKind.Patch);
+    if (patchRequest?.kind !== ArtifactDetectionRequestKind.Patch) return;
+    expect(patchRequest.upserts).toEqual([]);
+    expect(patchRequest.removedMessageIds).toEqual(['removed-message']);
+    expect(patchRequest.messageOrder).toEqual([]);
+  });
+
+  test('starts a new snapshot when the session id changes', async () => {
+    const message: CoworkMessage = {
+      id: 'same-message-id',
+      type: 'assistant',
+      content: 'Same content',
+      timestamp: 1,
+      metadata: { isFinal: true },
+    };
+    const service = new ArtifactDetectionService(() => {});
+
+    await service.processMessages([message], 'session-a');
+    await service.processMessages([message], 'session-b');
+
+    expect(FakeArtifactDetectionWorker.requests).toHaveLength(2);
+    expect(FakeArtifactDetectionWorker.requests[0]?.kind).toBe(
+      ArtifactDetectionRequestKind.Snapshot,
+    );
+    expect(FakeArtifactDetectionWorker.requests[1]?.kind).toBe(
+      ArtifactDetectionRequestKind.Snapshot,
+    );
   });
 
   test('does not read CSV files while detecting artifacts', async () => {
@@ -167,9 +277,7 @@ describe('ArtifactDetectionService', () => {
 
   test('keeps declared artifact metadata available before preview', async () => {
     const detectedArtifacts: ReturnType<typeof detectArtifactsFromMessages> = [];
-    const service = new ArtifactDetectionService(
-      detected => detectedArtifacts.push(...detected),
-    );
+    const service = new ArtifactDetectionService(detected => detectedArtifacts.push(...detected));
 
     await service.processMessages(
       [

--- a/src/renderer/services/artifactDetectionService.ts
+++ b/src/renderer/services/artifactDetectionService.ts
@@ -1,5 +1,6 @@
 import type { Artifact } from '../types/artifact';
 import type { CoworkMessage } from '../types/cowork';
+import { ArtifactDetectionRequestKind } from './artifactDetection.constants';
 import type {
   ArtifactDetectionWorkerRequest,
   ArtifactDetectionWorkerResponse,
@@ -52,10 +53,10 @@ export class ArtifactDetectionService {
   private pending = new Map<number, (result: ArtifactDetectionResult[]) => void>();
   private seq = 0;
   private processedMessages = new Map<string, ProcessedMessageSnapshot>();
+  private processedMessageOrder: string[] = [];
+  private processedSessionId: string | null = null;
 
-  constructor(
-    private onDetected: (artifacts: ArtifactDetectionResult[]) => void,
-  ) {}
+  constructor(private onDetected: (artifacts: ArtifactDetectionResult[]) => void) {}
 
   private ensureWorker(): Worker {
     if (this.worker) return this.worker;
@@ -86,32 +87,55 @@ export class ArtifactDetectionService {
     this.pending.clear();
   }
 
-  /**
-   * Process when messages are added or their artifact-relevant state changes.
-   *
-   * For incremental detection we send the full message list because tool_use
-   * messages need to be paired with their tool_result, and the result may
-   * arrive later. Assistant messages also update in place while streaming, so
-   * message ids alone cannot determine whether a snapshot was processed.
-   */
-  async processMessages(
-    messages: CoworkMessage[],
-    sessionId: string,
-  ): Promise<void> {
+  async processMessages(messages: CoworkMessage[], sessionId: string): Promise<void> {
     const snapshots = messages.map(message => ({
       id: message.id,
       snapshot: createMessageSnapshot(message),
     }));
-    const hasChanges = snapshots.some(({ id, snapshot }) =>
-      hasMessageChanged(this.processedMessages.get(id), snapshot),
+    const messagesById = new Map(messages.map(message => [message.id, message]));
+    const changedMessages = snapshots
+      .filter(({ id, snapshot }) => hasMessageChanged(this.processedMessages.get(id), snapshot))
+      .map(({ id }) => messagesById.get(id))
+      .filter((message): message is CoworkMessage => message !== undefined);
+    const currentMessageIds = new Set(snapshots.map(({ id }) => id));
+    const removedMessageIds = [...this.processedMessages.keys()].filter(
+      messageId => !currentMessageIds.has(messageId),
     );
-    if (!hasChanges) return;
+    const currentMessageOrder = snapshots.map(({ id }) => id);
+    const orderChanged = !areArraysEqual(this.processedMessageOrder, currentMessageOrder);
+    const sessionChanged = this.processedSessionId !== sessionId;
+    const hasChanges = changedMessages.length > 0 || removedMessageIds.length > 0 || orderChanged;
+    if (!hasChanges && !sessionChanged) return;
+
+    const isInitialSnapshot = sessionChanged || this.processedMessageOrder.length === 0;
 
     for (const { id, snapshot } of snapshots) {
       this.processedMessages.set(id, snapshot);
     }
+    for (const messageId of removedMessageIds) {
+      this.processedMessages.delete(messageId);
+    }
+    this.processedMessageOrder = currentMessageOrder;
+    this.processedSessionId = sessionId;
 
-    const detected = await this.detect(messages, sessionId);
+    const detected = await this.detect(
+      isInitialSnapshot
+        ? {
+            kind: ArtifactDetectionRequestKind.Snapshot,
+            messages,
+            sessionId,
+            seq: 0,
+          }
+        : {
+            kind: ArtifactDetectionRequestKind.Patch,
+            upserts: changedMessages,
+            relatedMessages: collectRelatedMessages(messages, changedMessages),
+            removedMessageIds,
+            messageOrder: orderChanged ? currentMessageOrder : undefined,
+            sessionId,
+            seq: 0,
+          },
+    );
     if (detected.length === 0) return;
 
     this.onDetected(detected);
@@ -119,18 +143,55 @@ export class ArtifactDetectionService {
 
   reset(): void {
     this.processedMessages.clear();
+    this.processedMessageOrder = [];
+    this.processedSessionId = null;
   }
 
-  private detect(messages: CoworkMessage[], sessionId: string): Promise<ArtifactDetectionResult[]> {
+  private detect(request: ArtifactDetectionWorkerRequest): Promise<ArtifactDetectionResult[]> {
     return new Promise(resolve => {
       const seq = ++this.seq;
       this.pending.set(seq, resolve);
-      this.ensureWorker().postMessage({
-        messages,
-        sessionId,
-        seq,
-      } satisfies ArtifactDetectionWorkerRequest);
+      this.ensureWorker().postMessage({ ...request, seq } satisfies ArtifactDetectionWorkerRequest);
     });
   }
+}
 
+function areArraysEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function collectRelatedMessages(
+  messages: CoworkMessage[],
+  changedMessages: CoworkMessage[],
+): CoworkMessage[] {
+  const changedIds = new Set(changedMessages.map(message => message.id));
+  const toolUseIds = new Set(
+    changedMessages
+      .map(message => message.metadata?.toolUseId)
+      .filter((toolUseId): toolUseId is string => typeof toolUseId === 'string'),
+  );
+  const related = new Map<string, CoworkMessage>();
+
+  for (const message of messages) {
+    if (changedIds.has(message.id)) continue;
+    if (message.metadata?.toolUseId && toolUseIds.has(message.metadata.toolUseId)) {
+      related.set(message.id, message);
+    }
+  }
+
+  for (const changedMessage of changedMessages) {
+    const index = messages.findIndex(message => message.id === changedMessage.id);
+    if (index < 0) continue;
+    for (const neighbor of [messages[index - 1], messages[index + 1]]) {
+      if (
+        neighbor &&
+        (neighbor.type === 'tool_use' || neighbor.type === 'tool_result') &&
+        !changedIds.has(neighbor.id)
+      ) {
+        related.set(neighbor.id, neighbor);
+      }
+    }
+  }
+
+  return [...related.values()];
 }


### PR DESCRIPTION
## Problem

`ArtifactDetectionService` sent the complete Cowork message history to a stateless Web Worker whenever any artifact-relevant message changed. Structured-clone copies grew with session history and amplified renderer CPU, memory, and worker transfer cost.

## Root Cause

The service tracked message snapshots only to decide whether to run detection. The Worker had no session state, so every change required a full `CoworkMessage[]` payload. Tool-use/tool-result pairing and message ordering made a naive single-message request unsafe.

## Solution

- Add explicit `snapshot` and `patch` Worker request kinds with centralized constants.
- Send one full snapshot per session, then only changed message upserts, matching tool-use/tool-result linkage messages, removed IDs, and optional message-order IDs.
- Keep a session-scoped message index inside the Worker and rebuild the parser input from that index.
- Force a fresh snapshot after `reset()` or a session-id change, and guard against patches arriving before a snapshot.
- Preserve the existing full Artifact response and renderer callback contract, so Redux, IPC, preview loading, and streaming UI behavior remain unchanged.

This PR intentionally preserves the existing pure parser semantics while removing repeated full-history transfer. Parser-level computation can be optimized separately after profiling.

## Impact

The first session load still sends one snapshot. Subsequent message updates no longer clone and transfer the full message bodies. Tool results arriving after their tool call remain paired, message deletions are represented, and stale session state is not reused.

No UI, Electron main-process, SQLite, IPC, or persisted-message format changes.

## Testing

- `npm test -- artifactDetectionService` (8 tests passed)
- `npm run build:tsc`
- `npm run lint`
- `npx oxfmt --check` on changed files
- `git diff --check`

Regression coverage includes patch payload shape, late tool-result linkage, removed messages, and session switching.

## Related Issue

Refs #669

## Follow-up

Benchmark 1,000-turn sessions for postMessage payload bytes, detection latency, renderer heap, and GC pressure before and after; then consider parser-level per-message artifact indexes and a unified content broker.
