### PR TITLE
perf(coding): 流式输出不再逐事件全量重建房间快照

### DIFF
--- a/src/main/codingAgent/codingRoomRepository.test.ts
+++ b/src/main/codingAgent/codingRoomRepository.test.ts
@@ -164,3 +164,19 @@ test('coalesces streamed tool call snapshots with the same tool call ID', () => 
     status: CodingToolCallStatus.Completed,
   });
 });
+
+test('loads a lane and its owning room directly by lane id', () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Direct lookup');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+
+  expect(repository.getLaneById(lane.id)).toEqual(expect.objectContaining({ id: lane.id }));
+  expect(repository.getRoomByLaneId(lane.id)).toEqual(
+    expect.objectContaining({ id: room.id, workspaceRoot: '/workspace/project' }),
+  );
+  expect(repository.getLaneById('missing-lane')).toBeNull();
+  expect(repository.getRoomByLaneId('missing-lane')).toBeNull();
+});

--- a/src/main/codingAgent/codingRoomRepository.ts
+++ b/src/main/codingAgent/codingRoomRepository.ts
@@ -274,6 +274,23 @@ export class CodingRoomRepository {
       .get(laneId) as Record<string, unknown> | undefined;
     return row ? rowAssignment(row) : null;
   }
+  getLaneById(laneId: string): CodingAgentLane | null {
+    const row = this.db
+      .prepare('SELECT * FROM coding_agent_lanes WHERE id = ?')
+      .get(laneId) as Record<string, unknown> | undefined;
+    return row ? rowLane(row) : null;
+  }
+  getRoomByLaneId(laneId: string): CodingRoom | null {
+    const row = this.db
+      .prepare(
+        `SELECT r.* FROM coding_rooms r
+         JOIN coding_missions m ON m.room_id = r.id
+         JOIN coding_agent_lanes l ON l.mission_id = m.id
+         WHERE l.id = ?`,
+      )
+      .get(laneId) as Record<string, unknown> | undefined;
+    return row ? rowRoom(row) : null;
+  }
   listEvents(laneIds: string[]): CodingEvent[] {
     if (!laneIds.length) return [];
     const marks = laneIds.map(() => '?').join(',');

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -160,9 +160,9 @@ export class CodingRoomService extends EventEmitter {
   private readonly stagedLaneIds = new Set<string>();
   /** Maps builtin sessionId → laneId to avoid scanning all rooms per event. */
   private readonly builtinSessionLaneMap = new Map<string, string>();
-  /** Throttle timer for publishing builtin event batches. */
-  private builtinPublishTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly BUILTIN_PUBLISH_THROTTLE_MS = 100;
+  /** Per-workspace throttle timers so streamed events publish snapshots in batches. */
+  private readonly publishTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly PUBLISH_THROTTLE_MS = 100;
 
   constructor(
     private readonly repository: CodingRoomRepository,
@@ -1333,31 +1333,33 @@ export class CodingRoomService extends EventEmitter {
     payload: Record<string, unknown>,
   ): void {
     const laneId = this.builtinSessionLaneMap.get(sessionId);
-    if (!laneId) {
-      // Cache miss: scan rooms once to find the lane, then cache the mapping.
-      for (const workspaceRoot of this.knownRooms()) {
-        const snapshot = this.bootstrap(workspaceRoot);
-        const lane = snapshot.lanes.find(candidate => candidate.localSessionId === sessionId);
-        if (!lane) continue;
-        this.builtinSessionLaneMap.set(sessionId, lane.id);
-        this.applyBuiltinEvent(workspaceRoot, snapshot, lane, kind, payload);
+    if (laneId) {
+      // Fast path: load the lane and its room directly instead of rebuilding
+      // full snapshots of every room per streamed event.
+      const lane = this.repository.getLaneById(laneId);
+      const room = lane ? this.repository.getRoomByLaneId(laneId) : null;
+      if (lane && room) {
+        this.applyBuiltinEvent(room.workspaceRoot, room.id, lane, kind, payload);
         return;
       }
-      return;
     }
-    // Fast path: use cached lane mapping without re-scanning rooms.
+    // Cache miss or stale mapping: scan rooms once to find the lane, then
+    // cache the mapping.
     for (const workspaceRoot of this.knownRooms()) {
       const snapshot = this.bootstrap(workspaceRoot);
-      const lane = snapshot.lanes.find(candidate => candidate.id === laneId);
+      const lane = snapshot.lanes.find(
+        candidate => candidate.localSessionId === sessionId || candidate.id === laneId,
+      );
       if (!lane) continue;
-      this.applyBuiltinEvent(workspaceRoot, snapshot, lane, kind, payload);
+      this.builtinSessionLaneMap.set(sessionId, lane.id);
+      this.applyBuiltinEvent(workspaceRoot, snapshot.room.id, lane, kind, payload);
       return;
     }
   }
 
   private applyBuiltinEvent(
     workspaceRoot: string,
-    snapshot: CodingRoomSnapshot,
+    roomId: string,
     lane: CodingAgentLane,
     kind: (typeof CodingEventKind)[keyof typeof CodingEventKind],
     payload: Record<string, unknown>,
@@ -1366,31 +1368,32 @@ export class CodingRoomService extends EventEmitter {
     if (kind === CodingEventKind.Permission) {
       this.repository.updateLaneStatus(lane.id, CodingLaneStatus.WaitingApproval);
       this.repository.updateMissionStatus(lane.missionId, CodingMissionStatus.WaitingApproval);
-      this.updateLaneAssignmentStatus(snapshot, lane.id, CodingAssignmentStatus.WaitingApproval);
+      const assignment = this.repository.getLatestAssignmentForLane(lane.id);
+      if (assignment) {
+        this.repository.updateAssignmentStatus(
+          assignment.id,
+          CodingAssignmentStatus.WaitingApproval,
+        );
+      }
     }
     if (kind === CodingEventKind.TurnComplete) {
-      this.finishTurn(
-        snapshot.room.id,
-        snapshot.room.workspaceRoot,
-        lane,
-        CodingLaneStatus.Completed,
-      );
+      this.finishTurn(roomId, workspaceRoot, lane, CodingLaneStatus.Completed);
       this.publish(workspaceRoot);
       return;
     }
     if (kind === CodingEventKind.TurnFailed) {
-      this.finishTurn(snapshot.room.id, snapshot.room.workspaceRoot, lane, CodingLaneStatus.Failed);
+      this.finishTurn(roomId, workspaceRoot, lane, CodingLaneStatus.Failed);
       this.publish(workspaceRoot);
       return;
     }
     // Throttle streaming events to avoid flooding the renderer with publishes.
-    this.scheduleBuiltinPublish(workspaceRoot);
+    this.schedulePublish(workspaceRoot);
   }
 
-  private scheduleBuiltinPublish(workspaceRoot: string): void {
-    if (this.builtinPublishTimer || this.isDisposed) return;
-    this.builtinPublishTimer = setTimeout(() => {
-      this.builtinPublishTimer = null;
+  private schedulePublish(workspaceRoot: string): void {
+    if (this.publishTimers.has(workspaceRoot) || this.isDisposed) return;
+    const timer = setTimeout(() => {
+      this.publishTimers.delete(workspaceRoot);
       if (!this.isDisposed) {
         try {
           this.publish(workspaceRoot);
@@ -1399,7 +1402,8 @@ export class CodingRoomService extends EventEmitter {
           console.debug('[CodingRoom] Skipped publish because the service is disposed:', error);
         }
       }
-    }, this.BUILTIN_PUBLISH_THROTTLE_MS);
+    }, this.PUBLISH_THROTTLE_MS);
+    this.publishTimers.set(workspaceRoot, timer);
   }
 
   private isDisposed = false;
@@ -1432,10 +1436,8 @@ export class CodingRoomService extends EventEmitter {
     this.driverSessionPromises.clear();
     this.authTerminals.dispose();
     this.builtinSessionLaneMap.clear();
-    if (this.builtinPublishTimer) {
-      clearTimeout(this.builtinPublishTimer);
-      this.builtinPublishTimer = null;
-    }
+    for (const timer of this.publishTimers.values()) clearTimeout(timer);
+    this.publishTimers.clear();
   }
 
   private getDriver(lane: CodingAgentLane): CodingAgentDriver {
@@ -1602,7 +1604,9 @@ export class CodingRoomService extends EventEmitter {
             );
           }
         }
-        this.publish(roomWorkspaceRoot);
+        // Rebuilding and broadcasting a full snapshot per streamed event makes
+        // streaming cost grow with session size, so publish in batches instead.
+        this.schedulePublish(roomWorkspaceRoot);
       }
       if (this.consumeCancelledTurn(lane.id, turnGeneration)) {
         if (queuedItemId) this.deletePendingMessage(lane.id, queuedItemId);


### PR DESCRIPTION
## 问题

流式路径存在复合性能问题（会话越长越卡，主进程事件循环承担全部开销）：

1. `runTurn` 事件循环对**每个流式 chunk** 调用 `publish` → `bootstrap`（从 SQLite 读 room、missions、lanes、assignments 和全部事件）→ 把完整快照 JSON 广播到所有窗口；
2. 内置驱动的 `recordBuiltinEvent` 快速路径在缓存命中时仍对每个已知房间做全量 bootstrap 来定位 lane；
3. 内置路径原本有 100ms 发布节流，但 bootstrap 本身未节流，且 `runTurn`（ACP 等）完全无节流。

这违反 AGENTS.md「agent-stream 路径不得加重活」的红线。

## 改动

- 泛化发布节流：`schedulePublish(workspaceRoot)` 用按工作区的 100ms 定时器批量发布；`runTurn` 与内置事件应用统一走该路径。**终态不受节流**：TurnComplete / TurnFailed / permission 状态仍立即发布。
- `recordBuiltinEvent` 快速路径改为 `getLaneById` + `getRoomByLaneId` 两条直查（新增 repository 方法），不再逐房间 bootstrap；缓存失效时保留原有扫描兜底并重新填充映射。
- `dispose()` 清理所有节流定时器。

## 测试

- 新增 `loads a lane and its owning room directly by lane id`（repository 直查 + miss 返回 null）。
- `npx vitest run src/main/codingAgent` 107/107 通过；`npm run lint` 通过。

## 行为影响

流式期间渲染器快照更新频率从「每 chunk」降为「每 100ms 批次」，消息滚动合并表现与内置路径现状一致；turn 结束/失败/待审批弹窗均为立即发布，交互时序不变。