### PR TITLE
ci: tier PR gates and strengthen candidate validation

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,0 +1,57 @@
+# CI gate ownership
+
+Every PR runs lint, renderer type checking/build/bundle budgets, Electron compilation,
+unit tests, and Presentation Studio tests. Documentation-only PRs retain these baseline
+checks in this first rollout. Unknown paths never skip the baseline.
+
+`scripts/ci/gates/policy.ts` owns expensive-check selection:
+
+| Change                                                                                                      | Additional PR checks                                                        |
+| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Dependencies, patches, build/configuration, workflows, scripts, bundled runtimes, Skills/MCPs, main process | Linux install/startup, Windows install/upgrade/uninstall, memory regression |
+| Renderer services, hooks, store, application entry points, cowork UI, shared conversation components        | Memory regression                                                           |
+| Other renderer UI, styles, documentation                                                                    | None                                                                        |
+
+The planner uses the full Git merge-base diff, with NUL-separated paths and rename
+detection disabled. Deleted paths and both sides of renames participate. Invalid SHAs
+or diff failures stop the planner; no API pagination or 300-file filter limit applies.
+
+`merge-gate` always runs and rejects failed, cancelled, missing, or unexpectedly skipped
+required jobs. Linux and Windows workflows are reusable/manual workflows, so they do
+not create duplicate PR runs. The parent CI owns concurrency cancellation.
+
+## Release and nightly checks
+
+Candidate builds run memory regression against the resolved candidate commit before
+platform packaging. Candidate quality also runs renderer type checking/bundle budgets
+and Presentation Studio tests. The Linux job installs and starts the exact candidate
+deb before assembling its payload; unpacked renderer verification is retained.
+Windows signing, runtime, install/upgrade/uninstall checks remain mandatory.
+
+Nightly uses the same memory scenario with additional MemLab analysis. Tag publishing
+retains mandatory memory regression through reusable CI; its own platform jobs still
+own packaging. Main pushes repeat baseline checks without duplicate installation jobs.
+
+After this workflow is available on main, use **CI → Run workflow** on a selected branch
+to force all expensive checks. Individual Linux/Windows manual workflows remain available.
+Manual checks supplement the PR checks; they do not replace the PR merge-commit check.
+
+## Required-check rollout and measurement
+
+After a real PR run confirms the `merge-gate` check name, configure it as a required
+status check in the main ruleset. Do not require the conditional platform jobs directly.
+This change does not modify repository rules or production environment permissions.
+
+Before rollout, the sampled successful PR runs had Linux median 16.2 minutes and CI
+median 6.3 minutes (short sample from September 4, 2026; queue time included). These
+are reference observations, not a performance guarantee.
+
+Compare one week before/after, separately for ordinary and packaging/lifecycle PRs:
+
+- PR ready-for-merge median/P95 and queue versus execution time.
+- Expensive jobs selected, skipped, failed, and cancelled; runner minutes per PR.
+- Candidate failures attributable to checks deferred from PR, and resulting rework.
+
+Initial target: ordinary PR feedback in 5–8 minutes without increased release rework.
+If deferred checks repeatedly find regressions in an unclassified area, expand its path
+ownership. Do not reduce the mandatory candidate checks to improve this metric.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,11 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
   workflow_call:
+    secrets:
+      MODELSCOPE_TOKENS:
+        required: false
 
 permissions:
   contents: read
