### PR TITLE
fix(todo): Completed 视图下侧栏「新建任务」改为切换到全部视图再聚焦

### DIFF
--- a/src/renderer/components/todo/TodoView.tsx
+++ b/src/renderer/components/todo/TodoView.tsx
@@ -246,6 +246,12 @@ const TodoView: React.FC<TodoViewProps> = ({
 
   const focusNewTodoInput = (): void => {
     setIsMobileNavigationOpen(false);
+    if (activeView === TodoViewFilter.Completed) {
+      // The Completed view has no create-task input; route the request to All
+      // where the input exists instead of doing nothing.
+      setActiveView(TodoViewFilter.All);
+      setActiveListId(null);
+    }
     window.setTimeout(() => document.getElementById('todo-new-input')?.focus(), 0);
   };
 


### PR DESCRIPTION
## 背景

#735 隐藏了 Completed 视图底部的创建输入框，但侧栏的「新建任务」按钮仍始终渲染：它只调用 `getElementById('todo-new-input')?.focus()`，而该输入框在 Completed 视图不存在，点击无任何效果。

## 改动

`focusNewTodoInput` 在 Completed 视图下先把视图切换到「全部」（并清空清单选择），随后聚焦创建输入框——保住侧栏单一入口，行为可预期；其他视图行为不变。

## 验证

`npx vitest run src/renderer/components/todo` 7/7 通过；`npm run lint` 通过。
