### PR TITLE
fix(coding): bootstrap 双侧兜底 reject，加载态不再永久卡死

### DIFF
--- a/src/main/ipcHandlers/codingAgent.ts
+++ b/src/main/ipcHandlers/codingAgent.ts
@@ -116,10 +116,13 @@ export function registerCodingAgentIpcHandlers(getService: () => CodingRoomServi
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
-  ipcMain.handle(CodingAgentIpc.Bootstrap, (_event, workspaceRoot: string) => ({
-    success: true,
-    snapshot: service.bootstrap(workspaceRoot),
-  }));
+  ipcMain.handle(CodingAgentIpc.Bootstrap, (_event, workspaceRoot: string) => {
+    try {
+      return { success: true, snapshot: service.bootstrap(workspaceRoot) };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
   ipcMain.handle(
     CodingAgentIpc.PrepareLane,
     async (_event, input: { workspaceRoot: string; laneId: string }) => {

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -158,16 +158,25 @@ export const CodingWorkbenchView = ({
       return;
     }
     let cancelled = false;
-    void window.electron.codingAgent.bootstrap(workspaceRoot).then(result => {
-      if (cancelled) return;
-      if (result.success && result.snapshot) {
-        setSnapshot(result.snapshot);
-        return;
-      }
+    const reportFailure = (message: string | undefined): void => {
       // Without a snapshot the workbench would be stuck on its loading
       // screen forever, so surface the failure with a retry.
-      setBootstrapError(result.error ?? i18nService.t('codingAgentActionFailed'));
-    });
+      setBootstrapError(message ?? i18nService.t('codingAgentActionFailed'));
+    };
+    void window.electron.codingAgent
+      .bootstrap(workspaceRoot)
+      .then(result => {
+        if (cancelled) return;
+        if (result.success && result.snapshot) {
+          setSnapshot(result.snapshot);
+          return;
+        }
+        reportFailure(result.error);
+      })
+      .catch(error => {
+        if (cancelled) return;
+        reportFailure(error instanceof Error ? error.message : undefined);
+      });
     const unsubscribe = window.electron.codingAgent.onChanged(next => {
       if (next.room.workspaceRoot === workspaceRoot) setSnapshot(next);
     });


### PR DESCRIPTION
## 背景

#731 只处理了 bootstrap 返回 `{ success: false }` 的情况，且主进程侧 `CodingAgentIpc.Bootstrap` 是 coding-agent 全部 handler 中**唯一没有 try/catch 的**（`ipcHandlers/codingAgent.ts:119`）。`service.bootstrap` 同步抛出时（数据库损坏等）`ipcRenderer.invoke` 的 promise 直接 reject，renderer 的 `.then()` 不执行、也没有 `.catch()`，`bootstrapError` 不会被设置，workbench 仍永久停在加载态。

## 改动

1. **主进程**：Bootstrap handler 包上 try/catch，与其他 handler 一致地返回 `{ success: false, error }`。
2. **渲染层**：bootstrap 调用链补 `.catch()`，把异常消息写入同一个 `bootstrapError` 状态（复用 #731 引入的错误+重试界面）。

## 验证

`npx vitest run src/renderer/components/coding` 49/49 通过；`npm run lint` 通过。失败路径（同步抛出/序列化异常）现在两种来源都会进入错误+重试状态。
