### PR TITLE
perf(artifacts): share preview file reads

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanel.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanel.tsx
@@ -27,7 +27,6 @@ import {
   ArtifactPreviewMode,
   ArtifactRole,
   getArtifactPreviewMode,
-  isBinaryArtifactFile,
   type Artifact,
   type ArtifactType,
 } from '@/types/artifact';
@@ -339,30 +338,19 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
     if (!selectedArtifact?.filePath) return;
     invalidateArtifactFile(selectedArtifact.filePath);
     try {
-      const result = await window.electron.dialog.readFileAsDataUrl(selectedArtifact.filePath);
-      if (result?.success && result.dataUrl) {
-        const isTextType = !isBinaryArtifactFile(selectedArtifact.filePath);
-        let content = result.dataUrl;
-        if (isTextType) {
-          try {
-            const base64 = result.dataUrl.split(',')[1] || '';
-            const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
-            content = new TextDecoder('utf-8').decode(bytes);
-          } catch {
-            content = result.dataUrl;
-          }
-        }
+      const loaded = await loadArtifactFile({ ...selectedArtifact, content: '' }, cwd);
+      if (loaded) {
         dispatch(
           addArtifact({
             sessionId: selectedArtifact.sessionId,
-            artifact: { ...selectedArtifact, content },
+            artifact: { ...selectedArtifact, content: loaded.content, filePath: loaded.filePath },
           }),
         );
       }
     } catch {
       // File unreadable or missing
     }
-  }, [selectedArtifact, dispatch]);
+  }, [cwd, dispatch, selectedArtifact]);
 
   return (
     <>
@@ -465,8 +453,7 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
                   <BrowserIcon />
                 </Button>
               )}
