### PR TITLE
ci: shorten windows pr verification

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -36,6 +36,28 @@ After this workflow is available on main, use **CI → Run workflow** on a selec
 to force all expensive checks. Individual Linux/Windows manual workflows remain available.
 Manual checks supplement the PR checks; they do not replace the PR merge-commit check.
 
+## Windows PR latency
+
+PR installation checks retain installer size, clean-PATH runtime probes, cold install,
+cache-hit upgrade and uninstall. Compression qualification runs on manual and weekly
+Windows builds, and is mandatory before both candidate assembly and tag publication.
+The shared action retains its JSON report and enforces the existing size, extraction
+time, content identity and Python import criteria.
+
+PRs only restore packaging caches; they do not archive and upload them after testing.
+Monday's Windows build (02:23 UTC) and manual builds on main save missing cache entries
+after all installation checks succeed. Other branches never write the shared cache.
+The restore/save paths and key match; frozen dependency installation still runs on a
+cache hit. Before the first successful main warmup, PRs can run cold. A cache miss
+affects speed only and does not skip installation or verification.
+
+The reference Windows job in run 33942412961 took 22m11s: compression qualification
+was 3m28s and cache saving was 3m50s (662 MB compressed cache, mostly local archiving
+time). The next-run acceptance target is under 17 minutes with every retained gate
+passing. Record restore time and cache hit/miss alongside the final duration; a single
+run is directional evidence, not a median/P95 claim. If the target is missed, report
+the miss and investigate the measured bottleneck without relaxing installation tests.
+
 ## Required-check rollout and measurement
 
 The main ruleset requires `merge-gate` from GitHub Actions (app ID 15368), with the

--- a/.github/actions/verify-windows-compression/action.yml
+++ b/.github/actions/verify-windows-compression/action.yml
@@ -1,0 +1,20 @@
+name: Verify Windows compression qualification
+description: Require compression size, extraction time, content identity and Python probes before publication
+runs:
+  using: composite
+  steps:
+    - name: Qualify the packaged Skill Python archive
+      shell: powershell
+      run: >-
+        powershell -NoProfile -ExecutionPolicy Bypass
+        -File scripts/ci/benchmark-skill-python-compression.ps1
+        -ProjectRoot '${{ github.workspace }}'
+        -RequireQualified
+    - name: Preserve compression qualification report
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: windows-compression-${{ github.job }}
+        path: build-tar/windows-components/skill-python-compression-benchmark.json
+        if-no-files-found: warn
+        retention-days: 3

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -299,6 +299,9 @@ jobs:
           powershell -NoProfile -ExecutionPolicy Bypass
           -File scripts/ci/windows-runtime-smoke.ps1
           -ProjectRoot ${{ github.workspace }}
+      - name: Qualify Windows compression before publication
+        if: ${{ matrix.platform == 'windows' }}
+        uses: ./.github/actions/verify-windows-compression
       - name: Verify the packaged renderer in a virtual Ubuntu desktop
         if: ${{ matrix.platform == 'linux' }}
         run: >-

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -295,6 +295,9 @@ jobs:
         run: |
           powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ci/windows-installer-size-smoke.ps1 -ProjectRoot '${{ github.workspace }}'
           powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ci/windows-runtime-smoke.ps1 -ProjectRoot '${{ github.workspace }}'
+      - name: Qualify Windows compression before candidate assembly
+        if: ${{ matrix.platform == 'windows' }}
+        uses: ./.github/actions/verify-windows-compression
       - name: Verify Windows cold install, cache-hit upgrade, and uninstall
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/.github/workflows/windows-installer-pr.yml
+++ b/.github/workflows/windows-installer-pr.yml
@@ -1,6 +1,8 @@
 name: Windows installer gate
 
 on:
+  schedule:
+    - cron: '23 2 * * 1'
   workflow_dispatch:
   workflow_call:
 
@@ -25,7 +27,8 @@ jobs:
         with:
           bun-version: '1.4.0'
       - name: Restore packaging caches
