### PR TITLE
ci: validate workflows and restore dependency audits

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,6 +1,6 @@
 # CI gate ownership
 
-Every PR runs lint, renderer type checking/build/bundle budgets, Electron compilation,
+Every PR runs workflow validation, lint, renderer type checking/build/bundle budgets, Electron compilation,
 unit tests, and Presentation Studio tests. Documentation-only PRs retain these baseline
 checks in this first rollout. Unknown paths never skip the baseline.
 
@@ -38,9 +38,37 @@ Manual checks supplement the PR checks; they do not replace the PR merge-commit 
 
 ## Required-check rollout and measurement
 
-After a real PR run confirms the `merge-gate` check name, configure it as a required
-status check in the main ruleset. Do not require the conditional platform jobs directly.
-This change does not modify repository rules or production environment permissions.
+The main ruleset requires `merge-gate` from GitHub Actions (app ID 15368), with the
+branch up to date before merging. This was enabled on September 5, 2026 after verifying
+the merged workflow's real check. Existing role bypasses remain unchanged; they can
+still bypass this requirement. Do not require conditional platform jobs directly.
+
+The lint job checks all workflows with actionlint 1.7.12 before installing application
+dependencies. Its Linux binary is verified against a pinned SHA-256. This validates
+workflow syntax, expressions, reusable-workflow inputs and job dependencies; ShellCheck
+is not enabled by this gate.
+
+## Security audit operation
+
+Weekly/manual Security Scan audits the root `bun.lock` using Bun 1.4.0. It audits
+every tracked nested Skill package and other child projects with npm lockfiles in
+isolated report directories. Existing locks are copied unchanged; lockless Skills
+resolve a fresh dependency graph with lifecycle scripts disabled. Their reports are
+labelled `unlocked-resolution` and are not evidence of the exact graph in a shipped
+installer. Root development dependencies are included because build tools and some
+bundled runtime dependencies live there.
+
+High/critical findings and audit/registry failures return nonzero. All child projects
+are attempted even if one fails; JSON reports, stderr, copied locks and a summary TSV
+are uploaded on failure as well as success. Artifact retention is seven days, matching
+the repository's existing artifact cleanup policy. A red audit with valid findings
+requires vulnerability triage; it must not be silenced with an unconditional success.
+Known vulnerability remediation is separate from repairing the scanning mechanism.
+This full scheduled scan is not an additional heavy PR gate.
+
+Reproduce child audits with `bash scripts/ci/audit-npm-projects.sh /tmp/npm-audit-report`.
+
+## Latency measurement
 
 Before rollout, the sampled successful PR runs had Linux median 16.2 minutes and CI
 median 6.3 minutes (short sample from September 4, 2026; queue time included). These

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -60,8 +60,8 @@ bundled runtime dependencies live there.
 
 High/critical findings and audit/registry failures return nonzero. All child projects
 are attempted even if one fails; JSON reports, stderr, copied locks and a summary TSV
-are uploaded on failure as well as success. Artifact retention is seven days, matching
-the repository's existing artifact cleanup policy. A red audit with valid findings
+are uploaded on failure as well as success. Artifact retention is three days, matching
+the repository's effective Actions retention setting. A red audit with valid findings
 requires vulnerability triage; it must not be silenced with an unconditional success.
 Known vulnerability remediation is separate from repairing the scanning mechanism.
 This full scheduled scan is not an additional heavy PR gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,18 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+      - name: Install checksum-pinned workflow validator
+        run: |
+          mkdir -p "$RUNNER_TEMP/actionlint"
+          curl --fail --location --retry 3 --max-time 60 \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz \
+            -o "$RUNNER_TEMP/actionlint/archive.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $RUNNER_TEMP/actionlint/archive.tar.gz" | sha256sum --check
+          tar -xzf "$RUNNER_TEMP/actionlint/archive.tar.gz" -C "$RUNNER_TEMP/actionlint" actionlint
+      - name: Validate workflow syntax and job dependencies
+        # ShellCheck policy is separate; this gate validates every workflow's
+        # YAML, expressions, reusable-workflow inputs and dependency graph.
+        run: '"$RUNNER_TEMP/actionlint/actionlint" -shellcheck='
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           name: security-bun-audit
           path: security-reports/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 3
 
   skills-audit:
     runs-on: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
           name: security-npm-audit
           path: ${{ runner.temp }}/security-npm-reports/
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 3
 
   codeql:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,98 +2,87 @@ name: Security Scan
 
 on:
   schedule:
