### PR TITLE
docs(readme): 翻新中英文项目介绍与上手指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,115 +1,88 @@
-# ZhiYuan Agent — Open-source, local-first desktop AI agent
-
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="public/zhiyuan-logo-dark-1600.png">
-    <img src="public/zhiyuan-logo-light-1600.png" alt="ZhiYuan Agent" width="120">
+    <img src="public/zhiyuan-logo-light-1600.png" alt="ZhiYuan Agent" width="160">
   </picture>
 </p>
 
-<p align="center">
-  <strong>An AI agent that works with your files, terminal, browser, skills, MCP tools, and local models — on your computer.</strong>
-</p>
+<h1 align="center">ZhiYuan Agent</h1>
+
+<p align="center"><strong>Give AI a task. Get work done on your computer.</strong></p>
+<p align="center">Open source · Local first · Files and browser tools · Local models · Reusable workflows</p>
 
 <p align="center">
-  <a href="https://github.com/rongxinzy/RongxinAI/stargazers"><img src="https://img.shields.io/github/stars/rongxinzy/RongxinAI?style=for-the-badge&logo=github&label=Stars" alt="GitHub Stars"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-red.svg?style=for-the-badge" alt="GNU AGPL v3 License"></a>
-  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-brightgreen?style=for-the-badge" alt="Platform">
-</p>
-
-<p align="center">
-  <a href="https://www.rongxzyai.com/">Website & download</a> ·
-  <a href="#quick-start-for-developers">Quick start</a> ·
-  <a href="#how-zhiyuan-agent-works">Architecture</a> ·
+  <a href="https://www.rongxzyai.com/#download">Download</a> ·
+  <a href="#get-started">Get started</a> ·
+  <a href="#developer-quick-start">Develop locally</a> ·
+  <a href="https://github.com/rongxinzy/RongxinAI/issues">Report an issue</a> ·
   <a href="README_zh.md">中文</a>
 </p>
 
-This project is maintained by Li Keran.
-
 <p align="center">
-  <img src="public/readme/zhiyuan-ppt-demo.gif" alt="ZhiYuan Agent creating an introductory AI presentation from a natural-language request" width="960">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="AGPL-3.0"></a>
+  <a href="https://github.com/rongxinzy/RongxinAI/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/rongxinzy/RongxinAI/ci.yml?branch=main&amp;label=CI" alt="CI"></a>
+  <a href="https://github.com/rongxinzy/RongxinAI/stargazers"><img src="https://img.shields.io/github/stars/rongxinzy/RongxinAI?style=flat" alt="GitHub Stars"></a>
 </p>
 
