### PR TITLE
fix(model-pool): mark chat and work requests explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,14 @@ documents.md
 reasonix.toml
 .reasonix/
 
+# Local Model Pool provider credentials
+.agens
+.cloudflare-aig
+.groq
+.kimi
+.openrouter
+.tokenrouter
+
 # Scratch/debug artifacts (theme capture scripts, ad-hoc HTML, screenshots)
 /tmp/
 

--- a/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.test.ts
@@ -141,7 +141,9 @@ describe('piOpenAICompatProxy', () => {
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(
         JSON.stringify({
-          choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+          choices: [
+            { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' },
+          ],
         }),
       );
     });
@@ -227,8 +229,12 @@ describe('piOpenAICompatProxy', () => {
 
   it('protects managed upstream credentials with a per-process local capability', async () => {
     let upstreamRequestCount = 0;
-    const upstream = http.createServer((_request, response) => {
+    let forwardedWorkload: string | undefined;
+    let forwardedConversationId: string | undefined;
+    const upstream = http.createServer((request, response) => {
       upstreamRequestCount += 1;
+      forwardedWorkload = request.headers['x-zhiyuan-workload'];
+      forwardedConversationId = request.headers['x-zhiyuan-conversation-id'];
       response.writeHead(200, { 'content-type': 'application/json' });
       response.end(JSON.stringify({ choices: [] }));
     });
@@ -250,6 +256,8 @@ describe('piOpenAICompatProxy', () => {
         headers: {
           authorization: 'Bearer random-local-capability',
           'content-type': 'application/json',
+          'x-zhiyuan-conversation-id': 'work-session-1',
+          'x-zhiyuan-workload': 'work',
         },
         body: JSON.stringify({ model: 'zhiyuan-free', messages: [] }),
       });
@@ -257,6 +265,8 @@ describe('piOpenAICompatProxy', () => {
       expect(unauthorized.status).toBe(401);
       expect(authorized.status).toBe(200);
       expect(upstreamRequestCount).toBe(1);
+      expect(forwardedWorkload).toBe('work');
+      expect(forwardedConversationId).toBe('work-session-1');
     } finally {
       await close(upstream);
     }

--- a/src/main/libs/agentEngine/piOpenAICompatProxy.ts
+++ b/src/main/libs/agentEngine/piOpenAICompatProxy.ts
@@ -2,7 +2,9 @@
 
 import { timingSafeEqual } from 'crypto';
 
+import { ZhiyuanModelPoolHeader } from '../../../shared/modelPool/constants';
 import { buildOpenAIChatCompletionsURL } from '../coworkFormatTransform';
+
 interface PiOpenAICompatUpstream {
   baseURL: string;
   apiKey?: string;
@@ -65,6 +67,11 @@ function createFetchHeaders(request: IncomingMessage, upstream: PiOpenAICompatUp
   const accept = request.headers.accept;
   if (typeof accept === 'string') {
     headers.set('accept', accept);
+  }
+
+  for (const name of Object.values(ZhiyuanModelPoolHeader)) {
+    const value = request.headers[name];
+    if (typeof value === 'string') headers.set(name, value);
   }
 
   const apiKey = upstream.apiKey?.trim();

--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -195,8 +195,7 @@ const mockModelRuntimeCreate = hoisted.mockModelRuntimeCreate;
 const mockResolveRawApiConfig = hoisted.mockResolveRawApiConfig;
 const mockResolveRawApiConfigForModelRef = hoisted.mockResolveRawApiConfigForModelRef;
 const mockRegisterPiOpenAICompatUpstream = hoisted.mockRegisterPiOpenAICompatUpstream;
-const mockRegisterPiOpenAICompatTokenRefresher =
-  hoisted.mockRegisterPiOpenAICompatTokenRefresher;
+const mockRegisterPiOpenAICompatTokenRefresher = hoisted.mockRegisterPiOpenAICompatTokenRefresher;
 const mockGetCommunityAuthAccessToken = hoisted.mockGetCommunityAuthAccessToken;
 const mockApplyApplicationRuntimeEnv = hoisted.mockApplyApplicationRuntimeEnv;
 
@@ -1266,6 +1265,19 @@ describe('PiRuntimeAdapter', () => {
       expect(mockRegisterPiOpenAICompatTokenRefresher).toHaveBeenCalledWith(
         'zhiyuan',
         expect.any(Function),
+      );
+      expect(mockModelRuntime.registerProvider).toHaveBeenCalledWith(
+        'zhiyuan',
+        expect.objectContaining({
+          models: [
+            expect.objectContaining({
+              headers: {
+                'x-zhiyuan-conversation-id': 'test',
+                'x-zhiyuan-workload': 'work',
+              },
+            }),
+          ],
+        }),
       );
 
       const refresher = mockRegisterPiOpenAICompatTokenRefresher.mock.calls.at(-1)?.[1];

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -43,6 +43,11 @@ import {
   type HarnessModelProfileInput,
 } from '../../../shared/harness';
 import {
+  ZhiyuanModelPoolHeader,
+  ZhiyuanModelPoolWorkload,
+  type ZhiyuanModelPoolWorkload as ZhiyuanModelPoolWorkloadValue,
+} from '../../../shared/modelPool/constants';
+import {
   MAX_STALE_PRODUCTION_ITERATIONS,
   ProductionLoopStatus,
 } from '../../../shared/productionLoop';
@@ -784,7 +789,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
       // default resource loader supplies the Pi Coding Assistant identity,
       // so override that loader per session to keep expert contexts isolated.
       // Resolve model early — needed by both MCP proxy and subagent tool
-      const resolvedModel = await resolvePiModel(pi, options.modelOverride);
+      const resolvedModel = await resolvePiModel(pi, options.modelOverride, undefined, {
+        conversationId: sessionId,
+        workload:
+          options.sessionMode === CoworkSessionMode.Chat
+            ? ZhiyuanModelPoolWorkload.Chat
+            : ZhiyuanModelPoolWorkload.Work,
+      });
       if (!isCurrentInitialization()) return;
       const modelId =
         typeof resolvedModel.model.id === 'string'
@@ -1602,7 +1613,13 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
 
     try {
       const pi = await getPiModules();
-      const resolvedModel = await resolvePiModel(pi, patch.model, active.modelRuntime);
+      const resolvedModel = await resolvePiModel(pi, patch.model, active.modelRuntime, {
+        conversationId: sessionId,
+        workload:
+          active.workbenchContract.kind === WorkbenchContractKind.Chat
+            ? ZhiyuanModelPoolWorkload.Chat
+            : ZhiyuanModelPoolWorkload.Work,
+      });
       const model = resolvedModel.model;
       await active.piSession.setModel(model);
       active.model = model;
@@ -2251,7 +2268,10 @@ export class PiRuntimeAdapter extends EventEmitter implements PiRuntime {
    */
   async chatDirect(prompt: string, modelId?: string): Promise<string> {
     const pi = await getPiModules();
-    const resolvedModel = await resolvePiModel(pi, modelId);
+    const resolvedModel = await resolvePiModel(pi, modelId, undefined, {
+      conversationId: randomUUID(),
+      workload: ZhiyuanModelPoolWorkload.Chat,
+    });
     const context = buildPiBackgroundCompletionContext([
       { role: SessionMemoryCompletionRole.User, content: prompt },
     ]);
@@ -3511,6 +3531,11 @@ const DEFAULT_PI_CLOUD_MAX_TOKENS = 32768;
 const PI_LOCAL_API_KEY = 'sk-zhiyuan-local';
 const PI_MANAGED_PROXY_API_KEY = `sk-zhiyuan-${randomUUID()}`;
 
+interface ModelPoolRequestContext {
+  conversationId: string;
+  workload: ZhiyuanModelPoolWorkloadValue;
+}
+
 function resolvePiCustomModelApi(resolution: ApiConfigResolution): ProviderModelPiApi {
   const configuredApi = resolution.providerMetadata?.piRuntime?.api;
   if (configuredApi) return configuredApi;
@@ -3528,6 +3553,7 @@ function hasRecordEntries(value: unknown): value is Record<string, unknown> {
 function buildPiCustomModel(
   resolution: ApiConfigResolution,
   baseUrlOverride?: string,
+  modelPoolRequestContext?: ModelPoolRequestContext,
 ): Record<string, unknown> {
   const config = resolution.config;
   const providerMetadata = resolution.providerMetadata;
@@ -3570,6 +3596,14 @@ function buildPiCustomModel(
       providerMetadata.contextTokens ||
       fallbackContextWindow,
     maxTokens: endpoint?.maxTokens || providerMetadata.maxTokens || fallbackMaxTokens,
+    ...(providerMetadata.providerName === ProviderName.Zhiyuan && modelPoolRequestContext
+      ? {
+          headers: {
+            [ZhiyuanModelPoolHeader.ConversationId]: modelPoolRequestContext.conversationId,
+            [ZhiyuanModelPoolHeader.Workload]: modelPoolRequestContext.workload,
+          },
+        }
+      : {}),
   };
 }
 
@@ -3639,6 +3673,7 @@ async function resolvePiCustomModelRuntime(
   resolution: ApiConfigResolution,
   builtinModel: Record<string, unknown> | null,
   existingModelRuntime?: PiModelRuntime | null,
+  modelPoolRequestContext?: ModelPoolRequestContext,
 ): Promise<PiCustomModelRuntimeResolution> {
   const config = resolution.config;
   const providerMetadata = resolution.providerMetadata;
@@ -3667,7 +3702,7 @@ async function resolvePiCustomModelRuntime(
     existingModelRuntime ?? (await pi.ModelRuntime.create({ allowModelNetwork: false }));
   const api = resolvePiCustomModelApi(resolution);
   const runtimeBaseUrl = await resolvePiCustomModelBaseUrl(resolution, api);
-  const model = buildPiCustomModel(resolution, runtimeBaseUrl);
+  const model = buildPiCustomModel(resolution, runtimeBaseUrl, modelPoolRequestContext);
   const providerId = providerMetadata.providerName;
   modelRuntime.registerProvider(providerId, {
     name: providerId,
@@ -3713,6 +3748,7 @@ async function resolvePiModel(
   pi: PiModules,
   modelRef?: string,
   existingModelRuntime?: PiModelRuntime | null,
+  modelPoolRequestContext?: ModelPoolRequestContext,
 ): Promise<PiResolvedModel> {
   const normalizedModelRef = modelRef?.trim() || '';
   const resolution = normalizedModelRef
@@ -3729,9 +3765,11 @@ async function resolvePiModel(
     resolution,
     builtinModel,
     existingModelRuntime,
+    modelPoolRequestContext,
   );
   const modelRuntime = customRuntime.modelRuntime;
-  const customModel = customRuntime.customModel ?? buildPiCustomModel(resolution);
+  const customModel =
+    customRuntime.customModel ?? buildPiCustomModel(resolution, undefined, modelPoolRequestContext);
   const registeredModel = modelRuntime?.getModel(
     resolution.providerMetadata.providerName,
     resolution.config.model,

--- a/src/main/modelPoolIpc.test.ts
+++ b/src/main/modelPoolIpc.test.ts
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 }));
 
 import { ModelPoolIpc } from '../shared/ipc/channels';
+import { ZhiyuanModelPoolHeader, ZhiyuanModelPoolWorkload } from '../shared/modelPool/constants';
 import type { CommunityAuthSessionManager } from './communityAuthSession';
 import { registerModelPoolIpcHandlers } from './modelPoolIpc';
 
@@ -104,15 +105,17 @@ describe('Model Pool IPC', () => {
         },
       ),
     ).resolves.toMatchObject({ ok: true, status: 200 });
-    await vi.waitFor(() =>
-      expect(send).toHaveBeenCalledWith(ModelPoolIpc.streamDone('request-1')),
-    );
+    await vi.waitFor(() => expect(send).toHaveBeenCalledWith(ModelPoolIpc.streamDone('request-1')));
 
     const [url, init] = electronMocks.fetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(
       'https://zhiyuan-model-pool-staging.windflyme5.workers.dev/v1/chat/completions',
     );
-    expect(init.headers).toMatchObject({ Authorization: 'Bearer model-pool-access-token' });
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer model-pool-access-token',
+      [ZhiyuanModelPoolHeader.ConversationId]: 'request-1',
+      [ZhiyuanModelPoolHeader.Workload]: ZhiyuanModelPoolWorkload.Chat,
+    });
     expect(JSON.parse(String(init.body))).toMatchObject({
       model: 'zhiyuan-free',
       stream: true,

--- a/src/main/modelPoolIpc.ts
+++ b/src/main/modelPoolIpc.ts
@@ -2,7 +2,11 @@ import { app, ipcMain, session } from 'electron';
 
 import { ModelPoolIpc } from '../shared/ipc/channels';
 import { ModelPoolModelsSchema, ModelPoolStreamSchema } from '../shared/ipc/schemas';
-import { ZhiyuanModelPool } from '../shared/modelPool/constants';
+import {
+  ZhiyuanModelPool,
+  ZhiyuanModelPoolHeader,
+  ZhiyuanModelPoolWorkload,
+} from '../shared/modelPool/constants';
 import type { CommunityAuthSessionManager } from './communityAuthSession';
 import { t } from './i18n';
 
@@ -47,6 +51,7 @@ async function fetchModelPool(
   body: Record<string, unknown>,
   token: string,
   signal: AbortSignal,
+  conversationId: string,
 ): Promise<Response> {
   return session.defaultSession.fetch(`${modelPoolBaseUrl()}/v1/chat/completions`, {
     method: 'POST',
@@ -54,6 +59,8 @@ async function fetchModelPool(
       Accept: 'text/event-stream',
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      [ZhiyuanModelPoolHeader.ConversationId]: conversationId,
+      [ZhiyuanModelPoolHeader.Workload]: ZhiyuanModelPoolWorkload.Chat,
     },
     body: JSON.stringify({ ...body, model: ZhiyuanModelPool.FreeModelId, stream: true }),
     signal,
@@ -125,10 +132,20 @@ export function registerModelPoolIpcHandlers(
 
     try {
       let accessToken = await communityAuthSession.getModelPoolAccessToken();
-      let response = await fetchModelPool(input.body, accessToken, controller.signal);
+      let response = await fetchModelPool(
+        input.body,
+        accessToken,
+        controller.signal,
+        input.requestId,
+      );
       if (response.status === 401) {
         accessToken = await communityAuthSession.getModelPoolAccessToken({ forceRefresh: true });
-        response = await fetchModelPool(input.body, accessToken, controller.signal);
+        response = await fetchModelPool(
+          input.body,
+          accessToken,
+          controller.signal,
+          input.requestId,
+        );
       }
 
       if (!response.ok || !response.body) {

--- a/src/shared/modelPool/constants.ts
+++ b/src/shared/modelPool/constants.ts
@@ -5,6 +5,19 @@ export const ZhiyuanModelPool = {
   DevelopmentBaseUrlEnvironmentVariable: 'ZHIYUAN_MODEL_POOL_BASE_URL',
 } as const;
 
+export const ZhiyuanModelPoolHeader = {
+  ConversationId: 'x-zhiyuan-conversation-id',
+  Workload: 'x-zhiyuan-workload',
+} as const;
+
+export const ZhiyuanModelPoolWorkload = {
+  Chat: 'chat',
+  Work: 'work',
+} as const;
+
+export type ZhiyuanModelPoolWorkload =
+  (typeof ZhiyuanModelPoolWorkload)[keyof typeof ZhiyuanModelPoolWorkload];
+
 export const ZhiyuanModelPoolEvent = {
   AuthChanged: 'zhiyuan:model-pool-auth-changed',
 } as const;


### PR DESCRIPTION
## Summary
- mark direct Chat requests as `chat` and preserve the request ID for key affinity
- mark Pi agent sessions as `work` or `chat` on the managed model definition
- forward only the two allowlisted Model Pool routing headers through the local compatibility proxy
- ignore local Model Pool credential files

## Validation
- `npm run compile:electron`
- `npm test -- modelPoolIpc piOpenAICompatProxy piRuntimeAdapter` (122 tests)
- `npm run lint`

No renderer UI changes.