-    - cron: '0 0 * * 1' # ???
+    - cron: '0 0 * * 1'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # ========== ?????? ==========
   secrets-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Run TruffleHog
+      - name: Scan repository history for verified secrets
         uses: trufflesecurity/trufflehog@v3.88.30
         with:
           path: ./
-          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --only-verified
 
-  # ========== ?????? ==========
   dependency-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: '24.x'
-      - uses: actions/cache@v5
+          bun-version: '1.4.0'
+      - name: Audit the checked-in Bun graph
+        run: |
+          mkdir -p security-reports
+          bun audit --audit-level=high --json > security-reports/bun-audit.json 2> security-reports/bun-audit.stderr
+      - name: Preserve the audit report even on failure
+        if: always()
+        uses: actions/upload-artifact@v6
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-${{ runner.os }}-
+          name: security-bun-audit
+          path: security-reports/
+          if-no-files-found: error
+          retention-days: 7
 
-      # Keep the audited dependency graph identical to the checked-in lockfile.
-      - run: npm ci --ignore-scripts
-
-      # npm audit
-      - name: Run npm audit
-        run: |
-          echo "Running npm audit..."
-          npm audit --audit-level=high || echo "? npm audit found issues (non-blocking)"
-
-      # ?? better-npm-audit ??????
-      - name: Run better-npm-audit
-        run: |
-          npx better-npm-audit audit --level=high || echo "? better-npm-audit found issues (non-blocking)"
-
-  # ========== Skill ???? ==========
   skills-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      npm_config_fetch_retries: '2'
+      npm_config_fetch_timeout: '60000'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24.x'
+      - name: Audit all nested Skills and locked npm tool projects
+        run: bash scripts/ci/audit-npm-projects.sh "$RUNNER_TEMP/security-npm-reports"
+      - name: Preserve graphs and reports even on failure
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: security-npm-audit
+          path: ${{ runner.temp }}/security-npm-reports/
+          if-no-files-found: error
+          retention-days: 7
 
