### PR TITLE
perf(coding): 流式 chunk 改为内存合并，chunk 路径零 SQL 写

### DIFF
--- a/src/main/codingAgent/codingRoomRepository.test.ts
+++ b/src/main/codingAgent/codingRoomRepository.test.ts
@@ -1,4 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
 import { afterEach, expect, test } from 'vitest';
 
 import {
@@ -11,10 +14,15 @@ import { initializeCodingAgentSchema } from './schema';
 import { CodingRoomRepository } from './codingRoomRepository';
 
 let db: Database.Database | undefined;
+const tempDirectories: string[] = [];
 
 afterEach(() => {
   db?.close();
   db = undefined;
+  for (const directory of tempDirectories.splice(0)) {
+    // Windows: a just-closed handle can briefly keep the directory busy.
+    rmSync(directory, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
+  }
 });
 
 test('persists independent mission lanes and append-only events', () => {
@@ -262,4 +270,72 @@ test('deleting a lane drops its buffered stream writes', () => {
   expect(
     db.prepare('SELECT COUNT(*) AS count FROM coding_events WHERE lane_id = ?').get(lane.id),
   ).toEqual({ count: 0 });
+});
+
+test('retains buffered stream writes when the flush hits a locked database', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'coding-stream-flush-'));
+  tempDirectories.push(directory);
+  const dbPath = path.join(directory, 'events.sqlite');
+  const lockedDb = new Database(dbPath, { timeout: 10 });
+  db = lockedDb;
+  initializeCodingAgentSchema(lockedDb);
+  const repository = new CodingRoomRepository(lockedDb);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Locked flush');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'Hel',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'lo',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+
+  const blocker = new Database(dbPath);
+  try {
+    blocker.exec('BEGIN EXCLUSIVE');
+    // SQLITE_BUSY must not discard the buffered content.
+    expect(() => repository.flushPendingStreamWrites()).not.toThrow();
+    blocker.exec('ROLLBACK');
+
+    const staleRow = lockedDb
+      .prepare('SELECT payload_json FROM coding_events WHERE id = ?')
+      .get(
+        repository.listEvents([lane.id])[0].id,
+      ) as { payload_json: string };
+    expect(JSON.parse(staleRow.payload_json).content).toBe('Hel');
+    expect(repository.listEvents([lane.id])[0].payload.content).toBe('Hello');
+
+    repository.flushPendingStreamWrites();
+    const flushedRow = lockedDb
+      .prepare('SELECT payload_json FROM coding_events WHERE id = ?')
+      .get(
+        repository.listEvents([lane.id])[0].id,
+      ) as { payload_json: string };
+    expect(JSON.parse(flushedRow.payload_json).content).toBe('Hello');
+  } finally {
+    blocker.close();
+  }
+});
+
+test('flushing against a closed database drops buffered writes without throwing', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'coding-stream-closed-'));
+  tempDirectories.push(directory);
+  db = new Database(path.join(directory, 'events.sqlite'));
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Closed flush');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'partial',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+
+  db.close();
+  expect(() => repository.flushPendingStreamWrites()).not.toThrow();
 });

--- a/src/main/codingAgent/codingRoomRepository.test.ts
+++ b/src/main/codingAgent/codingRoomRepository.test.ts
@@ -180,3 +180,86 @@ test('loads a lane and its owning room directly by lane id', () => {
   expect(repository.getLaneById('missing-lane')).toBeNull();
   expect(repository.getRoomByLaneId('missing-lane')).toBeNull();
 });
