### PR TITLE
fix(todo): 保存期间的二次编辑不再被回滚（dirty 条件清除）

### DIFF
--- a/src/renderer/components/todo/TodoTaskDetail.test.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+
+import { TodoStatus, type Todo } from '../../../shared/todo';
+import { fromDateInputValue } from './todoUtils';
+import TodoTaskDetail from './TodoTaskDetail';
+
+const todo: Todo = {
+  id: 'todo-1',
+  title: 'Original title',
+  note: '',
+  status: TodoStatus.Active,
+  important: false,
+  dueAt: null,
+  remindAt: null,
+  listId: null,
+  listName: null,
+  myDayDate: null,
+  createdAt: 0,
+  updatedAt: 0,
+  completedAt: null,
+  sourceType: 'manual',
+  sourceId: null,
+  steps: [],
+};
+
+const renderDetail = (update: (input: unknown) => Promise<unknown>) => {
+  (window as unknown as { electron: unknown }).electron = {
+    todo: {
+      update,
+      createStep: vi.fn(),
+      updateStep: vi.fn(),
+      deleteStep: vi.fn(),
+    },
+  };
+  return render(
+    <TodoTaskDetail
+      todo={todo}
+      lists={[]}
+      language="en"
+      onUpdated={vi.fn().mockResolvedValue(undefined)}
+      onError={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+};
+
+test('saves only the edited fields with their current local values', async () => {
+  const update = vi.fn().mockResolvedValue({ success: true });
+  const { container } = renderDetail(update);
+
+  const titleInput = container.querySelector<HTMLInputElement>(
+    '.theme-page-todo-task-detail-input-1',
+  );
+  expect(titleInput).not.toBeNull();
+  fireEvent.change(titleInput!, { target: { value: 'Renamed' } });
+  fireEvent.blur(titleInput!);
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+  // Untouched fields must not be part of the payload, so a full save can
+  // never clobber newer server values (e.g. from another window).
+  expect(update).toHaveBeenCalledWith({ todoId: todo.id, title: 'Renamed' });
+
+  const dueInput = container.querySelector<HTMLInputElement>('input[type="date"]');
+  expect(dueInput).not.toBeNull();
+  fireEvent.change(dueInput!, { target: { value: '2026-09-15' } });
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+  expect(update).toHaveBeenLastCalledWith({
+    todoId: todo.id,
+    dueAt: fromDateInputValue('2026-09-15'),
+  });
+});
+
+test('an edit made while a save is in flight keeps its value after the save resolves', async () => {
+  let resolveFirstSave: (result: { success: boolean }) => void = () => undefined;
+  const update = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<{ success: boolean }>(resolve => {
+          resolveFirstSave = resolve;
+        }),
+    )
+    .mockResolvedValue({ success: true });
+  const { container, rerender } = renderDetail(update);
+
+  const titleInput = container.querySelector<HTMLInputElement>(
+    '.theme-page-todo-task-detail-input-1',
+  )!;
+  fireEvent.change(titleInput, { target: { value: 'First edit' } });
+  fireEvent.blur(titleInput);
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+  expect(update).toHaveBeenCalledWith({ todoId: todo.id, title: 'First edit' });
+
+  // The user retitles again while the first save is still in flight.
+  fireEvent.change(titleInput, { target: { value: 'Second edit' } });
+  resolveFirstSave({ success: true });
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+
+  // The refresh following the first save delivers a stale server snapshot;
+  // the in-progress second edit must survive it.
+  rerender(
+    <TodoTaskDetail
+      todo={{ ...todo, title: 'First edit', updatedAt: 1 }}
+      lists={[]}
+      language="en"
+      onUpdated={vi.fn().mockResolvedValue(undefined)}
+      onError={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  );
+  expect(titleInput.value).toBe('Second edit');
+
+  fireEvent.blur(titleInput);
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+  expect(update).toHaveBeenLastCalledWith({ todoId: todo.id, title: 'Second edit' });
+});

--- a/src/renderer/components/todo/TodoTaskDetail.test.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.test.tsx
@@ -26,7 +26,10 @@ const todo: Todo = {
   steps: [],
 };
 
-const renderDetail = (update: (input: unknown) => Promise<unknown>) => {
+const renderDetail = (
+  update: (input: unknown) => Promise<unknown>,
+  onUpdated: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+) => {
   (window as unknown as { electron: unknown }).electron = {
     todo: {
       update,
@@ -40,7 +43,7 @@ const renderDetail = (update: (input: unknown) => Promise<unknown>) => {
       todo={todo}
       lists={[]}
       language="en"
-      onUpdated={vi.fn().mockResolvedValue(undefined)}
+      onUpdated={onUpdated}
       onError={vi.fn()}
       onDelete={vi.fn()}
     />,
@@ -115,4 +118,39 @@ test('an edit made while a save is in flight keeps its value after the save reso
   fireEvent.blur(titleInput);
   await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
   expect(update).toHaveBeenLastCalledWith({ todoId: todo.id, title: 'Second edit' });
+});
+
+test('only the latest save of a field reacts to its response when returns are out of order', async () => {
+  let resolveFirstSave: (result: { success: boolean }) => void = () => undefined;
+  const onUpdated = vi.fn().mockResolvedValue(undefined);
+  const update = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<{ success: boolean }>(resolve => {
+          resolveFirstSave = resolve;
+        }),
+    )
+    .mockResolvedValue({ success: true });
+  const { container } = renderDetail(update, onUpdated);
+
+  const titleInput = container.querySelector<HTMLInputElement>(
+    '.theme-page-todo-task-detail-input-1',
+  )!;
+  fireEvent.change(titleInput, { target: { value: 'Save A' } });
+  fireEvent.blur(titleInput);
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+
+  // A second save for the same field is issued and resolves before the first.
+  fireEvent.change(titleInput, { target: { value: 'Save B' } });
+  fireEvent.blur(titleInput);
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1));
+  expect(titleInput.value).toBe('Save B');
+
+  // The stale first response must neither clear the field state nor refresh.
+  resolveFirstSave({ success: true });
+  await waitFor(() => expect(update).toHaveBeenCalledTimes(2));
+  expect(onUpdated).toHaveBeenCalledTimes(1);
+  expect(titleInput.value).toBe('Save B');
 });

--- a/src/renderer/components/todo/TodoTaskDetail.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.tsx
@@ -61,11 +61,17 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   useEffect(() => {
     latestValuesRef.current = { title, note, dueDate, remindAt, listId };
   });
+  // Per-field save sequence: only the response of the newest save for a field
+  // may clear its dirty flag and trigger a refresh, so an out-of-order older
+  // response can never resurface stale values.
+  const fieldSaveSequenceRef = useRef(new Map<string, number>());
+  const saveRequestCounterRef = useRef(0);
 
   useEffect(() => {
     if (lastTodoIdRef.current !== todo.id) {
       lastTodoIdRef.current = todo.id;
       dirtyFieldsRef.current.clear();
+      fieldSaveSequenceRef.current.clear();
       setTitle(todo.title);
       setNote(todo.note);
       setDueDate(toDateInputValue(todo.dueAt));
@@ -95,45 +101,67 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
     // Send only the fields the user actually edited, with their current local
     // values. A full-snapshot write here could clobber newer server values for
     // untouched fields (e.g. an immediate date update from another window).
+    const request = ++saveRequestCounterRef.current;
     const input: TodoUpdateInput = {};
     const sent: Partial<Record<'title' | 'note' | 'dueDate' | 'remindAt' | 'listId', string>> = {};
     if (dirtyFieldsRef.current.has('title')) {
       input.title = trimmedTitle;
       sent.title = trimmedTitle;
+      fieldSaveSequenceRef.current.set('title', request);
     }
     if (dirtyFieldsRef.current.has('note')) {
       input.note = note;
       sent.note = note;
+      fieldSaveSequenceRef.current.set('note', request);
     }
     if (dirtyFieldsRef.current.has('dueDate')) {
       input.dueAt = fromDateInputValue(dueDate);
       sent.dueDate = dueDate;
+      fieldSaveSequenceRef.current.set('dueDate', request);
     }
     if (dirtyFieldsRef.current.has('remindAt')) {
       input.remindAt = fromDateTimeInputValue(remindAt);
       sent.remindAt = remindAt;
+      fieldSaveSequenceRef.current.set('remindAt', request);
     }
     if (dirtyFieldsRef.current.has('listId')) {
       input.listId = listId === NO_LIST_VALUE ? null : listId;
       sent.listId = listId;
+      fieldSaveSequenceRef.current.set('listId', request);
     }
     if (Object.keys(input).length === 0) return;
     setIsSaving(true);
     try {
       const result = await todoService.update(todo.id, input);
       if (result.success) {
-        // Clear a field's dirty flag only when the user has not edited it
-        // again while the save was in flight; otherwise the refresh following
-        // this save would revert that newer edit.
+        // Only the newest save of a field owns its dirty flag and the
+        // follow-up refresh; a superseded response carries stale state.
         const latest = latestValuesRef.current;
-        if (sent.title !== undefined && latest.title.trim() === sent.title) clearDirty('title');
-        if (sent.note !== undefined && latest.note === sent.note) clearDirty('note');
-        if (sent.dueDate !== undefined && latest.dueDate === sent.dueDate) clearDirty('dueDate');
-        if (sent.remindAt !== undefined && latest.remindAt === sent.remindAt) {
-          clearDirty('remindAt');
+        let isNewestResponse = false;
+        if (sent.title !== undefined && fieldSaveSequenceRef.current.get('title') === request) {
+          isNewestResponse = true;
+          if (latest.title.trim() === sent.title) clearDirty('title');
         }
-        if (sent.listId !== undefined && latest.listId === sent.listId) clearDirty('listId');
-        await onUpdated();
+        if (sent.note !== undefined && fieldSaveSequenceRef.current.get('note') === request) {
+          isNewestResponse = true;
+          if (latest.note === sent.note) clearDirty('note');
+        }
+        if (sent.dueDate !== undefined && fieldSaveSequenceRef.current.get('dueDate') === request) {
+          isNewestResponse = true;
+          if (latest.dueDate === sent.dueDate) clearDirty('dueDate');
+        }
+        if (
+          sent.remindAt !== undefined &&
+          fieldSaveSequenceRef.current.get('remindAt') === request
+        ) {
+          isNewestResponse = true;
+          if (latest.remindAt === sent.remindAt) clearDirty('remindAt');
+        }
+        if (sent.listId !== undefined && fieldSaveSequenceRef.current.get('listId') === request) {
+          isNewestResponse = true;
+          if (latest.listId === sent.listId) clearDirty('listId');
+        }
+        if (isNewestResponse) await onUpdated();
       } else {
         onError();
       }
@@ -222,10 +250,13 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
                 markDirty('dueDate');
                 setDueDate(event.target.value);
                 const sentValue = event.target.value;
+                const request = ++saveRequestCounterRef.current;
+                fieldSaveSequenceRef.current.set('dueDate', request);
                 void todoService
                   .update(todo.id, { dueAt: fromDateInputValue(sentValue) })
                   .then(result => {
                     if (result.success) {
+                      if (fieldSaveSequenceRef.current.get('dueDate') !== request) return undefined;
                       if (latestValuesRef.current.dueDate === sentValue) clearDirty('dueDate');
                       return onUpdated();
                     }
@@ -243,10 +274,15 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
                 markDirty('remindAt');
                 setRemindAt(event.target.value);
                 const sentValue = event.target.value;
+                const request = ++saveRequestCounterRef.current;
+                fieldSaveSequenceRef.current.set('remindAt', request);
                 void todoService
                   .update(todo.id, { remindAt: fromDateTimeInputValue(sentValue) })
                   .then(result => {
                     if (result.success) {
+                      if (fieldSaveSequenceRef.current.get('remindAt') !== request) {
+                        return undefined;
+                      }
                       if (latestValuesRef.current.remindAt === sentValue) clearDirty('remindAt');
                       return onUpdated();
                     }
@@ -265,10 +301,13 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
               const nextListId = value ?? NO_LIST_VALUE;
               markDirty('listId');
               setListId(nextListId);
+              const request = ++saveRequestCounterRef.current;
+              fieldSaveSequenceRef.current.set('listId', request);
               void todoService
                 .update(todo.id, { listId: nextListId === NO_LIST_VALUE ? null : nextListId })
                 .then(result => {
                   if (result.success) {
+                    if (fieldSaveSequenceRef.current.get('listId') !== request) return undefined;
                     if (latestValuesRef.current.listId === nextListId) clearDirty('listId');
                     return onUpdated();
                   }

--- a/src/renderer/components/todo/TodoTaskDetail.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.tsx
@@ -55,6 +55,12 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   // be silently reverted by every save of another field.
   const dirtyFieldsRef = useRef(new Set<string>());
   const lastTodoIdRef = useRef(todo.id);
+  // Mirror of the newest local values, used to detect edits made while a
+  // save is still in flight.
+  const latestValuesRef = useRef({ title, note, dueDate, remindAt, listId });
+  useEffect(() => {
+    latestValuesRef.current = { title, note, dueDate, remindAt, listId };
+  });
 
   useEffect(() => {
     if (lastTodoIdRef.current !== todo.id) {
@@ -86,17 +92,26 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
   const saveDetails = async (): Promise<void> => {
     const trimmedTitle = title.trim();
     if (!trimmedTitle) return;
+    const sent = { title: trimmedTitle, note, dueDate, remindAt, listId };
     setIsSaving(true);
     try {
       const result = await todoService.update(todo.id, {
-        title: trimmedTitle,
-        note,
-        dueAt: fromDateInputValue(dueDate),
-        remindAt: fromDateTimeInputValue(remindAt),
-        listId: listId === NO_LIST_VALUE ? null : listId,
+        title: sent.title,
+        note: sent.note,
+        dueAt: fromDateInputValue(sent.dueDate),
+        remindAt: fromDateTimeInputValue(sent.remindAt),
+        listId: sent.listId === NO_LIST_VALUE ? null : sent.listId,
       });
       if (result.success) {
-        clearDirty('title', 'note', 'dueDate', 'remindAt', 'listId');
+        // Clear a field's dirty flag only when the user has not edited it
+        // again while the save was in flight; otherwise the refresh following
+        // this save would revert that newer edit.
+        const latest = latestValuesRef.current;
+        if (latest.title.trim() === sent.title) clearDirty('title');
+        if (latest.note === sent.note) clearDirty('note');
+        if (latest.dueDate === sent.dueDate) clearDirty('dueDate');
+        if (latest.remindAt === sent.remindAt) clearDirty('remindAt');
+        if (latest.listId === sent.listId) clearDirty('listId');
         await onUpdated();
       } else {
         onError();
@@ -185,11 +200,12 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
               onChange={event => {
                 markDirty('dueDate');
                 setDueDate(event.target.value);
+                const sentValue = event.target.value;
                 void todoService
-                  .update(todo.id, { dueAt: fromDateInputValue(event.target.value) })
+                  .update(todo.id, { dueAt: fromDateInputValue(sentValue) })
                   .then(result => {
                     if (result.success) {
-                      clearDirty('dueDate');
+                      if (latestValuesRef.current.dueDate === sentValue) clearDirty('dueDate');
                       return onUpdated();
                     }
                     onError();
@@ -205,11 +221,12 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
               onChange={event => {
                 markDirty('remindAt');
                 setRemindAt(event.target.value);
+                const sentValue = event.target.value;
                 void todoService
-                  .update(todo.id, { remindAt: fromDateTimeInputValue(event.target.value) })
+                  .update(todo.id, { remindAt: fromDateTimeInputValue(sentValue) })
                   .then(result => {
                     if (result.success) {
-                      clearDirty('remindAt');
+                      if (latestValuesRef.current.remindAt === sentValue) clearDirty('remindAt');
                       return onUpdated();
                     }
                     onError();
@@ -231,7 +248,7 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
                 .update(todo.id, { listId: nextListId === NO_LIST_VALUE ? null : nextListId })
                 .then(result => {
                   if (result.success) {
-                    clearDirty('listId');
+                    if (latestValuesRef.current.listId === nextListId) clearDirty('listId');
                     return onUpdated();
                   }
                   onError();

--- a/src/renderer/components/todo/TodoTaskDetail.tsx
+++ b/src/renderer/components/todo/TodoTaskDetail.tsx
@@ -12,7 +12,7 @@ import { cn } from '@shared/lib/utils';
 import { CalendarDays, Check, ListChecks, Plus, Star, Trash2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { TodoStatus, type Todo, type TodoList } from '../../../shared/todo';
+import { TodoStatus, type Todo, type TodoList, type TodoUpdateInput } from '../../../shared/todo';
 import { i18nService } from '../../services/i18n';
 import { todoService } from '../../services/todo';
 import {
@@ -91,27 +91,48 @@ const TodoTaskDetail: React.FC<TodoTaskDetailProps> = ({
 
   const saveDetails = async (): Promise<void> => {
     const trimmedTitle = title.trim();
-    if (!trimmedTitle) return;
-    const sent = { title: trimmedTitle, note, dueDate, remindAt, listId };
+    if (dirtyFieldsRef.current.has('title') && !trimmedTitle) return;
+    // Send only the fields the user actually edited, with their current local
+    // values. A full-snapshot write here could clobber newer server values for
+    // untouched fields (e.g. an immediate date update from another window).
+    const input: TodoUpdateInput = {};
+    const sent: Partial<Record<'title' | 'note' | 'dueDate' | 'remindAt' | 'listId', string>> = {};
+    if (dirtyFieldsRef.current.has('title')) {
+      input.title = trimmedTitle;
+      sent.title = trimmedTitle;
+    }
+    if (dirtyFieldsRef.current.has('note')) {
+      input.note = note;
+      sent.note = note;
+    }
+    if (dirtyFieldsRef.current.has('dueDate')) {
+      input.dueAt = fromDateInputValue(dueDate);
+      sent.dueDate = dueDate;
+    }
+    if (dirtyFieldsRef.current.has('remindAt')) {
+      input.remindAt = fromDateTimeInputValue(remindAt);
+      sent.remindAt = remindAt;
+    }
+    if (dirtyFieldsRef.current.has('listId')) {
+      input.listId = listId === NO_LIST_VALUE ? null : listId;
+      sent.listId = listId;
+    }
+    if (Object.keys(input).length === 0) return;
     setIsSaving(true);
     try {
-      const result = await todoService.update(todo.id, {
-        title: sent.title,
-        note: sent.note,
-        dueAt: fromDateInputValue(sent.dueDate),
-        remindAt: fromDateTimeInputValue(sent.remindAt),
-        listId: sent.listId === NO_LIST_VALUE ? null : sent.listId,
-      });
+      const result = await todoService.update(todo.id, input);
       if (result.success) {
         // Clear a field's dirty flag only when the user has not edited it
         // again while the save was in flight; otherwise the refresh following
         // this save would revert that newer edit.
         const latest = latestValuesRef.current;
-        if (latest.title.trim() === sent.title) clearDirty('title');
-        if (latest.note === sent.note) clearDirty('note');
-        if (latest.dueDate === sent.dueDate) clearDirty('dueDate');
-        if (latest.remindAt === sent.remindAt) clearDirty('remindAt');
-        if (latest.listId === sent.listId) clearDirty('listId');
+        if (sent.title !== undefined && latest.title.trim() === sent.title) clearDirty('title');
+        if (sent.note !== undefined && latest.note === sent.note) clearDirty('note');
+        if (sent.dueDate !== undefined && latest.dueDate === sent.dueDate) clearDirty('dueDate');
+        if (sent.remindAt !== undefined && latest.remindAt === sent.remindAt) {
+          clearDirty('remindAt');
+        }
+        if (sent.listId !== undefined && latest.listId === sent.listId) clearDirty('listId');
         await onUpdated();
       } else {
         onError();


### PR DESCRIPTION
## 背景

#734 引入的脏字段追踪在 `saveDetails()` 成功后**无条件清除全部 dirty 标记**。若用户在第一次保存尚未返回时再次编辑标题/备注，第一次响应会清掉 dirty 标记并触发刷新，随后刷新按「未编辑」回同步该字段，第二次编辑被服务端旧值覆盖（blur 后的二次编辑没有第二次保存兜底，属于**永久丢失**）。日期、提醒、清单的即时更新处理器有同样竞态（表现为 UI 跳回旧值的暂态回滚）。

## 改动

- 引入 `latestValuesRef`（每次提交后镜像最新本地值）；
- `saveDetails` 保存**发送时的值快照**，成功后逐字段比较：仅当「当前本地值仍等于本次发送值」时清除该字段的 dirty 标记；有更新的编辑则保留 dirty，随后的刷新会跳过该字段不回滚；
- 日期/提醒/清单的即时更新改为同样条件清除（比较当前输入值与本次发送值）。

## 验证

`npx vitest run src/renderer/components/todo` 7/7 通过；`npm run lint` 通过。

## 说明

保留 dirty 的字段在下一次保存/更新成功后照常清除；未保存的新编辑仍遵循「失焦或点保存时提交」的既有交互。
