### PR TITLE
fix(coding): 滚动位置误存与文件浏览器嵌套过滤失效

### DIFF
--- a/src/renderer/components/coding/CodingEventStream.tsx
+++ b/src/renderer/components/coding/CodingEventStream.tsx
@@ -172,7 +172,15 @@ export const CodingEventStream = ({
       ref={scrollAreaRef}
       className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
       onScrollCapture={event => {
-        if (event.target instanceof HTMLElement) onScrollPositionChange(event.target.scrollTop);
+        // Persist only the conversation viewport's scroll position; inner
+        // scrollable previews (diffs, terminal output) must not overwrite it.
+        const target = event.target;
+        if (
+          target instanceof HTMLElement &&
+          target.classList.contains('coding-conversation-scroll')
+        ) {
+          onScrollPositionChange(target.scrollTop);
+        }
       }}
     >
       {headerActions ? (

--- a/src/renderer/components/coding/CodingWorkspaceFileBrowser.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceFileBrowser.tsx
@@ -31,6 +31,24 @@ const replaceNodeChildren = (nodes: TreeNode[], path: string, children: TreeNode
       : node;
   });
 
+/**
+ * Keeps the nodes whose own name matches the query plus the ancestor chain of
+ * every nested match, so the filter can surface files below unloaded-looking
+ * folders instead of hiding them with their non-matching parents.
+ */
+const filterTreeNodes = (nodes: TreeNode[], query: string): TreeNode[] => {
+  if (!query) return nodes;
+  const walk = (node: TreeNode): TreeNode | null => {
+    const children = node.children
+      ? node.children.map(walk).filter((child): child is TreeNode => child !== null)
+      : undefined;
+    const selfMatch = node.name.toLocaleLowerCase().includes(query);
+    if (!selfMatch && (!children || children.length === 0)) return null;
+    return children ? { ...node, children } : node;
+  };
+  return nodes.map(walk).filter((node): node is TreeNode => node !== null);
+};
+
 export const CodingWorkspaceFileBrowser = ({
   workspaceRoot,
   sourceRoot,
@@ -151,10 +169,7 @@ export const CodingWorkspaceFileBrowser = ({
 
   const normalizedFilter = filter.trim().toLocaleLowerCase();
   const visibleNodes = useMemo(
-    () =>
-      normalizedFilter
-        ? nodes.filter(node => node.name.toLocaleLowerCase().includes(normalizedFilter))
-        : nodes,
+    () => filterTreeNodes(nodes, normalizedFilter),
     [nodes, normalizedFilter],
   );
 
@@ -208,7 +223,7 @@ export const CodingWorkspaceFileBrowser = ({
                 expandedPaths={expandedPaths}
                 loadingPaths={loadingPaths}
                 selectedPath={selectedPath}
-                filter={normalizedFilter}
+                filterActive={Boolean(normalizedFilter)}
                 onToggleDirectory={toggleDirectory}
                 onOpenFile={openFile}
               />
@@ -225,7 +240,7 @@ interface FileTreeProps {
   expandedPaths: Set<string>;
   loadingPaths: Set<string>;
   selectedPath: string | null;
-  filter: string;
+  filterActive: boolean;
   onToggleDirectory: (node: TreeNode) => void;
   onOpenFile: (node: TreeNode) => void;
 }
@@ -235,14 +250,16 @@ const FileTree = ({
   expandedPaths,
   loadingPaths,
   selectedPath,
-  filter,
+  filterActive,
   onToggleDirectory,
   onOpenFile,
 }: FileTreeProps) => (
   <div className="flex flex-col gap-0.5">
     {nodes.map(node => {
       const directory = node.kind === CodingWorkspaceFileKind.Directory;
-      const expanded = expandedPaths.has(node.path);
+      // While filtering, reveal matching descendants even under folders the
+      // user had collapsed; the node list is already pruned to matches.
+      const expanded = expandedPaths.has(node.path) || (filterActive && Boolean(node.children));
       return (
         <div key={node.path} className="min-w-0">
           <Button
@@ -266,11 +283,11 @@ const FileTree = ({
           {directory && expanded && node.children ? (
             <div className="pl-4">
               <FileTree
-                nodes={filter ? node.children.filter(child => child.name.toLocaleLowerCase().includes(filter)) : node.children}
+                nodes={node.children}
                 expandedPaths={expandedPaths}
                 loadingPaths={loadingPaths}
                 selectedPath={selectedPath}
-                filter={filter}
+                filterActive={filterActive}
                 onToggleDirectory={onToggleDirectory}
                 onOpenFile={onOpenFile}
               />


### PR DESCRIPTION
## 问题

1. **内层滚动污染会话滚动位置。** `CodingEventStream` 的 `onScrollCapture` 不校验滚动目标，嵌入在会话里的可滚动区（diff 预览、终端输出等）一滚动，其 `scrollTop` 就被当成会话滚动位存库（`onScrollPositionChange` → `saveLaneView`），切换会话时恢复到错误位置。
2. **文件过滤搜不到嵌套文件。** 过滤只匹配节点自身名称：父目录不匹配但后代匹配时，整个子树被隐藏；子层过滤又只在「父级已匹配且展开」的分支生效，深层文件基本不可达。

## 改动

1. 滚动捕获仅在 `event.target` 为会话视口（`coding-conversation-scroll`）时上报 `scrollTop`。
2. 过滤改为对已加载子树递归匹配：保留自身匹配的节点与所有匹配节点的祖先链；过滤激活时折叠目录中的匹配后代直接可见（等价自动展开）。

## 验证

`npx vitest run src/renderer/components/coding` 49/49 通过；`npm run lint` 通过。

## 说明

目录子树按需加载，未加载过的深层目录仍无法参与匹配（需先展开加载一次）；这是懒加载结构的固有限制，本次修复保证「已加载范围内」过滤结果正确且可见。