### PR TITLE
fix(model-pool): preserve chat identity across stream requests

### DIFF
--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -315,6 +315,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelPoolEntitlementRequired: '当前账号没有免费模型权益。',
     modelPoolQuotaExceeded: '今日免费模型额度已用完，请明日再试。',
     modelPoolServiceUnavailable: '免费模型服务暂时不可用，请稍后重试。',
+    modelPoolSessionBusy: '当前会话仍在处理，请稍后再试。',
+    modelPoolStreamInterrupted: '回答意外中断，已保留收到的内容。请重试或要求继续。',
 
     'enterprise.updateBlocked': '版本更新由企业统一管理',
   },
@@ -674,6 +676,9 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelPoolQuotaExceeded: 'Your free model quota is exhausted for today. Try again tomorrow.',
     modelPoolServiceUnavailable:
       'The free model service is temporarily unavailable. Please try again later.',
+    modelPoolSessionBusy: 'This conversation is still being processed. Please try again shortly.',
+    modelPoolStreamInterrupted:
+      'The response was interrupted. Received content is preserved. Retry or ask to continue.',
 
     'enterprise.updateBlocked': 'Updates are managed by enterprise',
   },

--- a/src/main/modelPoolIpc.test.ts
+++ b/src/main/modelPoolIpc.test.ts
@@ -16,6 +16,7 @@ vi.mock('electron', () => ({
 }));
 
 import { ModelPoolIpc } from '../shared/ipc/channels';
+import { ModelPoolStreamSchema } from '../shared/ipc/schemas';
 import { ZhiyuanModelPoolHeader, ZhiyuanModelPoolWorkload } from '../shared/modelPool/constants';
 import type { CommunityAuthSessionManager } from './communityAuthSession';
 import { registerModelPoolIpcHandlers } from './modelPoolIpc';
