### PR TITLE
fix(coding): workbench 加载失败可见化、取消失败提示与 git 面板刷新风暴

### DIFF
--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -110,6 +110,8 @@ export const CodingWorkbenchView = ({
   onToggleSidebar,
 }: CodingWorkbenchViewProps) => {
   const [snapshot, setSnapshot] = useState<CodingRoomSnapshot | null>(EMPTY_SNAPSHOT);
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
+  const [bootstrapAttempt, setBootstrapAttempt] = useState(0);
   const [draftState, setDraftState] = useState({ laneId: '', value: '' });
   const [newSessionDraftState, setNewSessionDraftState] = useState({ id: '', value: '' });
   const [promptAttachments, setPromptAttachments] = useState<CodingPromptAttachment[]>([]);
@@ -150,13 +152,21 @@ export const CodingWorkbenchView = ({
     setPromptAttachments([]);
   }, [selectionKey]);
   useEffect(() => {
+    setBootstrapError(null);
     if (!workspaceRoot) {
       setSnapshot(null);
       return;
     }
     let cancelled = false;
     void window.electron.codingAgent.bootstrap(workspaceRoot).then(result => {
-      if (!cancelled && result.success && result.snapshot) setSnapshot(result.snapshot);
+      if (cancelled) return;
+      if (result.success && result.snapshot) {
+        setSnapshot(result.snapshot);
+        return;
+      }
+      // Without a snapshot the workbench would be stuck on its loading
+      // screen forever, so surface the failure with a retry.
+      setBootstrapError(result.error ?? i18nService.t('codingAgentActionFailed'));
     });
     const unsubscribe = window.electron.codingAgent.onChanged(next => {
       if (next.room.workspaceRoot === workspaceRoot) setSnapshot(next);
@@ -165,7 +175,7 @@ export const CodingWorkbenchView = ({
       cancelled = true;
       unsubscribe();
     };
-  }, [workspaceRoot]);
+  }, [workspaceRoot, bootstrapAttempt]);
   useEffect(() => {
     if (
       !workspaceRoot ||
@@ -368,7 +378,9 @@ export const CodingWorkbenchView = ({
     activeLane?.sourceRoot ??
     snapshot?.room.workspaceRoot ??
     workspaceRoot;
-  const gitRefreshKey = `${activeLane?.id ?? draftSession?.id ?? 'workspace'}:${activeLane?.status ?? 'draft'}:${activeEvents.length}`;
+  // Refresh the git panels on lane switch and turn status change only; keying
+  // on the event count would rerun `git status` on every streamed chunk.
+  const gitRefreshKey = `${activeLane?.id ?? draftSession?.id ?? 'workspace'}:${activeLane?.status ?? 'draft'}`;
   const desktopSidePanelOpen =
     !isNarrowViewport &&
     !sidePanelHidden &&
@@ -722,6 +734,7 @@ export const CodingWorkbenchView = ({
       laneId: activeLane.id,
     });
     if (result.success && result.snapshot) setSnapshot(result.snapshot);
+    else setError(result.error ?? i18nService.t('codingAgentActionFailed'));
   };
   const setLaneConfigOption = async (configId: string, value: string | boolean) => {
     if (!activeLane) return;
@@ -803,7 +816,20 @@ export const CodingWorkbenchView = ({
   if (!snapshot)
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        {i18nService.t('codingAgentLoading')}
+        {bootstrapError ? (
+          <div className="flex flex-col items-center gap-3 text-center">
+            <p>{bootstrapError}</p>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setBootstrapAttempt(attempt => attempt + 1)}
+            >
+              {i18nService.t('retry')}
+            </Button>
+          </div>
+        ) : (
+          i18nService.t('codingAgentLoading')
+        )}
       </div>
     );
 


### PR DESCRIPTION
## 问题

1. **bootstrap 失败永久卡在加载态。** `CodingWorkbenchView` 忽略 `bootstrap` 的失败结果，snapshot 恒为 null 时界面永远停留在「加载中」，且错误被渲染在 loading 早退之后根本不可见。
2. **取消失败静默。** `cancel()` 失败时既不更新快照也不提示，与其他 lane 操作行为不一致。
3. **git 面板刷新风暴。** `gitRefreshKey` 包含 `activeEvents.length`，Review 面板打开时每个流式事件都会触发一轮 `getGitStatus`（主进程起 6 个 git 子进程）。

## 改动

1. bootstrap 失败时在加载位置展示错误与重试按钮（新增 `bootstrapError`/`bootstrapAttempt` 状态，重试重跑 bootstrap）。
2. `cancel` 失败时 `setError` 显示错误。
3. `gitRefreshKey` 移除事件计数，仅保留 lane 切换与 turn 状态变化；窗口聚焦刷新保留。

## 验证

`npx vitest run src/renderer/components/coding` 49/49 通过；`npm run lint` 通过。

## 行为影响

代理运行期间 git 面板不再随每个流式事件自动刷新，改为会话切换 / turn 状态变化 / 窗口聚焦时刷新；如需即时状态可手动刷新或等 turn 结束。