-        uses: actions/cache@v5
+        id: packaging-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -65,13 +68,8 @@ jobs:
           -File scripts/ci/windows-installer-size-smoke.ps1
           -ProjectRoot ${{ github.workspace }}
       - name: Benchmark shared Skill Python solid compression
-        id: skill-python-compression
-        shell: powershell
-        run: >-
-          powershell -NoProfile -ExecutionPolicy Bypass
-          -File scripts/ci/benchmark-skill-python-compression.ps1
-          -ProjectRoot ${{ github.workspace }}
-          -RequireQualified
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: ./.github/actions/verify-windows-compression
       - name: Verify embedded runtimes with a clean PATH
         shell: powershell
         run: >-
@@ -84,6 +82,18 @@ jobs:
           powershell -NoProfile -ExecutionPolicy Bypass
           -File scripts/ci/windows-installer-smoke.ps1
           -ProjectRoot ${{ github.workspace }}
+      - name: Save shared packaging caches from verified main builds
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.packaging-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            ~/.npm
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+            vendor/engram-runtime
+            vendor/channel-runtime
+          key: ${{ steps.packaging-cache.outputs.cache-primary-key }}
       - name: Collect installer diagnostics
         if: ${{ failure() }}
         shell: powershell
@@ -103,4 +113,4 @@ jobs:
             installer-diagnostics/install-timing.log
             ${{ runner.temp }}/zhiyuan-build-logs
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 3

--- a/scripts/ci/gates/windows.test.ts
+++ b/scripts/ci/gates/windows.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { load } from 'js-yaml';
+import { expect, test } from 'vitest';
+
+interface Step {
+  name?: string;
+  id?: string;
+  uses?: string;
+  run?: string;
+  if?: string;
+  'continue-on-error'?: boolean;
+  with?: Record<string, unknown>;
+}
+
+interface Workflow {
+  on: Record<string, unknown>;
+  jobs: Record<string, { steps: Step[] }>;
+}
+
+function workflow(file: string): Workflow {
+  return load(
+    readFileSync(new URL(`../../../.github/workflows/${file}`, import.meta.url), 'utf8'),
+  ) as Workflow;
+}
+
+const compressionAction = './.github/actions/verify-windows-compression';
+const windows = workflow('windows-installer-pr.yml');
+const steps = windows.jobs['package-and-install'].steps;
+
+test('PRs defer compression qualification while manual and scheduled builds retain it', () => {
+  expect(windows.on).toHaveProperty('schedule');
+  expect(windows.on).toHaveProperty('workflow_dispatch');
+  expect(windows.on).toHaveProperty('workflow_call');
+  expect(steps.find(step => step.uses === compressionAction)?.if).toBe(
+    "${{ github.event_name != 'pull_request' }}",
+  );
+  for (const script of [
+    'windows-installer-size-smoke.ps1',
+    'windows-runtime-smoke.ps1',
+    'windows-installer-smoke.ps1',
+  ]) {
+    const gate = steps.find(step => step.run?.includes(script));
+    expect(gate).toBeDefined();
+    expect(gate?.if).toBeUndefined();
+    expect(gate?.['continue-on-error']).toBeUndefined();
+  }
+});
+
+test('PRs restore without saving; verified main runs publish the same cache graph', () => {
+  expect(steps.some(step => step.uses === 'actions/cache@v5')).toBe(false);
+  const restore = steps.find(step => step.uses === 'actions/cache/restore@v5');
+  const saveIndex = steps.findIndex(step => step.uses === 'actions/cache/save@v5');
+  const save = steps[saveIndex];
+  expect(restore?.id).toBe('packaging-cache');
+  expect(save.if).toBe(
+    "${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && steps.packaging-cache.outputs.cache-hit != 'true' }}",
+  );
+  expect(save.with?.path).toBe(restore?.with?.path);
+  expect(save.with?.key).toBe('${{ steps.packaging-cache.outputs.cache-primary-key }}');
+  expect(saveIndex).toBeGreaterThan(
+    steps.findIndex(step => step.run?.includes('windows-installer-smoke.ps1')),
+  );
+  const install = steps.find(step => step.run === 'bun install --frozen-lockfile --ignore-scripts');
+  expect(install).toBeDefined();
+  expect(install?.if).toBeUndefined();
+});
+
+test.each([
+  ['release-candidate.yml', 'build-candidate', 'Assemble Windows candidate payload'],
+  ['online-update-release.yml', 'build-platforms', 'Upload Windows immutable artifact to R2'],
+])('compression qualification blocks the publication path in %s', (file, job, publishName) => {
+  const releaseSteps = workflow(file).jobs[job].steps;
+  const index = releaseSteps.findIndex(step => step.uses === compressionAction);
+  expect(index).toBeGreaterThan(-1);
+  expect(releaseSteps[index].if).toBe("${{ matrix.platform == 'windows' }}");
+  expect(releaseSteps[index]['continue-on-error']).toBeUndefined();
+  const publishIndex = releaseSteps.findIndex(step => step.name === publishName);
+  expect(publishIndex).toBeGreaterThan(index);
+  expect(releaseSteps[publishIndex].if).toBe("${{ matrix.platform == 'windows' }}");
+});
+
+test('shared qualification fails on thresholds and retains reports without hiding failure', () => {
+  const action = load(
+    readFileSync(
+      new URL('../../../.github/actions/verify-windows-compression/action.yml', import.meta.url),
+      'utf8',
+    ),
+  ) as { runs: { steps: Step[] } };
+  expect(action.runs.steps[0].run).toContain('-RequireQualified');
+  expect(action.runs.steps[0].run).not.toContain('-SkipPythonProbe');
+  expect(action.runs.steps.every(step => !step['continue-on-error'])).toBe(true);
+  expect(action.runs.steps[1].if).toBe('always()');
+  expect(action.runs.steps[1].with?.['retention-days']).toBe(3);
+});


