### PR TITLE
fix(coding): 协作阶段自动启动失败在会话流中可见化

### DIFF
--- a/src/main/codingAgent/codingRoomService.test.ts
+++ b/src/main/codingAgent/codingRoomService.test.ts
@@ -14,6 +14,7 @@ import {
   CodingLaneStatus,
   CodingMissionStatus,
   CodingPermissionOutcome,
+  CodingWorkflowStage,
 } from '../../shared/codingAgent';
 import { CodingAgentRegistry } from './codingAgentRegistry';
 import { CodingRoomRepository } from './codingRoomRepository';
@@ -436,6 +437,55 @@ test('cancel leaves a lane without an active turn untouched', async () => {
   expect(
     updated.events.filter(event => event.kind === CodingEventKind.TurnCancelled),
   ).toHaveLength(0);
+});
+
+test('reports a failed automatic collaboration stage without changing assignment state', async () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const service = new CodingRoomService(repository, new CodingAgentRegistry(), {
+    startBuiltinSession: async () => undefined,
+    cancelBuiltinSession: async () => undefined,
+    getBuiltinWorkbenchLink: () => null,
+    beginExternalWorkbenchRun: () => ({ taskId: 'task', runId: 'run' }),
+    completeExternalWorkbenchRun: () => undefined,
+  });
+  const workspaceRoot = '/workspace/project';
+  const created = await service.createMission({
+    workspaceRoot,
+    profileId: 'builtin-zhiyuan-coding',
+  });
+  const sourceLane = created.lanes[0];
+  const mission = created.missions[0];
+  const sourceAssignment = created.assignments[0];
+  // A mission created without a Git baseline makes the automatic handoff fail
+  // deterministically when the completed turn triggers the next stage.
+  const targetLane = repository.createLane(mission.id, 'builtin-zhiyuan-coding', workspaceRoot);
+  repository.createAssignment({
+    missionId: mission.id,
+    laneId: targetLane.id,
+    title: 'Verify',
+    instructions: 'Verify the implementation.',
+    workflowStage: CodingWorkflowStage.Verification,
+    previousAssignmentId: sourceAssignment.id,
+  });
+
+  service.recordBuiltinEvent(sourceLane.localSessionId, CodingEventKind.TurnComplete, {});
+  // The stage failure surfaces through an async rejection handler.
+  await new Promise<void>(resolve => setImmediate(resolve));
+
+  const updated = service.bootstrap(workspaceRoot);
+  expect(updated.lanes.find(lane => lane.id === sourceLane.id)?.status).toBe(
+    CodingLaneStatus.Completed,
+  );
+  expect(
+    updated.assignments.find(assignment => assignment.laneId === targetLane.id)?.status,
+  ).toBe(CodingAssignmentStatus.Planned);
+  const sourceEvents = updated.events.filter(event => event.laneId === sourceLane.id);
+  expect(sourceEvents.at(-1)).toMatchObject({
+    kind: CodingEventKind.Message,
+    payload: { role: 'system', error: expect.stringContaining('frozen baseline') },
+  });
 });
 
 test('recovers stale running lanes after an application restart without losing the mission', async () => {

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -1734,6 +1734,21 @@ export class CodingRoomService extends EventEmitter {
     if (laneStatus === CodingLaneStatus.Completed) {
       void this.startNextCollaborationStage(roomWorkspaceRoot, lane.id).catch(error => {
         console.error('[CodingRoom] failed to start the next collaboration stage:', error);
+        // The next assignment stays Planned, so surface the failure in the
+        // completed lane's conversation instead of leaving silent state.
+        try {
+          this.repository.appendEvent(lane.id, CodingEventKind.Message, {
+            role: 'system',
+            content: t('codingAgentNextStageFailed'),
+            error: this.errorMessage(error),
+          });
+          this.publish(roomWorkspaceRoot);
+        } catch (publishError) {
+          console.debug(
+            '[CodingRoom] Skipped publishing the collaboration stage failure:',
+            publishError,
+          );
+        }
       });
     }
   }

--- a/src/main/i18n.ts
+++ b/src/main/i18n.ts
@@ -29,6 +29,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     coworkDefaultSessionTitle: '新对话',
     codingAgentDefaultMissionTitle: '新建编程任务',
     codingAgentSessionRecovery: '上一个 Agent 会话无法恢复，已将交接摘要发送到新会话。',
+    codingAgentNextStageFailed:
+      '自动启动下一协作阶段失败，目标阶段仍为待执行状态，可从对应会话手动发起交接。',
     codingAgentConfigModel: '模型',
     codingAgentConfigThinkingLevel: '思考等级',
     codingAgentConfigPermissionMode: '权限模式',
@@ -336,6 +338,8 @@ const translations: Record<LanguageType, Record<string, string>> = {
     codingAgentDefaultMissionTitle: 'New coding task',
     codingAgentSessionRecovery:
       'The previous agent session could not be restored. A handoff summary was sent to a new session.',
+    codingAgentNextStageFailed:
+      'Failed to start the next collaboration stage automatically. The target stage is still planned; start the handoff manually from its session.',
     codingAgentConfigModel: 'Model',
     codingAgentConfigThinkingLevel: 'Thinking level',
     codingAgentConfigPermissionMode: 'Permission mode',


### PR DESCRIPTION
## 背景

#728 为 `startNextCollaborationStage` 补了错误处理，但失败只写 console 日志：Review/Verify assignment 保持 `Planned`，用户界面上没有任何可见痕迹，也不会自动重试。

## 改动

- 阶段启动失败时，向**已完成 lane 的会话流**追加一条 `role: 'system'` 的 `Message` 事件，正文说明自动交接失败、目标阶段仍为待执行可手动发起，并附带底层错误；随后发布快照推送给渲染层。
- 目标 assignment **有意保持 `Planned`**：失败可能只是暂时的补丁冲突，自动置 `Failed` 过于武断；保持待执行状态让用户可从目标会话手动触发交接。
- 新增 i18n key `codingAgentNextStageFailed`（中英双语，主进程通知/事件文案）。

## 测试

新增 `reports a failed automatic collaboration stage without changing assignment state`：构造无 Git baseline 的 mission（`requireMissionBaseline` 必然抛错）+ 通过 repository 手工搭建 Review→Verify assignment 链，触发 `TurnComplete` 后断言：

- 源 lane 状态保持 `Completed`（不被失败改写）；
- 目标 assignment 保持 `Planned`；
- 源 lane 最后一条事件是 system Message 且 `error` 含底层错误。

`npx vitest run src/main/codingAgent/codingRoomService.test.ts` 29/29 通过；`npm run lint` 通过。
