### PR TITLE
fix(coding): 侧栏开关改为隐藏/恢复而非清空面板

### DIFF
--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -119,6 +119,7 @@ export const CodingWorkbenchView = ({
   const [sidePanelSheetOpen, setSidePanelSheetOpen] = useState(false);
   const [sidePanelView, setSidePanelView] = useState<CodingSidePanelViewType | null>(null);
   const [sidePanelTabs, setSidePanelTabs] = useState<CodingSidePanelViewType[]>([]);
+  const [sidePanelHidden, setSidePanelHidden] = useState(false);
   const [sidePanelWidth, setSidePanelWidth] = useState(CODING_PANEL_DEFAULT_WIDTH);
   const [sidePanelExpanded, setSidePanelExpanded] = useState(false);
   const [sidePanelMaxWidth, setSidePanelMaxWidth] = useState(CODING_PANEL_DEFAULT_WIDTH);
@@ -370,6 +371,7 @@ export const CodingWorkbenchView = ({
   const gitRefreshKey = `${activeLane?.id ?? draftSession?.id ?? 'workspace'}:${activeLane?.status ?? 'draft'}:${activeEvents.length}`;
   const desktopSidePanelOpen =
     !isNarrowViewport &&
+    !sidePanelHidden &&
     sidePanelView !== null &&
     (sidePanelView !== CodingSidePanelView.Inspector || hasInspectorContent);
   const resolvedSidePanelWidth = clampArtifactPanelWidth(
@@ -472,10 +474,12 @@ export const CodingWorkbenchView = ({
   useEffect(() => {
     setSidePanelView(null);
     setSidePanelTabs([]);
+    setSidePanelHidden(false);
     setSidePanelSheetOpen(false);
   }, [activeLane?.id]);
 
   const openSidePanelTab = useCallback((view: CodingSidePanelViewType) => {
+    setSidePanelHidden(false);
     if (view === CodingSidePanelView.Launcher) {
       setSidePanelTabs([]);
       setSidePanelView(CodingSidePanelView.Launcher);
@@ -483,6 +487,11 @@ export const CodingWorkbenchView = ({
     }
     setSidePanelTabs(current => (current.includes(view) ? current : [...current, view]));
     setSidePanelView(view);
+  }, []);
+
+  const restoreSidePanel = useCallback(() => {
+    setSidePanelHidden(false);
+    setSidePanelView(current => current ?? CodingSidePanelView.Launcher);
   }, []);
 
   const closeSidePanelTab = useCallback(
@@ -1010,7 +1019,7 @@ export const CodingWorkbenchView = ({
                     aria-label={i18nService.t('codingAgentSidePanel')}
                     aria-pressed={false}
                     onClick={() => {
-                      openSidePanelTab(CodingSidePanelView.Launcher);
+                      restoreSidePanel();
                       if (window.innerWidth < 1024) setSidePanelSheetOpen(true);
                     }}
                   >
@@ -1257,8 +1266,7 @@ export const CodingWorkbenchView = ({
                   aria-label={i18nService.t('codingAgentSidePanel')}
                   onClick={() => {
                     setSidePanelExpanded(false);
-                    setSidePanelView(null);
-                    setSidePanelTabs([]);
+                    setSidePanelHidden(true);
                   }}
                 >
                   <PanelRight />


### PR DESCRIPTION
## Summary

修复 Coding Workbench 侧栏开关交互：折叠侧栏时由“清空面板（销毁 tab 与视图）”改为“隐藏”，再次点击打开时恢复隐藏前的面板视图，而非强制回到 Launcher，避免误关已打开的 inspector / 文件浏览等面板。

## Related Issue

<!-- 无关联 issue；为 #719 的交互收尾修复 -->

## Changes Made

- 新增 `sidePanelHidden` 状态：折叠按钮触发时仅隐藏侧栏，保留当前 tab 与侧栏视图状态
- 打开侧栏按钮改为调用 `restoreSidePanel()`：取消隐藏并恢复之前的视图（无视图时回退到 Launcher）
- 切换会话（lane）时重置 `sidePanelHidden`，保证新会话侧栏回到初始状态

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

## Screenshots (if applicable)

<!-- 无 UI 截图 -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

改动集中在 Coding Workbench 渲染层状态管理，未涉及 Electron 主进程 / preload / IPC。