### PR DESCRIPTION
Windows PR verification previously spent 3m28s benchmarking compression and 3m50s archiving/saving a 662 MB packaging cache in a 22m11s job. PRs now restore caches without saving them and defer compression qualification to manual/weekly builds and both publication paths. Installer size, clean-PATH runtimes, cold install, cache-hit upgrade and uninstall remain unconditional PR checks.

A shared compression action enforces the original thresholds, content identity and Python probes before candidate assembly and before tagged Windows artifacts are uploaded. Reports are retained for three days. Weekly Windows builds and successful manual builds on main warm missing shared cache entries after all checks pass; PRs and other branches never save them. Cold cache misses still install and validate the full graph.

Validation: 59 focused tests, lint, actionlint and diff checks passed locally. Final commit `a84228e0` passed [all PR CI gates](https://github.com/rongxinzy/RongxinAI/actions/runs/33945773983), including `merge-gate`, and the [full manual Windows gate](https://github.com/rongxinzy/RongxinAI/actions/runs/33945773950). No application runtime or installer behavior changes.

Measured Windows PR duration: **14m11s**, down **8m00s (36%)** from the 22m11s reference job in run 33942412961, meeting the predeclared under-17-minute target. The packaging cache was a miss and no packaging cache was saved; the separate Bun executable cache was restored. Installer size, runtime probes, cold installation, upgrade and uninstall all passed. Tests took 3m24s, Linux 6m53s, memory 2m30s.

The full manual Windows run passed in 15m59s. Its downloaded compression report confirms qualification, identical extracted content hashes, successful Python probes, 24,879,053 bytes saved and a 0.96 extraction-time ratio (limit 1.25). Candidate/tag integration is covered by workflow contract tests; no signed candidate or production release was triggered. Main-only cache saving is covered by the guard/path/key contract tests; the first trusted main warmup will happen after merge. These are individual-run comparisons, not median/P95 or controlled benchmark claims. The unchanged memory workflow still reports its existing artifact-retention warning.
