### PR TITLE
perf(artifacts): index worker detection by message

### DIFF
--- a/src/renderer/services/artifactDetection.worker.ts
+++ b/src/renderer/services/artifactDetection.worker.ts
@@ -1,6 +1,7 @@
 import type { CoworkMessage } from '../types/cowork';
 import { ArtifactDetectionRequestKind } from './artifactDetection.constants';
-import { detectArtifactsFromMessages, type DetectedArtifact } from './artifactParser';
+import { ArtifactDetectionIndex } from './artifactDetectionIndex';
+import type { DetectedArtifact } from './artifactParser';
 
 interface ArtifactDetectionWorkerRequestBase {
   sessionId: string;
@@ -31,64 +32,33 @@ export interface ArtifactDetectionWorkerResponse {
 }
 
 let activeSessionId: string | null = null;
-const messagesById = new Map<string, CoworkMessage>();
-let messageOrder: string[] = [];
+const artifactIndex = new ArtifactDetectionIndex();
 
 function resetSession(sessionId: string): void {
   activeSessionId = sessionId;
-  messagesById.clear();
-  messageOrder = [];
-}
-
-function upsertMessages(messages: CoworkMessage[]): void {
-  const knownMessageIds = new Set(messageOrder);
-  for (const message of messages) {
-    messagesById.set(message.id, message);
-    if (!knownMessageIds.has(message.id)) {
-      messageOrder.push(message.id);
-      knownMessageIds.add(message.id);
-    }
-  }
-}
-
-function applySnapshot(request: ArtifactDetectionSnapshotRequest): void {
-  resetSession(request.sessionId);
-  for (const message of request.messages) messagesById.set(message.id, message);
-  messageOrder = request.messages.map(message => message.id);
-}
-
-function applyPatch(request: ArtifactDetectionPatchRequest): void {
-  if (activeSessionId !== request.sessionId) {
-    throw new Error('Artifact detection patch received before a session snapshot');
-  }
-
-  for (const messageId of request.removedMessageIds) {
-    messagesById.delete(messageId);
-  }
-  upsertMessages([...request.upserts, ...request.relatedMessages]);
-
-  if (request.messageOrder) {
-    messageOrder = request.messageOrder.filter(messageId => messagesById.has(messageId));
-  } else {
-    messageOrder = messageOrder.filter(messageId => messagesById.has(messageId));
-  }
+  artifactIndex.clear();
 }
 
 self.onmessage = (event: MessageEvent<ArtifactDetectionWorkerRequest>) => {
   const request = event.data;
-  const { sessionId, seq } = request;
+  const { seq } = request;
   try {
     if (request.kind === ArtifactDetectionRequestKind.Snapshot) {
-      applySnapshot(request);
+      resetSession(request.sessionId);
+      artifactIndex.replace(request.messages, request.sessionId);
     } else {
-      applyPatch(request);
+      if (activeSessionId !== request.sessionId) {
+        throw new Error('Artifact detection patch received before a session snapshot');
+      }
+      artifactIndex.applyPatch(
+        request.upserts,
+        request.relatedMessages,
+        request.removedMessageIds,
+        request.messageOrder,
+        request.sessionId,
+      );
     }
-    const artifacts = detectArtifactsFromMessages(
-      messageOrder
-        .map(messageId => messagesById.get(messageId))
-        .filter((message): message is CoworkMessage => message !== undefined),
-      sessionId,
-    );
+    const artifacts = artifactIndex.getArtifacts();
     self.postMessage({ artifacts, seq } satisfies ArtifactDetectionWorkerResponse);
   } catch (error) {
     self.postMessage({

--- a/src/renderer/services/artifactDetectionIndex.test.ts
+++ b/src/renderer/services/artifactDetectionIndex.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest';
+
+import { ArtifactRole } from '../types/artifact';
+import type { CoworkMessage } from '../types/cowork';
+import { ArtifactDetectionIndex } from './artifactDetectionIndex';
+
+function writeMessage(overrides: Partial<CoworkMessage> = {}): CoworkMessage {
+  return {
+    id: 'write-message',
+    type: 'tool_use',
+    content: '',
+    timestamp: 1,
+    metadata: {
+      toolName: 'write',
+      toolUseId: 'call-1',
+      toolInput: { path: 'C:/workspace/report.md', content: '# Report' },
+    },
+    ...overrides,
+  };
+}
+
+function resultMessage(overrides: Partial<CoworkMessage> = {}): CoworkMessage {
+  return {
+    id: 'result-message',
+    type: 'tool_result',
+    content: 'written',
+    timestamp: 2,
+    metadata: { toolUseId: 'call-1' },
+    ...overrides,
+  };
+}
+
+describe('ArtifactDetectionIndex', () => {
+  test('recomputes only the linked tool artifact when a result arrives late', () => {
+    const index = new ArtifactDetectionIndex();
+    index.replace([writeMessage()], 'session-1');
+    expect(index.getArtifacts()).toHaveLength(1);
+
+    index.applyPatch(
+      [resultMessage()],
+      [writeMessage()],
+      [],
+      ['write-message', 'result-message'],
+      'session-1',
+    );
+
+    expect(index.getArtifacts()).toHaveLength(1);
+    expect(index.getArtifacts()[0]?.artifact.filePath).toBe('C:/workspace/report.md');
+  });
+
+  test('removes a tool artifact when its result becomes an error', () => {
+    const index = new ArtifactDetectionIndex();
+    index.replace([writeMessage(), resultMessage()], 'session-2');
+    expect(index.getArtifacts()).toHaveLength(1);
+
+    index.applyPatch(
+      [resultMessage({ metadata: { toolUseId: 'call-1', isError: true } })],
+      [],
+      [],
+      undefined,
+      'session-2',
+    );
+
+    expect(index.getArtifacts()).toEqual([]);
+  });
+
+  test('keeps declared delivery identity over a duplicate final-answer path', () => {
+    const index = new ArtifactDetectionIndex();
+    const finalAnswer: CoworkMessage = {
+      id: 'final-answer',
+      type: 'assistant',
+      content: 'Saved to C:/workspace/report.md',
+      timestamp: 3,
+      metadata: { isFinal: true },
+    };
+    const declaration: CoworkMessage = {
+      id: 'declaration',
+      type: 'tool_use',
+      content: '',
+      timestamp: 4,
+      metadata: {
+        toolName: 'declare_artifact',
+        toolInput: {
+          filePath: 'C:/workspace/report.md',
+          title: 'Final report',
+          role: 'deliverable',
+        },
+      },
+    };
+    index.replace([finalAnswer, declaration], 'session-3');
+
+    const artifacts = index.getArtifacts();
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0]?.artifact).toMatchObject({
+      title: 'Final report',
+      declared: true,
+      role: ArtifactRole.Deliverable,
+    });
+  });
+});

--- a/src/renderer/services/artifactDetectionIndex.ts
+++ b/src/renderer/services/artifactDetectionIndex.ts
@@ -1,0 +1,225 @@
+import { ArtifactRole } from '../types/artifact';
+import type { CoworkMessage } from '../types/cowork';
+import {
+  normalizeFilePathForDedup,
+  parseCodeBlockArtifacts,
+  parseDeclareArtifactFromMessages,
+  parseFinalAnswerPathArtifactsForMessage,
+  parseToolArtifact,
+  type DetectedArtifact,
+} from './artifactParser';
+
+/**
+ * Maintains message-level artifact results for one session. Updates only
+ * reparse changed messages and tool-use/result pairs; path deduplication is
+ * applied once when the current projection is requested.
+ */
+export class ArtifactDetectionIndex {
+  private readonly messagesById = new Map<string, CoworkMessage>();
+  private readonly artifactsByMessage = new Map<string, DetectedArtifact[]>();
+  private readonly toolUseByCallId = new Map<string, string>();
+  private readonly toolResultByCallId = new Map<string, string>();
+  private readonly callIdByMessageId = new Map<string, string>();
+  private messageOrder: string[] = [];
+  private sessionId: string | null = null;
+
+  replace(messages: CoworkMessage[], sessionId: string): void {
+    this.clear();
+    this.sessionId = sessionId;
+    this.messageOrder = messages.map(message => message.id);
+    for (const message of messages) this.setMessage(message);
+    for (const message of messages) this.recomputeMessage(message.id);
+  }
+
+  applyPatch(
+    upserts: CoworkMessage[],
+    relatedMessages: CoworkMessage[],
+    removedMessageIds: string[],
+    messageOrder: string[] | undefined,
+    sessionId: string,
+  ): void {
+    if (this.sessionId !== sessionId) {
+      throw new Error('Artifact detection patch received before a session snapshot');
+    }
+
+    const affected = new Set<string>();
+    for (const messageId of removedMessageIds) {
+      this.addRelatedMessageIds(messageId, affected);
+      this.removeMessage(messageId);
+    }
+    for (const message of [...upserts, ...relatedMessages]) {
+      this.addRelatedMessageIds(message.id, affected);
+      this.setMessage(message);
+      affected.add(message.id);
+      this.addRelatedMessageIds(message.id, affected);
+    }
+
+    if (messageOrder) {
+      this.messageOrder = messageOrder.filter(messageId => this.messagesById.has(messageId));
+      this.addPositionalToolMessages(affected);
+    } else {
+      this.messageOrder = this.messageOrder.filter(messageId => this.messagesById.has(messageId));
+    }
+
+    for (const messageId of affected) this.recomputeMessage(messageId);
+  }
+
+  getArtifacts(): DetectedArtifact[] {
+    const detected: DetectedArtifact[] = [];
+    const detectedFilePathIndexes = new Map<string, number>();
+
+    for (const messageId of this.messageOrder) {
+      for (const detectedArtifact of this.artifactsByMessage.get(messageId) ?? []) {
+        const filePath = detectedArtifact.artifact.filePath;
+        if (!filePath) {
+          detected.push(detectedArtifact);
+          continue;
+        }
+
+        const normalized = normalizeFilePathForDedup(filePath);
+        const existingIndex = detectedFilePathIndexes.get(normalized);
+        if (existingIndex === undefined) {
+          detectedFilePathIndexes.set(normalized, detected.length);
+          detected.push(detectedArtifact);
+          continue;
+        }
+
+        const existing = detected[existingIndex];
+        if (
+          (detectedArtifact.artifact.declared && !existing.artifact.declared) ||
+          (existing.artifact.role !== ArtifactRole.Deliverable &&
+            detectedArtifact.artifact.role === ArtifactRole.Deliverable)
+        ) {
+          detected[existingIndex] = {
+            artifact: detectedArtifact.artifact,
+            needsFileLoad: existing.needsFileLoad || detectedArtifact.needsFileLoad,
+          };
+        } else if (existing.artifact.role === detectedArtifact.artifact.role) {
+          existing.needsFileLoad ||= detectedArtifact.needsFileLoad;
+        }
+      }
+    }
+
+    return detected;
+  }
+
+  clear(): void {
+    this.messagesById.clear();
+    this.artifactsByMessage.clear();
+    this.toolUseByCallId.clear();
+    this.toolResultByCallId.clear();
+    this.callIdByMessageId.clear();
+    this.messageOrder = [];
+    this.sessionId = null;
+  }
+
+  private setMessage(message: CoworkMessage): void {
+    this.clearCallId(message.id);
+    this.messagesById.set(message.id, message);
+    const callId = message.metadata?.toolUseId;
+    if (typeof callId !== 'string' || !callId) return;
+
+    this.callIdByMessageId.set(message.id, callId);
+    if (message.type === 'tool_use') this.toolUseByCallId.set(callId, message.id);
+    if (message.type === 'tool_result') this.toolResultByCallId.set(callId, message.id);
+  }
+
+  private clearCallId(messageId: string): void {
+    const previousCallId = this.callIdByMessageId.get(messageId);
+    if (!previousCallId) return;
+    this.callIdByMessageId.delete(messageId);
+    if (this.toolUseByCallId.get(previousCallId) === messageId) {
+      this.toolUseByCallId.delete(previousCallId);
+    }
+    if (this.toolResultByCallId.get(previousCallId) === messageId) {
+      this.toolResultByCallId.delete(previousCallId);
+    }
+  }
+
+  private removeMessage(messageId: string): void {
+    this.clearCallId(messageId);
+    this.messagesById.delete(messageId);
+    this.artifactsByMessage.delete(messageId);
+    this.messageOrder = this.messageOrder.filter(id => id !== messageId);
+  }
+
+  private addRelatedMessageIds(messageId: string, affected: Set<string>): void {
+    affected.add(messageId);
+    const message = this.messagesById.get(messageId);
+    if (!message) return;
+
+    const callId = this.callIdByMessageId.get(messageId);
+    if (callId) {
+      const relatedId =
+        message.type === 'tool_use'
+          ? this.toolResultByCallId.get(callId)
+          : this.toolUseByCallId.get(callId);
+      if (relatedId) affected.add(relatedId);
+      return;
+    }
+
+    const index = this.messageOrder.indexOf(messageId);
+    if (index < 0) return;
+    const neighbor =
+      message.type === 'tool_use' ? this.messageOrder[index + 1] : this.messageOrder[index - 1];
+    if (neighbor) affected.add(neighbor);
+  }
+
+  private addPositionalToolMessages(affected: Set<string>): void {
+    for (const message of this.messagesById.values()) {
+      if (
+        (message.type === 'tool_use' || message.type === 'tool_result') &&
+        !this.callIdByMessageId.has(message.id)
+      ) {
+        affected.add(message.id);
+      }
+    }
+  }
+
+  private findToolResult(toolUse: CoworkMessage): CoworkMessage | undefined {
+    const callId = this.callIdByMessageId.get(toolUse.id);
+    if (callId) {
+      const resultId = this.toolResultByCallId.get(callId);
+      return resultId ? this.messagesById.get(resultId) : undefined;
+    }
+    const index = this.messageOrder.indexOf(toolUse.id);
+    const next = index >= 0 ? this.messagesById.get(this.messageOrder[index + 1]) : undefined;
+    return next?.type === 'tool_result' ? next : undefined;
+  }
+
+  private recomputeMessage(messageId: string): void {
+    const message = this.messagesById.get(messageId);
+    if (!message || !this.sessionId) {
+      this.artifactsByMessage.delete(messageId);
+      return;
+    }
+
+    const artifacts: DetectedArtifact[] = [];
+    if (message.type === 'assistant' && !message.metadata?.isThinking && message.content) {
+      artifacts.push(
+        ...parseCodeBlockArtifacts(message.content, message.id, this.sessionId).map(artifact => ({
+          artifact,
+          needsFileLoad: false,
+        })),
+        ...parseFinalAnswerPathArtifactsForMessage(message, this.sessionId).map(artifact => ({
+          artifact,
+          needsFileLoad: true,
+        })),
+      );
+    }
+
+    if (message.type === 'tool_use') {
+      artifacts.push(
+        ...parseDeclareArtifactFromMessages(
+          [message],
+          this.sessionId,
+          () => ArtifactRole.Deliverable,
+        ).map(artifact => ({ artifact, needsFileLoad: true })),
+      );
+      const toolArtifact = parseToolArtifact(message, this.findToolResult(message), this.sessionId);
+      if (toolArtifact) artifacts.push({ artifact: toolArtifact, needsFileLoad: true });
+    }
+
+    this.artifactsByMessage.set(messageId, artifacts);
+  }
+}

--- a/src/renderer/services/artifactParser.ts
+++ b/src/renderer/services/artifactParser.ts
@@ -234,41 +234,45 @@ function normalizeDetectedPath(rawPath: string): string {
   }
 }
 
-function parseFinalAnswerPathArtifacts(messages: CoworkMessage[], sessionId: string): Artifact[] {
+export function parseFinalAnswerPathArtifactsForMessage(
+  message: CoworkMessage,
+  sessionId: string,
+): Artifact[] {
   const artifacts: Artifact[] = [];
+  const isFinalAnswer =
+    message.type === 'assistant' &&
+    !message.metadata?.isThinking &&
+    (message.metadata?.isFinalAnswer || message.metadata?.isFinal);
+  if (!isFinalAnswer || !message.content) return artifacts;
 
-  for (const message of messages) {
-    const isFinalAnswer =
-      message.type === 'assistant' &&
-      !message.metadata?.isThinking &&
-      (message.metadata?.isFinalAnswer || message.metadata?.isFinal);
-    if (!isFinalAnswer || !message.content) continue;
+  for (const match of message.content.matchAll(FINAL_ANSWER_PATH_PATTERN)) {
+    const rawPath = match[1];
+    if (!rawPath) continue;
+    const filePath = normalizeDetectedPath(rawPath);
+    const artifactType = getArtifactTypeFromExtension(getFileExtension(filePath));
+    if (!artifactType) continue;
 
-    for (const match of message.content.matchAll(FINAL_ANSWER_PATH_PATTERN)) {
-      const rawPath = match[1];
-      if (!rawPath) continue;
-      const filePath = normalizeDetectedPath(rawPath);
-      const artifactType = getArtifactTypeFromExtension(getFileExtension(filePath));
-      if (!artifactType) continue;
-
-      artifacts.push({
-        id: `artifact-final-path-${message.id}-${artifacts.length}`,
-        messageId: message.id,
-        sessionId,
-        type: artifactType,
-        title: getFileName(filePath),
-        content: '',
-        fileName: getFileName(filePath),
-        filePath,
-        source: 'tool',
-        role: ArtifactRole.Deliverable,
-        declared: false,
-        createdAt: message.timestamp || Date.now(),
-      });
-    }
+    artifacts.push({
+      id: `artifact-final-path-${message.id}-${artifacts.length}`,
+      messageId: message.id,
+      sessionId,
+      type: artifactType,
+      title: getFileName(filePath),
+      content: '',
+      fileName: getFileName(filePath),
+      filePath,
+      source: 'tool',
+      role: ArtifactRole.Deliverable,
+      declared: false,
+      createdAt: message.timestamp || Date.now(),
+    });
   }
 
   return artifacts;
+}
+
+function parseFinalAnswerPathArtifacts(messages: CoworkMessage[], sessionId: string): Artifact[] {
+  return messages.flatMap(message => parseFinalAnswerPathArtifactsForMessage(message, sessionId));
 }
 
 export function parseToolArtifact(


### PR DESCRIPTION
## Problem

PR #693 removed repeated full-history transfers to the artifact detection Worker, but the Worker still rebuilt the complete parser result from every indexed message after each patch. Long sessions could continue to spend unnecessary CPU rescanning unrelated messages.

## Root Cause

Artifact parsing was exposed only as a list-level function. Tool-use/tool-result pairing, path deduplication, and late result updates were handled by one full pass, so the Worker had no message-level result cache.

## Solution

- Add `ArtifactDetectionIndex`, a session-scoped Worker index keyed by message ID.
- Cache parsed artifacts per message and reparse only changed messages plus linked tool-use/tool-result entries.
- Maintain O(1) tool-use/tool-result lookup by `toolUseId`; preserve positional fallback for messages without IDs.
- Recompute positional tool messages when message order changes and remove cached entries when history shrinks.
- Extract final-answer path parsing into a per-message parser while preserving the existing full-list API.
- Preserve global path deduplication and declared-delivery precedence when producing the existing full Artifact response.

## Behavior and Scope

The first snapshot and final Artifact response format are unchanged. Streaming gating, Redux dispatch, preview loading, IPC, SQLite, and UI behavior are unchanged. Tool results arriving late, result errors, duplicate declarations, message deletion, and session reset are covered.

## Testing

- `npm test -- artifactParser artifactDetectionService artifactDetectionIndex` (39 tests passed)
- `npm run build:tsc`
- `npm run lint`
- `npx oxfmt --check` on changed files
- `git diff --check`

## Related Issue

Refs #669

## Follow-up

Benchmark 1,000-turn histories and sustained streaming updates for detection CPU, postMessage bytes, renderer heap, and p95 latency. The next P0 stage can unify file content loading and remove Base64 copies.