+
+test('coalesces stream chunks in memory and flushes them to SQLite', () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Memory coalesce');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+
+  const first = repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'Hel',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+  const second = repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'lo',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+
+  // Both projected reads observe the merged content, under one event id.
+  expect(second.id).toBe(first.id);
+  expect(second.payload.content).toBe('Hello');
+  expect(repository.listEvents([lane.id])).toHaveLength(1);
+  expect(repository.listEvents([lane.id])[0].payload.content).toBe('Hello');
+
+  // The buffered tail only reaches SQLite through the flush.
+  const staleRow = db
+    .prepare('SELECT payload_json FROM coding_events WHERE id = ?')
+    .get(first.id) as { payload_json: string };
+  expect(JSON.parse(staleRow.payload_json).content).toBe('Hel');
+  repository.flushPendingStreamWrites();
+  const flushedRow = db
+    .prepare('SELECT payload_json FROM coding_events WHERE id = ?')
+    .get(first.id) as { payload_json: string };
+  expect(JSON.parse(flushedRow.payload_json).content).toBe('Hello');
+});
+
+test('takes over an existing stream row without duplicating it after a restart', () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Restart takeover');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'Hel',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+  repository.flushPendingStreamWrites();
+  const resumed = repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'lo',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+
+  expect(resumed.payload.content).toBe('Hello');
+  expect(repository.listEvents([lane.id])).toHaveLength(1);
+  repository.flushPendingStreamWrites();
+  expect(repository.listEvents([lane.id])[0].payload.content).toBe('Hello');
+});
+
+test('deleting a lane drops its buffered stream writes', () => {
+  db = new Database(':memory:');
+  initializeCodingAgentSchema(db);
+  const repository = new CodingRoomRepository(db);
+  const room = repository.getOrCreateRoom('/workspace/project');
+  const mission = repository.createMission(room.id, 'Dropped writes');
+  const lane = repository.createLane(mission.id, 'agent', '/workspace/project');
+
+  repository.appendOrMergeStreamEvent(lane.id, CodingEventKind.MessageDelta, {
+    messageId: 'm1',
+    content: 'partial',
+    streamUpdateMode: CodingStreamUpdateMode.Append,
+  });
+  repository.deleteLane(room.id, lane.id);
+  repository.flushPendingStreamWrites();
+  expect(
+    db.prepare('SELECT COUNT(*) AS count FROM coding_events WHERE lane_id = ?').get(lane.id),
+  ).toEqual({ count: 0 });
+});

