### PR TITLE
fix(cowork): default sessions to production loop off and no auto expert

### DIFF
--- a/src/renderer/components/cowork/CoworkPromptInput.tsx
+++ b/src/renderer/components/cowork/CoworkPromptInput.tsx
@@ -15,7 +15,6 @@ import { ChevronDown, Folder, Target, TriangleAlert, X } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CoworkSessionExpertSource } from '../../../shared/cowork/sessionExperts';
 import { CoworkPermissionMode, CoworkSessionMode } from '../../../shared/cowork/constants';
 import {
   ProductionLoopMode,
@@ -284,17 +283,12 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
       [currentSession?.experts],
     );
     const [selectedExpertIds, setSelectedExpertIds] = useState<string[]>(() =>
-      persistedExpertIds.length > 0
-        ? persistedExpertIds
-        : currentAgent?.source === CoworkSessionExpertSource.Package ||
-            currentAgent?.source === CoworkSessionExpertSource.Member
-          ? [currentAgent.id]
-          : [],
+      persistedExpertIds,
     );
     const [value, setValue] = useState(draftPrompt);
     const [goalMode, setGoalMode] = useState(false);
     const [productionLoopMode, setProductionLoopMode] = useState<ProductionLoopModeValue>(
-      ProductionLoopMode.Auto,
+      ProductionLoopMode.Off,
     );
 
     // Keep a stable ref to the controller to avoid [controller] dep in the sync effect.
@@ -436,19 +430,10 @@ const CoworkPromptInputInner = React.forwardRef<CoworkPromptInputRef, CoworkProm
 
     // Load skills on mount
     useEffect(() => {
-      setSelectedExpertIds(
-        persistedExpertIds.length > 0
-          ? persistedExpertIds
-          : currentAgent?.source === CoworkSessionExpertSource.Package ||
-              currentAgent?.source === CoworkSessionExpertSource.Member
-            ? [currentAgent.id]
-            : [],
-      );
+      setSelectedExpertIds(persistedExpertIds);
     }, [
       currentSession?.id,
       currentAgentId,
-      currentAgent?.id,
-      currentAgent?.source,
       persistedExpertIds,
     ]);
 

--- a/src/renderer/components/cowork/CoworkView.tsx
+++ b/src/renderer/components/cowork/CoworkView.tsx
@@ -364,7 +364,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     fileAttachments?: CoworkFileAttachment[],
     expertIds: string[] = [],
     goalMode = false,
-    productionLoopMode: ProductionLoopModeValue = ProductionLoopMode.Auto,
+    productionLoopMode: ProductionLoopModeValue = ProductionLoopMode.Off,
   ): Promise<boolean | void> => {
     console.log('[CoworkView] handleStartSession: imageAttachments diagnosis', {
       hasImageAttachments: !!imageAttachments,
@@ -943,7 +943,7 @@ const CoworkView: React.FC<CoworkViewProps> = ({
     fileAttachments?: CoworkFileAttachment[],
     expertIds: string[] = [],
     goalMode = false,
-    productionLoopMode: ProductionLoopModeValue = ProductionLoopMode.Auto,
+    productionLoopMode: ProductionLoopModeValue = ProductionLoopMode.Off,
   ) => {
     if (!currentSession) return;
     if (taskResume.interruption) {


### PR DESCRIPTION
## Summary

Cherry-pick of xiaoruan-ai-agent PR #21 (commit c10867b7).

- Default new chat/work sessions to **production loop off** instead of auto — production loop is now opt-in via the composer.
- Stop auto-attaching the current package/member agent as the session expert when a session has no persisted experts.

Both features remain fully available, but plain sessions start as plain chats unless the user explicitly engages them.

## Test plan

- [ ] Start a new chat session and confirm the production loop toggle defaults to off.
- [ ] Run with a package/member agent active and confirm a new session does not pre-select it as an expert.
- [ ] Confirm resuming an interrupted session follows the same defaults.