### PR TITLE
fix(todo): 列表骨架屏闪烁、搜索乱序与通配符、已完成视图新建输入框

### DIFF
--- a/src/main/todo/reminderScheduler.test.ts
+++ b/src/main/todo/reminderScheduler.test.ts
@@ -93,6 +93,9 @@ test('does not acknowledge reminders when notifications are unsupported', () => 
       remind_notified_at: number | null;
     };
     expect(row.remind_notified_at).toBeNull();
+
+    vi.advanceTimersByTime(120_000);
+    expect(vi.getTimerCount()).toBe(0);
   } finally {
     scheduler.stop();
     db.close();

--- a/src/main/todo/reminderScheduler.ts
+++ b/src/main/todo/reminderScheduler.ts
@@ -48,6 +48,11 @@ export class TodoReminderScheduler {
 
   refresh(minimumDelayMs = 0): void {
     if (!this.isStarted) return;
+    if (!this.notifier.isSupported()) {
+      // Notifications can never be delivered on this system; scheduling a
+      // retry would poll forever.
+      return;
+    }
     if (this.timer) clearTimeout(this.timer);
     this.timer = null;
 

--- a/src/main/todo/repository.ts
+++ b/src/main/todo/repository.ts
@@ -84,8 +84,10 @@ export class TodoRepository {
     }
 
     if (query) {
-      conditions.push('(LOWER(t.title) LIKE ? OR LOWER(t.note) LIKE ?)');
-      const pattern = `%${query}%`;
+      // Escape LIKE wildcards so a literal "%" or "_" in the search text is
+      // matched literally instead of as a pattern.
+      conditions.push(`(LOWER(t.title) LIKE ? ESCAPE '\\' OR LOWER(t.note) LIKE ? ESCAPE '\\')`);
+      const pattern = `%${query.replace(/[\\%_]/g, match => `\\${match}`)}%`;
       params.push(pattern, pattern);
     }
 

--- a/src/renderer/components/todo/TodoView.tsx
+++ b/src/renderer/components/todo/TodoView.tsx
@@ -9,7 +9,7 @@ import {
   SheetTitle,
 } from '@shared/components/ui/sheet';
 import { ListTodo, Menu, Plus, Search } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   TodoStatus,
@@ -92,8 +92,11 @@ const TodoView: React.FC<TodoViewProps> = ({
     return counts;
   }, [allTodos]);
 
+  const loadDataSequence = useRef(0);
   const loadData = useCallback(async () => {
-    setIsLoading(true);
+    // Out-of-order responses (rapid typing, overlapping refreshes) must not
+    // clobber newer results.
+    const request = ++loadDataSequence.current;
     setLoadFailed(false);
     const listInput = {
       view: activeView,
@@ -117,6 +120,7 @@ const TodoView: React.FC<TodoViewProps> = ({
       todoService.list(allInput),
       todoService.list(completedInput),
     ]);
+    if (request !== loadDataSequence.current) return;
     const succeeded =
       todoResult.success && listsResult.success && allResult.success && completedResult.success;
     if (!succeeded) {
@@ -380,7 +384,7 @@ const TodoView: React.FC<TodoViewProps> = ({
                       ? i18nService.t('todoNoSearchResults')
                       : i18nService.t('todoEmpty')}
                   </p>
-                  {!query.trim() ? (
+                  {!query.trim() && activeView !== TodoViewFilter.Completed ? (
                     <Button
                       type="button"
                       variant="outline"
@@ -408,33 +412,35 @@ const TodoView: React.FC<TodoViewProps> = ({
               )}
             </div>
 
-            <form
-              onSubmit={handleCreateTodo}
-              className="shrink-0 border-t border-border-subtle py-4"
-            >
-              <div className="rounded-lg border border-border bg-card p-2 focus-within:ring-3 focus-within:ring-ring/30">
-                <div className="flex items-center gap-2">
-                  <Plus className="ml-1 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-                  <Input
-                    id="todo-new-input"
-                    value={newTodoTitle}
-                    onChange={event => setNewTodoTitle(event.target.value)}
-                    placeholder={i18nService.t('todoAddTaskPlaceholder')}
-                    aria-label={i18nService.t('todoNewTask')}
-                    className="theme-page-todo-view-input-1"
-                  />
+            {activeView !== TodoViewFilter.Completed ? (
+              <form
+                onSubmit={handleCreateTodo}
+                className="shrink-0 border-t border-border-subtle py-4"
+              >
+                <div className="rounded-lg border border-border bg-card p-2 focus-within:ring-3 focus-within:ring-ring/30">
+                  <div className="flex items-center gap-2">
+                    <Plus className="ml-1 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <Input
+                      id="todo-new-input"
+                      value={newTodoTitle}
+                      onChange={event => setNewTodoTitle(event.target.value)}
+                      placeholder={i18nService.t('todoAddTaskPlaceholder')}
+                      aria-label={i18nService.t('todoNewTask')}
+                      className="theme-page-todo-view-input-1"
+                    />
+                  </div>
+                  {parsedNewTodo.dueAt !== null || parsedNewTodo.important ? (
+                    <p className="mt-2 pl-7 text-xs text-muted-foreground">
+                      {parsedNewTodo.dueAt !== null
+                        ? `${i18nService.t('todoParsedDue')}: ${formatTodoDate(parsedNewTodo.dueAt, language)}`
+                        : null}
+                      {parsedNewTodo.dueAt !== null && parsedNewTodo.important ? ' · ' : null}
+                      {parsedNewTodo.important ? i18nService.t('todoParsedImportant') : null}
+                    </p>
+                  ) : null}
                 </div>
-                {parsedNewTodo.dueAt !== null || parsedNewTodo.important ? (
-                  <p className="mt-2 pl-7 text-xs text-muted-foreground">
-                    {parsedNewTodo.dueAt !== null
-                      ? `${i18nService.t('todoParsedDue')}: ${formatTodoDate(parsedNewTodo.dueAt, language)}`
-                      : null}
-                    {parsedNewTodo.dueAt !== null && parsedNewTodo.important ? ' · ' : null}
-                    {parsedNewTodo.important ? i18nService.t('todoParsedImportant') : null}
-                  </p>
-                ) : null}
-              </div>
-            </form>
+              </form>
+            ) : null}
           </div>
         </main>
       </div>


### PR DESCRIPTION
## 问题

1. **每次操作都闪骨架屏。** `loadData` 开头一律 `setIsLoading(true)`：搜索每敲一个字符、每次勾选/修改（经 onChanged 触发）都会把整个列表替换为骨架占位再恢复。
2. **搜索乱序覆盖。** 快速键入时多个并发 `loadData` 无序返回，晚到的旧响应可能覆盖新结果。
3. **LIKE 未转义。** 搜索 `100%` 会因 `%` 通配符匹配到全部任务（`_` 同理）。
4. **「已完成」视图仍显示新建输入框。** 在该视图创建的任务是 active 状态、当前视图不可见，看起来像创建失败。
5. **提醒调度器空转。** 系统不支持通知时仍按 60 秒间隔无限重试轮询数据库。

## 改动

1. `loadData` 不再在每次刷新时置 loading：骨架屏仅保留到首次加载完成；加入请求序号丢弃过期响应。
2. Completed 视图隐藏新建表单与空态中的「新建任务」按钮（该按钮聚焦的目标输入框在 Completed 视图不存在）。
3. repository 搜索为 LIKE 增加 ESCAPE 子句，并转义 `%`、`_` 与反斜杠本身。
4. `TodoReminderScheduler.refresh` 在通知不可用时直接不再调度（新增定时器计数断言：不支持时 `vi.getTimerCount()` 为 0）。

## 验证

`npx vitest run src/renderer/components/todo src/main/todo` 13/13 通过；`npm run lint` 通过。