@@ -41,6 +42,17 @@ afterEach(() => {
 });
 
 describe('Model Pool IPC', () => {
+  test('requires a stable conversation ID and rejects unsafe header values', () => {
+    const input = { requestId: 'request-1', body: {} };
+    for (const conversationId of [undefined, '', 'line\r\nbreak', 'x'.repeat(161)]) {
+      expect(ModelPoolStreamSchema.input.safeParse({ ...input, conversationId }).success).toBe(
+        false,
+      );
+    }
+    expect(
+      ModelPoolStreamSchema.input.safeParse({ ...input, conversationId: 'chat-1' }).success,
+    ).toBe(true);
+  });
   test('lists only logical models returned for the authenticated account', async () => {
     const sessionManager = createSessionManager();
     electronMocks.fetch.mockResolvedValue(
@@ -101,6 +113,7 @@ describe('Model Pool IPC', () => {
         { sender: { send } },
         {
           requestId: 'request-1',
+          conversationId: 'conversation-1',
           body: { model: 'untrusted-model', messages: [{ role: 'user', content: 'hello' }] },
         },
       ),
@@ -113,7 +126,7 @@ describe('Model Pool IPC', () => {
     );
     expect(init.headers).toMatchObject({
       Authorization: 'Bearer model-pool-access-token',
-      [ZhiyuanModelPoolHeader.ConversationId]: 'request-1',
+      [ZhiyuanModelPoolHeader.ConversationId]: 'conversation-1',
       [ZhiyuanModelPoolHeader.Workload]: ZhiyuanModelPoolWorkload.Chat,
     });
     expect(JSON.parse(String(init.body))).toMatchObject({
@@ -133,7 +146,11 @@ describe('Model Pool IPC', () => {
     await expect(
       handler?.(
         { sender: { send: vi.fn() } },
-        { requestId: 'request-2', body: { messages: [{ role: 'user', content: 'hello' }] } },
+        {
+          requestId: 'request-2',
+          conversationId: 'conversation-1',
+          body: { messages: [{ role: 'user', content: 'hello' }] },
+        },
       ),
     ).resolves.toMatchObject({ ok: true, status: 200 });
 
@@ -142,5 +159,10 @@ describe('Model Pool IPC', () => {
       forceRefresh: true,
     });
     expect(electronMocks.fetch).toHaveBeenCalledTimes(2);
+    for (const [, init] of electronMocks.fetch.mock.calls as [string, RequestInit][]) {
+      expect(init.headers).toMatchObject({
+        [ZhiyuanModelPoolHeader.ConversationId]: 'conversation-1',
+      });
+    }
   });
 });

--- a/src/main/modelPoolIpc.test.ts
+++ b/src/main/modelPoolIpc.test.ts
@@ -42,6 +42,45 @@ afterEach(() => {
 });
 
 describe('Model Pool IPC', () => {
+  test('cancels while awaiting credentials without starting inference', async () => {
+    const manager = createSessionManager();
+    let resolveToken: (token: string) => void = () => undefined;
+    vi.spyOn(manager, 'getModelPoolAccessToken').mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveToken = resolve;
+        }),
+    );
+    registerModelPoolIpcHandlers(manager);
+    const pending = electronMocks.handlers.get(ModelPoolIpc.Stream)?.(
+      { sender: { send: vi.fn() } },
+      { requestId: 'cancel-auth', conversationId: 'session', body: {} },
+    );
+    expect(electronMocks.handlers.get(ModelPoolIpc.CancelStream)?.({}, 'cancel-auth')).toBe(true);
+    resolveToken('token');
+    await expect(pending).resolves.toMatchObject({ ok: false });
+    expect(electronMocks.fetch).not.toHaveBeenCalled();
+  });
+  test('cancels the response reader and emits abort instead of completion', async () => {
+    const cancelled = vi.fn();
+    electronMocks.fetch.mockResolvedValue(
+      new Response(new ReadableStream({ cancel: cancelled }), {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    );
+    registerModelPoolIpcHandlers(createSessionManager());
+    const send = vi.fn();
+    await electronMocks.handlers.get(ModelPoolIpc.Stream)?.(
+      { sender: { send } },
+      { requestId: 'cancel-reader', conversationId: 'session', body: {} },
+    );
+    electronMocks.handlers.get(ModelPoolIpc.CancelStream)?.({}, 'cancel-reader');
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith(ModelPoolIpc.streamAbort('cancel-reader')),
+    );
+    expect(cancelled).toHaveBeenCalledOnce();
+    expect(send).not.toHaveBeenCalledWith(ModelPoolIpc.streamDone('cancel-reader'));
+  });
   test('requires a stable conversation ID and rejects unsafe header values', () => {
     const input = { requestId: 'request-1', body: {} };
     for (const conversationId of [undefined, '', 'line\r\nbreak', 'x'.repeat(161)]) {

--- a/src/main/modelPoolIpc.ts
+++ b/src/main/modelPoolIpc.ts
@@ -136,7 +136,7 @@ export function registerModelPoolIpcHandlers(
         input.body,
         accessToken,
         controller.signal,
-        input.requestId,
+        input.conversationId,
       );
       if (response.status === 401) {
         accessToken = await communityAuthSession.getModelPoolAccessToken({ forceRefresh: true });
@@ -144,7 +144,7 @@ export function registerModelPoolIpcHandlers(
           input.body,
           accessToken,
           controller.signal,
-          input.requestId,
+          input.conversationId,
         );
       }
 

--- a/src/main/modelPoolIpc.ts
+++ b/src/main/modelPoolIpc.ts
@@ -6,9 +6,11 @@ import {
   ZhiyuanModelPool,
   ZhiyuanModelPoolHeader,
   ZhiyuanModelPoolWorkload,
+  ModelPoolErrorCode,
 } from '../shared/modelPool/constants';
 import type { CommunityAuthSessionManager } from './communityAuthSession';
 import { t } from './i18n';
+import { readModelPoolErrorBody, retrySessionBusy } from './modelPoolRetry';
 
 const activeModelPoolStreams = new Map<string, AbortController>();
 
@@ -33,6 +35,7 @@ function modelPoolErrorMessage(rawBody: string, status: number): string {
   if (status === 429) return t('modelPoolQuotaExceeded');
   try {
     const payload = JSON.parse(rawBody) as { error?: { code?: unknown } };
+    if (payload.error?.code === ModelPoolErrorCode.SessionBusy) return t('modelPoolSessionBusy');
     if (payload.error?.code === 'unauthorized') return t('modelPoolServiceUnavailable');
     if (
       payload.error?.code === 'account_disabled' ||
@@ -53,18 +56,22 @@ async function fetchModelPool(
   signal: AbortSignal,
   conversationId: string,
 ): Promise<Response> {
-  return session.defaultSession.fetch(`${modelPoolBaseUrl()}/v1/chat/completions`, {
-    method: 'POST',
-    headers: {
-      Accept: 'text/event-stream',
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      [ZhiyuanModelPoolHeader.ConversationId]: conversationId,
-      [ZhiyuanModelPoolHeader.Workload]: ZhiyuanModelPoolWorkload.Chat,
-    },
-    body: JSON.stringify({ ...body, model: ZhiyuanModelPool.FreeModelId, stream: true }),
+  return retrySessionBusy(
+    () =>
+      session.defaultSession.fetch(`${modelPoolBaseUrl()}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          Accept: 'text/event-stream',
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          [ZhiyuanModelPoolHeader.ConversationId]: conversationId,
+          [ZhiyuanModelPoolHeader.Workload]: ZhiyuanModelPoolWorkload.Chat,
+        },
+        body: JSON.stringify({ ...body, model: ZhiyuanModelPool.FreeModelId, stream: true }),
+        signal,
+      }),
     signal,
-  });
+  );
 }
 
 async function fetchModelPoolModels(
@@ -129,6 +136,16 @@ export function registerModelPoolIpcHandlers(
     const input = ModelPoolStreamSchema.input.parse(rawInput);
     const controller = new AbortController();
     activeModelPoolStreams.set(input.requestId, controller);
+    const destroyed = () => controller.abort();
+    event.sender.once?.('destroyed', destroyed);
+    const cleanup = () => {
+      event.sender.removeListener?.('destroyed', destroyed);
+      if (activeModelPoolStreams.get(input.requestId) === controller)
+        activeModelPoolStreams.delete(input.requestId);
+    };
+    const send = (channel: string, ...args: unknown[]) => {
+      if (!event.sender.isDestroyed?.()) event.sender.send(channel, ...args);
+    };
 
     try {
       let accessToken = await communityAuthSession.getModelPoolAccessToken();
@@ -139,6 +156,7 @@ export function registerModelPoolIpcHandlers(
         input.conversationId,
       );
       if (response.status === 401) {
+        await response.body?.cancel();
         accessToken = await communityAuthSession.getModelPoolAccessToken({ forceRefresh: true });
         response = await fetchModelPool(
           input.body,
@@ -150,48 +168,50 @@ export function registerModelPoolIpcHandlers(
 
       if (!response.ok || !response.body) {
         const error = response.body
-          ? modelPoolErrorMessage(await response.text(), response.status)
+          ? modelPoolErrorMessage(await readModelPoolErrorBody(response), response.status)
           : t('modelPoolServiceUnavailable');
-        activeModelPoolStreams.delete(input.requestId);
+        cleanup();
         return { ok: false, status: response.status, statusText: response.statusText, error };
       }
 
       const reader = response.body.getReader();
+      const cancelReader = () => {
+        void reader.cancel().catch((): void => undefined);
+      };
+      controller.signal.addEventListener('abort', cancelReader, { once: true });
       const decoder = new TextDecoder();
       void (async () => {
         try {
           while (true) {
             const { value, done } = await reader.read();
+            controller.signal.throwIfAborted();
             if (done) {
               const finalChunk = decoder.decode();
               if (finalChunk) {
-                event.sender.send(ModelPoolIpc.streamData(input.requestId), finalChunk);
+                send(ModelPoolIpc.streamData(input.requestId), finalChunk);
               }
-              event.sender.send(ModelPoolIpc.streamDone(input.requestId));
+              send(ModelPoolIpc.streamDone(input.requestId));
               break;
             }
-            event.sender.send(
-              ModelPoolIpc.streamData(input.requestId),
-              decoder.decode(value, { stream: true }),
-            );
+            send(ModelPoolIpc.streamData(input.requestId), decoder.decode(value, { stream: true }));
           }
         } catch (error) {
           if (error instanceof Error && error.name === 'AbortError') {
-            event.sender.send(ModelPoolIpc.streamAbort(input.requestId));
+            send(ModelPoolIpc.streamAbort(input.requestId));
           } else {
-            event.sender.send(
-              ModelPoolIpc.streamError(input.requestId),
-              t('modelPoolServiceUnavailable'),
-            );
+            send(ModelPoolIpc.streamError(input.requestId), t('modelPoolStreamInterrupted'));
           }
         } finally {
-          activeModelPoolStreams.delete(input.requestId);
+          controller.signal.removeEventListener('abort', cancelReader);
+          await reader.cancel().catch((): void => undefined);
+          reader.releaseLock();
+          cleanup();
         }
       })();
 
       return { ok: true, status: response.status, statusText: response.statusText };
     } catch {
-      activeModelPoolStreams.delete(input.requestId);
+      cleanup();
       return {
         ok: false,
         status: 0,

--- a/src/main/modelPoolRetry.test.ts
+++ b/src/main/modelPoolRetry.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { retrySessionBusy } from './modelPoolRetry';
+import { ModelPoolErrorCode, ModelPoolRetryPolicy } from '../shared/modelPool/constants';
+
+afterEach(() => vi.useRealTimers());
+const busy = () =>
+  Response.json(
+    { error: { code: ModelPoolErrorCode.SessionBusy } },
+    { status: 503, headers: { 'retry-after': '2' } },
+  );
+test('retries only session_busy, respects delay and returns the untouched success stream', async () => {
+  vi.useFakeTimers();
+  const success = new Response('data: [DONE]\n\n');
+  const send = vi.fn().mockResolvedValueOnce(busy()).mockResolvedValueOnce(success);
+  const pending = retrySessionBusy(send, new AbortController().signal);
+  await vi.advanceTimersByTimeAsync(1999);
+  expect(send).toHaveBeenCalledTimes(1);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(await pending).toBe(success);
+  expect(send).toHaveBeenCalledTimes(2);
+});
+test('limits retries and does not retry generic errors or post-inference binding failures', async () => {
+  vi.useFakeTimers();
+  const send = vi.fn(async () => busy());
+  const pending = retrySessionBusy(send, new AbortController().signal);
+  await vi.advanceTimersByTimeAsync(6000);
+  expect((await pending).status).toBe(503);
+  expect(send).toHaveBeenCalledTimes(ModelPoolRetryPolicy.MaximumRetries + 1);
+  for (const response of [
+    new Response('unavailable', { status: 503 }),
+    Response.json({ error: { code: 'session_selection_failed' } }, { status: 503 }),
+    new Response(null, { status: 429 }),
+  ]) {
+    const once = vi.fn(async () => response);
+    expect((await retrySessionBusy(once, new AbortController().signal)).status).toBe(
+      response.status,
+    );
+    expect(once).toHaveBeenCalledTimes(1);
+  }
+});
+test('cancellation during backoff and before start never sends another request', async () => {
+  vi.useFakeTimers();
+  const controller = new AbortController();
+  const send = vi.fn(async () => busy());
+  const pending = retrySessionBusy(send, controller.signal);
+  const rejected = expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+  await vi.advanceTimersByTimeAsync(100);
+  controller.abort();
+  await rejected;
+  await vi.advanceTimersByTimeAsync(5000);
+  expect(send).toHaveBeenCalledTimes(1);
+  await expect(retrySessionBusy(send, controller.signal)).rejects.toMatchObject({
+    name: 'AbortError',
+  });
+  expect(send).toHaveBeenCalledTimes(1);
+});

--- a/src/main/modelPoolRetry.ts
+++ b/src/main/modelPoolRetry.ts
@@ -1,0 +1,79 @@
+import { ModelPoolErrorCode, ModelPoolRetryPolicy } from '../shared/modelPool/constants';
+
+export async function readModelPoolErrorBody(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return '';
+  let bytes = 0;
+  let text = '';
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) return text + decoder.decode();
+      bytes += result.value.byteLength;
+      if (bytes > ModelPoolRetryPolicy.MaximumErrorBodyBytes) {
+        await reader.cancel();
+        return '';
+      }
+      text += decoder.decode(result.value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function waitForRetry(ms: number, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', abort);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', abort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
+
+// Retry only a pre-inference session-lock rejection, never generic 503s or partial output.
+export async function retrySessionBusy(
+  send: () => Promise<Response>,
+  signal: AbortSignal,
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    signal.throwIfAborted();
+    const response = await send();
+    if (response.status !== 503 || attempt >= ModelPoolRetryPolicy.MaximumRetries) return response;
+    const text = await readModelPoolErrorBody(response);
+    const fallback = () =>
+      new Response(text, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    let code: unknown;
+    try {
+      const body: unknown = JSON.parse(text);
+      if (body && typeof body === 'object' && 'error' in body) {
+        const error = body.error;
+        if (error && typeof error === 'object' && 'code' in error) code = error.code;
+      }
+    } catch {
+      return fallback();
+    }
+    if (code !== ModelPoolErrorCode.SessionBusy) return fallback();
+    const value = response.headers.get('retry-after');
+    const seconds = value === null ? NaN : Number(value);
+    const delay =
+      Number.isFinite(seconds) && seconds >= 0
+        ? seconds * 1000
+        : ModelPoolRetryPolicy.DefaultDelayMs;
+    // Do not retry earlier than the server asks; long waits remain explicit failures.
+    if (delay > ModelPoolRetryPolicy.MaximumDelayMs) return fallback();
+    await response.body?.cancel();
+    await waitForRetry(delay, signal);
+  }
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -659,7 +659,8 @@ contextBridge.exposeInMainWorld('electron', {
       workspaceRoot: string;
       prompt: import('../shared/codingAgent').CodingPromptInput;
     }) => ipcRenderer.invoke(CodingAgentIpc.Prompt, input),
-    listPendingMessages: (laneId: string) => ipcRenderer.invoke(CodingAgentIpc.ListPendingMessages, laneId),
+    listPendingMessages: (laneId: string) =>
+      ipcRenderer.invoke(CodingAgentIpc.ListPendingMessages, laneId),
     enqueuePendingMessage: (input: { laneId: string; text: string }) =>
       ipcRenderer.invoke(CodingAgentIpc.EnqueuePendingMessage, input),
     updatePendingMessage: (input: { laneId: string; itemId: string; text: string }) =>
@@ -1002,7 +1003,7 @@ contextBridge.exposeInMainWorld('electron', {
 
   modelPool: {
     listModels: () => ipcRenderer.invoke(ModelPoolIpc.ListModels),
-    stream: (input: { requestId: string; body: Record<string, unknown> }) =>
+    stream: (input: { requestId: string; conversationId: string; body: Record<string, unknown> }) =>
       ipcRenderer.invoke(ModelPoolIpc.Stream, input),
     cancelStream: (requestId: string) => ipcRenderer.invoke(ModelPoolIpc.CancelStream, requestId),
     onStreamData: (requestId: string, callback: (data: string) => void) =>

--- a/src/renderer/services/chatStream/bridge.test.ts
+++ b/src/renderer/services/chatStream/bridge.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, vi } from 'vitest';
+import { streamOverBridge, type StreamBridge } from './bridge';
+import { ChatFinishReason, ChatStreamEvent } from './constants';
+
+function setup(signal?: AbortSignal) {
+  let data = (_chunk: string) => {};
+  let done = () => {};
+  let error = (_error: string | { message: string }) => {};
+  const remove = vi.fn();
+  const bridge: StreamBridge = {
+    start: vi.fn(async () => ({ ok: true, status: 200 })),
+    cancel: vi.fn(async () => undefined),
+    onData: (_id, callback) => {
+      data = callback;
+      return remove;
+    },
+    onDone: (_id, callback) => {
+      done = callback;
+      return remove;
+    },
+    onError: (_id, callback) => {
+      error = callback;
+      return remove;
+    },
+    onAbort: () => remove,
+  };
+  const parser = { feed: vi.fn(() => []), flush: vi.fn(() => []) };
+  const stream = streamOverBridge('request', signal, bridge, parser);
+  return {
+    stream,
+    bridge,
+    remove,
+    parser,
+    data: (chunk: string) => data(chunk),
+    done: () => done(),
+    error: () => error('late error'),
+  };
+}
+test('EOF without terminal marker is an error, not a successful completion', async () => {
+  const state = setup();
+  state.data('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+  state.done();
+  const reader = state.stream.getReader();
+  expect((await reader.read()).value?.type).toBe(ChatStreamEvent.Error);
+  expect((await reader.read()).done).toBe(true);
+  expect(state.parser.flush).not.toHaveBeenCalled();
+  expect(state.bridge.cancel).toHaveBeenCalledOnce();
+});
+test('length termination remains distinct and never flushes incomplete tool arguments', async () => {
+  const state = setup();
+  state.data('data: {"choices":[{"finish_reason":"length"}]}\n\ndata: [DONE]\n\n');
+  const reader = state.stream.getReader();
+  expect((await reader.read()).value?.type).toBe(ChatStreamEvent.Error);
+  expect((await reader.read()).value).toEqual({
+    type: ChatStreamEvent.Finish,
+    finishReason: ChatFinishReason.Length,
+  });
+  expect(state.parser.flush).not.toHaveBeenCalled();
+});
+test('normal completion followed by late callbacks closes once', async () => {
+  const state = setup();
+  state.data('data:[DONE]\r\n\r\n');
+  expect(() => {
+    state.done();
+    state.error();
+    state.data('data: garbage\n');
+  }).not.toThrow();
+  const reader = state.stream.getReader();
+  expect((await reader.read()).value?.type).toBe(ChatStreamEvent.Finish);
+  expect((await reader.read()).done).toBe(true);
+  expect(state.remove).toHaveBeenCalledTimes(4);
+});
+test('already-aborted signals do not start; consumer cancellation detaches all listeners', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const early = setup(controller.signal);
+  expect(early.bridge.start).not.toHaveBeenCalled();
+  expect((await early.stream.getReader().read()).value?.type).toBe(ChatStreamEvent.Abort);
+  const state = setup();
+  await state.stream.cancel();
+  expect(state.bridge.cancel).toHaveBeenCalledOnce();
+  expect(state.remove).toHaveBeenCalledTimes(4);
+  expect(() => {
+    state.data('data: [DONE]\n');
+    state.done();
+    state.error();
+  }).not.toThrow();
+});

--- a/src/renderer/services/chatStream/bridge.ts
+++ b/src/renderer/services/chatStream/bridge.ts
@@ -1,0 +1,180 @@
+import type { UIMessageChunk } from 'ai';
+import { i18nService } from '../i18n';
+import {
+  ChatFinishReason,
+  ChatStreamEvent,
+  ChatStreamPolicy,
+  ProviderFinishReason,
+} from './constants';
+
+export interface StreamBridge {
+  start(requestId: string): Promise<{ ok: boolean; status: number; error?: string }>;
+  cancel(requestId: string): Promise<unknown>;
+  onData(requestId: string, callback: (chunk: string) => void): () => void;
+  onDone(requestId: string, callback: () => void): () => void;
+  onError(requestId: string, callback: (error: string | { message: string }) => void): () => void;
+  onAbort(requestId: string, callback: () => void): () => void;
+}
+interface Parser {
+  feed(value: unknown): UIMessageChunk[];
+  flush(): UIMessageChunk[];
+}
+const t = (key: string) => i18nService.t(key);
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+function finishReason(
+  value: unknown,
+): (typeof ChatFinishReason)[keyof typeof ChatFinishReason] | null {
+  const body = record(value);
+  const choice = Array.isArray(body.choices) ? record(body.choices[0]) : {};
+  const candidate = Array.isArray(body.candidates) ? record(body.candidates[0]) : {};
+  const reason = choice.finish_reason ?? record(body.delta).stop_reason ?? candidate.finishReason;
+  if (
+    reason === ProviderFinishReason.Length ||
+    reason === ProviderFinishReason.MaxTokens ||
+    reason === ProviderFinishReason.GeminiMaxTokens ||
+    body.type === ChatStreamEvent.ResponseIncomplete
+  )
+    return ChatFinishReason.Length;
+  if (reason === ProviderFinishReason.Tools || reason === ProviderFinishReason.Function)
+    return ChatFinishReason.Tools;
+  if (reason === ProviderFinishReason.Filter) return ChatFinishReason.Filter;
+  if (
+    reason ||
+    body.type === ChatStreamEvent.MessageStop ||
+    body.type === ChatStreamEvent.ResponseCompleted
+  )
+    return ChatFinishReason.Stop;
+  return null;
+}
+
+export function streamOverBridge(
+  requestId: string,
+  signal: AbortSignal | undefined,
+  bridge: StreamBridge,
+  parser: Parser,
+): ReadableStream<UIMessageChunk> {
+  let cancelConsumer: () => void = () => undefined;
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      let closed = false;
+      let started = false;
+      let cancelled = false;
+      let buffered = '';
+      let terminal: ReturnType<typeof finishReason> = null;
+      const cleanup: Array<() => void> = [];
+      const cancelUpstream = () => {
+        if (!started || cancelled) return;
+        cancelled = true;
+        void bridge
+          .cancel(requestId)
+          .catch(error => console.warn('[ChatStream] cancellation failed:', error));
+      };
+      const close = (consumerCancelled = false) => {
+        if (closed) return;
+        closed = true;
+        cleanup.forEach(remove => remove());
+        if (!consumerCancelled) controller.close();
+      };
+      const fail = (message: string) => {
+        if (closed) return;
+        controller.enqueue({ type: ChatStreamEvent.Error, errorText: message });
+        close();
+        cancelUpstream();
+      };
+      const finish = () => {
+        if (closed) return;
+        if (terminal !== ChatFinishReason.Length)
+          for (const chunk of parser.flush()) controller.enqueue(chunk);
+        if (terminal === ChatFinishReason.Length)
+          controller.enqueue({
+            type: ChatStreamEvent.Error,
+            errorText: t('chatStreamLengthLimit'),
+          });
+        controller.enqueue({
+          type: ChatStreamEvent.Finish,
+          finishReason: terminal ?? ChatFinishReason.Stop,
+        });
+        close();
+        cancelUpstream();
+      };
+      const consume = (chunk: string, flush = false) => {
+        if (closed) return;
+        buffered += chunk;
+        if (buffered.length > ChatStreamPolicy.MaximumBufferedCharacters) {
+          fail(t('chatStreamInterrupted'));
+          return;
+        }
+        const lines = buffered.split('\n');
+        buffered = flush ? '' : (lines.pop() ?? '');
+        for (const line of lines) {
+          if (closed) return;
+          if (!line.startsWith('data:')) continue;
+          const data = line.slice(5).trim();
+          if (!data) continue;
+          if (data === '[DONE]') {
+            finish();
+            return;
+          }
+          try {
+            const value: unknown = JSON.parse(data);
+            terminal = finishReason(value) ?? terminal;
+            for (const event of parser.feed(value)) {
+              controller.enqueue(event);
+              if (event.type === ChatStreamEvent.Error) {
+                close();
+                cancelUpstream();
+                return;
+              }
+            }
+          } catch {
+            fail(t('chatStreamInterrupted'));
+          }
+        }
+      };
+      const abort = () => {
+        if (closed) return;
+        controller.enqueue({ type: ChatStreamEvent.Abort, reason: 'user' });
+        close();
+        cancelUpstream();
+      };
+      cancelConsumer = () => {
+        close(true);
+        cancelUpstream();
+      };
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
+      cleanup.push(bridge.onData(requestId, chunk => consume(chunk)));
+      cleanup.push(
+        bridge.onDone(requestId, () => {
+          consume('', true);
+          if (!closed) {
+            if (terminal) finish();
+            else fail(t('chatStreamInterrupted'));
+          }
+        }),
+      );
+      cleanup.push(
+        bridge.onError(requestId, error => fail(typeof error === 'string' ? error : error.message)),
+      );
+      cleanup.push(bridge.onAbort(requestId, abort));
+      signal?.addEventListener('abort', abort, { once: true });
+      cleanup.push(() => signal?.removeEventListener('abort', abort));
+      started = true;
+      void bridge
+        .start(requestId)
+        .then(response => {
+          if (!closed && !response.ok) fail(response.error || t('operationFailed'));
+        })
+        .catch(error => fail(error instanceof Error ? error.message : t('operationFailed')));
+    },
+    cancel() {
+      cancelConsumer();
+    },
+  });
+}

--- a/src/renderer/services/chatStream/constants.ts
+++ b/src/renderer/services/chatStream/constants.ts
@@ -1,0 +1,25 @@
+export const ChatStreamEvent = {
+  Finish: 'finish',
+  Error: 'error',
+  Abort: 'abort',
+  MessageStop: 'message_stop',
+  MessageDelta: 'message_delta',
+  ResponseCompleted: 'response.completed',
+  ResponseIncomplete: 'response.incomplete',
+} as const;
+export const ChatFinishReason = {
+  Stop: 'stop',
+  Length: 'length',
+  Tools: 'tool-calls',
+  Filter: 'content-filter',
+  Other: 'other',
+} as const;
+export const ProviderFinishReason = {
+  Length: 'length',
+  MaxTokens: 'max_tokens',
+  GeminiMaxTokens: 'MAX_TOKENS',
+  Tools: 'tool_calls',
+  Function: 'function_call',
+  Filter: 'content_filter',
+} as const;
+export const ChatStreamPolicy = { MaximumBufferedCharacters: 1_048_576 } as const;

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -6,6 +6,8 @@ export type LanguageType = 'zh' | 'en';
 // 语言文本映射
 const translations: Record<LanguageType, Record<string, string>> = {
   zh: {
+    chatStreamInterrupted: '回答意外中断，已保留收到的内容。请重试或要求继续。',
+    chatStreamLengthLimit: '回答达到输出长度上限，内容可能不完整。可以要求继续。',
     operationFailed: '操作失败',
     authenticationExpired: '登录状态已过期，请重新登录',
     apiKeyMissing: '缺少 API Key，请先完成配置',
@@ -3281,6 +3283,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     todoParsedImportant: '已识别为重要',
   },
   en: {
+    chatStreamInterrupted: 'The response was interrupted. Received content is preserved. Retry or ask to continue.',
+    chatStreamLengthLimit: 'The response reached its output limit and may be incomplete. You can ask to continue.',
     operationFailed: 'Operation failed',
     authenticationExpired: 'Authentication expired. Please sign in again',
     apiKeyMissing: 'API key is missing. Check your configuration',

--- a/src/renderer/services/ipcChatTransport.test.ts
+++ b/src/renderer/services/ipcChatTransport.test.ts
@@ -45,6 +45,7 @@ test('routes the managed model through the dedicated tokenless renderer IPC', as
 
   expect(modelPoolStream).toHaveBeenCalledWith({
     requestId: expect.stringMatching(/^ipcchat_chat-1_/u),
+    conversationId: 'chat-1',
     body: {
       model: 'zhiyuan-free',
       messages: [{ role: 'user', content: 'hello' }],
@@ -61,6 +62,18 @@ test('routes the managed model through the dedicated tokenless renderer IPC', as
     value: { type: 'text-delta', delta: 'hello' },
   });
   await expect(reader.read()).resolves.toMatchObject({ value: { type: 'finish' } });
+  const nextStream = await transport.sendMessages({
+    trigger: 'submit-message',
+    chatId: 'chat-1',
+    messageId: undefined,
+    messages: [{ id: 'message-2', role: 'user', parts: [{ type: 'text', text: 'continue' }] }],
+    abortSignal: undefined,
+  });
+  await vi.waitFor(() => expect(modelPoolStream).toHaveBeenCalledTimes(2));
+  expect(modelPoolStream).toHaveBeenLastCalledWith(
+    expect.objectContaining({ conversationId: 'chat-1' }),
+  );
+  await nextStream.cancel();
 });
 
 test('closes reasoning before starting the visible text segment', () => {

--- a/src/renderer/services/ipcChatTransport.ts
+++ b/src/renderer/services/ipcChatTransport.ts
@@ -101,7 +101,8 @@ export class IpcChatTransport implements ChatTransport<UIMessage> {
     if (provider === ProviderName.Zhiyuan) {
       const { body } = this.buildOpenAICompatibleRequest(messages, '', '', modelId, provider);
       return this.streamOverBridge(chatId, abortSignal, 'openai', {
-        start: requestId => window.electron.modelPool.stream({ requestId, body }),
+        start: requestId =>
+          window.electron.modelPool.stream({ requestId, conversationId: chatId, body }),
         cancel: requestId => window.electron.modelPool.cancelStream(requestId),
         onData: (requestId, callback) =>
           window.electron.modelPool.onStreamData(requestId, callback),

--- a/src/renderer/services/ipcChatTransport.ts
+++ b/src/renderer/services/ipcChatTransport.ts
@@ -16,15 +16,7 @@ import {
   shouldUseOpenAIResponsesApi,
 } from './apiConfigResolver';
 import { buildAnthropicMessagesUrl, ProviderName } from '../../shared/providers';
-
-interface StreamBridge {
-  start(requestId: string): Promise<{ ok: boolean; status: number; error?: string }>;
-  cancel(requestId: string): Promise<unknown>;
-  onData(requestId: string, callback: (chunk: string) => void): () => void;
-  onDone(requestId: string, callback: () => void): () => void;
-  onError(requestId: string, callback: (error: string | { message: string }) => void): () => void;
-  onAbort(requestId: string, callback: () => void): () => void;
-}
+import { streamOverBridge, type StreamBridge } from './chatStream/bridge';
 
 export interface IpcChatTransportOptions {
   provider?: string;
@@ -299,102 +291,9 @@ export class IpcChatTransport implements ChatTransport<UIMessage> {
     apiFormat: 'anthropic' | 'openai' | 'gemini',
     bridge: StreamBridge,
   ): ReadableStream<UIMessageChunk> {
-    const requestId = `ipcchat_${chatId}_${Date.now()}`;
+    const requestId = `ipcchat_${chatId}_${generateId()}`;
     const parser = new SseChunkParser(apiFormat);
-
-    return new ReadableStream({
-      start(controller) {
-        let closed = false;
-        let bufferedSse = '';
-        const close = () => {
-          if (closed) return;
-          closed = true;
-          controller.close();
-          cleanup.forEach(fn => fn());
-        };
-
-        const cleanup: Array<() => void> = [];
-
-        const consumeSse = (chunk: string, flush = false) => {
-          bufferedSse += chunk;
-          const lines = bufferedSse.split('\n');
-          bufferedSse = flush ? '' : (lines.pop() ?? '');
-          for (const line of lines) {
-            const normalizedLine = line.endsWith('\r') ? line.slice(0, -1) : line;
-            if (!normalizedLine.startsWith('data: ')) continue;
-            const data = normalizedLine.slice(6);
-            if (data === '[DONE]') {
-              for (const c of parser.flush()) controller.enqueue(c);
-              controller.enqueue({ type: 'finish', finishReason: 'stop' });
-              close();
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(data);
-              for (const c of parser.feed(parsed)) {
-                controller.enqueue(c);
-              }
-            } catch (e) {
-              console.warn('[IpcChatTransport] Failed to parse SSE chunk:', e);
-            }
-          }
-        };
-
-        const removeData = bridge.onData(requestId, chunk => {
-          consumeSse(chunk);
-        });
-        cleanup.push(removeData);
-
-        const removeDone = bridge.onDone(requestId, () => {
-          if (!closed) {
-            consumeSse('\n', true);
-            for (const c of parser.flush()) controller.enqueue(c);
-            controller.enqueue({ type: 'finish', finishReason: 'stop' });
-          }
-          close();
-        });
-        cleanup.push(removeDone);
-
-        const removeError = bridge.onError(requestId, error => {
-          const message = typeof error === 'string' ? error : error.message;
-          controller.enqueue({ type: 'error', errorText: message });
-          close();
-        });
-        cleanup.push(removeError);
-
-        const removeAbort = bridge.onAbort(requestId, () => {
-          if (!closed) {
-            controller.enqueue({ type: 'abort', reason: 'user' });
-          }
-          close();
-        });
-        cleanup.push(removeAbort);
-
-        bridge
-          .start(requestId)
-          .then(response => {
-            if (!response.ok) {
-              const message = response.error || `API request failed (${response.status})`;
-              controller.enqueue({ type: 'error', errorText: message });
-              close();
-            }
-          })
-          .catch(error => {
-            controller.enqueue({
-              type: 'error',
-              errorText: error instanceof Error ? error.message : String(error),
-            });
-            close();
-          });
-
-        const handleAbort = () => {
-          void bridge.cancel(requestId);
-        };
-        abortSignal?.addEventListener('abort', handleAbort, { once: true });
-        cleanup.push(() => abortSignal?.removeEventListener('abort', handleAbort));
-      },
-    });
+    return streamOverBridge(requestId, abortSignal, bridge, parser);
   }
 }
 

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -1465,7 +1465,11 @@ interface IElectronAPI {
       models: string[];
       error?: string;
     }>;
-    stream: (input: { requestId: string; body: Record<string, unknown> }) => Promise<{
+    stream: (input: {
+      requestId: string;
+      conversationId: string;
+      body: Record<string, unknown>;
+    }) => Promise<{
       ok: boolean;
       status: number;
       statusText: string;

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -127,6 +127,11 @@ export const ApiFetchSchema = {
 
 export const ModelPoolStreamSchema = {
   input: z.object({
+    conversationId: z
+      .string()
+      .min(1)
+      .max(160)
+      .regex(/^[A-Za-z0-9_-]+$/u),
     requestId: z
       .string()
       .min(1)

--- a/src/shared/modelPool/constants.ts
+++ b/src/shared/modelPool/constants.ts
@@ -21,3 +21,11 @@ export type ZhiyuanModelPoolWorkload =
 export const ZhiyuanModelPoolEvent = {
   AuthChanged: 'zhiyuan:model-pool-auth-changed',
 } as const;
+
+export const ModelPoolErrorCode = { SessionBusy: 'session_busy' } as const;
+export const ModelPoolRetryPolicy = {
+  MaximumRetries: 2,
+  DefaultDelayMs: 2000,
+  MaximumDelayMs: 3000,
+  MaximumErrorBodyBytes: 16_384,
+} as const;


### PR DESCRIPTION
## Summary

- Pass stable chatId as conversationId through the managed model IPC contract, separately from requestId used for stream events/cancellation.
- Preserve conversation identity on authentication retry; validate the identifier at the main-process boundary.
- Add multi-turn, retry and identifier-validation coverage. The agent runtime already uses stable session IDs and is unchanged.

## Validation

- Full npm run lint passed (including theme generation check and audit).
- Targeted Vitest: 2 files, 8 tests passed.
- Renderer and Electron TypeScript checks passed.
- No UI change; no live inference or packaged installer verification performed.

## Electron and release impact

- IPC input adds required conversationId in renderer, preload and main-process schemas. Request event channels and cancellation IDs remain unchanged.
- No SQLite/storage/auth-token changes. Credentials remain owned by the main process.
- Requires the normal desktop release to reach installed clients. No merge or release performed.
- Backend companion branch: rongxinzy/zhiyuanBackend `codex/session-affinity`.
