### PR TITLE
fix(im): 平台无配置实例时不展开空实例子列表

### DIFF
--- a/src/renderer/components/im/IMSettings.tsx
+++ b/src/renderer/components/im/IMSettings.tsx
@@ -733,7 +733,9 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('dingtalk');
                     setActiveDingTalkInstanceId(null);
-                    setDingtalkExpanded(!dingtalkExpanded);
+                    setDingtalkExpanded(current =>
+                      config.dingtalk.instances.length > 0 && !current,
+                    );
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-1 w-full justify-start',
@@ -812,7 +814,7 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('feishu');
                     setActiveFeishuInstanceId(null);
-                    setFeishuExpanded(!feishuExpanded);
+                    setFeishuExpanded(current => config.feishu.instances.length > 0 && !current);
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-7 w-full justify-start',
@@ -888,7 +890,7 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('qq');
                     setActiveQQInstanceId(null);
-                    setQqExpanded(!qqExpanded);
+                    setQqExpanded(current => config.qq.instances.length > 0 && !current);
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-13 w-full justify-start',
@@ -964,7 +966,7 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('wecom');
                     setActiveWecomInstanceId(null);
-                    setWecomExpanded(!wecomExpanded);
+                    setWecomExpanded(current => config.wecom.instances.length > 0 && !current);
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-19 w-full justify-start',
@@ -1040,7 +1042,7 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('telegram');
                     setActiveTelegramInstanceId(null);
-                    setTelegramExpanded(!telegramExpanded);
+                    setTelegramExpanded(current => config.telegram.instances.length > 0 && !current);
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-25 w-full justify-start',
@@ -1119,7 +1121,7 @@ const IMSettings: React.FC = () => {
                   onClick={() => {
                     setActivePlatform('discord');
                     setActiveDiscordInstanceId(null);
-                    setDiscordExpanded(!discordExpanded);
+                    setDiscordExpanded(current => config.discord.instances.length > 0 && !current);
                   }}
                   className={cn(
                     'theme-page-imsettings-button-variant-31 w-full justify-start',


### PR DESCRIPTION
## Summary

修复 IM 设置页平台列表的展开交互：点击平台标题时，仅当该平台已配置实例时才切换展开实例子列表；没有实例时保持收起，避免展开出无内容的空区域。添加实例仍由选中平台后的右侧面板表单完成。

## Related Issue

<!-- 无关联 issue -->

## Changes Made

- 钉钉 / 飞书 / QQ / 企业微信 / Telegram / Discord 六个平台标题的展开逻辑统一由 `!expanded` 改为 `instances.length > 0 && !expanded`
- 有已配置实例时：点击标题照常在展开/收起间切换
- 无已配置实例时：点击标题保持收起，不渲染空实例子列表

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [ ] Tested locally
- [ ] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed

## Screenshots (if applicable)

<!-- 无 UI 截图 -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

改动集中在 IM 设置页渲染层交互，未涉及 Electron 主进程 / preload / IPC。