-      - name: Audit Skills
-        run: |
-          set +e  # Don't exit on error
-
-          for skill in SKILLs/*/; do
-            if [ -f "$skill/package.json" ]; then
-              echo ""
-              echo "=== Auditing $skill ==="
-              (cd "$skill" && npm install --package-lock-only 2>/dev/null && npm audit --audit-level=moderate 2>/dev/null) || echo "? Audit issues found in $skill (non-blocking)"
-            fi
-          done
-
-          echo ""
-          echo "=== Skill audit complete ==="
-
-  # ========== ???? (CodeQL) ==========
   codeql:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@v4
         with:
-          languages: javascript, typescript
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+          languages: javascript-typescript
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4

--- a/scripts/ci/audit-npm-projects.sh
+++ b/scripts/ci/audit-npm-projects.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Audit child package graphs without running lifecycle scripts or rewriting the
+# checkout. Unlocked Skills get an explicitly labelled, retained resolution.
+report_root="${1:?Usage: audit-npm-projects.sh <report-directory>}"
+mkdir -p "$report_root"
+report_root="$(cd "$report_root" && pwd)"
+status=0
+index=0
+printf 'project\tgraph\tresult\n' > "$report_root/summary.tsv"
+# A failing Git command in process substitution would otherwise be ignored.
+git ls-files -z -- '*/package.json' > "$report_root/manifests.list"
+
+while IFS= read -r -d '' manifest; do
+  project="${manifest%/package.json}"
+  case "$manifest" in
+    SKILLs/*/package.json) ;;
+    *)
+      git ls-files --error-unmatch "$project/package-lock.json" > /dev/null 2>&1 || continue
+      ;;
+  esac
+  index=$((index + 1))
+  snapshot="$report_root/project-$index"
+  mkdir -p "$snapshot"
+  cp "$manifest" "$snapshot/package.json"
+  graph='locked'
+  if git ls-files --error-unmatch "$project/package-lock.json" > /dev/null 2>&1; then
+    cp "$project/package-lock.json" "$snapshot/package-lock.json"
+  else
+    graph='unlocked-resolution'
+    printf 'Resolving unlocked dependency ranges for %s\n' "$project"
+    if ! (cd "$snapshot" && npm install --package-lock-only --ignore-scripts --no-audit --no-fund > resolve.log 2>&1); then
+      printf '%s\t%s\tresolution-failed\n' "$project" "$graph" >> "$report_root/summary.tsv"
+      cat "$snapshot/resolve.log"
+      status=1
+      continue
+    fi
+  fi
+  printf 'Auditing %s (%s)\n' "$project" "$graph"
+  if (cd "$snapshot" && npm audit --package-lock-only --ignore-scripts --audit-level=high --json > audit.json 2> audit.stderr); then
+    printf '%s\t%s\tpassed\n' "$project" "$graph" >> "$report_root/summary.tsv"
+  else
+    printf '%s\t%s\tfailed\n' "$project" "$graph" >> "$report_root/summary.tsv"
+    cat "$snapshot/audit.json" "$snapshot/audit.stderr"
+    status=1
+  fi
+done < "$report_root/manifests.list"
+
+cat "$report_root/summary.tsv"
+exit "$status"

--- a/scripts/ci/audit-npm-projects.test.ts
+++ b/scripts/ci/audit-npm-projects.test.ts
@@ -1,0 +1,143 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect, test } from 'vitest';
+
+const script = path.resolve(__dirname, 'audit-npm-projects.sh');
+
+function fixture() {
+  const root = mkdtempSync(path.join(tmpdir(), 'npm-audit-test-'));
+  const reports = path.join(root, 'reports');
+  const bin = path.join(root, 'bin');
+  mkdirSync(bin);
+  const tracked: string[] = [];
+  for (const [directory, locked] of [
+    ['SKILLs/locked skill', true],
+    ['SKILLs/presets/nested', false],
+    ['scripts/release', true],
+    ['scripts/helper', false],
+  ] as const) {
+    mkdirSync(path.join(root, directory), { recursive: true });
+    const manifest = `${directory}/package.json`;
+    writeFileSync(path.join(root, manifest), JSON.stringify({ name: directory }));
+    tracked.push(manifest);
+    if (locked) {
+      const lock = `${directory}/package-lock.json`;
+      writeFileSync(path.join(root, lock), '{"lockfileVersion":3,"packages":{}}\n');
+      tracked.push(lock);
+    }
+  }
+  execFileSync('git', ['init', '-q', root]);
+  execFileSync('git', ['add', ...tracked], { cwd: root });
+  // A local fake npm verifies invocation boundaries; no registry access occurs.
+  writeFileSync(
+    path.join(bin, 'npm'),
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const name = JSON.parse(fs.readFileSync('package.json', 'utf8')).name;
+if (!args.includes('--ignore-scripts') || !args.includes('--package-lock-only')) process.exit(90);
+fs.appendFileSync(process.env.AUDIT_CALLS, JSON.stringify({name,args,cwd:process.cwd()})+'\\n');
+if (args[0] === 'install') {
+  if (process.env.FAIL_RESOLUTION === name) process.exit(2);
+  fs.writeFileSync('package-lock.json', '{"lockfileVersion":3,"packages":{}}');
+}
+if (args[0] === 'audit') {
+  console.log(JSON.stringify({project:name,vulnerabilities:process.env.FAIL_AUDIT === name}));
+  if (process.env.FAIL_AUDIT === name) process.exit(1);
+}
+`,
+    { mode: 0o755 },
+  );
+  return {
+    root,
+    reports,
+    run: (env: Record<string, string> = {}) =>
+      spawnSync('bash', [script, reports], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...env,
+          PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+          AUDIT_CALLS: path.join(root, 'calls.jsonl'),
+        },
+      }),
+    calls: () =>
+      readFileSync(path.join(root, 'calls.jsonl'), 'utf8')
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line) as { name: string; args: string[]; cwd: string }),
+    dispose: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test('audits locked graphs and nested unlocked Skills in isolated snapshots', () => {
+  const f = fixture();
+  try {
+    expect(f.run().status).toBe(0);
+    const calls = f.calls();
+    expect(calls).toHaveLength(4);
+    expect(calls.every(call => call.cwd.startsWith(realpathSync(f.reports)))).toBe(true);
+    expect(calls.filter(call => call.args[0] === 'install').map(call => call.name)).toEqual([
+      'SKILLs/presets/nested',
+    ]);
+    expect(calls.some(call => call.name === 'scripts/helper')).toBe(false);
+    expect(existsSync(path.join(f.root, 'SKILLs/presets/nested/package-lock.json'))).toBe(false);
+    expect(readFileSync(path.join(f.root, 'SKILLs/locked skill/package-lock.json'), 'utf8')).toBe(
+      '{"lockfileVersion":3,"packages":{}}\n',
+    );
+    expect(readFileSync(path.join(f.reports, 'summary.tsv'), 'utf8')).toContain(
+      'unlocked-resolution',
+    );
+  } finally {
+    f.dispose();
+  }
+});
+
+test('an audit failure stays nonzero while other projects still get reports', () => {
+  const f = fixture();
+  try {
+    expect(f.run({ FAIL_AUDIT: 'SKILLs/locked skill' }).status).toBe(1);
+    expect(f.calls().filter(call => call.args[0] === 'audit')).toHaveLength(3);
+    expect(readFileSync(path.join(f.reports, 'summary.tsv'), 'utf8')).toContain(
+      'SKILLs/locked skill\tlocked\tfailed',
+    );
+    expect(existsSync(path.join(f.reports, 'project-1/audit.json'))).toBe(true);
+  } finally {
+    f.dispose();
+  }
+});
+
+test('resolution errors are retained and cannot be mistaken for a clean graph', () => {
+  const f = fixture();
+  try {
+    expect(f.run({ FAIL_RESOLUTION: 'SKILLs/presets/nested' }).status).toBe(1);
+    expect(f.calls().filter(call => call.args[0] === 'audit')).toHaveLength(2);
+    expect(readFileSync(path.join(f.reports, 'summary.tsv'), 'utf8')).toContain(
+      'resolution-failed',
+    );
+  } finally {
+    f.dispose();
+  }
+});
+
+test('a missing Git inventory fails rather than silently auditing zero projects', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'npm-audit-no-git-'));
+  try {
+    expect(spawnSync('bash', [script, path.join(root, 'reports')], { cwd: root }).status).not.toBe(
+      0,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
PRs now validate every workflow before installing application dependencies. The validator is version-pinned and checksum-verified in the existing lint gate, so malformed workflow expressions and job dependencies fail early without adding a heavy PR job.

The weekly/manual Security Scan now audits the checked-in Bun graph and all nested Skill packages plus locked npm tool projects. Child audits run in isolated snapshots with lifecycle scripts disabled, preserve reports on failure, and continue scanning after individual findings. Lockless Skills are explicitly labelled as fresh resolutions. High/critical findings and tool failures remain failures.

Validation: 58 focused tests passed; `npm run lint`, all-workflow actionlint validation, shell syntax and diff checks passed. Real registry audits completed for the root and seven child projects; the root and three children reported vulnerabilities. This change repairs scanning and preserves evidence; it does not remediate those dependencies or add the full security scan to ordinary PR gates.

The [final-commit Security Scan](https://github.com/rongxinzy/RongxinAI/actions/runs/33942415264) completed: secret scanning and CodeQL passed. Both dependency audit jobs failed on vulnerability findings and successfully uploaded their reports. The initial run's downloaded artifacts confirm all seven child projects were scanned with no resolution errors. The npm reports identify 5 high-severity affected packages in the freshly resolved email Skill graph, 2 in Presentation Studio, and 1 in the release tools. These package counts can include multiple packages affected by the same underlying advisory. Remediation requires separate dependency review; suggested audit fixes must not be applied blindly. Audit artifacts now explicitly use the repository's effective three-day retention; final-run artifact expiry timestamps were verified.

Operational rollout: the main ruleset now requires GitHub Actions `merge-gate` with an up-to-date branch. Existing role bypasses were preserved. Documentation records this separate repository configuration change.

Final commit `786f00ae` passed the [complete PR CI run](https://github.com/rongxinzy/RongxinAI/actions/runs/33942412961): workflow validation/lint, unit tests, bundle budget, memory regression, real Linux installation/startup, Windows runtime/cold-install/upgrade/uninstall checks, and `merge-gate`. GitHub reports the PR as mergeable. Job durations were 3m23s for tests, 2m49s for memory, 7m18s for Linux, and 22m11s for Windows. These are single-run job timings, not evidence of an aggregate speedup. The unchanged memory workflow still emits an artifact-retention warning; the new audit artifacts use the verified three-day setting.