-              {hasLocalFilePreview &&
-                !BROWSER_OPENABLE_TYPES.has(selectedArtifact.type) && (
+              {hasLocalFilePreview && !BROWSER_OPENABLE_TYPES.has(selectedArtifact.type) && (
                 <Button
                   variant="ghost"
                   size="icon"
@@ -568,7 +555,10 @@ const ArtifactPanel: React.FC<ArtifactPanelProps> = ({
             </div>
 
             {/* Render area */}
-            <div key={`${selectedArtifact.id}-${displayedTab}`} className="flex-1 min-h-0 overflow-hidden animate-fade-in">
+            <div
+              key={`${selectedArtifact.id}-${displayedTab}`}
+              className="flex-1 min-h-0 overflow-hidden animate-fade-in"
+            >
               {loadingArtifactId === selectedArtifact.id ? (
                 <div className="h-full min-h-0 p-4" aria-busy="true">
                   <Skeleton className="h-full w-full rounded-lg" />

--- a/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/DocumentRenderer.tsx
@@ -3,6 +3,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { i18nService } from '@/services/i18n';
+import { loadArtifactDataUrl } from '@/services/artifactFileLoader';
 import type { Artifact } from '@/types/artifact';
 
 import type { CsvPreviewWorkerResponse } from './csvPreview.worker';
@@ -60,28 +61,11 @@ function useFileContent(artifact: Artifact): {
         return;
       }
 
-      if (artifact.filePath && window.electron?.dialog?.readFileAsDataUrl) {
-        let filePath = artifact.filePath;
-        if (filePath.startsWith('file:///')) {
-          filePath = filePath.slice(7);
-        } else if (filePath.startsWith('file://')) {
-          filePath = filePath.slice(7);
-        } else if (filePath.startsWith('file:/')) {
-          filePath = filePath.slice(5);
-        }
-        // Strip leading / before Windows drive letter
-        if (/^\/[A-Za-z]:/.test(filePath)) {
-          filePath = filePath.slice(1);
-        }
+      if (artifact.filePath) {
         try {
-          const result = await window.electron.dialog.readFileAsDataUrl(filePath);
+          const dataUrl = await loadArtifactDataUrl(artifact.filePath);
           if (cancelled) return;
-          if (result?.success && result.dataUrl) {
-            const buf = dataUrlToArrayBuffer(result.dataUrl);
-            setData(buf);
-          } else {
-            setError(result?.error || 'Failed to read file');
-          }
+          setData(dataUrlToArrayBuffer(dataUrl));
         } catch (e) {
           if (!cancelled) setError(e instanceof Error ? e.message : String(e));
         }
@@ -284,7 +268,8 @@ const XlsxSubRenderer: React.FC<{ artifact: Artifact }> = ({ artifact }) => {
         const fileName = artifact.fileName || artifact.filePath || '';
         if (isCsvOrTsv(fileName) || artifact.language === 'csv' || artifact.language === 'tsv') {
           const text = new TextDecoder('utf-8').decode(new Uint8Array(data));
-          const delimiter = fileName.toLowerCase().endsWith('.tsv') || artifact.language === 'tsv' ? '\t' : ',';
+          const delimiter =
+            fileName.toLowerCase().endsWith('.tsv') || artifact.language === 'tsv' ? '\t' : ',';
           const worker = new Worker(new URL('./csvPreview.worker.ts', import.meta.url), {
             type: 'module',
           });
@@ -847,23 +832,19 @@ const PptxHtmlFallback: React.FC<{ artifact: Artifact; data: ArrayBuffer }> = ({
     let cancelled = false;
 
     const loadSlideHtmls = async () => {
-      let filePath = artifact.filePath!;
-      if (filePath.startsWith('file:///')) filePath = filePath.slice(7);
-      else if (filePath.startsWith('file://')) filePath = filePath.slice(7);
-      else if (filePath.startsWith('file:/')) filePath = filePath.slice(5);
-      // Strip leading / before Windows drive letter
-      if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.slice(1);
-
-      const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+      const lastSeparator = Math.max(
+        artifact.filePath!.lastIndexOf('/'),
+        artifact.filePath!.lastIndexOf('\\'),
+      );
+      const dir = artifact.filePath!.substring(0, lastSeparator);
       const slidesDir = `${dir}/slides`;
       const nextSlides: PptxPreviewSlide[] = [];
 
       for (let i = 1; i <= 500; i++) {
         const slidePath = `${slidesDir}/slide${i}.html`;
         try {
-          const result = await window.electron?.dialog?.readFileAsDataUrl(slidePath);
-          if (!result?.success || !result.dataUrl) break;
-          const base64 = result.dataUrl.split(',')[1] || '';
+          const dataUrl = await loadArtifactDataUrl(slidePath);
+          const base64 = dataUrl.split(',')[1] || '';
           const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
           const html = new TextDecoder('utf-8').decode(bytes);
           nextSlides.push({ srcDoc: html, width: 960, height: 540 });

--- a/src/renderer/components/artifacts/renderers/HtmlRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/HtmlRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { loadArtifactDataUrl } from '@/services/artifactFileLoader';
 import type { Artifact } from '@/types/artifact';
 
 interface HtmlRendererProps {
@@ -44,8 +45,8 @@ const HtmlRenderer: React.FC<HtmlRendererProps> = ({ artifact }) => {
 
         // If content is empty but filePath exists, read file directly
         if (!html && artifact.filePath) {
-          const result = await readLocalFileAsDataUrl(artifact.filePath);
-          if (!result || cancelled) return;
+          const result = await loadArtifactDataUrl(artifact.filePath);
+          if (cancelled) return;
           try {
             const base64 = result.split(',')[1] || '';
             const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
@@ -120,16 +121,6 @@ const HtmlRenderer: React.FC<HtmlRendererProps> = ({ artifact }) => {
   );
 };
 
-async function readLocalFileAsDataUrl(absPath: string): Promise<string | null> {
-  if (typeof window.electron?.dialog?.readFileAsDataUrl !== 'function') return null;
-  try {
-    const res = await window.electron.dialog.readFileAsDataUrl(absPath);
-    return res?.success && res.dataUrl ? res.dataUrl : null;
-  } catch {
-    return null;
-  }
-}
-
 function resolveRelativePath(src: string, htmlDir: string): string | null {
   if (
     !src ||
@@ -157,9 +148,11 @@ async function inlineLocalResources(html: string, filePath: string): Promise<str
     const absPath = resolveRelativePath(originalSrc, dir);
     if (!absPath) continue;
 
-    const dataUrl = await readLocalFileAsDataUrl(absPath);
-    if (dataUrl) {
+    try {
+      const dataUrl = await loadArtifactDataUrl(absPath);
       replacements.push([originalSrc, dataUrl]);
+    } catch {
+      // Missing local resources are left untouched for the iframe to resolve.
     }
   }
 

--- a/src/renderer/components/artifacts/renderers/ModelRenderer.tsx
+++ b/src/renderer/components/artifacts/renderers/ModelRenderer.tsx
@@ -17,6 +17,7 @@ import { ThreeMFLoader } from 'three/examples/jsm/loaders/3MFLoader.js';
 
 import type { Artifact } from '@/types/artifact';
 import { i18nService } from '@/services/i18n';
+import { loadArtifactDataUrl } from '@/services/artifactFileLoader';
 
 import { MODEL_AUTO_ROTATE_SPEED, ModelFileExtension } from './constants';
 
@@ -84,16 +85,8 @@ function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
 async function loadModelBuffer(artifact: Artifact): Promise<ArrayBuffer> {
   if (artifact.content) return dataUrlToArrayBuffer(artifact.content);
   if (!artifact.filePath) throw new Error('No content available');
-  let filePath = artifact.filePath;
-  if (filePath.startsWith('file:///')) filePath = filePath.slice(7);
-  else if (filePath.startsWith('file://')) filePath = filePath.slice(7);
-  else if (filePath.startsWith('file:/')) filePath = filePath.slice(5);
-  if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.slice(1);
-  const result = await window.electron.dialog.readFileAsDataUrl(filePath);
-  if (!result?.success || !result.dataUrl) {
-    throw new Error(result?.error || 'Failed to read file');
-  }
-  return dataUrlToArrayBuffer(result.dataUrl);
+  const dataUrl = await loadArtifactDataUrl(artifact.filePath);
+  return dataUrlToArrayBuffer(dataUrl);
 }
 
 export async function parseModelObject(

--- a/src/renderer/services/artifactFileLoader.test.ts
+++ b/src/renderer/services/artifactFileLoader.test.ts
@@ -63,3 +63,26 @@ test('invalidating a path forces a fresh read', async () => {
   await expect(loadArtifactDataUrl('C:/workspace/notes.txt')).resolves.toContain('V29ybGQ');
   expect(readFileAsDataUrl).toHaveBeenCalledTimes(2);
 });
+
+test('clearing the cache prevents an old read from repopulating it', async () => {
+  let resolveRead: ((value: { success: true; dataUrl: string }) => void) | undefined;
+  const readFileAsDataUrl = vi.fn().mockImplementation(
+    () =>
+      new Promise<{ success: true; dataUrl: string }>(resolve => {
+        resolveRead = resolve;
+      }),
+  );
+  vi.stubGlobal('window', { electron: { dialog: { readFileAsDataUrl } } });
+
+  const firstLoad = loadArtifactDataUrl('C:/workspace/notes.txt');
+  clearArtifactFileCache();
+  resolveRead?.({ success: true, dataUrl: TEXT_DATA_URL });
+  await firstLoad;
+
+  readFileAsDataUrl.mockResolvedValueOnce({
+    success: true,
+    dataUrl: 'data:text/plain;base64,V29ybGQ=',
+  });
+  await expect(loadArtifactDataUrl('C:/workspace/notes.txt')).resolves.toContain('V29ybGQ');
+  expect(readFileAsDataUrl).toHaveBeenCalledTimes(2);
+});

--- a/src/renderer/services/artifactFileLoader.test.ts
+++ b/src/renderer/services/artifactFileLoader.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import {
+  clearArtifactFileCache,
+  invalidateArtifactFile,
+  loadArtifactDataUrl,
+  loadArtifactFile,
+} from './artifactFileLoader';
+
+const TEXT_DATA_URL = 'data:text/plain;base64,SGVsbG8=';
+
+beforeEach(() => {
+  clearArtifactFileCache();
+  vi.restoreAllMocks();
+});
+
+test('shares in-flight reads and reuses completed content', async () => {
+  const readFileAsDataUrl = vi.fn().mockResolvedValue({ success: true, dataUrl: TEXT_DATA_URL });
+  vi.stubGlobal('window', { electron: { dialog: { readFileAsDataUrl } } });
+
+  const [first, second] = await Promise.all([
+    loadArtifactDataUrl('C:\\workspace\\notes.txt'),
+    loadArtifactDataUrl('C:/workspace/notes.txt'),
+  ]);
+  expect(first).toBe(TEXT_DATA_URL);
+  expect(second).toBe(TEXT_DATA_URL);
+  expect(readFileAsDataUrl).toHaveBeenCalledTimes(1);
+
+  await loadArtifactDataUrl('C:/workspace/notes.txt');
+  expect(readFileAsDataUrl).toHaveBeenCalledTimes(1);
+});
+
+test('decodes text artifacts through the same broker', async () => {
+  const readFileAsDataUrl = vi.fn().mockResolvedValue({ success: true, dataUrl: TEXT_DATA_URL });
+  vi.stubGlobal('window', { electron: { dialog: { readFileAsDataUrl } } });
+
+  const loaded = await loadArtifactFile({
+    id: 'artifact-1',
+    messageId: 'message-1',
+    sessionId: 'session-1',
+    type: 'text',
+    title: 'Notes',
+    content: '',
+    filePath: 'C:/workspace/notes.txt',
+    source: 'tool',
+    role: 'deliverable',
+    createdAt: 1,
+  });
+
+  expect(loaded?.content).toBe('Hello');
+  expect(readFileAsDataUrl).toHaveBeenCalledTimes(1);
+});
+
+test('invalidating a path forces a fresh read', async () => {
+  const readFileAsDataUrl = vi
+    .fn()
+    .mockResolvedValueOnce({ success: true, dataUrl: TEXT_DATA_URL })
+    .mockResolvedValueOnce({ success: true, dataUrl: 'data:text/plain;base64,V29ybGQ=' });
+  vi.stubGlobal('window', { electron: { dialog: { readFileAsDataUrl } } });
+
+  await loadArtifactDataUrl('C:/workspace/notes.txt');
+  invalidateArtifactFile('C:\\workspace\\notes.txt');
+  await expect(loadArtifactDataUrl('C:/workspace/notes.txt')).resolves.toContain('V29ybGQ');
+  expect(readFileAsDataUrl).toHaveBeenCalledTimes(2);
+});

--- a/src/renderer/services/artifactFileLoader.ts
+++ b/src/renderer/services/artifactFileLoader.ts
@@ -21,6 +21,7 @@ const dataUrlCache = new Map<string, CachedDataUrl>();
 const pathGenerations = new Map<string, number>();
 let cachedBytes = 0;
 let usageCounter = 0;
+let cacheEpoch = 0;
 
 function normalizeFilePath(rawPath: string): string {
   let filePath = rawPath;
@@ -68,6 +69,7 @@ export function loadArtifactDataUrl(rawPath: string, cwd?: string | null): Promi
   const pending = pendingDataUrlLoads.get(filePath);
   if (pending) return pending;
   const generation = pathGenerations.get(filePath) ?? 0;
+  const epoch = cacheEpoch;
 
   const load = (async () => {
     const readFile = window.electron?.dialog?.readFileAsDataUrl;
@@ -78,7 +80,7 @@ export function loadArtifactDataUrl(rawPath: string, cwd?: string | null): Promi
       throw new Error(result?.error || 'Failed to read artifact file');
     }
 
-    if ((pathGenerations.get(filePath) ?? 0) === generation) {
+    if (cacheEpoch === epoch && (pathGenerations.get(filePath) ?? 0) === generation) {
       const entry: CachedDataUrl = {
         dataUrl: result.dataUrl,
         size: result.dataUrl.length * 2,
@@ -150,6 +152,7 @@ export function invalidateArtifactFile(filePath: string): void {
 }
 
 export function clearArtifactFileCache(): void {
+  cacheEpoch += 1;
   pendingLoads.clear();
   pendingDataUrlLoads.clear();
   dataUrlCache.clear();

--- a/src/renderer/services/artifactFileLoader.ts
+++ b/src/renderer/services/artifactFileLoader.ts
@@ -6,7 +6,21 @@ export type LoadedArtifactFile = {
   filePath: string;
 };
 
+const MAX_CACHE_ENTRIES = 8;
+const MAX_CACHE_BYTES = 64 * 1024 * 1024;
+
+type CachedDataUrl = {
+  dataUrl: string;
+  size: number;
+  lastUsed: number;
+};
+
 const pendingLoads = new Map<string, Promise<LoadedArtifactFile | null>>();
+const pendingDataUrlLoads = new Map<string, Promise<string>>();
+const dataUrlCache = new Map<string, CachedDataUrl>();
+const pathGenerations = new Map<string, number>();
+let cachedBytes = 0;
+let usageCounter = 0;
 
 function normalizeFilePath(rawPath: string): string {
   let filePath = rawPath;
@@ -14,7 +28,7 @@ function normalizeFilePath(rawPath: string): string {
   else if (filePath.startsWith('file://')) filePath = filePath.slice(7);
   else if (filePath.startsWith('file:/')) filePath = filePath.slice(5);
   if (/^\/[A-Za-z]:/.test(filePath)) filePath = filePath.slice(1);
-  return filePath;
+  return filePath.replace(/\\/g, '/');
 }
 
 function resolveFilePath(rawPath: string, cwd?: string | null): string {
@@ -27,6 +41,68 @@ function decodeTextDataUrl(dataUrl: string): string {
   const base64 = dataUrl.split(',')[1] || '';
   const bytes = Uint8Array.from(atob(base64), character => character.charCodeAt(0));
   return new TextDecoder('utf-8').decode(bytes);
+}
+
+function evictDataUrlCache(): void {
+  while (dataUrlCache.size > MAX_CACHE_ENTRIES || cachedBytes > MAX_CACHE_BYTES) {
+    const oldest = [...dataUrlCache.entries()].reduce<[string, CachedDataUrl] | null>(
+      (candidate, entry) =>
+        !candidate || entry[1].lastUsed < candidate[1].lastUsed ? entry : candidate,
+      null,
+    );
+    if (!oldest) return;
+    dataUrlCache.delete(oldest[0]);
+    cachedBytes -= oldest[1].size;
+  }
+}
+
+/** Loads a path-backed artifact as a data URL through the shared preview broker. */
+export function loadArtifactDataUrl(rawPath: string, cwd?: string | null): Promise<string> {
+  const filePath = resolveFilePath(rawPath, cwd);
+  const cached = dataUrlCache.get(filePath);
+  if (cached) {
+    cached.lastUsed = ++usageCounter;
+    return Promise.resolve(cached.dataUrl);
+  }
+
+  const pending = pendingDataUrlLoads.get(filePath);
+  if (pending) return pending;
+  const generation = pathGenerations.get(filePath) ?? 0;
+
+  const load = (async () => {
+    const readFile = window.electron?.dialog?.readFileAsDataUrl;
+    if (typeof readFile !== 'function') throw new Error('Artifact file reader unavailable');
+
+    const result = await readFile(filePath);
+    if (!result?.success || !result.dataUrl) {
+      throw new Error(result?.error || 'Failed to read artifact file');
+    }
+
+    if ((pathGenerations.get(filePath) ?? 0) === generation) {
+      const entry: CachedDataUrl = {
+        dataUrl: result.dataUrl,
+        size: result.dataUrl.length * 2,
+        lastUsed: ++usageCounter,
+      };
+      const previous = dataUrlCache.get(filePath);
+      if (previous) cachedBytes -= previous.size;
+      dataUrlCache.set(filePath, entry);
+      cachedBytes += entry.size;
+      evictDataUrlCache();
+    }
+    return result.dataUrl;
+  })();
+
+  pendingDataUrlLoads.set(filePath, load);
+  void load.then(
+    () => {
+      if (pendingDataUrlLoads.get(filePath) === load) pendingDataUrlLoads.delete(filePath);
+    },
+    () => {
+      if (pendingDataUrlLoads.get(filePath) === load) pendingDataUrlLoads.delete(filePath);
+    },
+  );
+  return load;
 }
 
 /** Loads a path-backed artifact only when its preview is opened. */
@@ -43,17 +119,9 @@ export function loadArtifactFile(
   if (cached) return cached;
 
   const load = (async (): Promise<LoadedArtifactFile | null> => {
-    const readFile = window.electron?.dialog?.readFileAsDataUrl;
-    if (typeof readFile !== 'function') return null;
+    const dataUrl = await loadArtifactDataUrl(filePath);
 
-    const result = await readFile(filePath);
-    if (!result?.success || !result.dataUrl) {
-      throw new Error(result?.error || 'Failed to read artifact file');
-    }
-
-    const content = isBinaryArtifactFile(filePath)
-      ? result.dataUrl
-      : decodeTextDataUrl(result.dataUrl);
+    const content = isBinaryArtifactFile(filePath) ? dataUrl : decodeTextDataUrl(dataUrl);
     return { content, filePath };
   })();
 
@@ -70,5 +138,21 @@ export function loadArtifactFile(
 }
 
 export function invalidateArtifactFile(filePath: string): void {
-  pendingLoads.delete(normalizeFilePath(filePath));
+  const normalizedPath = resolveFilePath(filePath);
+  pathGenerations.set(normalizedPath, (pathGenerations.get(normalizedPath) ?? 0) + 1);
+  pendingLoads.delete(normalizedPath);
+  pendingDataUrlLoads.delete(normalizedPath);
+  const cached = dataUrlCache.get(normalizedPath);
+  if (cached) {
+    cachedBytes -= cached.size;
+    dataUrlCache.delete(normalizedPath);
+  }
+}
+
+export function clearArtifactFileCache(): void {
+  pendingLoads.clear();
+  pendingDataUrlLoads.clear();
+  dataUrlCache.clear();
+  pathGenerations.clear();
+  cachedBytes = 0;
 }


### PR DESCRIPTION
## Summary

- centralize artifact preview file reads behind a shared renderer-side broker
- deduplicate concurrent reads by normalized path and reuse bounded LRU-cached Data URLs
- invalidate cached and in-flight results on refresh without allowing stale reads to repopulate the cache
- migrate ArtifactPanel, HTML, document, and model previews while leaving cowork attachment reads unchanged

## Issue

Part of #669. This is the second staged P0 optimization after the detection worker index in #695.

## Verification

- `npm test -- artifactFileLoader ModelRenderer artifactPanelResize` (11/11)
- `npm test -- artifactFileLoader` (4/4, including cache-clear race)
- `npm run build:tsc`
- `npm run lint`
- `npx oxfmt --check` on changed files
- `git diff --check`

## Scope and compatibility

- IPC channel and the existing 20 MB read limit are unchanged.
- Preview content remains in the existing Data URL format; binary IPC is intentionally deferred to a separate stage.
- Cowork prompt and inline attachment flows are not routed through this cache.
