### PR TITLE
fix(todo): 明细面板编辑被后台刷新回滚、Sheet 意外关闭与静默失败

### DIFF
--- a/src/renderer/components/todo/TodoTaskDetail.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.tsx
@@ -10,7 +10,7 @@ import {
 import { Textarea } from '@shared/components/ui/textarea';
 import { cn } from '@shared/lib/utils';
 import { CalendarDays, Check, ListChecks, Plus, Star, Trash2 } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { TodoStatus, type Todo, type TodoList } from '../../../shared/todo';
 import { i18nService } from '../../services/i18n';
@@ -29,6 +29,7 @@ interface TodoTaskDetailProps {
   lists: TodoList[];
   language: 'zh' | 'en';
   onUpdated: () => Promise<void>;
+  onError: () => void;
   onDelete: () => void;
 }
 
@@ -39,6 +40,7 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   lists,
   language,
   onUpdated,
+  onError,
   onDelete,
 }) => {
   const [title, setTitle] = useState(todo.title);
@@ -48,14 +50,38 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   const [listId, setListId] = useState(todo.listId ?? NO_LIST_VALUE);
   const [stepDraft, setStepDraft] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  // Background refreshes (onChanged -> loadData) replace the todo object; only
+  // resync fields the user is not editing, otherwise in-progress edits would
+  // be silently reverted by every save of another field.
+  const dirtyFieldsRef = useRef(new Set<string>());
+  const lastTodoIdRef = useRef(todo.id);
 
   useEffect(() => {
-    setTitle(todo.title);
-    setNote(todo.note);
-    setDueDate(toDateInputValue(todo.dueAt));
-    setRemindAt(toDateTimeInputValue(todo.remindAt));
-    setListId(todo.listId ?? NO_LIST_VALUE);
+    if (lastTodoIdRef.current !== todo.id) {
+      lastTodoIdRef.current = todo.id;
+      dirtyFieldsRef.current.clear();
+      setTitle(todo.title);
+      setNote(todo.note);
+      setDueDate(toDateInputValue(todo.dueAt));
+      setRemindAt(toDateTimeInputValue(todo.remindAt));
+      setListId(todo.listId ?? NO_LIST_VALUE);
+      return;
+    }
+    const dirty = dirtyFieldsRef.current;
+    setTitle(current => (dirty.has('title') ? current : todo.title));
+    setNote(current => (dirty.has('note') ? current : todo.note));
+    setDueDate(current => (dirty.has('dueDate') ? current : toDateInputValue(todo.dueAt)));
+    setRemindAt(current => (dirty.has('remindAt') ? current : toDateTimeInputValue(todo.remindAt)));
+    setListId(current => (dirty.has('listId') ? current : todo.listId ?? NO_LIST_VALUE));
   }, [todo]);
+
+  const markDirty = (field: string): void => {
+    dirtyFieldsRef.current.add(field);
+  };
+
+  const clearDirty = (...fields: string[]): void => {
+    for (const field of fields) dirtyFieldsRef.current.delete(field);
+  };
 
   const saveDetails = async (): Promise<void> => {
     const trimmedTitle = title.trim();
@@ -69,7 +95,12 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
         remindAt: fromDateTimeInputValue(remindAt),
         listId: listId === NO_LIST_VALUE ? null : listId,
       });
-      if (result.success) await onUpdated();
+      if (result.success) {
+        clearDirty('title', 'note', 'dueDate', 'remindAt', 'listId');
+        await onUpdated();
+      } else {
+        onError();
+      }
     } finally {
       setIsSaving(false);
     }
@@ -78,6 +109,7 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   const updateStatus = async (status: TodoStatus): Promise<void> => {
     const result = await todoService.update(todo.id, { status });
     if (result.success) await onUpdated();
+    else onError();
   };
 
   const toggleMyDay = async (): Promise<void> => {
@@ -85,11 +117,13 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
       myDayDate: todo.myDayDate === todayDateKey() ? null : todayDateKey(),
     });
     if (result.success) await onUpdated();
