### PR TITLE
codex/model thinking map v2

### DIFF
--- a/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.test.ts
@@ -1308,6 +1308,7 @@ describe('PiRuntimeAdapter', () => {
           piRuntime: {
             api: ProviderModelPiApi.OpenAIResponses,
             reasoning: true,
+            thinkingLevelMap: { off: null, low: 'low', high: 'high', max: 'max' },
             compat: {
               supportsDeveloperRole: false,
               maxTokensField: ProviderModelPiMaxTokensField.MaxTokens,
@@ -1332,6 +1333,7 @@ describe('PiRuntimeAdapter', () => {
               id: 'agent-model',
               api: ProviderModelPiApi.OpenAIResponses,
               reasoning: true,
+              thinkingLevelMap: { off: null, low: 'low', high: 'high', max: 'max' },
               input: ['text', 'image'],
               compat: {
                 supportsDeveloperRole: false,

--- a/src/main/libs/agentEngine/piRuntimeAdapter.ts
+++ b/src/main/libs/agentEngine/piRuntimeAdapter.ts
@@ -3582,6 +3582,7 @@ function buildPiCustomModel(
     provider: providerMetadata.providerName,
     baseUrl: baseUrlOverride || endpoint?.baseUrl || config.baseURL,
     reasoning: resolveProviderModelPiReasoning(piRuntime, capabilities),
+    ...(piRuntime?.thinkingLevelMap ? { thinkingLevelMap: piRuntime.thinkingLevelMap } : {}),
     input: supportsImage ? ['text', 'image'] : ['text'],
     ...(hasRecordEntries(compat) ? { compat } : {}),
     cost: {

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -25,7 +25,12 @@ export {
   ProviderModelPiThinkingFormat,
   resolveProviderModelPiReasoning,
 } from './piRuntime';
-export type { ProviderModelPiRuntimeCompat, ProviderModelPiRuntimeConfig } from './piRuntime';
+export type {
+  ProviderModelPiRuntimeCompat,
+  ProviderModelPiRuntimeConfig,
+  ProviderModelPiThinkingLevel,
+  ProviderModelPiThinkingLevelMap,
+} from './piRuntime';
 export type { ProviderConfig } from './types';
 export { isProviderEnabled } from './types';
 export {

--- a/src/shared/providers/piRuntime.test.ts
+++ b/src/shared/providers/piRuntime.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeProviderModelPiRuntimeConfig } from './piRuntime';
+
+describe('normalizeProviderModelPiRuntimeConfig', () => {
+  test('preserves provider thinking level maps and removes invalid entries', () => {
+    expect(
+      normalizeProviderModelPiRuntimeConfig({
+        api: 'openai-completions',
+        reasoning: true,
+        thinkingLevelMap: {
+          off: null,
+          low: 'low',
+          high: 'high',
+          max: 'max',
+          medium: '',
+          unsupported: 'ignored',
+        },
+        compat: { thinkingFormat: 'zai', supportsReasoningEffort: true },
+      }),
+    ).toEqual({
+      api: 'openai-completions',
+      reasoning: true,
+      thinkingLevelMap: { off: null, low: 'low', high: 'high', max: 'max' },
+      compat: { thinkingFormat: 'zai', supportsReasoningEffort: true },
+    });
+  });
+});

--- a/src/shared/providers/piRuntime.ts
+++ b/src/shared/providers/piRuntime.ts
@@ -29,6 +29,18 @@ export const ProviderModelPiThinkingFormat = {
 export type ProviderModelPiThinkingFormat =
   (typeof ProviderModelPiThinkingFormat)[keyof typeof ProviderModelPiThinkingFormat];
 
+export type ProviderModelPiThinkingLevel =
+  | 'off'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'max';
+export type ProviderModelPiThinkingLevelMap = Partial<
+  Record<ProviderModelPiThinkingLevel, string | null>
+>;
+
 export const ProviderModelPiCacheControlFormat = {
   Anthropic: 'anthropic',
 } as const;
@@ -52,6 +64,7 @@ export interface ProviderModelPiRuntimeCompat {
 export interface ProviderModelPiRuntimeConfig {
   readonly api?: ProviderModelPiApi;
   readonly reasoning?: boolean;
+  readonly thinkingLevelMap?: ProviderModelPiThinkingLevelMap;
   readonly compat?: ProviderModelPiRuntimeCompat;
 }
 
@@ -79,6 +92,20 @@ function optionalEnum<T extends string>(
 
 function hasKeys(value: object): boolean {
   return Object.keys(value).length > 0;
+}
+
+function normalizeThinkingLevelMap(value: unknown): ProviderModelPiThinkingLevelMap | undefined {
+  if (!isRecord(value)) return undefined;
+  const normalized: ProviderModelPiThinkingLevelMap = {};
+  for (const level of ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const) {
+    const mapped = value[level];
+    if (mapped === null) {
+      normalized[level] = null;
+    } else if (typeof mapped === 'string' && mapped.trim() !== '') {
+      normalized[level] = mapped;
+    }
+  }
+  return hasKeys(normalized) ? normalized : undefined;
 }
 
 export function normalizeProviderModelPiRuntimeConfig(
@@ -161,6 +188,9 @@ export function normalizeProviderModelPiRuntimeConfig(
       : {}),
     ...(optionalBoolean(input.reasoning) !== undefined
       ? { reasoning: optionalBoolean(input.reasoning) }
+      : {}),
+    ...(normalizeThinkingLevelMap(input.thinkingLevelMap)
+      ? { thinkingLevelMap: normalizeThinkingLevelMap(input.thinkingLevelMap) }
       : {}),
     ...(hasKeys(compat) ? { compat } : {}),
   };


### PR DESCRIPTION
- **fix(im): 平台无配置实例时不展开空实例子列表 (#723)**
- **feat(runtime): pass model thinking level maps to Pi**