@@ -18,8 +22,31 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+      linux-install: ${{ steps.plan.outputs.linux-install }}
+      windows-install: ${{ steps.plan.outputs.windows-install }}
+      memory-leak: ${{ steps.plan.outputs.memory-leak }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+      - name: Select expensive checks from the complete PR diff
+        id: plan
+        run: node scripts/ci/gates/plan.ts
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -46,6 +73,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -77,6 +105,7 @@ jobs:
 
   bundle-budget:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -94,6 +123,8 @@ jobs:
             bun-${{ runner.os }}-1.4.0-
       - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun run apply:patches
+      - name: Typecheck renderer sources
+        run: bun run build:tsc
       - name: Build renderer bundle
         run: bun run build:vite
         env:
@@ -102,42 +133,35 @@ jobs:
         run: bun run test:bundle-budget
 
   memory-leak:
+    needs: changes
+    if: needs.changes.outputs.memory-leak == 'true'
+    uses: ./.github/workflows/memory-regression.yml
+
+  linux-install:
+    needs: changes
+    if: needs.changes.outputs.linux-install == 'true'
+    uses: ./.github/workflows/linux-install-pr.yml
+    secrets:
+      MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+
+  windows-install:
+    needs: changes
+    if: needs.changes.outputs.windows-install == 'true'
+    uses: ./.github/workflows/windows-installer-pr.yml
+
+  merge-gate:
+    name: merge-gate
+    if: always()
+    needs: [changes, lint, test, bundle-budget, memory-leak, linux-install, windows-install]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.4.0'
-      - name: Restore Bun and Electron caches
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-            ~/.cache/electron
-          key: memory-leak-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            memory-leak-${{ runner.os }}-1.4.0-
-      - name: Install Electron runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 xvfb
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - run: bun run apply:patches
-      - name: Install Electron runtime
-        run: node node_modules/electron/install.js
-      - name: Build application for the memory regression scenario
-        run: |
-          bun run build:vite
-          bun run compile:electron
-      - name: Run Electron memory regression check
-        run: xvfb-run -a bun run test:memory-leak
-      - name: Upload heap snapshots when the threshold is exceeded
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: memory-leak-diagnostics
-          path: artifacts/memory-leak
-          if-no-files-found: error
+      - name: Require every selected check to succeed
+        run: node scripts/ci/gates/verify.ts
+        env:
+          GATE_PLAN: ${{ needs.changes.outputs.plan }}
+          GATE_RESULTS: ${{ toJSON(needs) }}

--- a/.github/workflows/linux-install-pr.yml
+++ b/.github/workflows/linux-install-pr.yml
@@ -1,15 +1,14 @@
 name: Linux install and startup gate
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      MODELSCOPE_TOKENS:
+        required: false
 
 permissions:
   contents: read
-
-concurrency:
-  group: linux-install-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/memory-leak-nightly.yml
+++ b/.github/workflows/memory-leak-nightly.yml
@@ -8,52 +8,8 @@ on:
 permissions:
   contents: read
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-
 jobs:
   memory-leak:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24.x'
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: '1.4.0'
-      - name: Restore Bun and Electron caches
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-            ~/.cache/electron
-          key: memory-leak-nightly-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            memory-leak-nightly-${{ runner.os }}-1.4.0-
-      - name: Install Electron runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 xvfb
-      - run: bun install --frozen-lockfile --ignore-scripts
-      - run: bun run apply:patches
-      - name: Install Electron runtime
-        run: node node_modules/electron/install.js
-      - name: Build application for the memory regression scenario
-        run: |
-          bun run build:vite
-          bun run compile:electron
-      - name: Run Electron memory regression check
-        run: xvfb-run -a bun run test:memory-leak
-      - name: Analyze Renderer heap snapshots with MemLab
-        run: npm exec --yes --package=memlab@2.0.5 -- memlab analyze unbound-object --snapshot-dir artifacts/memory-leak
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: 'true'
-      - name: Upload nightly heap diagnostics
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: memory-leak-nightly-diagnostics
-          path: artifacts/memory-leak
-          if-no-files-found: error
+    uses: ./.github/workflows/memory-regression.yml
+    with:
+      analyze-heap: true

--- a/.github/workflows/memory-regression.yml
+++ b/.github/workflows/memory-regression.yml
@@ -1,0 +1,69 @@
+name: Memory regression
+
+on:
+  workflow_call:
+    inputs:
+      source-ref:
+        type: string
+        default: ''
+      analyze-heap:
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+
+jobs:
+  memory-leak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source-ref || github.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
+      - name: Restore Bun and Electron caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.cache/electron
+          key: memory-leak-${{ runner.os }}-1.4.0-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            memory-leak-${{ runner.os }}-1.4.0-
+      - name: Install Electron runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 xvfb
+      - run: bun install --frozen-lockfile --ignore-scripts
+      - run: bun run apply:patches
+      - name: Install Electron runtime
+        run: node node_modules/electron/install.js
+      - name: Build application for the memory regression scenario
+        run: |
+          bun run build:vite
+          bun run compile:electron
+      - name: Run Electron memory regression check
+        run: xvfb-run -a bun run test:memory-leak
+      - name: Analyze Renderer heap snapshots with MemLab
+        if: inputs.analyze-heap
+        run: npm exec --yes --package=memlab@2.0.5 -- memlab analyze unbound-object --snapshot-dir artifacts/memory-leak
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+      - name: Upload available memory diagnostics
+        if: ${{ always() && hashFiles('artifacts/memory-leak/**') != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: memory-leak-diagnostics
+          path: artifacts/memory-leak
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -63,9 +63,16 @@ jobs:
             echo '- external publication: disabled'
           } >> "$GITHUB_STEP_SUMMARY"
 
+  memory-regression:
+    needs: prepare-candidate
+    uses: ./.github/workflows/memory-regression.yml
+    with:
+      source-ref: ${{ needs.prepare-candidate.outputs.commit }}
+
   quality:
     needs: prepare-candidate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -104,13 +111,22 @@ jobs:
           bun run check:openclaw-decoupling
           bun run check:supply-chain-inputs
           bun run lint
+      - name: Typecheck and enforce renderer bundle budgets
+        run: |
+          bun run build:tsc
+          bun run build:vite
+          bun run test:bundle-budget
+        env:
+          VITE_SKIP_ELECTRON: '1'
+      - name: Verify Presentation Studio compiler and validator
+        run: npm test --prefix SKILLs/presentation-studio
       - name: Compile and test
         run: |
           bun run compile:electron
           bun run test
 
   build-candidate:
-    needs: [prepare-candidate, quality]
+    needs: [prepare-candidate, quality, memory-regression]
     strategy:
       fail-fast: true
       matrix:
@@ -289,6 +305,24 @@ jobs:
       - name: Verify the Linux renderer
         if: ${{ matrix.platform == 'linux' }}
         run: xvfb-run -a node scripts/verify-linux-renderer.mjs release/linux-unpacked release/linux-render-smoke.png
+      - name: Install and start the exact Linux candidate deb
+        if: ${{ matrix.platform == 'linux' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          debs=(release/*.deb)
+          [[ ${#debs[@]} -eq 1 ]] || { echo 'Expected exactly one Linux deb package' >&2; exit 1; }
+          sudo apt-get install -y "$(realpath "${debs[0]}")"
+          node scripts/verify-linux-renderer.mjs '/opt/知远/知远' release/linux-deb-install-smoke.png
+      - name: Upload Linux candidate startup diagnostics
+        if: ${{ always() && matrix.platform == 'linux' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: candidate-linux-startup-diagnostics
+          path: release/*smoke.png
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Assemble Windows candidate payload
         if: ${{ matrix.platform == 'windows' }}
         shell: bash

--- a/.github/workflows/windows-installer-pr.yml
+++ b/.github/workflows/windows-installer-pr.yml
@@ -1,27 +1,11 @@
 name: Windows installer gate
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/windows-installer-pr.yml"
-      - "bun.lock"
-      - "package.json"
-      - "electron-builder.json"
-      - "vite.config.ts"
-      - "build/icons/**"
-      - "build/installer-assets/**"
-      - "scripts/**"
-      - "MCPs/**"
-      - "SKILLs/**"
-      - "resources/vc_redist.x64.exe"
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
-
-concurrency:
-  group: windows-installer-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -36,10 +20,10 @@ jobs:
         run: node scripts/ci/check-openclaw-decoupling.mjs
       - uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: '24.x'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.4.0"
+          bun-version: '1.4.0'
       - name: Restore packaging caches
         uses: actions/cache@v5
         with:
@@ -72,8 +56,8 @@ jobs:
             -TimeoutMinutes 55 `
             -HeartbeatSeconds 60
         env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
       - name: Check offline installer size
         shell: powershell
         run: >-

--- a/scripts/ci/gates/constants.ts
+++ b/scripts/ci/gates/constants.ts
@@ -1,0 +1,25 @@
+export const CiEvent = {
+  PullRequest: 'pull_request',
+  Push: 'push',
+  Manual: 'workflow_dispatch',
+} as const;
+
+export const JobResult = {
+  Success: 'success',
+  Skipped: 'skipped',
+  Failure: 'failure',
+  Cancelled: 'cancelled',
+} as const;
+
+export const HeavyJob = {
+  Linux: 'linux-install',
+  Windows: 'windows-install',
+  Memory: 'memory-leak',
+} as const;
+
+export const BaselineJob = {
+  Changes: 'changes',
+  Lint: 'lint',
+  Test: 'test',
+  Bundle: 'bundle-budget',
+} as const;

--- a/scripts/ci/gates/package.json
+++ b/scripts/ci/gates/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/scripts/ci/gates/plan.test.ts
+++ b/scripts/ci/gates/plan.test.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from 'vitest';
+import { CiEvent, HeavyJob } from './constants.ts';
+
+const planner = fileURLToPath(new URL('./plan.ts', import.meta.url));
+
+test('Git diff includes deleted and renamed sensitive paths beyond 300 files', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'ci-gate-plan-'));
+  const git = (...args: string[]) =>
+    execFileSync('git', args, { cwd: dir, encoding: 'utf8' }).trim();
+  try {
+    git('init', '-q');
+    git('config', 'user.name', 'CI Test');
+    git('config', 'user.email', 'ci@example.invalid');
+    mkdirSync(join(dir, 'src/main'), { recursive: true });
+    writeFileSync(join(dir, 'src/main/runtime.ts'), 'sensitive runtime');
+    git('add', 'src/main/runtime.ts');
+    git('-c', 'commit.gpgsign=false', 'commit', '-qm', 'base');
+    const base = git('rev-parse', 'HEAD');
+    git('mv', 'src/main/runtime.ts', 'ordinary.ts');
+    mkdirSync(join(dir, 'docs'));
+    const docs = Array.from({ length: 350 }, (_, i) => `docs/${i}.md`);
+    for (const doc of docs) writeFileSync(join(dir, doc), 'documentation');
+    git('add', ...docs);
+    git('-c', 'commit.gpgsign=false', 'commit', '-qm', 'rename with many docs');
+    const output = join(dir, 'output');
+    execFileSync(process.execPath, [planner], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        GITHUB_EVENT_NAME: CiEvent.PullRequest,
+        GITHUB_REF: 'refs/pull/1/merge',
+        PR_BASE_SHA: base,
+        PR_HEAD_SHA: git('rev-parse', 'HEAD'),
+        GITHUB_OUTPUT: output,
+        GITHUB_STEP_SUMMARY: join(dir, 'summary'),
+      },
+    });
+    expect(readFileSync(output, 'utf8')).toContain(`${HeavyJob.Linux}=true`);
+    expect(readFileSync(join(dir, 'summary'), 'utf8')).toContain('352 changed paths');
+    expect(() =>
+      execFileSync(process.execPath, [planner], {
+        cwd: dir,
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: CiEvent.PullRequest,
+          PR_BASE_SHA: '',
+          PR_HEAD_SHA: '',
+          GITHUB_OUTPUT: output,
+        },
+      }),
+    ).toThrow();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/ci/gates/plan.ts
+++ b/scripts/ci/gates/plan.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { CiEvent } from './constants.ts';
+import { planGates } from './policy.ts';
+
+const event = process.env.GITHUB_EVENT_NAME ?? '';
+let paths: string[] = [];
+if (event === CiEvent.PullRequest) {
+  const base = process.env.PR_BASE_SHA ?? '';
+  const head = process.env.PR_HEAD_SHA ?? '';
+  if (![base, head].every(sha => /^[a-f0-9]{40}$/.test(sha))) {
+    throw new Error('PR base and head must be complete commit SHAs');
+  }
+  // Local Git has no API file-count cap. --no-renames includes both old and new
+  // paths so moving a sensitive file out of its directory cannot bypass checks.
+  paths = execFileSync(
+    'git',
+    ['diff', '--name-only', '--no-renames', '-z', `${base}...${head}`, '--'],
+    {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  )
+    .split('\0')
+    .filter(Boolean);
+}
+const plan = planGates(paths, event, process.env.GITHUB_REF ?? '');
+if (!process.env.GITHUB_OUTPUT) throw new Error('GITHUB_OUTPUT is required');
+appendFileSync(process.env.GITHUB_OUTPUT, `plan=${JSON.stringify(plan)}\n`);
+for (const [name, enabled] of Object.entries(plan)) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${enabled}\n`);
+}
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `### CI gate plan\n\nCompared ${paths.length} changed paths. Baseline checks always run.\n\n` +
+      Object.entries(plan)
+        .map(([name, enabled]) => `- ${name}: ${enabled ? 'required' : 'not required'}`)
+        .join('\n') +
+      '\n',
+  );
+}

--- a/scripts/ci/gates/policy.test.ts
+++ b/scripts/ci/gates/policy.test.ts
@@ -1,0 +1,169 @@
+import { readFileSync } from 'node:fs';
+import { load } from 'js-yaml';
+import { expect, test } from 'vitest';
+import { BaselineJob, CiEvent, HeavyJob, JobResult } from './constants.ts';
+import { planGates, verifyGateResults, type GatePlan } from './policy.ts';
+
+const prRef = 'refs/pull/42/merge';
+const light = planGates(['src/renderer/components/Settings.tsx'], CiEvent.PullRequest, prRef);
+const full = planGates(['package.json'], CiEvent.PullRequest, prRef);
+
+test.each([
+  'README.md',
+  'docs/development.md',
+  'src/renderer/components/Settings.tsx',
+  'src/renderer/theme/themes.css',
+  'unknown/new-module.ts',
+])('ordinary and unknown paths retain only baseline checks: %s', file => {
+  expect(Object.values(planGates([file], CiEvent.PullRequest, prRef))).toEqual([
+    false,
+    false,
+    false,
+  ]);
+});
+
+test.each([
+  'bun.lock',
+  'package.json',
+  'electron-builder.json',
+  'electron-builder.windows-signed.cjs',
+  'electron-tsconfig.json',
+  'vite.config.ts',
+  'patches/runtime.patch',
+  'resources/python-linux/bin/python',
+  'build/installer.nsh',
+  'scripts/setup-python-runtime.js',
+  'SKILLs/pdf/requirements.txt',
+  'MCPs/feishu/server.js',
+  '.github/workflows/ci.yml',
+  'src/main/main.ts',
+  'src/main/newPlatformModule.ts',
+])('packaging and main-process changes run all heavy checks: %s', file => {
+  expect(Object.values(planGates([file], CiEvent.PullRequest, prRef))).toEqual([true, true, true]);
+});
+
+test.each([
+  'src/renderer/services/cowork.ts',
+  'src/renderer/services/streamRequestRegistry.ts',
+  'src/renderer/hooks/useIpcChat.ts',
+  'src/renderer/store/slices/coworkSlice.ts',
+  'src/renderer/components/cowork/hooks/useTodoQueueLifecycle.ts',
+  'src/shared/components/ai-elements/conversation.tsx',
+  'src/renderer/App.tsx',
+])('renderer lifecycle changes run memory without packaging: %s', file => {
+  expect(planGates([file], CiEvent.PullRequest, prRef)).toEqual({
+    ...light,
+    [HeavyJob.Memory]: true,
+  });
+});
+
+test('manual runs and unknown events fail closed to the complete suite', () => {
+  expect(planGates([], CiEvent.Manual, 'refs/heads/main')).toEqual(full);
+  expect(planGates([], 'unexpected-event', 'refs/heads/main')).toEqual(full);
+});
+
+test('main pushes are light while tag releases retain mandatory memory regression', () => {
+  expect(planGates(['package.json'], CiEvent.Push, 'refs/heads/main')).toEqual(light);
+  expect(planGates([], CiEvent.Push, 'refs/tags/v2026.9.5')).toEqual({
+    ...light,
+    [HeavyJob.Memory]: true,
+  });
+});
+
+function resultsFor(plan: GatePlan) {
+  const results: Record<string, { result: string }> = Object.fromEntries(
+    Object.values(BaselineJob).map(name => [name, { result: JobResult.Success }]),
+  );
+  for (const [name, enabled] of Object.entries(plan)) {
+    results[name] = { result: enabled ? JobResult.Success : JobResult.Skipped };
+  }
+  return results;
+}
+
+test('merge gate permits only intentional skips', () => {
+  expect(() => verifyGateResults(light, resultsFor(light))).not.toThrow();
+  expect(() => verifyGateResults(full, resultsFor(full))).not.toThrow();
+});
+
+test.each([JobResult.Failure, JobResult.Cancelled, JobResult.Skipped])(
+  'required check %s cannot pass the gate',
+  result => {
+    for (const name of Object.keys(resultsFor(full))) {
+      const results = resultsFor(full);
+      results[name] = { result };
+      expect(() => verifyGateResults(full, results)).toThrow();
+    }
+  },
+);
+
+test('missing jobs and incomplete decisions cannot pass the gate', () => {
+  const results = resultsFor(full);
+  delete results[HeavyJob.Linux];
+  expect(() => verifyGateResults(full, results)).toThrow();
+  expect(() => verifyGateResults({} as GatePlan, resultsFor(light))).toThrow();
+});
+
+test('unexpected failure of an optional check cannot be hidden', () => {
+  const results = resultsFor(light);
+  results[HeavyJob.Memory] = { result: JobResult.Failure };
+  expect(() => verifyGateResults(light, results)).toThrow();
+});
+
+interface WorkflowJob {
+  needs?: string | string[];
+  if?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  steps?: Array<{ name?: string; run?: string; uses?: string; with?: Record<string, unknown> }>;
+}
+
+function workflow(name: string) {
+  return load(
+    readFileSync(new URL(`../../../.github/workflows/${name}`, import.meta.url), 'utf8'),
+  ) as {
+    on: Record<string, unknown>;
+    jobs: Record<string, WorkflowJob>;
+  };
+}
+
+test('CI waits for every selected reusable check and always runs the merge gate', () => {
+  const ci = workflow('ci.yml');
+  expect(ci.on).toHaveProperty(CiEvent.PullRequest);
+  const gate = ci.jobs['merge-gate'];
+  expect(gate.if).toBe('always()');
+  expect(gate.needs).toEqual(
+    expect.arrayContaining([...Object.values(BaselineJob), ...Object.values(HeavyJob)]),
+  );
+  for (const job of Object.values(HeavyJob)) {
+    expect(ci.jobs[job].needs).toBe(BaselineJob.Changes);
+    expect(ci.jobs[job].if).toBe(`needs.changes.outputs.${job} == 'true'`);
+    expect(ci.jobs[job].uses).toMatch(/\.yml$/);
+  }
+  for (const file of ['linux-install-pr.yml', 'windows-installer-pr.yml']) {
+    expect(workflow(file).on).toHaveProperty('workflow_call');
+    expect(workflow(file).on).not.toHaveProperty(CiEvent.PullRequest);
+  }
+});
+
+test('candidate checks bind the source commit and block packaging before memory succeeds', () => {
+  const candidate = workflow('release-candidate.yml');
+  const memoryJob = candidate.jobs['memory-regression'];
+  expect(memoryJob.uses).toBe(workflow('ci.yml').jobs[HeavyJob.Memory].uses);
+  expect(memoryJob.with?.['source-ref']).toBe('${{ needs.prepare-candidate.outputs.commit }}');
+  expect(candidate.jobs['build-candidate'].needs).toContain('memory-regression');
+  const qualityCommands = candidate.jobs.quality.steps?.map(step => step.run ?? '').join('\n');
+  expect(qualityCommands).toContain('bun run build:tsc');
+  expect(qualityCommands).toContain('bun run test:bundle-budget');
+  const steps = candidate.jobs['build-candidate'].steps ?? [];
+  const install = steps.findIndex(step =>
+    step.run?.includes('sudo apt-get install -y "$(realpath'),
+  );
+  const payload = steps.findIndex(step => step.name === 'Assemble Linux candidate payload');
+  expect(install).toBeGreaterThan(-1);
+  expect(payload).toBeGreaterThan(install);
+  expect(steps[install].run).toContain("'/opt/知远/知远'");
+  expect(workflow('memory-leak-nightly.yml').jobs[HeavyJob.Memory].uses).toBe(memoryJob.uses);
+  expect(workflow('memory-leak-nightly.yml').jobs[HeavyJob.Memory].with?.['analyze-heap']).toBe(
+    true,
+  );
+});

--- a/scripts/ci/gates/policy.ts
+++ b/scripts/ci/gates/policy.ts
@@ -1,0 +1,48 @@
+import { BaselineJob, CiEvent, HeavyJob, JobResult } from './constants.ts';
+
+export type GatePlan = Record<(typeof HeavyJob)[keyof typeof HeavyJob], boolean>;
+
+// Packaging inputs and main-process changes require real platform verification.
+// Keep unknown paths on the baseline checks; never skip lint, types or unit tests.
+const packaging =
+  /^(?:package\.json$|bun\.lock$|electron-builder[^/]*$|(?:electron-)?tsconfig[^/]*$|vite\.config\.|\.github\/|patches\/|build\/|resources\/|vendor\/|scripts\/|SKILLs\/|MCPs\/|skills\.config\.json$|src\/main\/|src\/shared\/(?:llamacpp|channelRuntime)\/)/;
+const memory =
+  /^(?:src\/main\/|src\/renderer\/(?:App\.tsx$|main\.tsx$|hooks\/|store\/|services\/|components\/cowork\/)|src\/shared\/components\/ai-elements\/)/;
+
+export function planGates(paths: string[], event: string, ref: string): GatePlan {
+  // Manual runs are the escape hatch for risks not captured by path ownership.
+  const full = event === CiEvent.Manual;
+  // main pushes repeat fast checks; PRs already own the expensive install checks.
+  // Unknown events run everything rather than silently weakening the gate.
+  const unknown =
+    event !== CiEvent.PullRequest && event !== CiEvent.Push && event !== CiEvent.Manual;
+  const relevant = paths.some(file => packaging.test(file));
+  const installations = event === CiEvent.PullRequest && relevant;
+  return {
+    [HeavyJob.Linux]: full || unknown || installations,
+    [HeavyJob.Windows]: full || unknown || installations,
+    [HeavyJob.Memory]:
+      full ||
+      unknown ||
+      ref.startsWith('refs/tags/') ||
+      (event === CiEvent.PullRequest && (relevant || paths.some(file => memory.test(file)))),
+  };
+}
+
+export function verifyGateResults(
+  plan: GatePlan,
+  results: Record<string, { result: string }>,
+): void {
+  for (const name of Object.values(BaselineJob)) {
+    if (results[name]?.result !== JobResult.Success) {
+      throw new Error(`Required check ${name} did not succeed`);
+    }
+  }
+  for (const name of Object.values(HeavyJob)) {
+    if (typeof plan[name] !== 'boolean') throw new Error(`Missing decision for ${name}`);
+    const expected = plan[name] ? JobResult.Success : JobResult.Skipped;
+    if (results[name]?.result !== expected) {
+      throw new Error(`Check ${name} must be ${expected}, received ${results[name]?.result}`);
+    }
+  }
+}

--- a/scripts/ci/gates/verify.ts
+++ b/scripts/ci/gates/verify.ts
@@ -1,0 +1,8 @@
+import { verifyGateResults } from './policy.ts';
+
+// Invalid or missing JSON fails closed, including an unsuccessful planner.
+verifyGateResults(
+  JSON.parse(process.env.GATE_PLAN ?? ''),
+  JSON.parse(process.env.GATE_RESULTS ?? ''),
+);
+console.log('[CiGate] all required checks passed');

--- a/tests/linuxInstallGate.test.ts
+++ b/tests/linuxInstallGate.test.ts
@@ -6,13 +6,14 @@ import { test } from 'vitest';
 
 const root = path.resolve(__dirname, '..');
 
-test('every pull request installs and starts the generated Ubuntu package', () => {
+test('selected pull requests install and start the generated Ubuntu package', () => {
   const workflow = readFileSync(
     path.join(root, '.github', 'workflows', 'linux-install-pr.yml'),
     'utf8',
   );
 
-  assert.match(workflow, /pull_request:/);
+  assert.match(workflow, /workflow_call:/);
+  assert.doesNotMatch(workflow, /pull_request:/);
   assert.doesNotMatch(workflow, /paths:/);
   assert.match(workflow, /runs-on: ubuntu-latest/);
   assert.match(workflow, /bun run dist:linux/);

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -391,10 +391,9 @@ test("installer-related pull requests build and exercise the Windows installer",
     path.join(root, ".github", "workflows", "windows-installer-pr.yml"),
     "utf8",
   );
-  assert.match(workflow, /pull_request:/);
-  assert.match(workflow, /paths:/);
-  assert.match(workflow, /"vite\.config\.ts"/);
-  assert.match(workflow, /"scripts\/\*\*"/);
+  assert.match(workflow, /workflow_call:/);
+  assert.doesNotMatch(workflow, /pull_request:/);
+  assert.doesNotMatch(workflow, /paths:/);
   assert.match(workflow, /runs-on: windows-latest/);
   assert.match(workflow, /@\('run', 'dist:win:offline'\)/);
   assert.match(workflow, /windows-runtime-smoke\.ps1/);


### PR DESCRIPTION
Ordinary renderer UI and documentation PRs currently wait for a complete Linux installation and an Electron memory scenario. Select expensive checks from the complete PR Git diff while retaining lint, renderer types/build/bundle budgets, Electron compilation and unit tests for every PR.

- Packaging inputs and main-process changes require Linux installation/startup, Windows installation/upgrade/uninstall, and memory regression. Renderer lifecycle changes require memory regression. Manual CI runs force the full suite.
- Always run `merge-gate`; reject failed, cancelled, missing or unexpectedly skipped required jobs. Reusable platform workflows remove duplicate PR triggers.
- Reuse the memory scenario for PRs, nightly and candidates. Candidates bind it to the resolved source SHA, run renderer budgets and Presentation Studio tests, and install/start the exact candidate deb before assembling its payload.
- Preserve the existing signing, publication and rollback behavior. No application IPC, storage or window behavior changes.

Validation: 54 focused tests passed, including rename/deletion and >300-file diff coverage, gate failure semantics, and workflow wiring; renderer typecheck and gate TypeScript checks passed; repository lint passed; actionlint 1.7.12 passed for all changed workflows (ShellCheck integration disabled). [GitHub CI passed](https://github.com/rongxinzy/RongxinAI/actions/runs/33934659424): baseline checks, Linux deb installation/first paint, Windows installation/upgrade/uninstall, memory regression and merge-gate.

The first attempt encountered a Mermaid dependency extraction failure and an unhandled post-test virtualizer callback; rerunning only failed jobs passed without source/test changes. The gate correctly rejected the first attempt. Candidate workflow wiring is locally verified; a signed candidate build/publication was not dispatched by this PR.

This PR changes workflow policy, so it intentionally runs all heavy PR checks. Ordinary PR latency improvement must be measured after rollout; the 5–8 minute target is not a measured result. After verifying the real check name, configure `merge-gate` as required in the main ruleset. Repository rules and production environment permissions are unchanged.

Replaying the file lists of the 20 most recently merged PRs selects 13 fewer Linux installation jobs and 3 fewer memory jobs. This is a workload projection, not a measured latency reduction.
