### PR TITLE
refactor(coding): 精简 Agent 管理弹窗并收拢编程区入口

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -38,7 +38,6 @@ import {
   CodingWorkspaceSidebar,
   type CodingSidebarSelection,
 } from './coding/CodingWorkspaceSidebar';
-import { CodingUiEvent, type CodingManageAgentsEventDetail } from './coding/constants';
 import { SidebarSearchTrigger } from './shell/SidebarSearchTrigger';
 import CoworkSearchModal from './cowork/CoworkSearchModal';
 import { workspaceService } from '../services/workspace';
@@ -445,13 +444,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                 <CodingWorkspaceSidebar
                   selection={codingSelection}
                   onSelectionChange={onCodingSelectionChange}
-                  onManageAgents={workspaceRoot =>
-                    window.dispatchEvent(
-                      new CustomEvent<CodingManageAgentsEventDetail>(CodingUiEvent.ManageAgents, {
-                        detail: { workspaceRoot },
-                      }),
-                    )
-                  }
                 />
               </div>
             ) : null}

--- a/src/renderer/components/coding/CodingAgentManager.tsx
+++ b/src/renderer/components/coding/CodingAgentManager.tsx
@@ -121,7 +121,7 @@ export const CodingAgentManager = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="theme-control-sizing-4 flex h-[min(44rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden sm:max-w-3xl">
+      <DialogContent className="theme-control-sizing-4 flex h-[min(38rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden sm:max-w-2xl">
         <DialogHeader className="theme-part-coding-agent-manager-dialog-header-1">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 space-y-2">
