### PR TITLE
fix(theme): 主题审计脚本在 Windows 上允许清单失效

### DIFF
--- a/src/renderer/theme/scripts/audit-styles.ts
+++ b/src/renderer/theme/scripts/audit-styles.ts
@@ -25,7 +25,8 @@ function scan(dir: string): void {
       continue;
     }
     if (!/\.tsx?$/.test(entry.name) || /\.test\./.test(entry.name)) continue;
-    const name = relative(root, path);
+    // Normalize separators so the allowlist keys match on Windows too.
+    const name = relative(root, path).split('\\').join('/');
     if (name.includes('/icons/') || exceptions[name]) continue;
     scanned++;
     const source = readFileSync(path, 'utf8');


### PR DESCRIPTION
## 问题

`audit-styles.ts` 的 `exceptions` 白名单以 POSIX 风格路径（`src/renderer/...`）为 key，但 Windows 上 `path.relative()` 返回反斜杠路径，`exceptions[name]` 永远不命中，导致 4 个豁免文件全部被报违规，`npm run lint` 在 Windows 上无法通过（CI 为 Linux 故未暴露）。

## 改动

生成相对路径时把分隔符归一化为正斜杠。

## 验证

Windows（Node 24）上 `npm run lint` 全绿：`[Theme] 370 component modules audited`。