### PR TITLE
refactor(ui): modularize shell controls and polish navigation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -312,7 +312,7 @@ Tailwind 工具类经 `index.css` 中 `@theme` 块桥接：`--color-background: 
 
 输入框工具栏上的选择器/触发按钮（参照实现：`PermissionModeMenu`、`CoworkModelPicker`）是**工具栏按钮的质感基准**，新做同类按钮（下拉选择器、菜单触发器、工具栏动作）时一律使用，不自造变体：
 
-1. **统一用 ghost `PromptInputButton`**（ai-elements）：无边框、无背景、无阴影，静止时完全融入工具栏。
+1. **统一用 `PromptInputButton`**（ai-elements）：无边框、无背景、无阴影，静止时完全融入工具栏。普通动作使用 ghost；模型、权限下拉使用共享 `PromptSelectorButton`，由 `prompt-selector` variant 统一提供以下 hover 和展开状态。
 2. **hover 用背景表达**：`hover:bg-surface-raised`，200ms 内过渡；不用边框、阴影或颜色变化做 hover 信号。
 3. **下拉触发器带尾部箭头**：`ChevronDown`（`h-3.5 w-3.5 text-muted-foreground`），表明"点开有菜单"；纯动作按钮（如「+」）只放图标，不加箭头。
 4. **内容从左到右**：可选的前置图标（`size-4` 或供应商标识）→ `text-sm` 文字 → 尾部箭头；文字过长用 `max-w` + `truncate` 截断。
@@ -419,3 +419,14 @@ src/shared/components/ui/page-tabs.tsx
 - 系统提示统一复用 `src/renderer/components/Toast.tsx` 的视觉：内容自适应宽度、顶部居中；失败使用深色底配红色圆形 X，成功使用浅色底配绿色圆形对勾，信息提示使用蓝色信息图标；不显示右侧关闭图标。
 - 新增提示不得自行实现 Toast 容器或另起视觉分支；跨页面通知使用 `app:showToast`，第三方 Toast 仅通过共享 Sonner 宿主调用。
 - 用户可见错误必须经过错误归一化和 i18n。已知错误显示明确中文类别；未知错误显示“操作失败：原因摘要”，同时将原始错误写入日志供开发者定位。
+
+
+## Shell 展示模块边界
+
+- 侧栏导航使用共享 `SidebarNavigationView` / `SidebarNavigationItem`：32px 行高、8px 圆角、统一图标槽和文字省略；选中态使用 `card`、`border` 与正文色，悬停使用同一语义表面。状态、可见性策略、预加载与新任务回调由原控制组件提供。
+- `Button` 的 `navigation` variant / size 负责导航视觉；`toolbar` variant 配合 `icon` size 负责侧栏及顶栏的 32px 图标按钮。页面不再覆盖这些按钮的颜色、圆角和高度。
+- `PageHeaderLayout` 只排列导航、标题、操作、系统窗口控制与 tabs 槽位。导航和操作不压缩，标题允许省略；macOS 原生窗口按钮预留区继续保留，交互控件继续位于不可拖动区域。
+- 输入区模型、权限触发器复用 `PromptSelectorButton`，保留 `PromptInputButton` 的无背景外观和 sm 尺寸，使用共享 `prompt-selector` variant；统一图标槽、箭头、截断与紧凑模式。菜单状态、搜索、权限及模型选择回调留在原组件。
+- 展示层不新增 IPC、持久化或业务状态，不通过主题 key 重建编辑器。工作/对话开关只有一个变更入口；沿用原有受控 Switch 与浅深主题。
+
+- 工作/对话开关保留白色滑块；选中文字使用 `switch-thumb-foreground`，浅深色均为深色，避免深色主题的正文白色落到白色滑块上。该语义 token 同步登记到主题契约、共享默认值、静态 CSS 与 Tailwind 映射。

--- a/src/renderer/components/PageHeader.interaction.test.ts
+++ b/src/renderer/components/PageHeader.interaction.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, useState } from 'react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import PageHeader from './PageHeader';
+
+vi.mock('../services/i18n', () => ({ i18nService: { t: (key: string) => key } }));
+vi.mock('./window/WindowTitleBar', () => ({
+  default: () => createElement('div', { 'data-testid': 'window-controls' }),
+}));
+beforeEach(() => {
+  window.electron = { platform: 'darwin' } as typeof window.electron;
+});
+
+test('preserves custom content state and shell callbacks when navigation visibility changes', async () => {
+  const user = userEvent.setup();
+  const onToggleSidebar = vi.fn();
+  const onNewChat = vi.fn();
+  function Draft() {
+    const [value, setValue] = useState('');
+    return createElement('input', {
+      'aria-label': 'workspace name',
+      value,
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value),
+    });
+  }
+  const props = {
+    title: 'Task',
+    leftContent: createElement(Draft),
+    onToggleSidebar,
+    onNewChat,
+    updateBadge: createElement('span', null, 'Update'),
+  };
+  const view = render(createElement(PageHeader, { ...props, isSidebarCollapsed: false }));
+  await user.type(screen.getByRole('textbox'), 'Keep draft');
+  view.rerender(createElement(PageHeader, { ...props, isSidebarCollapsed: true }));
+  expect(screen.getByRole('textbox')).toHaveValue('Keep draft');
+  await user.click(screen.getByRole('button', { name: 'expand' }));
+  await user.click(screen.getByRole('button', { name: 'newChat' }));
+  expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  expect(onNewChat).toHaveBeenCalledTimes(1);
+  expect(screen.getByText('Update')).toBeTruthy();
+  expect(screen.getAllByTestId('window-controls')).toHaveLength(1);
+  view.rerender(createElement(PageHeader, { ...props, isSidebarCollapsed: false }));
+  expect(screen.queryByRole('button', { name: 'expand' })).toBeNull();
+  expect(screen.getByRole('textbox')).toHaveValue('Keep draft');
+});

--- a/src/renderer/components/PageHeader.tsx
+++ b/src/renderer/components/PageHeader.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@shared/components/ui/button';
 import { cn } from '@shared/lib/utils';
 import React from 'react';
 
@@ -6,6 +5,8 @@ import { i18nService } from '../services/i18n';
 import { SidebarAnimatedMessageCirclePlusIcon } from './icons/SidebarAnimatedMessageCirclePlusIcon';
 import { SidebarAnimatedPanelLeftCloseIcon } from './icons/SidebarAnimatedPanelLeftCloseIcon';
 import WindowTitleBar from './window/WindowTitleBar';
+import { PageHeaderLayout } from './shell/PageHeaderLayout';
+import { ShellIconButton } from './shell/ShellIconButton';
 
 /**
  * Shared top bar for every sidebar-switched page. All feature views must use
@@ -45,57 +46,34 @@ const PageHeader: React.FC<PageHeaderProps> = ({
 }) => {
   const isMac = window.electron.platform === 'darwin';
   return (
-    <header className="shrink-0 bg-background">
-      <div
-        className={cn(
-          'draggable flex h-12 items-center justify-between gap-3 px-4',
-          !tabs && 'border-b border-border-subtle',
-        )}
-      >
-        <div className="flex h-8 min-w-0 items-center gap-3">
-          {isSidebarCollapsed && (
-            <div className={cn('non-draggable flex items-center gap-1', isMac && 'pl-[68px]')}>
-              {onToggleSidebar && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={onToggleSidebar}
-                  aria-label={i18nService.t('expand')}
-                  title={i18nService.t('expand')}
-                  className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised hover:text-foreground"
-                >
-                  <SidebarAnimatedPanelLeftCloseIcon direction="right" />
-                </Button>
-              )}
-              {onNewChat && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={onNewChat}
-                  aria-label={i18nService.t('newChat')}
-                  title={i18nService.t('newChat')}
-                  className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised hover:text-foreground"
-                >
-                  <SidebarAnimatedMessageCirclePlusIcon />
-                </Button>
-              )}
-              {updateBadge}
-            </div>
-          )}
-          {leftContent ??
-            (title ? (
-              <h1 className="truncate text-lg font-semibold text-foreground">{title}</h1>
-            ) : null)}
-        </div>
-        <div className="non-draggable flex shrink-0 items-center gap-1">
-          {actions}
-          <WindowTitleBar inline />
-        </div>
-      </div>
-      {tabs ? <div className="non-draggable border-b border-border-subtle px-4">{tabs}</div> : null}
-    </header>
+    <PageHeaderLayout
+      navigation={
+        isSidebarCollapsed ? (
+          <div
+            className={cn('non-draggable flex shrink-0 items-center gap-1', isMac && 'pl-[68px]')}
+          >
+            {onToggleSidebar && (
+              <ShellIconButton onClick={onToggleSidebar} label={i18nService.t('expand')}>
+                <SidebarAnimatedPanelLeftCloseIcon direction="right" />
+              </ShellIconButton>
+            )}
+            {onNewChat && (
+              <ShellIconButton onClick={onNewChat} label={i18nService.t('newChat')}>
+                <SidebarAnimatedMessageCirclePlusIcon />
+              </ShellIconButton>
+            )}
+            {updateBadge}
+          </div>
+        ) : null
+      }
+      content={
+        leftContent ??
+        (title ? <h1 className="truncate text-lg font-semibold text-foreground">{title}</h1> : null)
+      }
+      actions={actions}
+      windowControls={<WindowTitleBar inline />}
+      tabs={tabs}
+    />
   );
 };
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -43,6 +43,7 @@ import {
   SidebarAnimatedSearchIcon,
   type SidebarAnimatedSearchIconHandle,
 } from './icons/SidebarAnimatedSearchIcon';
+import { ShellIconButton } from './shell/ShellIconButton';
 import { SidebarAnimatedPanelLeftCloseIcon } from './icons/SidebarAnimatedPanelLeftCloseIcon';
 import { toggleBatchSelection, toggleVisibleBatchSelection } from './agentSidebar/batchSelection';
 import MyAgentSidebarTree from './agentSidebar/MyAgentSidebarTree';
@@ -542,16 +543,12 @@ const Sidebar: React.FC<SidebarProps> = ({
                   className="logo-dark h-5 w-auto select-none"
                 />
               </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
+              <ShellIconButton
                 onClick={onToggleCollapse}
-                className="non-draggable h-8 w-8 rounded-lg text-muted-foreground hover:bg-surface-raised transition-colors"
-                aria-label={isCollapsed ? i18nService.t('expand') : i18nService.t('collapse')}
+                label={i18nService.t(isCollapsed ? 'expand' : 'collapse')}
               >
                 <SidebarAnimatedPanelLeftCloseIcon />
-              </Button>
+              </ShellIconButton>
             </div>
             <SidebarNavigationControls
               activeView={activeView}

--- a/src/renderer/components/SidebarNavigationControls.interaction.test.ts
+++ b/src/renderer/components/SidebarNavigationControls.interaction.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement } from 'react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { SidebarNavigationControls } from './SidebarNavigationControls';
+import { WorkMode } from '../store/workMode/constants';
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    activity: { runs: [] as { status: string }[] },
+    skill: { activeSkillIds: [] as string[] },
+  },
+  clearWorkspaceSelection: vi.fn(async () => {}),
+}));
+vi.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector(mocks.state),
+}));
+vi.mock('../services/workspace', () => ({
+  workspaceService: { clearWorkspaceSelection: mocks.clearWorkspaceSelection },
+}));
+vi.mock('../services/i18n', () => ({ i18nService: { t: (key: string) => key } }));
+beforeEach(() => {
+  mocks.state = { activity: { runs: [] }, skill: { activeSkillIds: [] } };
+});
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const props = () => ({
+  activeView: 'cowork' as const,
+  workMode: WorkMode.Work,
+  onNewChat: vi.fn(),
+  onShowExpert: vi.fn(),
+  onShowCoding: vi.fn(),
+  onShowTodo: vi.fn(),
+  onShowLocalInference: vi.fn(),
+  onShowScheduledTasks: vi.fn(),
+  onShowActivity: vi.fn(),
+  onWorkModeChange: vi.fn(),
+  onPrefetchView: vi.fn(),
+});
+
+test('changes work mode exactly once per click or keyboard activation', async () => {
+  const user = userEvent.setup();
+  const handlers = props();
+  render(createElement(SidebarNavigationControls, handlers));
+  const toggle = screen.getByRole('switch');
+  await user.click(toggle);
+  expect(handlers.onWorkModeChange).toHaveBeenCalledTimes(1);
+  expect(handlers.onWorkModeChange.mock.calls[0][0]).toBe(true);
+  handlers.onWorkModeChange.mockClear();
+  toggle.focus();
+  await user.keyboard(' ');
+  expect(handlers.onWorkModeChange).toHaveBeenCalledTimes(1);
+});
+
+test('preserves new-task workspace cleanup and view navigation callbacks', async () => {
+  const user = userEvent.setup();
+  const handlers = props();
+  render(createElement(SidebarNavigationControls, { ...handlers, activeView: 'todo' }));
+  await user.click(screen.getByTestId('sidebar-new-conversation'));
+  expect(mocks.clearWorkspaceSelection).toHaveBeenCalledTimes(1);
+  expect(handlers.onNewChat).toHaveBeenCalledTimes(1);
+  expect(mocks.clearWorkspaceSelection.mock.invocationCallOrder[0]).toBeLessThan(
+    handlers.onNewChat.mock.invocationCallOrder[0],
+  );
+  const views = [
+    ['localInferenceTitle', handlers.onShowLocalInference, 'localInference'],
+    ['codingAgent', handlers.onShowCoding, undefined],
+    ['todoTitle', handlers.onShowTodo, 'todo'],
+    ['scheduledTasks', handlers.onShowScheduledTasks, 'scheduledTasks'],
+    ['activityTitle', handlers.onShowActivity, 'activity'],
+    ['expert', handlers.onShowExpert, 'expert'],
+  ] as const;
+  for (const [label, callback, prefetch] of views) {
+    const button = screen.getByRole('button', { name: label });
+    handlers.onPrefetchView.mockClear();
+    await user.hover(button);
+    if (prefetch) expect(handlers.onPrefetchView).toHaveBeenCalledWith(prefetch);
+    handlers.onPrefetchView.mockClear();
+    button.focus();
+    if (prefetch) expect(handlers.onPrefetchView).toHaveBeenCalledWith(prefetch);
+    await user.keyboard('{Enter}');
+    expect(callback).toHaveBeenCalledTimes(1);
+  }
+  expect(screen.getByRole('button', { name: 'todoTitle' })).toHaveAttribute('aria-current', 'page');
+  expect(screen.getByTestId('sidebar-new-conversation')).not.toHaveAttribute('aria-current');
+});
+
+test('keeps managed-only and chat navigation policies and chat workspace selection', async () => {
+  const user = userEvent.setup();
+  const handlers = props();
+  const view = render(
+    createElement(SidebarNavigationControls, { ...handlers, managedModelsOnly: true }),
+  );
+  expect(screen.queryByRole('button', { name: 'localInferenceTitle' })).toBeNull();
+  expect(screen.getByRole('button', { name: 'todoTitle' })).toBeTruthy();
+  view.rerender(createElement(SidebarNavigationControls, { ...handlers, workMode: WorkMode.Chat }));
+  expect(screen.getAllByRole('button')).toHaveLength(1);
+  await user.click(screen.getByRole('button', { name: 'newChat' }));
+  expect(handlers.onNewChat).toHaveBeenCalledTimes(1);
+  expect(mocks.clearWorkspaceSelection).not.toHaveBeenCalled();
+  await user.click(screen.getByRole('switch', { name: 'workMode / chatMode' }));
+  expect(handlers.onWorkModeChange.mock.calls[0][0]).toBe(false);
+});
+
+test('preserves activity status and skill-aware new-conversation highlighting', () => {
+  mocks.state = {
+    activity: { runs: [{ status: 'running' }] },
+    skill: { activeSkillIds: ['skill-1'] },
+  };
+  const handlers = props();
+  const view = render(createElement(SidebarNavigationControls, handlers));
+  expect(
+    screen.getByTestId('sidebar-view-activity').querySelector('span[aria-hidden="true"]'),
+  ).toBeTruthy();
+  view.rerender(createElement(SidebarNavigationControls, { ...handlers, workMode: WorkMode.Chat }));
+  expect(screen.getByTestId('sidebar-new-conversation')).toHaveAttribute('data-active', 'false');
+  mocks.state = { activity: { runs: [] }, skill: { activeSkillIds: [] } };
+  view.rerender(createElement(SidebarNavigationControls, { ...handlers, workMode: WorkMode.Chat }));
+  expect(screen.getByTestId('sidebar-new-conversation')).toHaveAttribute('data-active', 'true');
+});

--- a/src/renderer/components/SidebarNavigationControls.tsx
+++ b/src/renderer/components/SidebarNavigationControls.tsx
@@ -1,45 +1,13 @@
-import { Button } from '@shared/components/ui/button';
-import { Switch } from '@shared/components/ui/switch';
-import { cn } from '@shared/lib/utils';
-import { useReducedMotion } from 'motion/react';
-import { type RefObject, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import { i18nService } from '../services/i18n';
 import { workspaceService } from '../services/workspace';
+import { shouldShowLocalInferenceNavigation } from '../services/managedModelUiPolicy';
 import type { RootState } from '../store';
 import { selectHasActiveActivityRun } from '../store/selectors/activitySelectors';
 import { WorkMode } from '../store/workMode/constants';
 import type { PrefetchableFeatureView } from './featureViewPrefetch';
-import { shouldShowLocalInferenceNavigation } from '../services/managedModelUiPolicy';
-import {
-  SidebarAnimatedAlarmClockIcon,
-  type SidebarAnimatedAlarmClockIconHandle,
-} from './icons/SidebarAnimatedAlarmClockIcon';
-import {
-  SidebarAnimatedActivityIcon,
-  type SidebarAnimatedActivityIconHandle,
-} from './icons/SidebarAnimatedActivityIcon';
-import {
-  SidebarAnimatedBotIcon,
-  type SidebarAnimatedBotIconHandle,
-} from './icons/SidebarAnimatedBotIcon';
-import {
-  SidebarAnimatedMessageCirclePlusIcon,
-  type SidebarAnimatedMessageCirclePlusIconHandle,
-} from './icons/SidebarAnimatedMessageCirclePlusIcon';
-import {
-  SidebarAnimatedUsersIcon,
-  type SidebarAnimatedUsersIconHandle,
-} from './icons/SidebarAnimatedUsersIcon';
-import {
-  SidebarAnimatedTerminalIcon,
-  type SidebarAnimatedTerminalIconHandle,
-} from './icons/SidebarAnimatedTerminalIcon';
-import {
-  SidebarAnimatedTodoIcon,
-  type SidebarAnimatedTodoIconHandle,
-} from './icons/SidebarAnimatedTodoIcon';
+import { SidebarNavigationView, type SidebarNavigationEntry } from './shell/SidebarNavigationView';
 
 export type SidebarActiveView =
   | 'cowork'
@@ -68,19 +36,6 @@ interface SidebarNavigationControlsProps {
   onPrefetchView?: (view: PrefetchableFeatureView) => void;
 }
 
-const sidebarViewNavItemClassName =
-  'w-full inline-flex items-center justify-start gap-2 rounded-lg border border-transparent bg-transparent px-3 py-1.5 text-left text-sm font-normal text-muted-foreground !transition-colors !duration-200 ease-out hover:border-border hover:!bg-card hover:!text-foreground';
-const activeSidebarViewNavItemClassName = cn(
-  sidebarViewNavItemClassName,
-  'border-border bg-card font-medium text-foreground hover:border-border hover:!bg-card hover:!text-foreground',
-);
-const sidebarActionNavItemClassName =
-  'w-full inline-flex items-center justify-start gap-2 rounded-lg border border-transparent bg-transparent px-3 py-1.5 text-left text-sm font-normal text-muted-foreground !transition-colors !duration-200 ease-out hover:border-border hover:!bg-card hover:!text-foreground';
-const activeSidebarActionNavItemClassName = cn(
-  sidebarActionNavItemClassName,
-  'border-border bg-card font-medium text-foreground hover:border-border hover:!bg-card hover:!text-foreground',
-);
-
 export const SidebarNavigationControls = ({
   activeView,
   onNewChat,
@@ -97,217 +52,66 @@ export const SidebarNavigationControls = ({
 }: SidebarNavigationControlsProps) => {
   const hasActiveActivityRun = useSelector((state: RootState) => selectHasActiveActivityRun(state));
   const activeSkillIds = useSelector((state: RootState) => state.skill.activeSkillIds);
-  const scheduledTasksIconRef = useRef<SidebarAnimatedAlarmClockIconHandle>(null);
-  const activityIconRef = useRef<SidebarAnimatedActivityIconHandle>(null);
-  const newConversationIconRef = useRef<SidebarAnimatedMessageCirclePlusIconHandle>(null);
-  const localInferenceIconRef = useRef<SidebarAnimatedBotIconHandle>(null);
-  const expertIconRef = useRef<SidebarAnimatedUsersIconHandle>(null);
-  const codingIconRef = useRef<SidebarAnimatedTerminalIconHandle>(null);
-  const todoIconRef = useRef<SidebarAnimatedTodoIconHandle>(null);
-  const prefersReducedMotion = useReducedMotion();
-  const isNewConversationActive =
-    activeView === 'cowork' && (workMode !== WorkMode.Chat || activeSkillIds.length === 0);
-
-  const startIconAnimation = (iconRef: RefObject<{ startAnimation: () => void } | null>) => {
-    if (!prefersReducedMotion) iconRef.current?.startAnimation();
-  };
+  const isChat = workMode === WorkMode.Chat;
   const handleNewConversation = () => {
     if (workMode === WorkMode.Work) void workspaceService.clearWorkspaceSelection();
     onNewChat();
   };
-
+  const entries: SidebarNavigationEntry[] = [];
+  const addView = (
+    id: SidebarNavigationEntry['icon'] & SidebarActiveView,
+    label: string,
+    onClick: () => void,
+    prefetch?: PrefetchableFeatureView,
+  ) => {
+    entries.push({
+      id,
+      icon: id,
+      label,
+      onClick,
+      active: activeView === id,
+      currentPage: activeView === id,
+      onIntent: prefetch ? () => onPrefetchView?.(prefetch) : undefined,
+      ...(id === 'activity'
+        ? { running: hasActiveActivityRun, testId: 'sidebar-view-activity' }
+        : {}),
+    });
+  };
+  if (shouldShowLocalInferenceNavigation(isChat, managedModelsOnly)) {
+    addView(
+      'localInference',
+      i18nService.t('localInferenceTitle'),
+      onShowLocalInference,
+      'localInference',
+    );
+  }
+  if (!isChat) {
+    addView('coding', i18nService.t('codingAgent'), onShowCoding);
+    addView('todo', i18nService.t('todoTitle'), onShowTodo, 'todo');
+    addView(
+      'scheduledTasks',
+      i18nService.t('scheduledTasks'),
+      onShowScheduledTasks,
+      'scheduledTasks',
+    );
+    addView('activity', i18nService.t('activityTitle'), onShowActivity, 'activity');
+    addView('expert', i18nService.t('expert'), onShowExpert, 'expert');
+  }
   return (
-    <div
-      className={cn(
-        'mt-[5px] flex flex-col gap-0.5 px-3',
-        workMode === WorkMode.Chat ? 'pb-0' : 'pb-3',
-      )}
-    >
-      <div
-        className="relative h-7 w-full cursor-pointer"
-        onClick={() => onWorkModeChange(workMode !== WorkMode.Chat)}
-      >
-        <Switch
-          checked={workMode === WorkMode.Chat}
-          onCheckedChange={onWorkModeChange}
-          data-mode="work-chat"
-        />
-        <span
-          className={cn(
-            'absolute top-1/2 flex items-center gap-1 pointer-events-none transition-opacity duration-200',
-            workMode === WorkMode.Work
-              ? 'font-semibold text-foreground'
-              : 'font-normal text-muted-foreground opacity-50',
-          )}
-          style={{ left: '25%', transform: 'translate(-50%, -50%)' }}
-        >
-          <span className="text-sm">{i18nService.t('workMode')}</span>
-        </span>
-        <span
-          className={cn(
-            'absolute top-1/2 flex items-center gap-1 pointer-events-none transition-opacity duration-200',
-            workMode === WorkMode.Chat
-              ? 'font-semibold text-foreground'
-              : 'font-normal text-muted-foreground opacity-50',
-          )}
-          style={{ left: '75%', transform: 'translate(-50%, -50%)' }}
-        >
-          <span className="text-sm">{i18nService.t('chatMode')}</span>
-        </span>
-      </div>
-      <div className="mt-2!">
-        <Button
-          type="button"
-          variant="ghost"
-          data-testid="sidebar-new-conversation"
-          onClick={handleNewConversation}
-          onMouseEnter={() => startIconAnimation(newConversationIconRef)}
-          onMouseLeave={() => newConversationIconRef.current?.stopAnimation()}
-          className={
-            isNewConversationActive
-              ? activeSidebarActionNavItemClassName
-              : sidebarActionNavItemClassName
-          }
-        >
-          <SidebarAnimatedMessageCirclePlusIcon ref={newConversationIconRef} />
-          {workMode === WorkMode.Chat ? i18nService.t('newChat') : i18nService.t('newTask')}
-        </Button>
-      </div>
-      {shouldShowLocalInferenceNavigation(workMode === WorkMode.Chat, managedModelsOnly) && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onShowLocalInference}
-          onMouseEnter={() => {
-            startIconAnimation(localInferenceIconRef);
-            onPrefetchView?.('localInference');
-          }}
-          onFocus={() => onPrefetchView?.('localInference')}
-          onMouseLeave={() => localInferenceIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'localInference'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'localInference' ? 'page' : undefined}
-        >
-          <SidebarAnimatedBotIcon ref={localInferenceIconRef} />
-          {i18nService.t('localInferenceTitle')}
-        </Button>
-      )}
-      {workMode !== WorkMode.Chat && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onShowCoding}
-          onMouseEnter={() => startIconAnimation(codingIconRef)}
-          onMouseLeave={() => codingIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'coding'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'coding' ? 'page' : undefined}
-        >
-          <SidebarAnimatedTerminalIcon ref={codingIconRef} />
-          {i18nService.t('codingAgent')}
-        </Button>
-      )}
-      {workMode !== WorkMode.Chat && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onShowTodo}
-          onMouseEnter={() => {
-            startIconAnimation(todoIconRef);
-            onPrefetchView?.('todo');
-          }}
-          onFocus={() => onPrefetchView?.('todo')}
-          onMouseLeave={() => todoIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'todo'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'todo' ? 'page' : undefined}
-        >
-          <SidebarAnimatedTodoIcon ref={todoIconRef} />
-          {i18nService.t('todoTitle')}
-        </Button>
-      )}
-      {workMode !== WorkMode.Chat && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onShowScheduledTasks}
-          onMouseEnter={() => {
-            startIconAnimation(scheduledTasksIconRef);
-            onPrefetchView?.('scheduledTasks');
-          }}
-          onFocus={() => onPrefetchView?.('scheduledTasks')}
-          onMouseLeave={() => scheduledTasksIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'scheduledTasks'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'scheduledTasks' ? 'page' : undefined}
-        >
-          <SidebarAnimatedAlarmClockIcon ref={scheduledTasksIconRef} />
-          {i18nService.t('scheduledTasks')}
-        </Button>
-      )}
-      {workMode !== WorkMode.Chat && (
-        <Button
-          type="button"
-          variant="ghost"
-          data-testid="sidebar-view-activity"
-          onClick={onShowActivity}
-          onMouseEnter={() => {
-            startIconAnimation(activityIconRef);
-            onPrefetchView?.('activity');
-          }}
-          onFocus={() => onPrefetchView?.('activity')}
-          onMouseLeave={() => activityIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'activity'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'activity' ? 'page' : undefined}
-        >
-          <SidebarAnimatedActivityIcon ref={activityIconRef} />
-          {i18nService.t('activityTitle')}
-          {hasActiveActivityRun && (
-            <span
-              className="ml-auto size-1.5 rounded-full bg-primary motion-safe:animate-pulse"
-              aria-hidden="true"
-            />
-          )}
-        </Button>
-      )}
-      {workMode !== WorkMode.Chat && (
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onShowExpert}
-          onMouseEnter={() => {
-            startIconAnimation(expertIconRef);
-            onPrefetchView?.('expert');
-          }}
-          onFocus={() => onPrefetchView?.('expert')}
-          onMouseLeave={() => expertIconRef.current?.stopAnimation()}
-          className={
-            activeView === 'expert'
-              ? activeSidebarViewNavItemClassName
-              : sidebarViewNavItemClassName
-          }
-          aria-current={activeView === 'expert' ? 'page' : undefined}
-        >
-          <SidebarAnimatedUsersIcon ref={expertIconRef} />
-          {i18nService.t('expert')}
-        </Button>
-      )}
-    </div>
+    <SidebarNavigationView
+      isChat={isChat}
+      workLabel={i18nService.t('workMode')}
+      chatLabel={i18nService.t('chatMode')}
+      onModeChange={onWorkModeChange}
+      newConversation={{
+        id: 'conversation',
+        icon: 'conversation',
+        label: i18nService.t(isChat ? 'newChat' : 'newTask'),
+        active: activeView === 'cowork' && (!isChat || activeSkillIds.length === 0),
+        onClick: handleNewConversation,
+        testId: 'sidebar-new-conversation',
+      }}
+      entries={entries}
+    />
   );
 };

--- a/src/renderer/components/cowork/CoworkModelPicker.tsx
+++ b/src/renderer/components/cowork/CoworkModelPicker.tsx
@@ -1,5 +1,4 @@
 import { ModelSelectorName } from '@shared/components/ai-elements/model-selector';
-import { PromptInputButton } from '@shared/components/ai-elements/prompt-input';
 import {
   Command,
   CommandEmpty,
@@ -9,12 +8,13 @@ import {
   CommandList,
 } from '@shared/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@shared/components/ui/popover';
-import { ChevronDown } from 'lucide-react';
+import { Bot } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { ProviderIcon } from '../../providers/uiRegistry';
 import { i18nService } from '../../services/i18n';
 import type { Model } from '../../store/slices/modelSlice';
+import { PromptSelectorButton } from './PromptSelectorButton';
 
 type CoworkModelPickerProps = {
   models: Model[];
@@ -26,7 +26,7 @@ type CoworkModelPickerProps = {
 };
 
 function ModelProviderIcon({ provider }: { provider: string }) {
-  return <ProviderIcon id={provider} className="size-3" />;
+  return <ProviderIcon id={provider} className="size-4" />;
 }
 
 export function CoworkModelPicker({
@@ -64,12 +64,11 @@ export function CoworkModelPicker({
       <PopoverTrigger
         nativeButton={true}
         render={
-          <PromptInputButton
-            className={compact ? 'gap-1 px-2' : 'max-w-[200px] gap-1 px-2 text-sm'}
-            aria-label={displayedSelectedModel?.name ?? i18nService.t('selectModel')}
-          >
-            {displayedSelectedModel ? (
-              <>
+          <PromptSelectorButton
+            compact={compact}
+            label={displayedSelectedModel?.name ?? i18nService.t('selectModel')}
+            icon={
+              displayedSelectedModel ? (
                 <ModelProviderIcon
                   provider={
                     displayedSelectedModel.providerKey ||
@@ -77,15 +76,11 @@ export function CoworkModelPicker({
                     'openai'
                   }
                 />
-                {!compact && <ModelSelectorName>{displayedSelectedModel.name}</ModelSelectorName>}
-              </>
-            ) : (
-              !compact && (
-                <span className="text-muted-foreground">{i18nService.t('selectModel')}</span>
+              ) : (
+                <Bot className="size-4" />
               )
-            )}
-            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          </PromptInputButton>
+            }
+          />
         }
       />
       <PopoverContent

--- a/src/renderer/components/cowork/PermissionModeMenu.tsx
+++ b/src/renderer/components/cowork/PermissionModeMenu.tsx
@@ -1,4 +1,3 @@
-import { PromptInputButton } from '@shared/components/ai-elements/prompt-input';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -6,11 +5,12 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
-import { ChevronDown, ShieldAlert, ShieldCheck } from 'lucide-react';
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
 import React from 'react';
 
 import { CoworkPermissionMode } from '../../../shared/cowork/constants';
 import { i18nService } from '../../services/i18n';
+import { PromptSelectorButton } from './PromptSelectorButton';
 
 interface PermissionModeMenuProps {
   value: CoworkPermissionMode;
@@ -42,15 +42,12 @@ const PermissionModeMenu: React.FC<PermissionModeMenuProps> = ({
         nativeButton={true}
         disabled={disabled}
         render={
-          <PromptInputButton
+          <PromptSelectorButton
             disabled={disabled}
-            aria-label={i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}
-            className={compact ? 'gap-1 px-2' : 'sidebar-interactive-surface gap-1 px-2 text-sm'}
-          >
-            <TriggerIcon className="size-4 text-foreground" />
-            {!compact && <span>{i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}</span>}
-            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-          </PromptInputButton>
+            compact={compact}
+            label={i18nService.t(PERMISSION_MODE_LABEL_KEYS[value])}
+            icon={<TriggerIcon className="size-4" />}
+          />
         }
       />
       <DropdownMenuContent side="bottom" align="start" sideOffset={4} className="w-56 p-2">

--- a/src/renderer/components/cowork/PromptSelectorButton.tsx
+++ b/src/renderer/components/cowork/PromptSelectorButton.tsx
@@ -1,0 +1,36 @@
+import { PromptInputButton } from '@shared/components/ai-elements/prompt-input';
+import { cn } from '@shared/lib/utils';
+import { ChevronDown } from 'lucide-react';
+import type { ComponentProps, ReactNode } from 'react';
+
+type PromptSelectorButtonProps = Omit<
+  ComponentProps<typeof PromptInputButton>,
+  'children' | 'size' | 'variant'
+> & {
+  label: string;
+  icon: ReactNode;
+  compact?: boolean;
+};
+
+/** Shared trigger geometry; callers own menu state and selection behavior. */
+export function PromptSelectorButton({
+  label,
+  icon,
+  compact = false,
+  className,
+  ...props
+}: PromptSelectorButtonProps) {
+  return (
+    <PromptInputButton
+      {...props}
+      variant="prompt-selector"
+      size="sm"
+      aria-label={label}
+      className={cn('min-w-0 max-w-48 gap-1.5', className)}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center">{icon}</span>
+      {!compact && <span className="min-w-0 truncate">{label}</span>}
+      <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+    </PromptInputButton>
+  );
+}

--- a/src/renderer/components/cowork/PromptSelectors.interaction.test.ts
+++ b/src/renderer/components/cowork/PromptSelectors.interaction.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement, useState } from 'react';
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import { CoworkPermissionMode } from '../../../shared/cowork/constants';
+import { CoworkModelPicker } from './CoworkModelPicker';
+import PermissionModeMenu from './PermissionModeMenu';
+
+vi.mock('../../services/i18n', () => ({ i18nService: { t: (key: string) => key } }));
+vi.mock('../../providers/uiRegistry', () => ({ ProviderIcon: () => null }));
+beforeAll(() => {
+  Element.prototype.scrollIntoView ??= vi.fn();
+});
+const models = [
+  { id: 'first', name: 'A long model name for the task', providerKey: 'openai' },
+  { id: 'second', name: 'Other model', providerKey: 'anthropic' },
+];
+
+test('preserves provider search, selection, close/reset and keyboard focus in compact mode', async () => {
+  const user = userEvent.setup();
+  const onSelect = vi.fn();
+  function Picker() {
+    const [open, setOpen] = useState(false);
+    return createElement(CoworkModelPicker, {
+      models,
+      selectedModel: models[0],
+      open,
+      onOpenChange: setOpen,
+      onSelect,
+      compact: true,
+    });
+  }
+  render(createElement(Picker));
+  const trigger = screen.getByRole('button', { name: models[0].name });
+  await user.click(trigger);
+  await user.type(screen.getByPlaceholderText('searchModels'), 'anthropic');
+  expect(screen.queryByRole('option', { name: models[0].name })).toBeNull();
+  await user.click(screen.getByRole('option', { name: models[1].name }));
+  expect(onSelect).toHaveBeenCalledExactlyOnceWith(models[1]);
+  await waitFor(() => expect(trigger).toHaveFocus());
+  await user.keyboard('{Enter}');
+  expect(screen.getByPlaceholderText('searchModels')).toHaveValue('');
+  expect(screen.getByRole('option', { name: models[0].name })).toBeTruthy();
+  await user.keyboard('{Escape}');
+  await waitFor(() => expect(trigger).toHaveFocus());
+});
+
+test('keeps an accessible empty model trigger and empty menu state', async () => {
+  const user = userEvent.setup();
+  function Picker() {
+    const [open, setOpen] = useState(false);
+    return createElement(CoworkModelPicker, {
+      models: [],
+      selectedModel: models[0],
+      open,
+      onOpenChange: setOpen,
+      onSelect: vi.fn(),
+      compact: true,
+    });
+  }
+  render(createElement(Picker));
+  await user.click(screen.getByRole('button', { name: 'selectModel' }));
+  expect(screen.getByRole('option', { name: 'modelSelectorNone' })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+});
+
+test.each([false, true])(
+  'preserves permission selection and disabled behavior (compact=%s)',
+  async compact => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const props = { value: CoworkPermissionMode.Ask, onChange, compact };
+    const view = render(createElement(PermissionModeMenu, props));
+    const trigger = screen.getByRole('button', { name: 'permissionModeAsk' });
+    await user.click(trigger);
+    await user.click(await screen.findByRole('menuitemradio', { name: /permissionModeAllowAll/ }));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(CoworkPermissionMode.AllowAll);
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(trigger).toHaveFocus());
+    view.rerender(createElement(PermissionModeMenu, { ...props, disabled: true }));
+    expect(trigger).toBeDisabled();
+    await user.click(trigger);
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  },
+);

--- a/src/renderer/components/shell/PageHeaderLayout.tsx
+++ b/src/renderer/components/shell/PageHeaderLayout.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@shared/lib/utils';
+import type { ReactNode } from 'react';
+
+interface PageHeaderLayoutProps {
+  navigation?: ReactNode;
+  content?: ReactNode;
+  actions?: ReactNode;
+  windowControls?: ReactNode;
+  tabs?: ReactNode;
+}
+
+/** Presentation only: feature state and native window behavior stay in the caller. */
+export function PageHeaderLayout({
+  navigation,
+  content,
+  actions,
+  windowControls,
+  tabs,
+}: PageHeaderLayoutProps) {
+  return (
+    <header className="shrink-0 bg-background">
+      <div
+        className={cn(
+          'draggable flex h-12 items-center justify-between gap-3 px-4',
+          !tabs && 'border-b border-border-subtle',
+        )}
+      >
+        <div className="flex h-8 min-w-0 flex-1 items-center gap-3">
+          {navigation}
+          {content}
+        </div>
+        <div className="non-draggable flex shrink-0 items-center gap-1">
+          {actions}
+          {windowControls}
+        </div>
+      </div>
+      {tabs ? <div className="non-draggable border-b border-border-subtle px-4">{tabs}</div> : null}
+    </header>
+  );
+}

--- a/src/renderer/components/shell/ShellIconButton.tsx
+++ b/src/renderer/components/shell/ShellIconButton.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@shared/components/ui/button';
+import { cn } from '@shared/lib/utils';
+import type { ComponentProps } from 'react';
+
+type ShellIconButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  'variant' | 'size' | 'aria-label'
+> & {
+  label: string;
+};
+
+export function ShellIconButton({ label, className, ...props }: ShellIconButtonProps) {
+  return (
+    <Button
+      type="button"
+      {...props}
+      variant="toolbar"
+      size="icon"
+      aria-label={label}
+      title={label}
+      className={cn('non-draggable', className)}
+    />
+  );
+}

--- a/src/renderer/components/shell/SidebarNavigationView.tsx
+++ b/src/renderer/components/shell/SidebarNavigationView.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@shared/components/ui/button';
+import { Switch } from '@shared/components/ui/switch';
+import { cn } from '@shared/lib/utils';
+import { useReducedMotion } from 'motion/react';
+import { useRef } from 'react';
+
+import { SidebarAnimatedActivityIcon } from '../icons/SidebarAnimatedActivityIcon';
+import { SidebarAnimatedAlarmClockIcon } from '../icons/SidebarAnimatedAlarmClockIcon';
+import { SidebarAnimatedBotIcon } from '../icons/SidebarAnimatedBotIcon';
+import { SidebarAnimatedMessageCirclePlusIcon } from '../icons/SidebarAnimatedMessageCirclePlusIcon';
+import { SidebarAnimatedTerminalIcon } from '../icons/SidebarAnimatedTerminalIcon';
+import { SidebarAnimatedTodoIcon } from '../icons/SidebarAnimatedTodoIcon';
+import { SidebarAnimatedUsersIcon } from '../icons/SidebarAnimatedUsersIcon';
+
+const icons = {
+  conversation: SidebarAnimatedMessageCirclePlusIcon,
+  localInference: SidebarAnimatedBotIcon,
+  coding: SidebarAnimatedTerminalIcon,
+  todo: SidebarAnimatedTodoIcon,
+  scheduledTasks: SidebarAnimatedAlarmClockIcon,
+  activity: SidebarAnimatedActivityIcon,
+  expert: SidebarAnimatedUsersIcon,
+};
+
+export interface SidebarNavigationEntry {
+  id: string;
+  icon: keyof typeof icons;
+  label: string;
+  active: boolean;
+  currentPage?: boolean;
+  running?: boolean;
+  testId?: string;
+  onClick: () => void;
+  onIntent?: () => void;
+}
+
+function SidebarNavigationItem({ entry }: { entry: SidebarNavigationEntry }) {
+  const iconRef = useRef<{ startAnimation: () => void; stopAnimation: () => void }>(null);
+  const reducedMotion = useReducedMotion();
+  const Icon = icons[entry.icon];
+  return (
+    <Button
+      type="button"
+      variant="navigation"
+      size="navigation"
+      data-active={entry.active}
+      data-testid={entry.testId}
+      aria-current={entry.currentPage ? 'page' : undefined}
+      onClick={entry.onClick}
+      onMouseEnter={() => {
+        if (!reducedMotion) iconRef.current?.startAnimation();
+        entry.onIntent?.();
+      }}
+      onMouseLeave={() => iconRef.current?.stopAnimation()}
+      onFocus={entry.onIntent}
+    >
+      <div className="flex size-4 shrink-0 items-center justify-center">
+        <Icon ref={iconRef} />
+      </div>
+      <span className="min-w-0 truncate">{entry.label}</span>
+      {entry.running && (
+        <span
+          className="ml-auto size-1.5 shrink-0 rounded-full bg-primary motion-safe:animate-pulse"
+          aria-hidden="true"
+        />
+      )}
+    </Button>
+  );
+}
+
+interface SidebarNavigationViewProps {
+  isChat: boolean;
+  workLabel: string;
+  chatLabel: string;
+  onModeChange: (checked: boolean) => void;
+  newConversation: SidebarNavigationEntry;
+  entries: SidebarNavigationEntry[];
+}
+
+export function SidebarNavigationView({
+  isChat,
+  workLabel,
+  chatLabel,
+  onModeChange,
+  newConversation,
+  entries,
+}: SidebarNavigationViewProps) {
+  return (
+    <div className={cn('mt-1 flex flex-col gap-0.5 px-3', isChat ? 'pb-0' : 'pb-3')}>
+      <div className="relative h-7 w-full">
+        <Switch
+          checked={isChat}
+          onCheckedChange={onModeChange}
+          data-mode="work-chat"
+          aria-label={`${workLabel} / ${chatLabel}`}
+        />
+        {[workLabel, chatLabel].map((label, index) => (
+          <span
+            key={index}
+            data-mode-selected={isChat === (index === 1)}
+            aria-hidden="true"
+            className={cn(
+              'pointer-events-none absolute inset-y-0 flex w-1/2 items-center justify-center text-sm',
+              index === 0 ? 'left-0' : 'left-1/2',
+              isChat === (index === 1)
+                ? 'font-semibold text-switch-thumb-foreground'
+                : 'font-normal text-muted-foreground',
+            )}
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+      <div className="mt-2">
+        <SidebarNavigationItem entry={newConversation} />
+      </div>
+      {entries.map(entry => (
+        <SidebarNavigationItem key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -25,6 +25,7 @@
   --color-background: var(--zy-background);
   --color-foreground: var(--zy-foreground);
   --color-primary: var(--zy-primary);
+  --color-switch-thumb-foreground: var(--zy-switch-thumb-foreground);
   --color-primary-foreground: var(--zy-primary-foreground);
   --color-primary-hover: var(--zy-primary-hover);
   --color-primary-muted: var(--zy-primary-muted);

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -9,6 +9,7 @@
   --zy-primary-hover: oklch(0.514 0.207 260.5);
   --zy-primary-muted: oklch(0.95 0.025 258);
   --zy-primary-strong: oklch(0.564 0.218 259.8);
+  --zy-switch-thumb-foreground: oklch(0.366 0.008 253);
   --zy-switch-track-checked: var(--zy-primary);
   --zy-switch-track-checked-hover: var(--zy-primary-hover);
   --zy-accent: oklch(0.97 0.001 106.424);
@@ -74,6 +75,7 @@
   --zy-primary-hover: oklch(0.74 0.14 259);
   --zy-primary-muted: oklch(0.3 0.05 259);
   --zy-primary-strong: oklch(0.564 0.218 259.8);
+  --zy-switch-thumb-foreground: oklch(0.366 0.008 253);
   --zy-switch-track-checked: var(--zy-primary);
   --zy-switch-track-checked-hover: var(--zy-primary-hover);
   --zy-accent: oklch(0.268 0.007 34.298);

--- a/src/renderer/theme/tokens/contract.ts
+++ b/src/renderer/theme/tokens/contract.ts
@@ -15,6 +15,7 @@ export const TOKEN_CONTRACT = {
   // Button-grade primary: deep enough for AA white text even in dark themes
   // where `primary` is brightened for text/icon legibility.
   'primary-strong': '--zy-primary-strong',
+  'switch-thumb-foreground': '--zy-switch-thumb-foreground',
   'switch-track-checked': '--zy-switch-track-checked',
   'switch-track-checked-hover': '--zy-switch-track-checked-hover',
 

--- a/src/renderer/theme/tokens/shared.ts
+++ b/src/renderer/theme/tokens/shared.ts
@@ -7,8 +7,14 @@ import type { ThemeTokens } from '../themes/types';
 
 export const SHARED_TOKENS: Pick<
   ThemeTokens,
-  'destructive' | 'destructive-foreground' | 'success' | 'warning' | 'radius'
+  | 'switch-thumb-foreground'
+  | 'destructive'
+  | 'destructive-foreground'
+  | 'success'
+  | 'warning'
+  | 'radius'
 > = {
+  'switch-thumb-foreground': 'oklch(0.366 0.008 253)',
   destructive: 'oklch(0.577 0.245 27.325)',
   'destructive-foreground': 'oklch(0.985 0.001 106.423)',
   success: '#22c55e',

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -14,6 +14,12 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
         ghost:
           'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
+        'prompt-selector':
+          'hover:bg-surface-raised aria-expanded:bg-surface-raised transition-colors duration-200 ease-out motion-reduce:transition-none',
+        navigation:
+          'justify-start text-left font-normal text-muted-foreground transition-colors duration-200 ease-out hover:border-border hover:bg-card hover:text-foreground data-[active=true]:border-border data-[active=true]:bg-card data-[active=true]:font-medium data-[active=true]:text-foreground motion-reduce:transition-none',
+        toolbar:
+          'text-muted-foreground hover:bg-surface-raised hover:text-foreground aria-expanded:bg-surface-raised aria-expanded:text-foreground motion-reduce:transition-none',
         destructive:
           'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
         link: 'text-primary underline-offset-4 hover:underline',
@@ -24,6 +30,7 @@ const buttonVariants = cva(
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        navigation: 'h-8 w-full gap-2 px-3',
         icon: 'size-8',
         'icon-xs':
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",


### PR DESCRIPTION
Polish the current Codex-style shell and separate navigation, header layout, and prompt selector presentation from existing state and callbacks. Sidebar items now share geometry and interaction states; model and permission triggers share the same layout. Fix Work/Chat toggles invoking the callback three times per click and unreadable selected labels on the white thumb in dark mode.

Validation: 135 related tests, lint, renderer type checking, production renderer build, and bundle budgets passed. Chrome component fixtures covered light/dark, compact English, long titles, macOS/Windows header layouts, search/selection, keyboard focus, and draft retention. Selected switch text measured 10.13:1 contrast. Fixtures use example data and mocked native APIs; full packaged Electron regression is still pending. A pre-existing activity selector development warning also occurs on the base commit.

No IPC, persistence, agent execution, or permission policy changes. Preview screenshots were delivered in the originating task; local fixture screenshots are not publicly hosted.
