### PR TITLE
fix(coding): Git 面板切换会话时重置 diff 状态并废弃在途请求

### DIFF
--- a/src/renderer/components/coding/CodingGitPanel.tsx
+++ b/src/renderer/components/coding/CodingGitPanel.tsx
@@ -166,6 +166,18 @@ export const CodingGitPanel = ({ workspaceRoot, laneId, sourceRoot, refreshKey, 
   const requestSequence = useRef(0);
   const diffRequestSequence = useRef(0);
   const target = useMemo<CodingGitTargetInput>(() => ({ workspaceRoot, laneId: laneId ?? undefined, sourceRoot }), [laneId, sourceRoot, workspaceRoot]);
+  // Switching lane or source must invalidate in-flight diff responses (the
+  // sequence guard only orders concurrent selectDiff calls) and clear the
+  // previous lane's selection and diff content.
+  useEffect(() => {
+    diffRequestSequence.current += 1;
+    requestSequence.current += 1;
+    setStatus(null);
+    setDiffSelection(null);
+    setDiff('');
+    setDiffLoading(false);
+    setError(null);
+  }, [target]);
   const refresh = useCallback(async () => {
     const request = ++requestSequence.current;
     setLoading(true);


### PR DESCRIPTION
## 背景

#732 给 `selectDiff` 加的请求序号只在 `selectDiff` 内部递增，只保证「并发 selectDiff 之间」的乱序防护。`CodingGitPanel` 在切换 lane / sourceRoot 时是**同实例换 props**：`target` 变化不会递增序号，旧会话的在途 diff 响应仍可写进新会话；同时 `diffSelection` 跨 target 残留，压制新会话首文件的自动选中并显示旧 diff。

## 改动

新增 `useEffect([target])`，target 变化时：

- 递增 `diffRequestSequence` 与 `requestSequence`，使旧 target 的在途 `getGitDiff` / `getGitStatus` 响应一律丢弃；
- 清空 `diffSelection`、`diff`、`diffLoading`、`error`、`status`。

`status` 一并清空的原因：自动选中首文件的 effect 以 `status` 为依赖，若保留旧 status 会在新 status 返回前用旧文件列表自动选中；清空后 `loading && !status` 呈现加载态，新 status 到达后再自动选中新会话的首个文件。

## 验证

`npx vitest run src/renderer/components/coding` 49/49 通过；`npm run lint` 通过。
