### PR TITLE
fix(coding): 主进程 turn 生命周期加固，避免误改终态与静默失败

### DIFF
--- a/src/main/codingAgent/codingRoomService.test.ts
+++ b/src/main/codingAgent/codingRoomService.test.ts
@@ -377,7 +377,39 @@ test('pauses a builtin lane when its runtime reports a recoverable interruption'
   });
 });
 
-test('cancels only the active turn and retains the mission and lane', async () => {
+test('cancels a running turn and retains the mission and lane', async () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const cancelled: string[] = [];
+  const service = new CodingRoomService(new CodingRoomRepository(db), new CodingAgentRegistry(), {
+    startBuiltinSession: async () => undefined,
+    cancelBuiltinSession: async sessionId => {
+      cancelled.push(sessionId);
+    },
+    getBuiltinWorkbenchLink: () => null,
+    beginExternalWorkbenchRun: () => ({ taskId: 'task', runId: 'run' }),
+    completeExternalWorkbenchRun: () => undefined,
+  });
+  const workspaceRoot = '/workspace/project';
+  const created = await service.createMission({
+    workspaceRoot,
+    profileId: 'builtin-zhiyuan-coding',
+  });
+  const lane = created.lanes[0];
+  await service.prompt(workspaceRoot, {
+    laneId: lane.id,
+    prompt: 'Implement the change.',
+  });
+  const updated = await service.cancel(workspaceRoot, lane.id);
+
+  expect(cancelled).toEqual([lane.localSessionId]);
+  expect(updated.missions).toHaveLength(1);
+  expect(updated.lanes).toHaveLength(1);
+  expect(updated.lanes[0].status).toBe(CodingLaneStatus.Idle);
+  expect(updated.events.at(-1)?.kind).toBe(CodingEventKind.TurnCancelled);
+});
+
+test('cancel leaves a lane without an active turn untouched', async () => {
   db = new Database(':memory:');
   initializeCodingAgentSchema(db);
   const cancelled: string[] = [];
@@ -398,11 +430,12 @@ test('cancels only the active turn and retains the mission and lane', async () =
   const lane = created.lanes[0];
   const updated = await service.cancel(workspaceRoot, lane.id);
 
-  expect(cancelled).toEqual([lane.localSessionId]);
-  expect(updated.missions).toHaveLength(1);
-  expect(updated.lanes).toHaveLength(1);
+  expect(cancelled).toEqual([]);
   expect(updated.lanes[0].status).toBe(CodingLaneStatus.Idle);
-  expect(updated.events.at(-1)?.kind).toBe(CodingEventKind.TurnCancelled);
+  expect(updated.missions[0].status).toBe(CodingMissionStatus.Draft);
+  expect(
+    updated.events.filter(event => event.kind === CodingEventKind.TurnCancelled),
+  ).toHaveLength(0);
 });
 
 test('recovers stale running lanes after an application restart without losing the mission', async () => {

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -811,6 +811,11 @@ export class CodingRoomService extends EventEmitter {
   async cancel(workspaceRoot: string, laneId: string): Promise<CodingRoomSnapshot> {
     const snapshot = this.bootstrap(workspaceRoot);
     const lane = this.requireLane(snapshot.lanes, laneId);
+    if (lane.status !== CodingLaneStatus.Running && lane.status !== CodingLaneStatus.WaitingApproval) {
+      // Only an active turn can be cancelled; stopping an idle, completed, or
+      // failed lane must not overwrite its mission outcome with "cancelled".
+      return snapshot;
+    }
     const driver = this.getDriver(lane);
     const session = await this.ensureDriverSession(
       driver,
@@ -1723,7 +1728,9 @@ export class CodingRoomService extends EventEmitter {
       this.repository.releaseWriterLease(roomId, lane.sourceRoot, lane.id);
     }
     if (laneStatus === CodingLaneStatus.Completed) {
-      void this.startNextCollaborationStage(roomWorkspaceRoot, lane.id);
+      void this.startNextCollaborationStage(roomWorkspaceRoot, lane.id).catch(error => {
+        console.error('[CodingRoom] failed to start the next collaboration stage:', error);
+      });
     }
   }
 


### PR DESCRIPTION
## 问题

1. **协作流水线的下一阶段可能静默失败。** `finishTurn` 用 `void this.startNextCollaborationStage(...)` 触发 Review/Verify 阶段，没有任何错误处理。补丁应用冲突、下一阶段 prompt 失败都会变成 unhandled rejection，下一阶段静默不启动。
2. **对非运行中的会话调用 cancel 会破坏终态。** `cancel()` 没有状态守卫：对空闲、已完成、失败的 lane 取消，仍会把 mission 置为 Cancelled、追加 TurnCancelled 事件，还会为从未运行过的 ACP lane 新建一个驱动会话。

## 改动

- `cancel()` 增加状态守卫：仅 `Running` / `WaitingApproval` 的 lane 可取消，其余直接返回当前快照（不再改写 mission 结果、不再创建会话）。
- `startNextCollaborationStage` 失败时记录错误日志，消除 unhandled rejection。

## 测试

- 更新 `cancels only the active turn...` 为运行中 lane 的取消路径（prompt 后取消，断言驱动被取消、lane 回 Idle、追加 TurnCancelled）。
- 新增 `cancel leaves a lane without an active turn untouched`：空闲 lane 取消后 mission 保持 Draft、无 TurnCancelled、不触碰驱动。
- `npx vitest run src/main/codingAgent/codingRoomService.test.ts` 28/28 通过，`npm run lint` 通过。

## 行为变化说明

取消一个非运行中的会话从「重置状态」变为「无操作」。UI 侧停止按钮仅在会话运行时出现，ACP steer 路径仅在 Running 时调用 cancel，均不受影响。