@@ -129,7 +129,6 @@ export const CodingAgentManager = ({
               <DialogDescription>
                 {i18nService.t('codingAgentManagerDescription')}
               </DialogDescription>
-              <p className="text-xs text-muted-foreground">{summary}</p>
             </div>
             <Button
               type="button"
@@ -153,27 +152,29 @@ export const CodingAgentManager = ({
           onValueChange={value => setActiveTab(value as CodingAgentManagerTabValue)}
           className="min-h-0 flex-1 gap-0"
         >
-          <PageTabs
-            bare
-            value={activeTab}
-            className="mx-6 mt-2 shrink-0"
-            items={[
-              {
-                value: CodingAgentManagerTab.Local,
-                label: `${i18nService.t('codingAgentLocalAgents')} (${profiles.length})`,
-              },
-              {
-                value: CodingAgentManagerTab.Custom,
-                label: i18nService.t('codingAgentCustomAgent'),
-              },
-            ]}
-          />
+          <div className="mx-6 mt-2 flex shrink-0 items-center justify-between gap-3">
+            <PageTabs
+              bare
+              value={activeTab}
+              items={[
+                {
+                  value: CodingAgentManagerTab.Local,
+                  label: `${i18nService.t('codingAgentLocalAgents')} (${profiles.length})`,
+                },
+                {
+                  value: CodingAgentManagerTab.Custom,
+                  label: i18nService.t('codingAgentCustomAgent'),
+                },
+              ]}
+            />
+            <p className="truncate text-xs text-muted-foreground">{summary}</p>
+          </div>
 
           <TabsContent value={CodingAgentManagerTab.Local} className="min-h-0">
             <ScrollArea className="h-full">
               <div className="p-6 pt-4">
                 {profiles.length === 0 ? (
-                  <Empty className="theme-scene-coding-empty min-h-80">
+                  <Empty className="theme-scene-coding-empty min-h-48">
                     <EmptyHeader>
                       <EmptyMedia variant="icon">
                         <Bot />
@@ -316,8 +317,8 @@ const AgentRow = ({
     profile.environment[CodingAgentEnvironmentKey.ClaudeCodeExecutable] ??
     profile.command;
   return (
-    <div className="flex min-w-0 items-center gap-3 border-b border-border px-4 py-3 last:border-b-0">
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+    <div className="flex min-w-0 items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
         <Bot className="size-4" />
       </div>
       <div className="min-w-0 flex-1">
@@ -332,11 +333,11 @@ const AgentRow = ({
           </Badge>
         </div>
         {profile.description && (
-          <p className="mt-0.5 truncate text-sm text-muted-foreground">{profile.description}</p>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">{profile.description}</p>
         )}
         {installedCommand && (
           <p
-            className="mt-1 truncate font-mono text-xs text-muted-foreground"
+            className="mt-0.5 truncate font-mono text-xs text-muted-foreground"
             title={installedCommand}
           >
             {installedCommand}

--- a/src/renderer/components/coding/CodingAgentManager.tsx
+++ b/src/renderer/components/coding/CodingAgentManager.tsx
@@ -122,10 +122,8 @@ export const CodingAgentManager = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="theme-control-sizing-4 flex h-[min(36rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden sm:max-w-xl">
         <DialogHeader className="theme-part-coding-agent-manager-dialog-header-1">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 space-y-2">
-              <DialogTitle>{i18nService.t('codingAgentManagerTitle')}</DialogTitle>
-            </div>
+          <div className="flex min-w-0 items-center gap-3">
+            <DialogTitle>{i18nService.t('codingAgentManagerTitle')}</DialogTitle>
             <Button
               type="button"
               size="sm"

--- a/src/renderer/components/coding/CodingAgentManager.tsx
+++ b/src/renderer/components/coding/CodingAgentManager.tsx
@@ -3,7 +3,6 @@ import { Button } from '@shared/components/ui/button';
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -126,9 +125,6 @@ export const CodingAgentManager = ({
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 space-y-2">
               <DialogTitle>{i18nService.t('codingAgentManagerTitle')}</DialogTitle>
-              <DialogDescription>
-                {i18nService.t('codingAgentManagerDescription')}
-              </DialogDescription>
             </div>
             <Button
               type="button"

--- a/src/renderer/components/coding/CodingAgentManager.tsx
+++ b/src/renderer/components/coding/CodingAgentManager.tsx
@@ -121,7 +121,7 @@ export const CodingAgentManager = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="theme-control-sizing-4 flex h-[min(38rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden sm:max-w-2xl">
+      <DialogContent className="theme-control-sizing-4 flex h-[min(36rem,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden sm:max-w-xl">
         <DialogHeader className="theme-part-coding-agent-manager-dialog-header-1">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 space-y-2">
@@ -174,7 +174,7 @@ export const CodingAgentManager = ({
             <ScrollArea className="h-full">
               <div className="p-6 pt-4">
                 {profiles.length === 0 ? (
-                  <Empty className="theme-scene-coding-empty min-h-48">
+                  <Empty className="theme-scene-coding-empty min-h-40">
                     <EmptyHeader>
                       <EmptyMedia variant="icon">
                         <Bot />
@@ -318,19 +318,20 @@ const AgentRow = ({
     profile.command;
   return (
     <div className="flex min-w-0 items-center gap-3 border-b border-border px-3 py-2 last:border-b-0">
-      <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-        <Bot className="size-4" />
-      </div>
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-2">
           <p className="truncate text-sm font-medium">{profile.name}</p>
-          <Badge
-            variant={
-              profile.status === CodingAgentProfileStatus.Incompatible ? 'destructive' : 'secondary'
-            }
-          >
-            {i18nService.t(CodingAgentStatusI18nKey[profile.status])}
-          </Badge>
+          {profile.status !== CodingAgentProfileStatus.Ready && (
+            <Badge
+              variant={
+                profile.status === CodingAgentProfileStatus.Incompatible
+                  ? 'destructive'
+                  : 'secondary'
+              }
+            >
+              {i18nService.t(CodingAgentStatusI18nKey[profile.status])}
+            </Badge>
+          )}
         </div>
         {profile.description && (
           <p className="mt-0.5 truncate text-xs text-muted-foreground">{profile.description}</p>

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -69,7 +69,6 @@ import {
   CodingSidePanelView,
   CodingUiEvent,
   type CodingCreateSessionEventDetail,
-  type CodingManageAgentsEventDetail,
   type CodingSidePanelView as CodingSidePanelViewType,
 } from './constants';
 import type { CodingSessionDraft, CodingSidebarSelection } from './CodingWorkspaceSidebar';
@@ -203,14 +202,6 @@ export const CodingWorkbenchView = ({
         else setError(result.error ?? i18nService.t('codingAgentActionFailed'));
       });
   }, [selectedLaneId, snapshot, workspaceRoot]);
-  useEffect(() => {
-    const openManager = (event: Event) => {
-      const detail = (event as CustomEvent<CodingManageAgentsEventDetail>).detail;
-      if (detail.workspaceRoot === workspaceRoot) setAgentManagerOpen(true);
-    };
-    window.addEventListener(CodingUiEvent.ManageAgents, openManager);
-    return () => window.removeEventListener(CodingUiEvent.ManageAgents, openManager);
-  }, [workspaceRoot]);
   useEffect(() => {
     const openSessionSetup = (event: Event) => {
       const detail = (event as CustomEvent<CodingCreateSessionEventDetail>).detail;

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.structure.test.ts
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.structure.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync(
+  fileURLToPath(new URL('./CodingWorkspaceSidebar.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('uses the animated folder-plus icon for the add workspace action', () => {
+  expect(source).toContain(
+    "import {\n  AnimatedFolderPlusIcon,\n  type AnimatedFolderPlusIconHandle,\n} from '../icons/AnimatedFolderPlusIcon';",
+  );
+  expect(source).toContain(
+    'const addWorkspaceIconRef = useRef<AnimatedFolderPlusIconHandle>(null);',
+  );
+  expect(source).toContain('<AnimatedFolderPlusIcon ref={addWorkspaceIconRef} />');
+});
+
+test('animates the add workspace icon on hover but respects reduced motion', () => {
+  expect(source).toContain(
+    'if (!prefersReducedMotion) addWorkspaceIconRef.current?.startAnimation();',
+  );
+  expect(source).toContain('onMouseLeave={() => addWorkspaceIconRef.current?.stopAnimation()}');
+});
+
+test('does not fall back to the static lucide plus icon', () => {
+  expect(source).not.toContain('Plus,');
+  expect(source).not.toContain('<Plus />');
+});

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.structure.test.ts
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.structure.test.ts
@@ -29,3 +29,8 @@ test('does not fall back to the static lucide plus icon', () => {
   expect(source).not.toContain('Plus,');
   expect(source).not.toContain('<Plus />');
 });
+
+test('keeps the agent manager entry out of the workspace sidebar header', () => {
+  expect(source).not.toContain('<Settings2 />');
+  expect(source).not.toContain('onManageAgents');
+});

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -7,9 +7,9 @@ import {
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
 import { cn } from '@shared/lib/utils';
-import { Ellipsis, Folder, Settings2, Trash2 } from 'lucide-react';
+import { Ellipsis, Folder, Trash2 } from 'lucide-react';
 import { useReducedMotion } from 'motion/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   CodingLaneStatus,
@@ -53,7 +53,6 @@ export interface CodingSidebarSelection {
 interface CodingWorkspaceSidebarProps {
   selection: CodingSidebarSelection;
   onSelectionChange: (selection: CodingSidebarSelection) => void;
-  onManageAgents: (workspaceRoot: string) => void;
 }
 
 const statusClassName: Record<CodingLaneStatus, string> = {
@@ -71,7 +70,6 @@ const SESSIONS_TRANSITION_MS = 200;
 export const CodingWorkspaceSidebar = ({
   selection,
   onSelectionChange,
-  onManageAgents,
 }: CodingWorkspaceSidebarProps) => {
   const [workspaces, setWorkspaces] = useState<CodingWorkspaceSummary[]>([]);
   const [profiles, setProfiles] = useState<CodingAgentProfile[]>([]);
@@ -157,11 +155,6 @@ export const CodingWorkspaceSidebar = ({
       void refresh();
     });
   }, [refresh, selection.workspaceRoot]);
-
-  const selectedWorkspace = useMemo(
-    () => workspaces.find(workspace => workspace.id === selection.workspaceId) ?? null,
-    [selection.workspaceId, workspaces],
-  );
 
   const openSessionSetup = (workspace: CodingWorkspaceSummary) => {
     setError(null);
@@ -252,18 +245,6 @@ export const CodingWorkspaceSidebar = ({
           {i18nService.t('codingWorkspaceSection')}
         </h2>
         <div className="flex items-center">
-          {selectedWorkspace ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              className="theme-action-faint"
-              aria-label={i18nService.t('codingAgentManageAgents')}
-              onClick={() => onManageAgents(selectedWorkspace.primaryRoot)}
-            >
-              <Settings2 />
-            </Button>
-          ) : null}
           <Button
             type="button"
             variant="ghost"

--- a/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
+++ b/src/renderer/components/coding/CodingWorkspaceSidebar.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
 import { cn } from '@shared/lib/utils';
-import { Ellipsis, Folder, Plus, Settings2, Trash2 } from 'lucide-react';
+import { Ellipsis, Folder, Settings2, Trash2 } from 'lucide-react';
 import { useReducedMotion } from 'motion/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -23,6 +23,10 @@ import {
   AnimatedFolderOpenIcon,
   type AnimatedFolderOpenIconHandle,
 } from '../icons/AnimatedFolderOpenIcon';
+import {
+  AnimatedFolderPlusIcon,
+  type AnimatedFolderPlusIconHandle,
+} from '../icons/AnimatedFolderPlusIcon';
 import {
   SidebarAnimatedMessageCirclePlusIcon,
   type SidebarAnimatedMessageCirclePlusIconHandle,
@@ -81,6 +85,8 @@ export const CodingWorkspaceSidebar = ({
     session: CodingSessionSummary;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const addWorkspaceIconRef = useRef<AnimatedFolderPlusIconHandle>(null);
+  const prefersReducedMotion = useReducedMotion();
 
   const applyWorkspaces = useCallback(
     (next: CodingWorkspaceSummary[]) => {
@@ -264,13 +270,17 @@ export const CodingWorkspaceSidebar = ({
             size="icon-sm"
             className="theme-action-faint"
             aria-label={i18nService.t('codingWorkspaceAdd')}
+            onMouseEnter={() => {
+              if (!prefersReducedMotion) addWorkspaceIconRef.current?.startAnimation();
+            }}
+            onMouseLeave={() => addWorkspaceIconRef.current?.stopAnimation()}
             onClick={() => {
               setError(null);
               setEditingWorkspace(null);
               setWorkspaceDialogOpen(true);
             }}
           >
-            <Plus />
+            <AnimatedFolderPlusIcon ref={addWorkspaceIconRef} />
           </Button>
         </div>
       </div>

--- a/src/renderer/components/coding/constants.ts
+++ b/src/renderer/components/coding/constants.ts
@@ -2,15 +2,10 @@ import { CodingAgentProfileStatus, type CodingWorkspaceSummary } from '../../../
 
 export const CodingUiEvent = {
   CreateSession: 'coding:create-session',
-  ManageAgents: 'coding:manage-agents',
 } as const;
 
 export interface CodingCreateSessionEventDetail {
   workspace: CodingWorkspaceSummary;
-}
-
-export interface CodingManageAgentsEventDetail {
-  workspaceRoot: string;
 }
 
 export const CodingAgentStatusI18nKey: Record<CodingAgentProfileStatus, string> = {

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1104,8 +1104,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     codingAgentManageAgents: '扫描并管理 Agent',
     codingAgentManageAgentsDescription: '扫描本机 Agent，并管理手动添加的 Agent。',
     codingAgentManagerTitle: 'Agent 管理',
-    codingAgentManagerDescription:
-      '扫描设备上已安装的编程 Agent；Codex 与 Claude Code 安装后即可连接，扫描不会启动外部命令。',
     codingAgentManagerSummary: '已发现 {count} 个，其中 {ready} 个可用',
     codingAgentRescan: '重新扫描',
     codingAgentScanning: '扫描中…',
@@ -4539,8 +4537,6 @@ const translations: Record<LanguageType, Record<string, string>> = {
     codingAgentManageAgents: 'Scan and manage agents',
     codingAgentManageAgentsDescription: 'Scan local agents and manage manually added agents.',
     codingAgentManagerTitle: 'Agent management',
-    codingAgentManagerDescription:
-      'Scan installed coding agents. Codex and Claude Code connect once installed; scanning never starts external commands.',
     codingAgentManagerSummary: '{count} found, {ready} ready',
     codingAgentRescan: 'Scan again',
     codingAgentScanning: 'Scanning…',

--- a/src/renderer/theme/components/classic-part-controls.ts
+++ b/src/renderer/theme/components/classic-part-controls.ts
@@ -5,8 +5,7 @@ export function classicPartControls(dark: boolean) {
   return {
     'part-coding-agent-manager-dialog-header-1': recipe({
       base: {
-        'border-bottom-width': '1px',
-        'border-color': 'var(--zy-border)',
+        'border-bottom-width': '0px',
         'padding-inline': '1.5rem',
         'padding-block': '1.25rem',
         'padding-right': '3.5rem',
@@ -14,6 +13,7 @@ export function classicPartControls(dark: boolean) {
     }),
     'part-coding-agent-manager-dialog-footer-1': recipe({
       base: {
+        'border-top-width': '0px',
         'border-radius': '0px',
         'background-color': 'var(--zy-background)',
         'padding-inline': '1.5rem',

--- a/src/renderer/theme/css/themes.css
+++ b/src/renderer/theme/css/themes.css
@@ -3699,13 +3699,13 @@
   box-shadow: none;
 }
 :where(:root:not([data-theme]), [data-theme="classic-light"]) :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 :where(:root:not([data-theme]), [data-theme="classic-light"]) :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -11299,13 +11299,13 @@ to {
   box-shadow: none;
 }
 [data-theme="classic-dark"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="classic-dark"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -18910,13 +18910,13 @@ to {
   box-shadow: none;
 }
 [data-theme="daming-light"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="daming-light"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -26510,13 +26510,13 @@ to {
   box-shadow: none;
 }
 [data-theme="daming-dark"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="daming-dark"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -34123,13 +34123,13 @@ to {
   box-shadow: none;
 }
 [data-theme="changan-light"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="changan-light"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -41728,13 +41728,13 @@ to {
   box-shadow: none;
 }
 [data-theme="changan-dark"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="changan-dark"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -49344,13 +49344,13 @@ to {
   box-shadow: none;
 }
 [data-theme="weiyang-light"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="weiyang-light"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;
@@ -56949,13 +56949,13 @@ to {
   box-shadow: none;
 }
 [data-theme="weiyang-dark"] :where(.theme-part-coding-agent-manager-dialog-header-1) {
-  border-bottom-width: 1px;
-  border-color: var(--zy-border);
+  border-bottom-width: 0px;
   padding-inline: 1.5rem;
   padding-block: 1.25rem;
   padding-right: 3.5rem;
 }
 [data-theme="weiyang-dark"] :where(.theme-part-coding-agent-manager-dialog-footer-1) {
+  border-top-width: 0px;
   border-radius: 0px;
   background-color: var(--zy-background);
   padding-inline: 1.5rem;


### PR DESCRIPTION
## Summary

精简编程模式的 Agent 管理弹窗，并收拢编程工作区侧栏的操作入口。改动都在渲染层展示范围，不涉及 IPC、持久化与业务状态。

## Related Issue

无。

## Changes Made

- Agent 管理弹窗由 44rem/3xl 收到 36rem/xl，去掉头部说明文案与页脚分隔线，重新扫描按钮移到标题右侧。
- Agent 列表行去掉每行重复的 Bot 图标底，状态徽章只标注非 Ready 状态。
- 编程工作区侧栏的「添加工作区」改用与「添加项目」一致的动态 folder-plus 图标，hover 播放描边动画并遵守 `prefers-reduced-motion`。
- 移除侧栏头部的「扫描并管理 Agent」入口；Agent 管理仍可由工作台顶栏和新建 Session 弹窗打开，随之删除不再有触发方的 `CodingUiEvent.ManageAgents` 事件与 `CodingManageAgentsEventDetail` 类型。
- 删除不再使用的 i18n key `codingAgentManagerDescription`（中英各一条）。

## Type of Change

- [x] Code refactoring

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [x] Manual testing performed
- `npx vitest run src/renderer`：171 个文件、809 项通过，含新增的 `CodingWorkspaceSidebar.structure.test.ts`。
- `npm run lint`（oxlint + theme:check + theme:audit）：通过。
- `npm run build:tsc`：通过。
- `git diff --check`：通过。
- 开发版实机验证：编程侧栏标题行只剩添加工作区按钮，弹窗尺寸、列表行与重新扫描位置均正常，浅色主题下未发现溢出。

## Screenshots (if applicable)

本地验证时已截图（精简后的弹窗、只剩添加按钮的侧栏），未附加到本 PR；需要的话可以补。

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented on hard-to-understand code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

弹窗头部/页脚边框来自主题 recipe（`src/renderer/theme/components/classic-part-controls.ts`），改动后已重跑 `bun run theme:generate`，`src/renderer/theme/css/themes.css` 为生成产物。
