### PR TITLE
fix(coding): 优化 ACP Agent 发现与安装包校验

### DIFF
--- a/.github/workflows/build-platforms.yml
+++ b/.github/workflows/build-platforms.yml
@@ -134,6 +134,8 @@ jobs:
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
           MODELSCOPE_TOKENS: ${{ secrets.MODELSCOPE_TOKENS }}
+      - name: Verify packaged ACP registry and bridges
+        run: node scripts/ci/verify-packaged-acp-resources.mjs
       - name: Verify Windows package runtimes with a clean PATH
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/.github/workflows/online-update-release.yml
+++ b/.github/workflows/online-update-release.yml
@@ -284,6 +284,9 @@ jobs:
       - name: Verify packaged app version
         shell: bash
         run: node scripts/ci/verify-packaged-app-version.mjs '${{ needs.prepare-release.outputs.version }}'
+      - name: Verify packaged ACP registry and bridges
+        shell: bash
+        run: node scripts/ci/verify-packaged-acp-resources.mjs
       - name: Verify Windows Authenticode signatures
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -281,6 +281,9 @@ jobs:
       - name: Verify packaged candidate version
         shell: bash
         run: node scripts/ci/verify-packaged-app-version.mjs '${{ needs.prepare-candidate.outputs.version }}'
+      - name: Verify packaged ACP registry and bridges
+        shell: bash
+        run: node scripts/ci/verify-packaged-acp-resources.mjs
       - name: Verify Windows Authenticode signatures
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell

--- a/resources/acp/registry.json
+++ b/resources/acp/registry.json
@@ -592,6 +592,7 @@
       "distribution": {
         "uvx": {
           "package": "fast-agent-acp==0.10.1",
+          "executable": "fast-agent",
           "args": [
             "-x"
           ],
@@ -993,6 +994,7 @@
       "distribution": {
         "uvx": {
           "package": "minion-code@0.1.44",
+          "executable": "minion-code",
           "args": [
             "acp"
           ]

--- a/scripts/ci/verify-packaged-acp-resources.mjs
+++ b/scripts/ci/verify-packaged-acp-resources.mjs
@@ -1,0 +1,70 @@
+import { access, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const [packageRootArgument = 'release'] = process.argv.slice(2);
+const projectRoot = path.resolve(import.meta.dirname, '..', '..');
+const sourceRegistryPath = path.join(projectRoot, 'resources', 'acp', 'registry.json');
+
+const BUNDLED_ADAPTERS = [
+  { packageName: '@agentclientprotocol/codex-acp', binName: 'codex-acp' },
+  { packageName: '@agentclientprotocol/claude-agent-acp', binName: 'claude-agent-acp' },
+];
+
+async function findAppArchives(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const archives = await Promise.all(
+    entries.map(async entry => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return findAppArchives(entryPath);
+      return entry.isFile() && entry.name === 'app.asar' ? [entryPath] : [];
+    }),
+  );
+  return archives.flat();
+}
+
+function packageBinEntry(manifest, binName) {
+  if (typeof manifest.bin === 'string') return manifest.bin;
+  if (!manifest.bin || typeof manifest.bin !== 'object') return null;
+  const entry = manifest.bin[binName];
+  return typeof entry === 'string' ? entry : null;
+}
+
+const archives = await findAppArchives(path.resolve(packageRootArgument));
+if (archives.length !== 1) {
+  throw new Error(`Expected one packaged app.asar, found ${archives.length}`);
+}
+
+const archivePath = archives[0];
+const resourcesPath = path.dirname(archivePath);
+const [sourceRegistry, packagedRegistry] = await Promise.all([
+  readFile(sourceRegistryPath),
+  readFile(path.join(resourcesPath, 'acp', 'registry.json')),
+]);
+if (!sourceRegistry.equals(packagedRegistry)) {
+  throw new Error('Packaged ACP registry differs from resources/acp/registry.json');
+}
+
+const snapshot = JSON.parse(packagedRegistry.toString('utf8'));
+if (!Array.isArray(snapshot.agents) || snapshot.agents.length !== 39) {
+  throw new Error('Packaged ACP registry must contain exactly 39 agents');
+}
+if (new Set(snapshot.agents.map(agent => agent?.id)).size !== snapshot.agents.length) {
+  throw new Error('Packaged ACP registry contains duplicate agent IDs');
+}
+
+for (const adapter of BUNDLED_ADAPTERS) {
+  const packageRoot = path.join(
+    resourcesPath,
+    'app.asar.unpacked',
+    'node_modules',
+    adapter.packageName,
+  );
+  const manifest = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+  const entry = packageBinEntry(manifest, adapter.binName);
+  if (!entry) {
+    throw new Error(`Packaged ${adapter.packageName} does not declare ${adapter.binName}`);
+  }
+  await access(path.resolve(packageRoot, entry));
+}
+
+console.log(`[PackagedAcp] verified registry and bundled bridges in ${resourcesPath}`);

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -11,6 +11,18 @@ function Assert-Path {
   }
 }
 
+function Invoke-Checked {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [string]$Label = $FilePath
+  )
+  & $FilePath @ArgumentList
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Label failed with exit code $LASTEXITCODE"
+  }
+}
+
 function Invoke-Installer {
   param(
     [Parameter(Mandatory = $true)][string]$Path,

--- a/scripts/ci/windows-installer-smoke.ps1
+++ b/scripts/ci/windows-installer-smoke.ps1
@@ -113,6 +113,10 @@ try {
     throw "Expected exactly one installed application executable; found $($applicationExecutables.Count)"
   }
   Assert-Path $applicationExecutables[0].FullName 'installed application executable'
+  Invoke-Checked 'node' @(
+    (Join-Path $ProjectRoot 'scripts\ci\verify-packaged-acp-resources.mjs'),
+    (Join-Path $installRoot 'resources')
+  ) 'installed ACP registry and bundled bridge verification'
   Assert-Path $timingLog 'cold installation timing log'
 
   $coldLog = Get-Content -LiteralPath $timingLog -Raw -Encoding UTF8

--- a/src/main/codingAgent/acp/discoveryService.test.ts
+++ b/src/main/codingAgent/acp/discoveryService.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, realpath, rm, writeFile } from 'fs/promises';
+import { chmod, mkdir, readFile, realpath, rm, writeFile } from 'fs/promises';
 import path from 'path';
 import { expect, test } from 'vitest';
 
@@ -13,6 +13,19 @@ import {
   resolveClaudeNativeExecutable,
 } from './discoveryService';
 import { resolveAcpAdapterRoot } from './adapterRoot';
+
+test('ships an immutable 39-agent registry with explicit uvx executable names', async () => {
+  const registryPath = path.join(process.cwd(), 'resources', 'acp', 'registry.json');
+  const snapshot = JSON.parse(await readFile(registryPath, 'utf8')) as {
+    agents?: Array<{ distribution?: { uvx?: { executable?: unknown } } }>;
+  };
+
+  expect(snapshot.agents).toHaveLength(39);
+  for (const agent of snapshot.agents ?? []) {
+    const uvx = agent.distribution?.uvx;
+    if (uvx) expect(uvx.executable).toEqual(expect.any(String));
+  }
+});
 
 test('uses unpacked resources for packaged ACP adapter entrypoints', () => {
   expect(
@@ -31,7 +44,7 @@ test('uses unpacked resources for packaged ACP adapter entrypoints', () => {
   ).toBe('/workspace/application');
 });
 
-test('discovers only PATH and known user-level installation directories', () => {
+test('discovers PATH and known user-level installation directories', () => {
   const directories = discoveryDirectories(
     'darwin',
     {
@@ -49,10 +62,16 @@ test('discovers only PATH and known user-level installation directories', () => 
     path.join('/packages/npm', 'bin'),
     path.join('/packages/bun', 'bin'),
     path.join('/packages/volta', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
     path.join('/home/agent', '.local', 'bin'),
     path.join('/home/agent', '.npm-global', 'bin'),
     path.join('/home/agent', '.bun', 'bin'),
+    path.join('/home/agent', '.cargo', 'bin'),
     path.join('/home/agent', '.kimi-code', 'bin'),
+    path.join('/home/agent', '.volta', 'bin'),
+    path.join('/home/agent', '.local', 'share', 'mise', 'shims'),
+    path.join('/home/agent', '.local', 'share', 'fnm'),
     path.join('/home/agent', '.local', 'share', 'pnpm'),
     path.join('/home/agent', 'Library', 'pnpm'),
   ]);
@@ -70,8 +89,57 @@ test('covers Windows user-level npm, pnpm, and Bun locations without scanning di
 
   expect(directories).toContain(path.join('C:\\Users\\agent\\AppData\\Roaming', 'npm'));
   expect(directories).toContain(path.join('C:\\Users\\agent\\AppData\\Local', 'pnpm'));
+  expect(directories).toContain(
+    path.join('C:\\Users\\agent\\AppData\\Local', 'Microsoft', 'WinGet', 'Links'),
+  );
   expect(directories).toContain(path.join('C:\\Users\\agent', '.bun', 'bin'));
+  expect(directories).toContain(path.join('C:\\Users\\agent', '.cargo', 'bin'));
   expect(directories).toContain(path.join('C:\\Users\\agent', '.kimi-code', 'bin'));
+});
+
+test('discovers uvx-installed ACP agents through their command-line executable', async () => {
+  const root = path.join(process.cwd(), `.coding-agent-discovery-uvx-${Date.now()}`);
+  const directory = path.join(root, 'bin');
+  const executable = path.join(directory, 'fast-agent');
+  const registryPath = path.join(root, 'registry.json');
+  try {
+    await mkdir(directory, { recursive: true });
+    await writeFile(executable, '#!/bin/sh\nexit 0\n');
+    await chmod(executable, 0o755);
+    await writeFile(
+      registryPath,
+      JSON.stringify({
+        agents: [
+          {
+            id: 'fast-agent',
+            name: 'fast-agent',
+            description: 'Python ACP agent.',
+            distribution: {
+              uvx: { package: 'fast-agent-acp==1.0.0', executable: 'fast-agent', args: ['-x'] },
+            },
+          },
+        ],
+      }),
+    );
+
+    const profiles = await new AcpDiscoveryService(registryPath, {
+      platform: 'darwin',
+      architecture: 'arm64',
+      environment: { PATH: directory },
+      home: root,
+      adapterRoot: process.cwd(),
+    }).discover();
+
+    expect(profiles).toContainEqual(
+      expect.objectContaining({
+        name: 'fast-agent',
+        command: await realpath(executable),
+        args: ['-x'],
+      }),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test('discovers a standalone Kimi installation without npm package metadata', async () => {
@@ -244,27 +312,128 @@ test('uses bundled ACP bridges for locally installed Codex and Claude Code', asy
   }
 });
 
-test('discovers npx packages from Windows global npm node_modules layout', async () => {
-  const root = path.join(process.cwd(), `.coding-agent-discovery-npx-win-${Date.now()}`);
-  const npmGlobalBin = path.join(root, 'npm');
-  const packageDir = path.join(npmGlobalBin, 'node_modules', 'test-agent');
+test('discovers npx packages from pnpm global node_modules layouts', async () => {
+  const root = path.join(process.cwd(), `.coding-agent-discovery-pnpm-${Date.now()}`);
+  const pnpmHome = path.join(root, 'pnpm');
+  const binDirectory = path.join(root, 'bin');
+  const executable = path.join(binDirectory, 'test-agent');
+  const packageDir = path.join(pnpmHome, 'global', '9', 'node_modules', 'test-agent');
+  const registryPath = path.join(root, 'registry.json');
   try {
     await mkdir(packageDir, { recursive: true });
+    await mkdir(binDirectory, { recursive: true });
+    await writeFile(executable, '#!/bin/sh\nexit 0\n');
+    await chmod(executable, 0o755);
     await writeFile(
       path.join(packageDir, 'package.json'),
       JSON.stringify({ name: 'test-agent', version: '1.0.0', bin: { 'test-agent': 'dist/cli.js' } }),
     );
+    await writeFile(
+      registryPath,
+      JSON.stringify({
+        agents: [
+          {
+            id: 'test-agent',
+            name: 'Test Agent',
+            distribution: { npx: { package: 'test-agent@1.0.0' } },
+          },
+        ],
+      }),
+    );
 
-    const service = new AcpDiscoveryService(undefined, {
-      platform: 'win32',
-      environment: { PATH: npmGlobalBin, APPDATA: root },
+    const profiles = await new AcpDiscoveryService(registryPath, {
+      platform: 'darwin',
+      environment: { PATH: binDirectory, PNPM_HOME: pnpmHome },
       home: root,
       adapterRoot: process.cwd(),
-    });
-    // packageBinNames is private, but we can exercise it through readRegistry
-    // by creating a registry with an npx entry. For now, verify the discovery
-    // service can be constructed with the Windows layout without throwing.
-    expect(service).toBeDefined();
+    }).discover();
+
+    expect(profiles).toContainEqual(
+      expect.objectContaining({ name: 'Test Agent', command: await realpath(executable) }),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('discovers npx packages from nvm and fnm version directories', async () => {
+  const root = path.join(process.cwd(), `.coding-agent-discovery-node-managers-${Date.now()}`);
+  const nvmBin = path.join(root, '.nvm', 'versions', 'node', 'v24.0.0', 'bin');
+  const fnmBin = path.join(
+    root,
+    '.local',
+    'share',
+    'fnm',
+    'node-versions',
+    'v24.0.0',
+    'installation',
+    'bin',
+  );
+  const nvmPackage = path.join(root, '.nvm', 'versions', 'node', 'v24.0.0', 'lib', 'node_modules', 'nvm-agent');
+  const fnmPackage = path.join(
+    root,
+    '.local',
+    'share',
+    'fnm',
+    'node-versions',
+    'v24.0.0',
+    'installation',
+    'lib',
+    'node_modules',
+    'fnm-agent',
+  );
+  const registryPath = path.join(root, 'registry.json');
+  try {
+    await Promise.all([
+      mkdir(nvmBin, { recursive: true }),
+      mkdir(fnmBin, { recursive: true }),
+      mkdir(nvmPackage, { recursive: true }),
+      mkdir(fnmPackage, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(path.join(nvmBin, 'nvm-agent'), '#!/bin/sh\nexit 0\n'),
+      writeFile(path.join(fnmBin, 'fnm-agent'), '#!/bin/sh\nexit 0\n'),
+      writeFile(path.join(nvmPackage, 'package.json'), JSON.stringify({ bin: 'bin/nvm-agent' })),
+      writeFile(path.join(fnmPackage, 'package.json'), JSON.stringify({ bin: 'bin/fnm-agent' })),
+      writeFile(
+        registryPath,
+        JSON.stringify({
+          agents: [
+            {
+              id: 'nvm-agent',
+              name: 'NVM Agent',
+              distribution: { npx: { package: 'nvm-agent@1.0.0' } },
+            },
+            {
+              id: 'fnm-agent',
+              name: 'FNM Agent',
+              distribution: { npx: { package: 'fnm-agent@1.0.0' } },
+            },
+          ],
+        }),
+      ),
+    ]);
+    await Promise.all([chmod(path.join(nvmBin, 'nvm-agent'), 0o755), chmod(path.join(fnmBin, 'fnm-agent'), 0o755)]);
+
+    const profiles = await new AcpDiscoveryService(registryPath, {
+      platform: 'darwin',
+      environment: { PATH: '' },
+      home: root,
+      adapterRoot: process.cwd(),
+    }).discover();
+
+    expect(profiles).toContainEqual(
+      expect.objectContaining({
+        name: 'NVM Agent',
+        command: await realpath(path.join(nvmBin, 'nvm-agent')),
+      }),
+    );
+    expect(profiles).toContainEqual(
+      expect.objectContaining({
+        name: 'FNM Agent',
+        command: await realpath(path.join(fnmBin, 'fnm-agent')),
+      }),
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -276,6 +445,7 @@ test('does not expose bundled bridges when their corresponding agents are not in
   try {
     await mkdir(directory, { recursive: true });
     const profiles = await new AcpDiscoveryService(undefined, {
+      platform: 'win32',
       environment: { PATH: directory },
       home: root,
       adapterRoot: process.cwd(),

--- a/src/main/codingAgent/acp/discoveryService.ts
+++ b/src/main/codingAgent/acp/discoveryService.ts
@@ -14,6 +14,7 @@ import { BUNDLED_ACP_ADAPTERS, type BundledAcpAdapterDefinition } from './bundle
 
 type RegistryLaunchDistribution = {
   package?: unknown;
+  executable?: unknown;
   args?: unknown;
   env?: unknown;
 };
@@ -61,6 +62,17 @@ const uniqueDirectories = (directories: string[]): string[] => [
 ];
 const stringArguments = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((arg): arg is string => typeof arg === 'string') : [];
+const stringExecutables = (value: unknown): string[] =>
+  typeof value === 'string' && value.trim() ? [value.trim()] : [];
+
+const childDirectories = async (directory: string): Promise<string[]> => {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true });
+    return entries.filter(entry => entry.isDirectory()).map(entry => path.join(directory, entry.name));
+  } catch {
+    return [];
+  }
+};
 
 const claudeNativeExecutablePath = (packageRoot: string): string =>
   path.join(packageRoot, '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
@@ -107,23 +119,39 @@ export const discoveryDirectories = (
   ]
     .filter((prefix): prefix is string => Boolean(prefix))
     .map(prefix => path.join(prefix, 'bin'));
+  const environmentDirectories = [
+    environment.PNPM_HOME,
+    environment.NVM_BIN,
+    environment.FNM_MULTISHELL_PATH ? path.join(environment.FNM_MULTISHELL_PATH, 'bin') : '',
+  ].filter((directory): directory is string => Boolean(directory));
   const userDirectories =
     platform === 'win32'
       ? [
           environment.APPDATA ? path.join(environment.APPDATA, 'npm') : '',
           environment.LOCALAPPDATA ? path.join(environment.LOCALAPPDATA, 'pnpm') : '',
+          environment.LOCALAPPDATA
+            ? path.join(environment.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links')
+            : '',
+          environment.USERPROFILE ? path.join(environment.USERPROFILE, 'scoop', 'shims') : '',
           path.join(home, '.bun', 'bin'),
+          path.join(home, '.cargo', 'bin'),
           path.join(home, '.kimi-code', 'bin'),
         ]
       : [
+          '/opt/homebrew/bin',
+          '/usr/local/bin',
           path.join(home, '.local', 'bin'),
           path.join(home, '.npm-global', 'bin'),
           path.join(home, '.bun', 'bin'),
+          path.join(home, '.cargo', 'bin'),
           path.join(home, '.kimi-code', 'bin'),
+          path.join(home, '.volta', 'bin'),
+          path.join(home, '.local', 'share', 'mise', 'shims'),
+          path.join(home, '.local', 'share', 'fnm'),
           path.join(home, '.local', 'share', 'pnpm'),
           platform === 'darwin' ? path.join(home, 'Library', 'pnpm') : '',
         ];
-  return uniqueDirectories([...paths, ...packagePrefixes, ...userDirectories]);
+  return uniqueDirectories([...paths, ...packagePrefixes, ...environmentDirectories, ...userDirectories]);
 };
 
 /** Passive discovery only: it never starts a discovered executable. */
@@ -134,6 +162,7 @@ export class AcpDiscoveryService {
   private readonly home: string;
   private readonly adapterRoot: string;
   private readonly adapterHostExecutable: string;
+  private readonly packageBins = new Map<string, Promise<string[]>>();
 
   constructor(
     private readonly registryPath = path.join(process.cwd(), 'resources', 'acp', 'registry.json'),
@@ -148,7 +177,7 @@ export class AcpDiscoveryService {
   }
 
   async discover(): Promise<Array<Omit<CodingAgentProfile, 'id' | 'isBuiltin'>>> {
-    const directories = discoveryDirectories(this.platform, this.environment, this.home);
+    const directories = await this.resolutionDirectories();
     const bundledProfiles = await Promise.all(
       BUNDLED_ACP_ADAPTERS.map(adapter => this.discoverBundledAdapter(directories, adapter)),
     );
@@ -249,24 +278,53 @@ export class AcpDiscoveryService {
       (snapshot.agents ?? []).map(async agent => {
         if (typeof agent.id !== 'string' || typeof agent.name !== 'string') return [];
         const binary = agent.distribution?.binary?.[platformKey];
-        const launcher = agent.distribution?.npx ?? agent.distribution?.uvx;
-        const executables =
-          typeof binary?.cmd === 'string'
-            ? [path.basename(binary.cmd)]
-            : await this.packageBinNames(launcher?.package);
-        if (!executables.length) return [];
-        return [
-          {
-            id: agent.id,
-            name: agent.name,
-            description: typeof agent.description === 'string' ? agent.description : 'ACP agent.',
-            executables,
-            args: stringArguments(binary?.args ?? launcher?.args),
-            environment: this.registryEnvironment(binary?.env ?? launcher?.env),
-          },
-        ];
+        const candidates = await this.registryLaunchCandidates(agent, binary);
+        return candidates.map(candidate => ({
+          id: agent.id as string,
+          name: agent.name as string,
+          description: typeof agent.description === 'string' ? agent.description : 'ACP agent.',
+          ...candidate,
+        }));
       }),
     ).then(entries => entries.flat());
+  }
+
+  private async registryLaunchCandidates(
+    agent: RegistryAgent,
+    binary: RegistryBinaryDistribution | undefined,
+  ): Promise<Array<{ executables: string[]; args: string[]; environment: Record<string, string> }>> {
+    if (typeof binary?.cmd === 'string') {
+      return [
+        {
+          executables: [path.basename(binary.cmd)],
+          args: stringArguments(binary.args),
+          environment: this.registryEnvironment(binary.env),
+        },
+      ];
+    }
+    const npx = agent.distribution?.npx;
+    const npxExecutables = await this.packageBinNames(npx?.package);
+    if (npxExecutables.length) {
+      return [
+        {
+          executables: npxExecutables,
+          args: stringArguments(npx?.args),
+          environment: this.registryEnvironment(npx?.env),
+        },
+      ];
+    }
+    const uvx = agent.distribution?.uvx;
+    const uvxExecutables = stringExecutables(uvx?.executable);
+    if (uvxExecutables.length) {
+      return [
+        {
+          executables: uvxExecutables,
+          args: stringArguments(uvx?.args),
+          environment: this.registryEnvironment(uvx?.env),
+        },
+      ];
+    }
+    return [];
   }
 
   private registryEnvironment(value: unknown): Record<string, string> {
@@ -280,8 +338,16 @@ export class AcpDiscoveryService {
 
   private async packageBinNames(packageSpec: unknown): Promise<string[]> {
     if (typeof packageSpec !== 'string') return [];
+    const cached = this.packageBins.get(packageSpec);
+    if (cached) return await cached;
+    const resolving = this.resolvePackageBinNames(packageSpec);
+    this.packageBins.set(packageSpec, resolving);
+    return await resolving;
+  }
+
+  private async resolvePackageBinNames(packageSpec: string): Promise<string[]> {
     const packageName = packageSpec.replace(/@[^@]+$/, '');
-    const directories = discoveryDirectories(this.platform, this.environment, this.home);
+    const directories = await this.resolutionDirectories();
     const manifests = [
       path.join(this.adapterRoot, 'node_modules', packageName, 'package.json'),
       ...directories.flatMap(directory => [
@@ -291,6 +357,7 @@ export class AcpDiscoveryService {
         path.resolve(directory, '..', 'node_modules', packageName, 'package.json'),
         path.resolve(directory, '..', 'lib', 'node_modules', packageName, 'package.json'),
       ]),
+      ...(await this.pnpmPackageManifests(directories, packageName)),
     ];
     for (const manifestPath of uniqueDirectories(manifests)) {
       const manifest = await this.readPackageManifest(manifestPath);
@@ -299,6 +366,41 @@ export class AcpDiscoveryService {
       if (manifest.bin && typeof manifest.bin === 'object') return Object.keys(manifest.bin);
     }
     return [];
+  }
+
+  private async resolutionDirectories(): Promise<string[]> {
+    const directories = discoveryDirectories(this.platform, this.environment, this.home);
+    if (this.platform === 'win32') return directories;
+
+    const nvmDirectory = this.environment.NVM_DIR || path.join(this.home, '.nvm');
+    const fnmDirectory = this.environment.FNM_DIR || path.join(this.home, '.local', 'share', 'fnm');
+    const [nvmVersions, fnmVersions] = await Promise.all([
+      childDirectories(path.join(nvmDirectory, 'versions', 'node')),
+      childDirectories(path.join(fnmDirectory, 'node-versions')),
+    ]);
+    return uniqueDirectories([
+      ...directories,
+      ...nvmVersions.map(version => path.join(version, 'bin')),
+      ...fnmVersions.map(version => path.join(version, 'installation', 'bin')),
+    ]);
+  }
+
+  private async pnpmPackageManifests(
+    directories: string[],
+    packageName: string,
+  ): Promise<string[]> {
+    const pnpmHomes = uniqueDirectories(
+      directories.filter(
+        directory =>
+          directory === this.environment.PNPM_HOME || path.basename(directory).toLowerCase() === 'pnpm',
+      ),
+    );
+    const globalDirectories = (
+      await Promise.all(pnpmHomes.map(home => childDirectories(path.join(home, 'global'))))
+    ).flat();
+    return globalDirectories.map(globalDirectory =>
+      path.join(globalDirectory, 'node_modules', packageName, 'package.json'),
+    );
   }
 
   private async readPackageManifest(manifestPath: string): Promise<PackageManifest | null> {

--- a/tests/runtimePackagingConfig.test.ts
+++ b/tests/runtimePackagingConfig.test.ts
@@ -410,6 +410,8 @@ test("installer-related pull requests build and exercise the Windows installer",
   assert.match(smoke, /phase=component-cache-hit/);
   assert.doesNotMatch(smoke, /phase=defender-exclusion/);
   assert.match(smoke, /'uninstall'/);
+  assert.match(smoke, /function Invoke-Checked/);
+  assert.match(smoke, /verify-packaged-acp-resources\.mjs/);
 
   const sizeSmoke = readFileSync(
     path.join(root, "scripts", "ci", "windows-installer-size-smoke.ps1"),


### PR DESCRIPTION
## Summary

完善 Coding 模式下 ACP Agent 的本地发现，并验证开发版与安装包中的 ACP 资源一致。保持静态 39 条注册表，不引入在线更新。

## Related Issue

无。

## Changes Made

- 补充 pnpm 全局包、nvm、fnm 等固定目录的 ACP Agent 发现。
- 为 uvx 分发项增加明确的可执行文件名，避免从包名猜测。
- 锁定注册表为 39 个 Agent，并增加对应测试。
- 增加安装包 ACP 注册表、Codex/Claude ACP 桥接器的产物校验。
- 将产物校验接入平台构建、正式发布、候选发布和 Windows 安装后检查。

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [x] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [x] Updated existing tests
- [ ] Manual testing performed
- `npm test -- discoveryService`：11 项通过。
- `npm run lint`：通过。
- `node --check scripts/ci/verify-packaged-acp-resources.mjs`：通过。
- 工作流 YAML 和 `git diff --check`：通过。
- `npm run compile:electron` 仍受 origin/main 已存在的两处类型错误阻塞：`src/main/codingAgent/codingRoomService.ts:1606`、`src/main/libs/agentEngine/piCodingElicitation.ts:34`，本次未新增编译错误。
- 本机未生成完整安装包；实际安装包验证已接入 CI。

## Screenshots (if applicable)

不适用，本 PR 不涉及 UI。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of the code
- [x] I have commented on hard-to-understand code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix works
- [ ] New and existing unit tests pass locally

## Electron-Specific Changes

- [x] Changes to main process (`src/main/`)
- [ ] Changes to preload script (`src/main/preload.ts`)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [ ] None

## Additional Notes

- 注册表仍为仓库内静态文件，后续新增 ACP Agent 可直接修改 `resources/acp/registry.json`。
- 提交：`aacbb028`。分支已基于最新 `origin/main`。