-ZhiYuan Agent is an open-source, local-first desktop AI agent built by Beijing Rongxin Zhiyuan for development, research, automation, and everyday knowledge work. It is not another chat wrapper: the agent can execute multi-step tasks on your machine, show its progress, and pause for approval before sensitive actions.
-
-Its agent runtime and GGUF inference engine are developed in-house. The desktop app brings execution, local models, 40+ built-in skills, MCP integrations, recurring tasks, and IM or email delivery into one workspace.
-
-## Why ZhiYuan: a local-first AI agent that can act
-
-| What you need | What ZhiYuan does |
-| --- | --- |
-| Work completed, not just suggested | Reads and writes files, runs terminal commands, operates a browser, and produces documents |
-| Control over sensitive actions | Shows tool state and requests per-action approval before high-risk operations |
-| A private local-model option | Installs and runs GGUF models with configurable context, GPU offload, threads, and lifecycle |
-| Reusable workflows | Combines 40+ bundled skills, custom skills, MCP services, and scheduled tasks |
-| Results beyond the desktop | Delivers completed work through WeChat, WeCom, DingTalk, Feishu/Lark, QQ, or email |
-
-Typical use cases include repository research, document and spreadsheet work, browser-based operations, recurring briefings, inbox cleanup, local-model experiments, and internal tool automation.
-
-## Download ZhiYuan Agent
-
-Download the latest release from the [official website](https://www.rongxzyai.com/#download):
-
-- Windows 10/11 (x64)
-- macOS (Apple silicon)
-- Linux (build from source)
-
-If you find ZhiYuan useful, consider giving the repository a star.
-
-## Key features
-
-- **Cowork agent workflows**: Run multi-step tasks with file tools, shell commands, browser automation, document processing, and approval-gated actions.
-- **Local GGUF inference**: Manage models, tune the inference service, and connect local models to agent workflows.
-- **Model marketplace**: Search GGUF models from ModelScope and install them into the app-managed model directory.
-- **Skills and MCP**: Use 40+ bundled skills, create your own, and connect external tools or internal services through MCP.
-- **Scheduled tasks**: Create recurring briefings, follow-ups, inbox cleanup, reports, and other background work.
-- **Messaging and email channels**: Reach the agent through WeChat, WeCom, DingTalk, Feishu(Lark), QQ, and email.
-- **Local data and permission control**: Sessions, configuration, and task metadata stay in local SQLite; sensitive tool calls require approval.
-
-## How ZhiYuan Agent works
+ZhiYuan Agent is a desktop AI workspace from Beijing Rongxin Zhiyuan, maintained by Li Keran. Use it to organize research, create documents, analyze spreadsheets, work on code, or run recurring tasks. The agent can read and write files, run commands, and operate a browser while showing messages, tool activity, and results.
 
 <p align="center">
-  <img src="public/readme/zhiyuan_agent_architecture_en.svg" alt="ZhiYuan Agent architecture" width="760">
+  <img src="public/readme/zhiyuan-ppt-demo.gif" alt="A recording of ZhiYuan creating a presentation from a natural-language task" width="960">
+</p>
+<p align="center"><sub>From a task description to a presentation, with visible progress and generated files.</sub></p>
+
+## What you can do
+
+| Task | Workflow |
+| --- | --- |
+| Research | Search the web, read local material, and organize findings with sources |
+| Documents and data | Create presentations, work with Word, PDF, and Excel, and produce files from analysis |
+| Code | Select a project directory, explore a repository, edit code, run commands, and inspect artifacts |
+| Everyday work | Track work in Todos and schedule briefings, reports, and other recurring tasks |
+| Browser tasks | Find information and operate web pages while following the agent's progress |
+| Messaging | Connect WeChat, WeCom, DingTalk, Feishu/Lark, QQ, or email to use the agent through configured channels |
+
+Experts provide presets for specific kinds of work. Skills package reusable methods and tools. MCP connects external services. Start with the bundled integrations and extend the workflows you need.
+
+## Get started
+
+1. Choose an installer for your system on the [official website](https://www.rongxzyai.com/#download). Release history and attached downloads are also available in [GitHub Releases](https://github.com/rongxinzy/RongxinAI/releases).
+2. Open the app and start with the **built-in ZhiYuan free model**, without entering a third-party API key. You can also configure your own provider in model settings.
+3. For local files or code, select a project directory, describe the task, and attach any relevant material.
+4. Follow the progress, respond to approval requests, inspect the output, and continue with feedback.
+
+The free model requires a network connection; availability and usage limits are shown in the app. The desktop project supports macOS, Windows, and Linux. Check the download page for available installers and architectures, or [run from source](#developer-quick-start).
+
+### Use local models
+
+Open the local inference workspace, browse the model marketplace, and choose a GGUF model and quantization suited to your hardware. Install the model and start its service. Adjust context length, GPU allocation, threads, and other options, then use a running local model for agent tasks.
+
+Local models reduce reliance on cloud inference. Web search, model downloads, remote MCP services, and messaging channels still require their respective network services.
+
+### Data and permissions
+
+Sessions, configuration, and task metadata are stored locally. The desktop execution environment accesses local files. When you use a cloud model or remote tool, the content needed for that request is sent to the corresponding service.
+
+Tool execution follows the selected permission mode. Operations requiring approval display a request; automatic authorization allows some operations to run directly. Progress and results remain visible in the workspace.
+
+## Choose your workspace appearance
+
+ZhiYuan includes **Codex** and **Daming Fenghua** themes. Codex uses neutral surfaces and compact controls. Daming Fenghua combines paper white, cinnabar, and ink with jade, bronze, and a dark ink appearance.
+
+In **Settings → Appearance**, select a theme preview card and choose light, dark, or system mode. Every card updates with the selected mode. Backgrounds, textures, typography, shapes, controls, and interaction states belong to the complete theme package.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/theme-previews/appearance-settings-dark.png">
+    <img src="docs/theme-previews/appearance-settings-light.png" alt="Appearance settings component: theme preview cards above a shared light, dark, and system selector; Chinese UI shown" width="760">
+  </picture>
 </p>
 
-ZhiYuan Agent uses Electron with strict process isolation. The renderer hosts the React UI, preload exposes controlled IPC through `contextBridge`, and the main process manages agent sessions, local inference, storage, skills, MCP integrations, scheduled tasks, and messaging gateways.
+To create a theme, start with the [theme authoring guide](src/renderer/theme/README.md) and [design specification](DESIGN.md). Packages supply presentation data; shared components retain interaction and state ownership.
 
-### Cowork agent runtime
+## Developer quick start
 
-A task moves from the renderer through controlled IPC to the built-in agent runtime. Messages, permission requests, tool state, and completion events stream back to the UI in real time.
-
-| Event | Description |
-| --- | --- |
-| `message` | A new message enters the session |
-| `messageUpdate` | Incremental streaming content update |
-| `permissionRequest` | A tool call requires approval |
-| `complete` | The session has finished |
-| `error` | The session failed |
-
-### Local inference and model marketplace
-
-The local inference workspace manages the app-owned service, GGUF models, the ModelScope-backed marketplace, and per-model settings such as context length, GPU offload layers, threads, batch size, main GPU, memory mapping, and keep-alive.
-
-### Skills, MCP, and automation
-
-`SKILLs/` contains the bundled skills, while `SKILLs/skills.config.json` controls default enablement and ordering. MCP settings connect external tool services such as GitHub, browsers, databases, file systems, and internal enterprise systems.
-
-Scheduled tasks can be created with natural language or through the GUI. A run starts a Cowork session, stores its result in the desktop app, and can deliver a notification through a configured IM or email channel.
-
-## Quick start for developers
-
-### Requirements
-
-- Git
-- Node.js `24.x`
-- Bun `1.4.x`
-
-On Windows, native dependency builds may also require:
-
-- Python 3
-- Visual Studio Build Tools with **Desktop development with C++**
-
-### Run locally
+Install Git, Node.js **24.x**, and Bun **1.4.0**, as pinned in [`package.json`](package.json). Native dependencies may require Python and a C/C++ toolchain when prebuilt binaries are unavailable. See the [contributing guide](CONTRIBUTING.md) for Windows build requirements.
 
 ```bash
 git clone https://github.com/rongxinzy/RongxinAI.git ZhiYuanAgent
@@ -118,58 +91,61 @@ bun install
 bun run electron:dev
 ```
 
-To prepare local inference separately:
+The development command prepares the channel and memory runtimes, then starts Vite and Electron. Initial runtime preparation requires network access. To use local inference, download the inference runtime for your host separately:
 
 ```bash
-# Download the llama.cpp runtime for the current host
 bun run llamacpp:runtime:download
 ```
 
-The Pi execution kernel runs in-process. Channel and Cron transport is provided by
-the pinned `cc-connect` sidecar during release builds; it does not own agent execution
-or persistent task state.
+### Useful commands
 
-### Build, test, and package
-
-```bash
-bun run build              # TypeScript typecheck + Vite production build
-bun run lint               # oxlint
-bun run format:check       # oxfmt
-bun test                   # Vitest
-bun run compile:electron   # Electron main process only
-
-bun run dist:mac
-bun run dist:win
-bun run dist:linux
-```
-
-## Tech stack
-
-| Layer | Technology |
+| Command | Purpose |
 | --- | --- |
-| Desktop | Electron 40 |
-| Frontend | React 19, TypeScript 7 |
-| Build | Vite 8 (Rolldown) |
-| Styling | Tailwind CSS 4 |
-| Tooling | Bun, oxlint, oxfmt |
-| State | Redux Toolkit |
-| Agent runtime | Self-developed |
-| Local inference | Self-developed, GGUF-compatible |
-| Storage | better-sqlite3 |
-| Rendering | react-markdown, Mermaid, KaTeX |
+| `bun run build` | Typecheck, build production assets, and verify runtime dependencies |
+| `bun run test` | Run the project test script with native-module preparation and Electron dependency restoration |
+| `bun run lint` | Check code, generated theme consistency, and style ownership |
+| `bun run format:check` | Check formatting |
+| `bun run test:bundle-budget` | Check the built renderer's bundle size |
+| `bun run theme:generate` | Regenerate CSS after changing theme definitions |
+| `bun run compile:electron` | Compile the Electron main process, including native dependency preparation |
 
-## Contributing
+Release packaging uses `bun run dist:mac`, `bun run dist:win`, or `bun run dist:linux`. These also involve platform runtimes, resources, and signing configuration; see [CONTRIBUTING.md](CONTRIBUTING.md) and [`package.json`](package.json).
 
-Bug reports, feature requests, and pull requests are welcome.
+### Project map
 
-- [Report a bug](https://github.com/rongxinzy/RongxinAI/issues/new?template=bug_report.yml)
-- [Request a feature](https://github.com/rongxinzy/RongxinAI/issues/new?template=feature_request.yml)
-- Read the [contributing guide](CONTRIBUTING.md) before opening a pull request
+| Path | Responsibility |
+| --- | --- |
+| [`src/renderer`](src/renderer) | React workspace, conversations, settings, and local inference UI |
+| [`src/shared`](src/shared) | Shared UI, types, and communication contracts |
+| [`src/main`](src/main) | Desktop lifecycle, task execution, storage, and system services |
+| [`src/main/preload.ts`](src/main/preload.ts) | Controlled IPC through `contextBridge` |
+| [`src/renderer/theme`](src/renderer/theme) | Theme contracts, component appearance, backgrounds, and generation |
+| [`SKILLs`](SKILLs) / [`MCPs`](MCPs) | Bundled skills and tool integrations |
+| [`.github/workflows`](.github/workflows) | Tests, installer validation, and releases |
 
-## Sponsors
+The stack includes Electron, React, TypeScript, Vite, Tailwind CSS, Redux Toolkit, and SQLite. Refer to [`package.json`](package.json) and [`bun.lock`](bun.lock) for dependency versions.
 
-Special thanks to [AnySearch](https://github.com/anysearch-ai) for supporting the built-in web search capability. See the implementation in [`SKILLs/web-search`](SKILLs/web-search) before leaving the repository for the sponsor site.
+<details>
+<summary>Desktop architecture</summary>
 
-## License
+<p align="center">
+  <img src="public/readme/zhiyuan_agent_architecture_en.svg" alt="ZhiYuan desktop architecture and module relationships" width="760">
+</p>
+
+The renderer owns the UI, preload provides the communication boundary, and the main process owns sessions, execution, data, and service lifecycles. Task messages, tool status, and approval requests stream back to the UI. Dedicated services manage local inference, skills, MCP, and messaging channels.
+
+</details>
+
+## Contribute
+
+- [Report a bug](https://github.com/rongxinzy/RongxinAI/issues/new?template=bug_report.yml) with your system, app version, reproduction steps, and relevant logs.
+- [Suggest a feature](https://github.com/rongxinzy/RongxinAI/issues/new?template=feature_request.yml) by describing the workflow and expected behavior.
+- [Contribute code or documentation](CONTRIBUTING.md). Read [`AGENTS.md`](AGENTS.md) first and follow [`DESIGN.md`](DESIGN.md) for UI changes.
+
+Star the repository to follow the project, or share a workflow you have built with ZhiYuan.
+
+## Acknowledgments and license
+
+Thanks to [AnySearch](https://github.com/anysearch-ai) for supporting the built-in web search capability. Its integration lives in [`SKILLs/web-search`](SKILLs/web-search).
 
 ZhiYuan Agent is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,117 +1,88 @@
-# 知远智能体 — 开源、本地优先的桌面 AI Agent
-
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="public/zhiyuan-logo-dark-1600.png">
-    <img src="public/zhiyuan-logo-light-1600.png" alt="知远智能体" width="120">
+    <img src="public/zhiyuan-logo-light-1600.png" alt="知远智能体" width="160">
   </picture>
 </p>
 
-<p align="center">
-  <strong>能读写文件、运行终端、操作浏览器、调用技能与 MCP，也能使用本地模型的桌面智能体。</strong>
-</p>
+<h1 align="center">知远智能体</h1>
+
+<p align="center"><strong>把任务交给 AI，在自己的电脑上完成工作。</strong></p>
+<p align="center">开源 · 本地优先 · 文件与浏览器操作 · 本地模型 · 可复用工作流</p>
 
 <p align="center">
-  <a href="https://github.com/rongxinzy/RongxinAI/stargazers"><img src="https://img.shields.io/github/stars/rongxinzy/RongxinAI?style=for-the-badge&logo=github&label=Stars" alt="GitHub Stars"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-red.svg?style=for-the-badge" alt="GNU AGPL v3 License"></a>
-  <img src="https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20%7C%20Linux-brightgreen?style=for-the-badge" alt="Platform">
-</p>
-
-<p align="center">
-  <a href="https://www.rongxzyai.com/">官网与下载</a> ·
-  <a href="#开发者快速开始">快速开始</a> ·
-  <a href="#知远智能体如何工作">技术架构</a> ·
+  <a href="https://www.rongxzyai.com/#download">下载安装</a> ·
+  <a href="#开始使用">开始使用</a> ·
+  <a href="#开发者快速开始">本地开发</a> ·
+  <a href="https://github.com/rongxinzy/RongxinAI/issues">反馈问题</a> ·
   <a href="README.md">English</a>
 </p>
 
 <p align="center">
-  <img src="public/readme/zhiyuan-workspace.png" alt="知远智能体真实桌面工作台，包含本地推理、自动化、技能和任务输入" width="960">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="AGPL-3.0"></a>
+  <a href="https://github.com/rongxinzy/RongxinAI/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/rongxinzy/RongxinAI/ci.yml?branch=main&amp;label=CI" alt="CI"></a>
+  <a href="https://github.com/rongxinzy/RongxinAI/stargazers"><img src="https://img.shields.io/github/stars/rongxinzy/RongxinAI?style=flat" alt="GitHub Stars"></a>
 </p>
 
-知远智能体是北京容芯致远推出的开源、本地优先桌面 AI Agent，面向开发、研究、自动化和日常知识工作。它不是又一个聊天套壳：Agent 可以在你的电脑上执行多步骤任务，持续展示过程，并在敏感操作前停下来等待批准。
-
-知远的 Agent 运行时与 GGUF 本地推理引擎均为自研；桌面端把执行环境、本地模型、42 个内置技能、MCP 接入、定时任务以及 IM/邮件触达整合在一个工作台里。
-
-## 为什么选择能执行的本地优先 AI Agent
-
-| 你的需求                 | 知远的处理方式                                                    |
-| ------------------------ | ----------------------------------------------------------------- |
-| 不只给建议，而是完成工作 | 读写文件、运行终端、操作浏览器并制作文档                          |
-| 敏感操作仍由人控制       | 展示工具状态，高风险操作按次请求批准                              |
-| 需要本地模型与隐私空间   | 安装并运行 GGUF 模型，可调上下文、GPU offload、线程与服务生命周期 |
-| 把经验变成可复用流程     | 组合 42 个内置技能、自定义技能、MCP 服务与定时任务                |
-| 离开电脑也能收到结果     | 通过微信、企微、钉钉、飞书/Lark、QQ 或邮件投递结果                |
-
-典型场景包括代码仓库调研、文档与表格处理、浏览器操作、周期简报、收件箱清理、本地模型实验和企业内部工具自动化。
-
-## 下载知远智能体
-
-当前稳定安装包可从[官方下载页](https://www.rongxzyai.com/#download)获取：
-
-- Windows 10/11 x64（Lite 安装包）
-- macOS Apple Silicon
-- Linux 可从源码构建
-
-想知道安装包执行了什么、在线升级如何保护？可以直接检查 GitHub 上的[发布工作流](.github/workflows/online-update-release.yml)与[在线升级设计](https://github.com/rongxinzy/zhiyuanBackend/blob/main/docs/online-update-design.md)。
-
-## 关注项目进展
-
-如果知远已经帮你把真实工作向前推进，欢迎[给项目一个 Star](https://github.com/rongxinzy/RongxinAI)。你可以及时看到新版本，也能让更多人发现一个源码可检查、权限可控制的开源桌面 AI Agent。
+知远智能体是北京容芯致远推出的桌面 AI 工作台，由李可然维护。你可以让它整理资料、制作文档、分析表格、研究代码或执行周期任务。它能读写文件、运行命令、操作浏览器，并在工作过程中展示消息、工具调用与结果。
 
 <p align="center">
-  <a href="https://github.com/rongxinzy/RongxinAI">
-    <img src="https://img.shields.io/badge/在_GitHub_上_Star_知远-121724?style=for-the-badge&logo=github&logoColor=white" alt="在 GitHub 上 Star 知远智能体">
-  </a>
+  <img src="public/readme/zhiyuan-ppt-demo.gif" alt="知远根据自然语言任务制作演示文稿的操作录屏" width="960">
 </p>
+<p align="center"><sub>从任务描述到演示文稿，查看执行过程并取得生成文件。</sub></p>
 
-## 核心能力
+## 用知远完成什么
 
-- **Cowork Agent 工作流**：执行多步骤任务，覆盖文件操作、终端命令、浏览器自动化、文档处理和审批门控操作。
-- **GGUF 本地推理**：管理模型、调优推理服务参数，并把本地模型接入 Agent 工作流。
-- **模型市场**：通过云端目录搜索 ModelScope 上的 GGUF 模型，按任务、设备余量和量化规格给出带证据的星级推荐，并安装到应用管理的模型目录。
-- **技能与 MCP**：使用 42 个内置技能、创建自己的技能，并通过 MCP 接入外部工具或企业内部服务。
-- **定时任务**：创建简报、跟进、收件箱清理、周期报告等后台任务。
-- **IM 与邮件触达**：通过微信、企业微信、钉钉、飞书/Lark、QQ 和邮箱触达 Agent。
-- **本地数据与权限控制**：会话、配置和任务元数据保存在本地 SQLite，敏感工具调用需要审批。
+| 场景 | 工作方式 |
+| --- | --- |
+| 资料研究 | 检索网页、阅读本地资料，整理带来源的研究结果 |
+| 文档与表格 | 制作演示文稿，处理 Word、PDF、Excel，分析数据并生成文件 |
+| 代码工作 | 选择项目目录，阅读仓库、修改代码、运行命令并检查产物 |
+| 日常任务 | 用待办记录工作，通过定时任务安排简报、报告和其他重复流程 |
+| 浏览器操作 | 让智能体在浏览器中查找信息、操作页面，并展示执行进度 |
+| 消息协作 | 配置微信、企业微信、钉钉、飞书/Lark、QQ 或邮箱，在已接入的渠道中使用智能体 |
 
-## 知远智能体如何工作
+专家提供面向具体工作的预设；技能封装可复用的方法和工具；MCP 用于连接外部服务。你可以使用内置内容，也可以扩展自己的工作流。
+
+## 开始使用
+
+1. 从[官网](https://www.rongxzyai.com/#download)选择适合自己系统的安装包。发布记录和可下载附件见 [GitHub Releases](https://github.com/rongxinzy/RongxinAI/releases)。
+2. 打开应用，使用内置的**知远免费模型**开始对话，无需先填写第三方 API Key。也可以在模型设置中配置自己的服务。
+3. 处理本地文件或代码时，选择对应项目目录，描述任务，并按需附上资料。
+4. 查看执行过程、处理授权请求，检查生成结果后继续追问或修改。
+
+免费模型需要联网，服务可用性及额度以应用内提示为准。桌面工程支持 macOS、Windows 和 Linux；具体安装包与架构以下载页为准，也可以[从源码运行](#开发者快速开始)。
+
+### 使用本地模型
+
+在「本地推理」中浏览模型市场，选择适合设备的 GGUF 模型及量化版本，安装后启动服务。工作台提供上下文长度、GPU 分配、线程等设置，可将运行中的本地模型用于智能体任务。
+
+本地运行模型可以减少对云端推理的依赖。联网搜索、模型下载、远程 MCP 和消息渠道仍需要对应网络服务。
+
+### 数据与权限
+
+会话、配置和任务元数据保存在本机；本地文件由桌面执行环境访问。使用云端模型或远程工具时，请求所需内容会发送给相应服务。
+
+工具执行遵循当前权限模式。需要审批的操作会显示授权请求；开启自动授权后，部分操作可直接执行。任务执行过程和结果可以在工作台中查看。
+
+## 选择一套喜欢的界面
+
+知远提供 **Codex** 与 **大明风华** 两套主题。Codex 使用中性色与紧凑控件；大明风华以纸白、朱红、墨色为主，配合玉色、古铜与墨夜外观。
+
+在「设置 → 外观」直接选择主题预览卡片，再选择浅色、深色或跟随系统。所有卡片随模式同步更新。背景、纹理、字体、圆角、控件与交互状态由整套主题统一定义。
 
 <p align="center">
-  <img src="public/readme/zhiyuan_agent_architecture_zh.svg" alt="知远智能体架构" width="760">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/theme-previews/appearance-settings-dark.png">
+    <img src="docs/theme-previews/appearance-settings-light.png" alt="外观设置组件：上方选择主题预览卡片，下方统一切换明暗模式" width="760">
+  </picture>
 </p>
 
-知远使用 Electron 严格进程隔离架构。Renderer 承载 React UI，Preload 通过 `contextBridge` 暴露受控 IPC，Main Process 负责 Agent 会话、本地推理、存储、技能系统、MCP、定时任务和消息网关。
-
-### Cowork Agent 运行时
-
-任务从 Renderer 通过受控 IPC 发送到内置 Agent 运行时。消息、权限请求、工具状态和完成事件会实时流回界面。
-
-| 事件                | 说明             |
-| ------------------- | ---------------- |
-| `message`           | 会话新增消息     |
-| `messageUpdate`     | 流式内容增量更新 |
-| `permissionRequest` | 工具调用需要审批 |
-| `complete`          | 会话执行完成     |
-| `error`             | 会话执行失败     |
-
-### 本地推理与模型市场
-
-本地推理工作台管理应用托管的推理服务、GGUF 模型、基于 ModelScope 的模型市场，以及上下文长度、GPU offload 层数、线程数、批大小、主 GPU、内存映射和 keep-alive 等启动参数。
-
-### 技能、MCP 与自动化
-
-`SKILLs/` 包含内置技能，`SKILLs/skills.config.json` 控制默认启停与排序。MCP 设置用于接入 GitHub、浏览器、数据库、文件系统以及企业内部服务等工具。
-
-定时任务既可以通过自然语言创建，也可以在 GUI 中配置。触发后，知远会启动 Cowork 会话、在桌面端保存结果，并可通过已配置的 IM 或邮件渠道发送通知。
+主题作者可从[主题开发文档](src/renderer/theme/README.md)和[设计规范](DESIGN.md)开始。主题包提供展示数据，业务组件继续负责交互与状态。
 
 ## 开发者快速开始
 
-### 环境要求
-
-- Node.js `>=24 <25`
-- Bun `>=1.3`
-
-### 本地运行
+需要 Git、Node.js **24.x** 和 [`package.json`](package.json) 指定的 Bun **1.4.0**。原生依赖无法使用预编译包时，需要 Python 与 C/C++ 构建工具；Windows 构建环境见[贡献指南](CONTRIBUTING.md)。
 
 ```bash
 git clone https://github.com/rongxinzy/RongxinAI.git ZhiYuanAgent
@@ -120,55 +91,61 @@ bun install
 bun run electron:dev
 ```
 
-分别准备运行时：
+开发启动脚本会准备消息渠道和记忆运行时，启动 Vite 与 Electron。首次准备运行时需要联网。若需要本地推理，可单独下载当前主机的推理运行时：
 
 ```bash
-# 下载当前主机对应的 llama.cpp 运行时
 bun run llamacpp:runtime:download
-
-# 下载当前主机对应的记忆运行时
-bun run engram:runtime:host
 ```
 
-### 构建、测试与打包
+### 常用命令
 
-```bash
-bun run build              # TypeScript 类型检查 + Vite 生产构建
-bun run lint               # oxlint
-bun run format:check       # oxfmt
-bun test                   # Vitest
-bun run compile:electron   # 仅编译 Electron 主进程
+| 命令 | 用途 |
+| --- | --- |
+| `bun run build` | 类型检查、生产构建与运行时依赖检查 |
+| `bun run test` | 运行项目测试脚本，处理原生模块环境并恢复 Electron 依赖 |
+| `bun run lint` | 代码检查、主题生成一致性与样式归属审计 |
+| `bun run format:check` | 检查代码格式 |
+| `bun run test:bundle-budget` | 检查已构建的渲染端包体积 |
+| `bun run theme:generate` | 修改主题定义后重新生成 CSS |
+| `bun run compile:electron` | 编译 Electron 主进程，含原生依赖准备 |
 
-bun run dist:mac
-bun run dist:win
-bun run dist:linux
-```
+发行打包命令为 `bun run dist:mac`、`bun run dist:win`、`bun run dist:linux`。它们还涉及平台运行时、资源与签名配置，详见[贡献指南](CONTRIBUTING.md)及 [`package.json`](package.json)。
 
-## 技术栈
+### 项目结构
 
-| 层           | 技术                           |
-| ------------ | ------------------------------ |
-| 桌面框架     | Electron 40                    |
-| 前端         | React 19 + TypeScript 7        |
-| 构建         | Vite 8（Rolldown）             |
-| 样式         | Tailwind CSS 4                 |
-| 工具链       | Bun、oxlint、oxfmt             |
-| 状态管理     | Redux Toolkit                  |
-| Agent 运行时 | 自研                           |
-| 本地推理     | 自研、兼容 GGUF 模型           |
-| 存储         | better-sqlite3                 |
-| 渲染         | react-markdown、Mermaid、KaTeX |
+| 路径 | 职责 |
+| --- | --- |
+| [`src/renderer`](src/renderer) | 工作台、会话、设置、本地推理等 React 界面 |
+| [`src/shared`](src/shared) | 共享 UI、类型与通信契约 |
+| [`src/main`](src/main) | 桌面生命周期、任务执行、存储与系统服务 |
+| [`src/main/preload.ts`](src/main/preload.ts) | 通过 `contextBridge` 暴露受控 IPC |
+| [`src/renderer/theme`](src/renderer/theme) | 主题契约、组件外观、背景与生成器 |
+| [`SKILLs`](SKILLs) / [`MCPs`](MCPs) | 内置技能与工具集成 |
+| [`.github/workflows`](.github/workflows) | 测试、安装验收和发布流程 |
 
-## 社区与贡献
+技术栈包括 Electron、React、TypeScript、Vite、Tailwind CSS、Redux Toolkit 和 SQLite，具体版本以 [`package.json`](package.json) 与 [`bun.lock`](bun.lock) 为准。
 
-- 发现问题或有新想法，可以[提交 Issue](https://github.com/rongxinzy/RongxinAI/issues)。
-- 想交流工作流、使用经验和社区提案，可以提交标题清晰的[功能提案](https://github.com/rongxinzy/RongxinAI/issues)。
-- 修改代码前请先阅读 [`AGENTS.md`](AGENTS.md)，然后提交 Pull Request。
+<details>
+<summary>查看桌面架构</summary>
 
-## License
+<p align="center">
+  <img src="public/readme/zhiyuan_agent_architecture_zh.svg" alt="知远桌面架构与模块关系" width="760">
+</p>
 
-[GNU Affero General Public License v3.0](LICENSE)
+渲染进程负责界面，Preload 提供通信边界，主进程负责会话、执行、数据与服务生命周期。任务消息、工具状态和授权请求通过事件回到界面；本地推理、技能、MCP 和消息渠道由对应服务管理。
 
-## 赞助
+</details>
 
-感谢 [AnySearch](https://www.anysearch.com/) 对内置联网搜索能力的支持。离开仓库访问赞助方之前，也可以先查看 [`SKILLs/web-search`](SKILLs/web-search) 里的实现。
+## 参与项目
+
+- [报告问题](https://github.com/rongxinzy/RongxinAI/issues/new?template=bug_report.yml)：附上系统、版本、复现步骤和相关日志。
+- [提出功能建议](https://github.com/rongxinzy/RongxinAI/issues/new?template=feature_request.yml)：描述实际场景与预期行为。
+- [贡献代码或文档](CONTRIBUTING.md)：先阅读 [`AGENTS.md`](AGENTS.md)；涉及界面时同时遵守 [`DESIGN.md`](DESIGN.md)。
+
+欢迎通过 Star 关注项目，也欢迎分享你用知远完成的工作流。
+
+## 致谢与许可证
+
+感谢 [AnySearch](https://github.com/anysearch-ai) 对内置联网搜索能力的支持，相关实现见 [`SKILLs/web-search`](SKILLs/web-search)。
+
+本项目采用 [GNU Affero General Public License v3.0](LICENSE)。


### PR DESCRIPTION
## Summary

同步翻新英文与中文 README，将重复的功能介绍整理为使用场景、上手步骤、主题展示与开发入口，补齐免费模型、待办和整套主题的现有能力。

## Changes Made

- 统一首页结构与导航，保留演示录屏和可折叠架构图，使用已有的明暗主题设置预览。
- 增加免费模型上手、本地模型使用、数据流向及实际权限模式说明。
- 统一 Node.js / Bun 要求，修正测试入口为 `bun run test`，补齐主题生成、样式审计和体积检查命令。
- 移除不一致的技能数量和重复文案，增加项目目录与贡献入口。

## Type of Change

- [x] Documentation update

## Testing

- [x] 两版各 29 处本地资源引用、页内锚点及文档中的 package scripts 名称检查通过。
- [x] GitHub Markdown API 渲染成功，核对表格、主题图片和架构折叠区结构。
- [x] `git diff --check` 通过。

仅修改 `README.md` 与 `README_zh.md`，未修改应用代码，未重复运行应用测试或构建。

## Electron-Specific Changes

- [x] None