--- a/src/main/codingAgent/codingRoomRepository.ts
+++ b/src/main/codingAgent/codingRoomRepository.ts
@@ -116,7 +116,9 @@ export class CodingRoomRepository {
   /** Stream events whose accumulated payload is newer in memory than in SQLite. */
   private readonly pendingStreamWrites = new Map<string, PendingStreamWrite>();
   private readonly streamFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly streamFlushBackoffMs = new Map<string, number>();
   private static readonly STREAM_FLUSH_THROTTLE_MS = 500;
+  private static readonly STREAM_FLUSH_MAX_BACKOFF_MS = 30_000;
 
   constructor(private readonly db: Database.Database) {}
   listRooms(): CodingRoom[] {
@@ -655,17 +657,24 @@ export class CodingRoomRepository {
     return event;
   }
 
-  private scheduleStreamFlush(laneId: string): void {
+  private scheduleStreamFlush(laneId: string, delayMs?: number): void {
     if (this.streamFlushTimers.has(laneId)) return;
+    const delay = delayMs ?? CodingRoomRepository.STREAM_FLUSH_THROTTLE_MS;
     const timer = setTimeout(() => {
       this.streamFlushTimers.delete(laneId);
       this.flushPendingStreamWrites(laneId);
-    }, CodingRoomRepository.STREAM_FLUSH_THROTTLE_MS);
+    }, delay);
     this.streamFlushTimers.set(laneId, timer);
   }
 
   /** Writes coalesced stream payloads to SQLite; defaults to every lane. */
   flushPendingStreamWrites(laneId?: string): void {
+    const hasPendingFor = (id: string): boolean => {
+      for (const entry of this.pendingStreamWrites.values()) {
+        if (entry.laneId === id) return true;
+      }
+      return false;
+    };
     for (const [key, entry] of this.pendingStreamWrites) {
       if (laneId !== undefined && entry.laneId !== laneId) continue;
       try {
@@ -673,16 +682,37 @@ export class CodingRoomRepository {
           .prepare('UPDATE coding_events SET payload_json = ? WHERE id = ?')
           .run(JSON.stringify(entry.payload), entry.id);
       } catch (error) {
-        // The flush timer can fire after the database was closed (test
-        // teardown); the buffered write is best-effort.
-        console.debug('[CodingRoom] Skipped flushing a stream write:', error);
+        if (!this.db.open) {
+          // The database is closed for good (shutdown, test teardown); the
+          // buffered write can never be persisted again.
+          console.debug('[CodingRoom] Dropped a stream write for a closed database:', error);
+          this.pendingStreamWrites.delete(key);
+          continue;
+        }
+        // Transient failure (busy, lock contention): retain the buffer so no
+        // streamed content is lost, and retry with backoff.
+        console.warn('[CodingRoom] Deferred flushing a stream write:', error);
+        const backoff = Math.min(
+          (this.streamFlushBackoffMs.get(entry.laneId) ?? CodingRoomRepository.STREAM_FLUSH_THROTTLE_MS) *
+            2,
+          CodingRoomRepository.STREAM_FLUSH_MAX_BACKOFF_MS,
+        );
+        this.streamFlushBackoffMs.set(entry.laneId, backoff);
+        this.scheduleStreamFlush(entry.laneId, backoff);
+        continue;
       }
       this.pendingStreamWrites.delete(key);
+      this.streamFlushBackoffMs.delete(entry.laneId);
     }
+    // Keep a lane's retry timer alive while it still has buffered writes.
     if (laneId === undefined) {
-      for (const timer of this.streamFlushTimers.values()) clearTimeout(timer);
-      this.streamFlushTimers.clear();
-    } else {
+      for (const [id, timer] of this.streamFlushTimers) {
+        if (!hasPendingFor(id)) {
+          clearTimeout(timer);
+          this.streamFlushTimers.delete(id);
+        }
+      }
+    } else if (!hasPendingFor(laneId)) {
       const timer = this.streamFlushTimers.get(laneId);
       if (timer) {
         clearTimeout(timer);
@@ -698,6 +728,7 @@ export class CodingRoomRepository {
       if (dropped.has(entry.laneId)) this.pendingStreamWrites.delete(key);
     }
     for (const laneId of laneIds) {
+      this.streamFlushBackoffMs.delete(laneId);
       const timer = this.streamFlushTimers.get(laneId);
       if (timer) {
         clearTimeout(timer);

--- a/src/main/codingAgent/codingRoomRepository.ts
+++ b/src/main/codingAgent/codingRoomRepository.ts
@@ -82,7 +82,42 @@ const rowWorkspaceSource = (row: Record<string, unknown>): CodingWorkspaceSource
   isPrimary: Boolean(row.is_primary),
 });
 
+/**
+ * A stream chunk whose DB row exists but whose payload is newer in memory.
+ * Writes are coalesced so the per-chunk hot path never touches SQLite.
+ */
+interface PendingStreamWrite {
+  laneId: string;
+  id: string;
+  sequence: number;
+  kind: CodingEvent['kind'];
+  createdAt: number;
+  payload: Record<string, unknown>;
+}
+
+const mergeStreamPayload = (
+  kind: CodingEvent['kind'],
+  previousPayload: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (kind === CodingEventKind.ToolCall) {
+    return { ...previousPayload, ...payload };
+  }
+  const content =
+    payload.streamUpdateMode === CodingStreamUpdateMode.Replace
+      ? payload.content
+      : `${typeof previousPayload.content === 'string' ? previousPayload.content : ''}${
+          typeof payload.content === 'string' ? payload.content : ''
+        }`;
+  return { ...previousPayload, ...payload, content };
+};
+
 export class CodingRoomRepository {
+  /** Stream events whose accumulated payload is newer in memory than in SQLite. */
+  private readonly pendingStreamWrites = new Map<string, PendingStreamWrite>();
+  private readonly streamFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly STREAM_FLUSH_THROTTLE_MS = 500;
+
   constructor(private readonly db: Database.Database) {}
   listRooms(): CodingRoom[] {
     return (
@@ -210,6 +245,7 @@ export class CodingRoomRepository {
   deleteWorkspace(roomId: string): void {
     const missionIds = this.listMissions(roomId).map(mission => mission.id);
     const laneIds = this.listLanes(missionIds).map(lane => lane.id);
+    this.dropPendingStreamWrites(laneIds);
     const remove = this.db.transaction(() => {
       if (laneIds.length) {
         const laneMarks = laneIds.map(() => '?').join(',');
@@ -294,7 +330,7 @@ export class CodingRoomRepository {
   listEvents(laneIds: string[]): CodingEvent[] {
     if (!laneIds.length) return [];
     const marks = laneIds.map(() => '?').join(',');
-    return (
+    const events = (
       this.db
         .prepare(
           `SELECT * FROM coding_events WHERE lane_id IN (${marks}) ORDER BY lane_id, sequence`,
@@ -308,6 +344,27 @@ export class CodingRoomRepository {
       payload: JSON.parse(String(row.payload_json)) as Record<string, unknown>,
       createdAt: Number(row.created_at),
     }));
+    // Overlay coalesced streams so readers observe the newest in-memory
+    // payload even before the throttled flush has run.
+    for (const entry of this.pendingStreamWrites.values()) {
+      if (!laneIds.includes(entry.laneId)) continue;
+      const index = events.findIndex(event => event.id === entry.id);
+      const projected: CodingEvent = {
+        id: entry.id,
+        laneId: entry.laneId,
+        sequence: entry.sequence,
+        kind: entry.kind,
+        payload: entry.payload,
+        createdAt: entry.createdAt,
+      };
+      if (index >= 0) events[index] = projected;
+      else events.push(projected);
+    }
+    return events.sort((left, right) =>
+      left.laneId === right.laneId
+        ? left.sequence - right.sequence
+        : left.laneId.localeCompare(right.laneId),
+    );
   }
   createMission(roomId: string, title: string, gitBaseline: string | null = null): CodingMission {
     const now = Date.now();
@@ -337,6 +394,7 @@ export class CodingRoomRepository {
   }
   deleteMission(roomId: string, missionId: string): void {
     const laneIds = this.listLanes([missionId]).map(lane => lane.id);
+    this.dropPendingStreamWrites(laneIds);
     const remove = this.db.transaction(() => {
       if (laneIds.length) {
         const marks = laneIds.map(() => '?').join(',');
@@ -357,6 +415,7 @@ export class CodingRoomRepository {
     remove();
   }
   deleteLane(roomId: string, laneId: string): void {
+    this.dropPendingStreamWrites([laneId]);
     const remove = this.db.transaction(() => {
       this.db.prepare('DELETE FROM coding_events WHERE lane_id = ?').run(laneId);
       this.db.prepare('DELETE FROM coding_assignments WHERE lane_id = ?').run(laneId);
@@ -540,44 +599,111 @@ export class CodingRoomRepository {
     if (!streamId || (kind !== CodingEventKind.MessageDelta && kind !== CodingEventKind.ToolCall)) {
       return this.appendEvent(laneId, kind, payload);
     }
+    const key = `${laneId}:${kind}:${streamId}`;
+    const pending = this.pendingStreamWrites.get(key);
+    if (pending) {
+      // Hot path: accumulate in memory only; SQLite is updated by the
+      // throttled flush, so per-chunk cost does not grow with the message.
+      pending.payload = mergeStreamPayload(kind, pending.payload, payload);
+      this.scheduleStreamFlush(laneId);
+      return {
+        id: pending.id,
+        laneId,
+        sequence: pending.sequence,
+        kind,
+        payload: pending.payload,
+        createdAt: pending.createdAt,
+      };
+    }
     const payloadIdPath = kind === CodingEventKind.MessageDelta ? '$.messageId' : '$.toolCallId';
     const previous = this.db
       .prepare(
         `SELECT * FROM coding_events WHERE lane_id = ? AND kind = ? AND json_extract(payload_json, '${payloadIdPath}') = ? ORDER BY sequence DESC LIMIT 1`,
       )
       .get(laneId, kind, streamId) as Record<string, unknown> | undefined;
-    if (!previous) return this.appendEvent(laneId, kind, payload);
-    const previousPayload = JSON.parse(String(previous.payload_json)) as Record<string, unknown>;
-    if (kind === CodingEventKind.ToolCall) {
-      const event = {
-        id: String(previous.id),
+    if (previous) {
+      // The stream row already exists (written before this process saw it);
+      // take it over and continue merging in memory.
+      const event: PendingStreamWrite = {
         laneId,
+        id: String(previous.id),
         sequence: Number(previous.sequence),
         kind,
-        payload: { ...previousPayload, ...payload },
         createdAt: Number(previous.created_at),
-      } satisfies CodingEvent;
-      this.db
-        .prepare('UPDATE coding_events SET payload_json = ? WHERE id = ?')
-        .run(JSON.stringify(event.payload), event.id);
-      return event;
+        payload: mergeStreamPayload(
+          kind,
+          JSON.parse(String(previous.payload_json)) as Record<string, unknown>,
+          payload,
+        ),
+      };
+      this.pendingStreamWrites.set(key, event);
+      this.scheduleStreamFlush(laneId);
+      return { ...event };
     }
-    const content =
-      payload.streamUpdateMode === CodingStreamUpdateMode.Replace
-        ? payload.content
-        : `${typeof previousPayload.content === 'string' ? previousPayload.content : ''}${typeof payload.content === 'string' ? payload.content : ''}`;
-    const event = {
-      id: String(previous.id),
+    // First chunk of a new stream: write through so the row and its sequence
+    // exist, then keep merging subsequent chunks in memory.
+    const event = this.appendEvent(laneId, kind, payload);
+    this.pendingStreamWrites.set(key, {
       laneId,
-      sequence: Number(previous.sequence),
+      id: event.id,
+      sequence: event.sequence,
       kind,
-      payload: { ...previousPayload, ...payload, content },
-      createdAt: Number(previous.created_at),
-    } satisfies CodingEvent;
-    this.db
-      .prepare('UPDATE coding_events SET payload_json = ? WHERE id = ?')
-      .run(JSON.stringify(event.payload), event.id);
+      createdAt: event.createdAt,
+      payload: event.payload,
+    });
+    this.scheduleStreamFlush(laneId);
     return event;
+  }
+
+  private scheduleStreamFlush(laneId: string): void {
+    if (this.streamFlushTimers.has(laneId)) return;
+    const timer = setTimeout(() => {
+      this.streamFlushTimers.delete(laneId);
+      this.flushPendingStreamWrites(laneId);
+    }, CodingRoomRepository.STREAM_FLUSH_THROTTLE_MS);
+    this.streamFlushTimers.set(laneId, timer);
+  }
+
+  /** Writes coalesced stream payloads to SQLite; defaults to every lane. */
+  flushPendingStreamWrites(laneId?: string): void {
+    for (const [key, entry] of this.pendingStreamWrites) {
+      if (laneId !== undefined && entry.laneId !== laneId) continue;
+      try {
+        this.db
+          .prepare('UPDATE coding_events SET payload_json = ? WHERE id = ?')
+          .run(JSON.stringify(entry.payload), entry.id);
+      } catch (error) {
+        // The flush timer can fire after the database was closed (test
+        // teardown); the buffered write is best-effort.
+        console.debug('[CodingRoom] Skipped flushing a stream write:', error);
+      }
+      this.pendingStreamWrites.delete(key);
+    }
+    if (laneId === undefined) {
+      for (const timer of this.streamFlushTimers.values()) clearTimeout(timer);
+      this.streamFlushTimers.clear();
+    } else {
+      const timer = this.streamFlushTimers.get(laneId);
+      if (timer) {
+        clearTimeout(timer);
+        this.streamFlushTimers.delete(laneId);
+      }
+    }
+  }
+
+  private dropPendingStreamWrites(laneIds: string[]): void {
+    if (!laneIds.length) return;
+    const dropped = new Set(laneIds);
+    for (const [key, entry] of this.pendingStreamWrites) {
+      if (dropped.has(entry.laneId)) this.pendingStreamWrites.delete(key);
+    }
+    for (const laneId of laneIds) {
+      const timer = this.streamFlushTimers.get(laneId);
+      if (timer) {
+        clearTimeout(timer);
+        this.streamFlushTimers.delete(laneId);
+      }
+    }
   }
   updateLaneStatus(laneId: string, status: CodingLaneStatus): void {
     this.db

--- a/src/main/codingAgent/codingRoomService.ts
+++ b/src/main/codingAgent/codingRoomService.ts
@@ -1434,6 +1434,7 @@ export class CodingRoomService extends EventEmitter {
 
   async dispose(): Promise<void> {
     this.isDisposed = true;
+    this.repository.flushPendingStreamWrites();
     await Promise.all([...this.drivers.values()].map(driver => driver.dispose()));
     this.drivers.clear();
     this.driverProfileIds.clear();


### PR DESCRIPTION
## 背景

#730 降低了流式事件的**广播**频率，但 `appendOrMergeStreamEvent` 本身仍是同步 O(N) 热点：每个 chunk 执行一次 `json_extract` 扫描、JSON.parse 累积内容、再把完整内容重新 stringify 后 `UPDATE`。单条消息的流式成本是 O(长度²)，会话越长、消息越长主进程越卡，未完全满足 AGENTS.md 的 agent-stream 热路径约束。

## 改动

**写路径（核心）**：流式累积内容提到内存。

- 流的第一个 chunk 照旧 write-through（行与 sequence 立即存在，避免并发 sequence 分配问题）；
- 后续 chunk 只做内存合并（`mergeStreamPayload` 纯函数，与原 SQL 逻辑一致：ToolCall 增量覆盖、MessageDelta append/replace），**chunk 路径零 SQL 写、零 JSON 重解析**；
- 每个 lane 一个 500ms 节流定时器把缓冲 payload 批量 `UPDATE` 落盘。

**读路径**：`listEvents` 用内存缓冲覆盖（overlay）对应行的 payload，快照重建、`eventsToAnswer`、permission 查找等所有读取方无需等待落盘即可看到最新内容，事件 id/sequence 不变、顺序不变。

**生命周期**：

- 删除 lane/mission/workspace 时丢弃对应缓冲（`dropPendingStreamWrites`），不会向已删除行写回；
- `CodingRoomService.dispose()` 先 flush；
- flush 为 best-effort：DB 已关闭（如测试 teardown 后定时器迟到触发）时 debug 日志并跳过，与 #730 的 disposed 防护同范式。

**进程重启**：若流行已存在但本进程没有内存缓存（如 ACP 重连续流），沿用原 `json_extract` 查找接管该行并继续内存合并，不产生重复行。

## 测试

新增 3 个 repository 测试：

- `coalesces stream chunks in memory and flushes them to SQLite`：合并读可见、单行；flush 前 DB 行仍是旧内容、flush 后为新内容；
- `takes over an existing stream row without duplicating it after a restart`：flush 后继续追加同一 messageId，仍是单行且内容完整；
- `deleting a lane drops its buffered stream writes`：删 lane 后 flush 不回写。

既有 4 个流式合并测试全部保持通过。`npx vitest run src/main/codingAgent` 111/111 通过；`npm run lint` 通过。

## 行为影响

崩溃时最多丢失最近 500ms 的流式尾部（与进程被杀时驱动内存态丢失同级）；正常运行下读取方总是看到最新内容。