+    else onError();
   };
 
   const toggleImportant = async (): Promise<void> => {
     const result = await todoService.update(todo.id, { important: !todo.important });
     if (result.success) await onUpdated();
+    else onError();
   };
 
   const addStep = async (): Promise<void> => {
@@ -99,28 +133,31 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
     if (result.success) {
       setStepDraft('');
       await onUpdated();
+    } else {
+      onError();
     }
   };
+
+  const inMyDay = todo.myDayDate === todayDateKey();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 pb-6">
       <div className="space-y-4">
         <Input
           value={title}
-          onChange={event => setTitle(event.target.value)}
+          onChange={event => {
+            markDirty('title');
+            setTitle(event.target.value);
+          }}
           onBlur={() => void saveDetails()}
           aria-label={i18nService.t('todoTitleLabel')}
           className="theme-page-todo-task-detail-input-1"
         />
 
         <div className="flex flex-wrap gap-2 border-b border-border-subtle pb-4">
-          <Button
-            type="button"
-            variant={todo.myDayDate ? 'secondary' : 'outline'}
-            onClick={toggleMyDay}
-          >
+          <Button type="button" variant={inMyDay ? 'secondary' : 'outline'} onClick={toggleMyDay}>
             <CalendarDays />
-            {todo.myDayDate === todayDateKey()
+            {inMyDay
               ? i18nService.t('todoRemoveFromMyDay')
               : i18nService.t('todoAddToMyDay')}
           </Button>
@@ -146,10 +183,17 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
               type="date"
               value={dueDate}
               onChange={event => {
+                markDirty('dueDate');
                 setDueDate(event.target.value);
                 void todoService
                   .update(todo.id, { dueAt: fromDateInputValue(event.target.value) })
-                  .then(result => (result.success ? onUpdated() : undefined));
+                  .then(result => {
+                    if (result.success) {
+                      clearDirty('dueDate');
+                      return onUpdated();
+                    }
+                    onError();
+                  });
               }}
             />
           </label>
@@ -159,10 +203,17 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
               type="datetime-local"
               value={remindAt}
               onChange={event => {
+                markDirty('remindAt');
                 setRemindAt(event.target.value);
                 void todoService
                   .update(todo.id, { remindAt: fromDateTimeInputValue(event.target.value) })
-                  .then(result => (result.success ? onUpdated() : undefined));
+                  .then(result => {
+                    if (result.success) {
+                      clearDirty('remindAt');
+                      return onUpdated();
+                    }
+                    onError();
+                  });
               }}
             />
           </label>
@@ -174,10 +225,17 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
             value={listId}
             onValueChange={value => {
               const nextListId = value ?? NO_LIST_VALUE;
+              markDirty('listId');
               setListId(nextListId);
               void todoService
                 .update(todo.id, { listId: nextListId === NO_LIST_VALUE ? null : nextListId })
-                .then(result => (result.success ? onUpdated() : undefined));
+                .then(result => {
+                  if (result.success) {
+                    clearDirty('listId');
+                    return onUpdated();
+                  }
+                  onError();
+                });
             }}
           >
             <SelectTrigger className="w-full">
@@ -202,7 +260,10 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
           <span className="text-muted-foreground">{i18nService.t('todoNote')}</span>
           <Textarea
             value={note}
-            onChange={event => setNote(event.target.value)}
+            onChange={event => {
+              markDirty('note');
+              setNote(event.target.value);
+            }}
             onBlur={() => void saveDetails()}
             placeholder={i18nService.t('todoNotePlaceholder')}
             rows={5}
@@ -231,7 +292,10 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
                 onClick={() =>
                   void todoService
                     .updateStep({ id: step.id, completed: !step.completed })
-                    .then(result => (result.success ? onUpdated() : undefined))
+                    .then(result => {
+                      if (result.success) return onUpdated();
+                      onError();
+                    })
                 }
               >
                 {step.completed ? <Check /> : null}
@@ -251,9 +315,10 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
                 aria-label={i18nService.t('todoDeleteStep')}
                 title={i18nService.t('todoDeleteStep')}
                 onClick={() =>
-                  void todoService
-                    .deleteStep(step.id)
-                    .then(result => (result.success ? onUpdated() : undefined))
+                  void todoService.deleteStep(step.id).then(result => {
+                    if (result.success) return onUpdated();
+                    onError();
+                  })
                 }
               >
                 <Trash2 className="text-muted-foreground" />

--- a/src/renderer/components/todo/TodoView.tsx
+++ b/src/renderer/components/todo/TodoView.tsx
@@ -57,6 +57,7 @@ const TodoView: React.FC<TodoViewProps> = ({
   const [activeListId, setActiveListId] = useState<string | null>(null);
   const [todos, setTodos] = useState<Todo[]>([]);
   const [allTodos, setAllTodos] = useState<Todo[]>([]);
+  const [completedTodos, setCompletedTodos] = useState<Todo[]>([]);
   const [completedCount, setCompletedCount] = useState(0);
   const [suggestionTodos, setSuggestionTodos] = useState<Todo[]>([]);
   const [lists, setLists] = useState<TodoList[]>([]);
@@ -70,9 +71,15 @@ const TodoView: React.FC<TodoViewProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
 
+  // Look up the selected task in the completed snapshot as well: completing a
+  // task moves it out of the active list, and losing the lookup would close
+  // the detail sheet mid-interaction.
   const selectedTodo = useMemo(
-    () => todos.find(todo => todo.id === selectedTodoId) ?? null,
-    [selectedTodoId, todos],
+    () =>
+      todos.find(todo => todo.id === selectedTodoId) ??
+      completedTodos.find(todo => todo.id === selectedTodoId) ??
+      null,
+    [selectedTodoId, todos, completedTodos],
   );
 
   const activeList = useMemo(
@@ -128,7 +135,9 @@ const TodoView: React.FC<TodoViewProps> = ({
     setLists(listsResult.lists ?? []);
     const allTodoItems = allResult.todos ?? [];
     setAllTodos(allTodoItems);
-    setCompletedCount(completedResult.todos?.length ?? 0);
+    const completedTodoItems = completedResult.todos ?? [];
+    setCompletedTodos(completedTodoItems);
+    setCompletedCount(completedTodoItems.length);
     setSuggestionTodos(
       allTodoItems
         .filter(todo => todo.myDayDate !== todayDateKey())
@@ -480,6 +489,7 @@ const TodoView: React.FC<TodoViewProps> = ({
               lists={lists}
               language={language}
               onUpdated={loadData}
+              onError={showError}
               onDelete={() => setDeleteTodo(selectedTodo)}
             />
           ) : null}


### PR DESCRIPTION
## 问题

1. **编辑内容被静默回滚。** `TodoTaskDetail` 的 `useEffect([todo])` 在 todo 对象引用变化时重置全部本地字段。修改日期/提醒/清单会立即触发 update → onChanged → loadData → 新 todo 对象 → 此时未保存的标题/备注编辑被覆盖回旧值。
2. **完成任务后面板突然关闭。** 完成后任务从当前视图的活跃列表消失，`selectedTodo` 查找失败导致 Sheet 自动关闭；移动任务到其他清单同理。
3. **操作失败无提示。** `saveDetails`/`updateStatus`/`toggleMyDay`/`toggleImportant`/`addStep` 及步骤增删改失败时静默返回，与行内操作的 toast 行为不一致。
4. **「我的一天」按钮状态不一致。** `my_day_date` 为过去日期时按钮显示按下态但文案是「添加到「我的一天」」。

## 改动

1. 引入脏字段追踪：后台刷新只回同步用户**未在编辑**的字段；保存成功后清除对应脏标记；切换任务时全量重置。
2. 明细面板同时在已完成快照中查找选中任务（完成列表本就已全量拉取、此前只用了 count），Sheet 在任务完成/移动后保持打开。
3. 新增 `onError` 回调，TodoView 传入既有 `showError`，所有明细操作失败均有 toast。
4. 按钮按压态与文案统一以 `myDayDate === 今天` 判断。

## 验证

`npx vitest run src/renderer/components/todo` 7/7 通过；`npm run lint` 通过。