### PR TITLE
fix(coding): 修复渲染层 git/侧栏异步竞态与按钮卡死

### DIFF
--- a/src/renderer/components/coding/CodingAgentManager.tsx
+++ b/src/renderer/components/coding/CodingAgentManager.tsx
@@ -98,22 +98,25 @@ export const CodingAgentManager = ({
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setSubmitting(true);
-    const saved = await onAddProfile({
-      name,
-      description,
-      command,
-      args: argumentsText
-        .split('\n')
-        .map(argument => argument.trim())
-        .filter(Boolean),
-    });
-    setSubmitting(false);
-    if (!saved) return;
-    setName('');
-    setDescription('');
-    setCommand('');
-    setArgumentsText('');
-    setActiveTab(CodingAgentManagerTab.Local);
+    try {
+      const saved = await onAddProfile({
+        name,
+        description,
+        command,
+        args: argumentsText
+          .split('\n')
+          .map(argument => argument.trim())
+          .filter(Boolean),
+      });
+      if (!saved) return;
+      setName('');
+      setDescription('');
+      setCommand('');
+      setArgumentsText('');
+      setActiveTab(CodingAgentManagerTab.Local);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (

--- a/src/renderer/components/coding/CodingGitPanel.tsx
+++ b/src/renderer/components/coding/CodingGitPanel.tsx
@@ -164,6 +164,7 @@ export const CodingGitPanel = ({ workspaceRoot, laneId, sourceRoot, refreshKey, 
   const [diff, setDiff] = useState('');
   const [diffLoading, setDiffLoading] = useState(false);
   const requestSequence = useRef(0);
+  const diffRequestSequence = useRef(0);
   const target = useMemo<CodingGitTargetInput>(() => ({ workspaceRoot, laneId: laneId ?? undefined, sourceRoot }), [laneId, sourceRoot, workspaceRoot]);
   const refresh = useCallback(async () => {
     const request = ++requestSequence.current;
@@ -177,8 +178,10 @@ export const CodingGitPanel = ({ workspaceRoot, laneId, sourceRoot, refreshKey, 
   useEffect(() => { void refresh(); }, [refresh, refreshKey]);
   useEffect(() => { const handleFocus = () => void refresh(); window.addEventListener('focus', handleFocus); return () => window.removeEventListener('focus', handleFocus); }, [refresh]);
   const selectDiff = useCallback(async (selection: DiffSelection) => {
+    const request = ++diffRequestSequence.current;
     setDiffSelection(selection); setDiff(''); setDiffLoading(true);
     const result = await window.electron.codingAgent.getGitDiff({ ...target, ...selection });
+    if (request !== diffRequestSequence.current) return;
     setDiffLoading(false);
     setDiff(result.success ? (result.diff ?? '') : (result.error ?? i18nService.t('codingGitActionFailed')));
   }, [target]);

--- a/src/renderer/components/coding/CodingGitQuickActions.tsx
+++ b/src/renderer/components/coding/CodingGitQuickActions.tsx
@@ -78,14 +78,17 @@ export const CodingGitQuickActions = ({
 
   const loadStatus = useCallback(async () => {
     setLoading(true);
-    const result = await window.electron.codingAgent.getGitStatus(target);
-    setLoading(false);
-    if (result.success && result.status) {
-      setStatus(result.status);
-      return result.status;
+    try {
+      const result = await window.electron.codingAgent.getGitStatus(target);
+      if (result.success && result.status) {
+        setStatus(result.status);
+        return result.status;
+      }
+      toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
+      return null;
+    } finally {
+      setLoading(false);
     }
-    toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
-    return null;
   }, [target]);
 
   useEffect(() => {
@@ -114,31 +117,37 @@ export const CodingGitQuickActions = ({
   const createPullRequest = async () => {
     if (!status || !pullRequestTitle.trim() || !pullRequestBase.trim()) return;
     setPendingAction('pullRequest');
-    const result = await window.electron.codingAgent.createGitPullRequest({ ...target, title: pullRequestTitle, body: pullRequestBody, base: pullRequestBase });
-    setPendingAction(null);
-    if (!result.success || !result.url) {
-      toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
-      return;
+    try {
+      const result = await window.electron.codingAgent.createGitPullRequest({ ...target, title: pullRequestTitle, body: pullRequestBody, base: pullRequestBase });
+      if (!result.success || !result.url) {
+        toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
+        return;
+      }
+      setPullRequestOpen(false);
+      setPullRequestTitle('');
+      setPullRequestBody('');
+      toast.success(i18nService.t('codingGitPullRequestCreated'));
+      void window.electron.shell.openExternal(result.url);
+    } finally {
+      setPendingAction(null);
     }
-    setPullRequestOpen(false);
-    setPullRequestTitle('');
-    setPullRequestBody('');
-    toast.success(i18nService.t('codingGitPullRequestCreated'));
-    void window.electron.shell.openExternal(result.url);
   };
 
   const switchBranch = async (branch: string) => {
       if (!status || branch === status.branch || !status.canMutate) return;
     setPendingBranch(branch);
-    const result = await window.electron.codingAgent.switchGitBranch({ ...target, branch });
-    setPendingBranch(null);
-    if (result.success && result.status) {
-      setStatus(result.status);
-      setBranchOpen(false);
-      toast.success(i18nService.t('codingGitBranchSwitched'));
-      return;
+    try {
+      const result = await window.electron.codingAgent.switchGitBranch({ ...target, branch });
+      if (result.success && result.status) {
+        setStatus(result.status);
+        setBranchOpen(false);
+        toast.success(i18nService.t('codingGitBranchSwitched'));
+        return;
+      }
+      toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
+    } finally {
+      setPendingBranch(null);
     }
-    toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
   };
 
   const runCommit = async (pushAfterCommit: boolean) => {
@@ -169,14 +178,17 @@ export const CodingGitQuickActions = ({
 
   const push = async () => {
     setPendingAction('push');
-    const result = await window.electron.codingAgent.pushGitBranch(target);
-    setPendingAction(null);
-    if (result.success) {
-      toast.success(i18nService.t('codingGitPushed'));
-      await loadStatus();
-      return;
+    try {
+      const result = await window.electron.codingAgent.pushGitBranch(target);
+      if (result.success) {
+        toast.success(i18nService.t('codingGitPushed'));
+        await loadStatus();
+        return;
+      }
+      toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
+    } finally {
+      setPendingAction(null);
     }
-    toast.error(normalizeError(result.error ?? i18nService.t('codingGitActionFailed')));
   };
 
   const openRepository = async () => {

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -74,6 +74,7 @@ export const CodingWorkspaceSidebar = ({
   const [workspaceDialogOpen, setWorkspaceDialogOpen] = useState(false);
   const [editingWorkspace, setEditingWorkspace] = useState<CodingWorkspaceSummary | null>(null);
   const [removingWorkspace, setRemovingWorkspace] = useState<CodingWorkspaceSummary | null>(null);
+  const [isRemoving, setIsRemoving] = useState(false);
   const [removingSession, setRemovingSession] = useState<{
     workspace: CodingWorkspaceSummary;
     session: CodingSessionSummary;
@@ -124,11 +125,14 @@ export const CodingWorkspaceSidebar = ({
     ],
   );
 
+  const refreshSequence = useRef(0);
   const refresh = useCallback(async () => {
+    const request = ++refreshSequence.current;
     const [workspaceResult, profileResult] = await Promise.all([
       window.electron.codingAgent.listWorkspaces(),
       window.electron.codingAgent.listProfiles(),
     ]);
+    if (request !== refreshSequence.current) return;
     if (workspaceResult.success && workspaceResult.workspaces) {
       applyWorkspaces(workspaceResult.workspaces);
     } else {
@@ -196,28 +200,42 @@ export const CodingWorkspaceSidebar = ({
   };
 
   const removeWorkspace = async () => {
-    if (!removingWorkspace) return;
-    const result = await window.electron.codingAgent.deleteWorkspace(removingWorkspace.id);
-    if (!result.success || !result.workspaces) {
-      setError(result.error ?? i18nService.t('codingAgentActionFailed'));
-      return;
+    if (!removingWorkspace || isRemoving) return;
+    setIsRemoving(true);
+    try {
+      const result = await window.electron.codingAgent.deleteWorkspace(removingWorkspace.id);
+      if (!result.success || !result.workspaces) {
+        setError(result.error ?? i18nService.t('codingAgentActionFailed'));
+        return;
+      }
+      setRemovingWorkspace(null);
+      applyWorkspaces(result.workspaces);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : i18nService.t('codingAgentActionFailed'));
+    } finally {
+      setIsRemoving(false);
     }
-    setRemovingWorkspace(null);
-    applyWorkspaces(result.workspaces);
   };
 
   const removeSession = async () => {
-    if (!removingSession) return;
-    const result = await window.electron.codingAgent.deleteSession({
-      workspaceRoot: removingSession.workspace.primaryRoot,
-      laneId: removingSession.session.id,
-    });
-    if (!result.success || !result.workspaces) {
-      setError(result.error ?? i18nService.t('codingAgentActionFailed'));
-      return;
+    if (!removingSession || isRemoving) return;
+    setIsRemoving(true);
+    try {
+      const result = await window.electron.codingAgent.deleteSession({
+        workspaceRoot: removingSession.workspace.primaryRoot,
+        laneId: removingSession.session.id,
+      });
+      if (!result.success || !result.workspaces) {
+        setError(result.error ?? i18nService.t('codingAgentActionFailed'));
+        return;
+      }
+      setRemovingSession(null);
+      applyWorkspaces(result.workspaces);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : i18nService.t('codingAgentActionFailed'));
+    } finally {
+      setIsRemoving(false);
     }
-    setRemovingSession(null);
-    applyWorkspaces(result.workspaces);
   };
 
   return (
@@ -319,6 +337,7 @@ export const CodingWorkspaceSidebar = ({
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingWorkspaceRemove')}
         confirmVariant="outline"
+        isConfirming={isRemoving}
         onCancel={() => setRemovingWorkspace(null)}
         onConfirm={() => void removeWorkspace()}
       />
@@ -329,6 +348,7 @@ export const CodingWorkspaceSidebar = ({
         cancelLabel={i18nService.t('codingWorkspaceCancel')}
         confirmLabel={i18nService.t('codingSessionRemove')}
         confirmVariant="outline"
+        isConfirming={isRemoving}
         onCancel={() => setRemovingSession(null)}
         onConfirm={() => void removeSession()}
       />


### PR DESCRIPTION
## 问题

1. **Git 面板 diff 乱序覆盖。** `selectDiff` 无请求序号守卫（同文件 `refresh` 有），快速点击文件 A→B，A 的晚到响应会把 diff 内容覆盖为 A 的，而选中态是 B。
2. **异步失败导致按钮永久锁死。** `CodingGitQuickActions` 的 loadStatus / createPullRequest / switchBranch / push（仅 commit 有防护）与 `CodingAgentManager.submit` 缺 try/finally，promise reject 后 `loading`/`pendingAction`/`pendingBranch`/`submitting` 永久残留，相关按钮永久禁用并产生 unhandled rejection。
3. **删除确认可重复提交且无错误兜底。** 侧栏删除工作区/会话的两个 `DestructiveConfirmDialog` 未传 `isConfirming`，等待期间可重复确认；操作无 try/catch，reject 时对话框不关、无提示。
4. **侧栏 refresh 乱序回滚。** 连续 `onChanged` 触发的并发 `listWorkspaces`，晚到的旧快照会覆盖新列表。

## 改动

1. `selectDiff` 引入 `diffRequestSequence`，过期响应直接丢弃（与 `refresh` 同范式）。
2. 上述四处异步操作统一 try/finally 复位 pending 状态。
3. 删除确认传 `isConfirming`，操作包裹 try/catch/finally，失败写入可见 error 状态。
4. `refresh` 引入请求序号，过期响应丢弃。

## 验证

`npx vitest run src/renderer/components/coding` 49/49 通过；`npm run lint` 通过。