### PR TITLE
fix(settings): stop model discovery button from hanging on connection tests

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6405,6 +6405,7 @@ if (!gotTheLock) {
         method: options.method,
         headers,
         body: options.body,
+        signal: options.timeoutMs ? AbortSignal.timeout(options.timeoutMs) : undefined,
       });
 
       const contentType = response.headers.get('content-type') || '';

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -326,6 +326,7 @@ contextBridge.exposeInMainWorld('electron', {
       method: string;
       headers: Record<string, string>;
       body?: string;
+      timeoutMs?: number;
     }) => ipcRenderer.invoke(ApiIpc.Fetch, options),
 
     fetchModels: (input: ProviderModelDiscoveryRequest): Promise<ProviderModelDiscoveryResult> =>

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -2561,59 +2561,63 @@ const Settings: React.FC<SettingsProps> = ({
       },
     }));
 
-    const results = await testProviderModelsSequentially({
-      providerId: provider,
-      provider: nextProviderConfig,
-      baseUrl: resolveBaseUrl(
-        provider,
-        nextProviderConfig.baseUrl,
-        getEffectiveApiFormat(provider, nextProviderConfig.apiFormat),
-      ),
-      apiFormat: getEffectiveApiFormat(provider, nextProviderConfig.apiFormat),
-      models: modelsToTest,
-    });
-    if (modelConnectionTestRequestIdRef.current[provider] !== requestId) return true;
-
-    const statuses = Object.fromEntries(
-      results.map(({ model, result }) => [
-        model.id,
-        result.success ? ModelConnectionStatus.Success : ModelConnectionStatus.Failure,
-      ]),
-    );
-    setProviderModelConnectionStatuses(provider, statuses);
-
-    const successCount = results.filter(({ result }) => result.success).length;
-    const failureCount = results.length - successCount;
-    if (successCount > 0) {
-      try {
-        await persistTestedProviderConfiguration(provider, nextProviderConfig);
-        if (provider !== ProviderName.LlamaCpp) enableProvider(provider);
-      } catch (error) {
-        console.error('[Settings] failed to save auto-tested provider configuration:', error);
-        showConnectionTestNotification(
-          { success: false, message: i18nService.t('failedToSaveSettings') },
+    // Run connection tests in the background so the discovery button stops
+    // loading once the model list is merged; per-model status dots show progress.
+    void (async () => {
+      const results = await testProviderModelsSequentially({
+        providerId: provider,
+        provider: nextProviderConfig,
+        baseUrl: resolveBaseUrl(
           provider,
-        );
-        return true;
-      }
-    }
+          nextProviderConfig.baseUrl,
+          getEffectiveApiFormat(provider, nextProviderConfig.apiFormat),
+        ),
+        apiFormat: getEffectiveApiFormat(provider, nextProviderConfig.apiFormat),
+        models: modelsToTest,
+      });
+      if (modelConnectionTestRequestIdRef.current[provider] !== requestId) return;
 
-    const summary = i18nService
-      .t(failureCount === 0 ? 'modelConnectionTestSuccessSummary' : 'modelConnectionTestSummary')
-      .replace('{total}', String(results.length))
-      .replace('{success}', String(successCount))
-      .replace('{failure}', String(failureCount));
-    window.dispatchEvent(
-      new CustomEvent('app:showToast', {
-        detail: {
-          message: summary,
-          isError: failureCount > 0,
-          isSuccess: failureCount === 0,
-          autoClose: true,
-          durationMs: failureCount > 0 ? 5_000 : undefined,
-        },
-      }),
-    );
+      const statuses = Object.fromEntries(
+        results.map(({ model, result }) => [
+          model.id,
+          result.success ? ModelConnectionStatus.Success : ModelConnectionStatus.Failure,
+        ]),
+      );
+      setProviderModelConnectionStatuses(provider, statuses);
+
+      const successCount = results.filter(({ result }) => result.success).length;
+      const failureCount = results.length - successCount;
+      if (successCount > 0) {
+        try {
+          await persistTestedProviderConfiguration(provider, nextProviderConfig);
+          if (provider !== ProviderName.LlamaCpp) enableProvider(provider);
+        } catch (error) {
+          console.error('[Settings] failed to save auto-tested provider configuration:', error);
+          showConnectionTestNotification(
+            { success: false, message: i18nService.t('failedToSaveSettings') },
+            provider,
+          );
+          return;
+        }
+      }
+
+      const summary = i18nService
+        .t(failureCount === 0 ? 'modelConnectionTestSuccessSummary' : 'modelConnectionTestSummary')
+        .replace('{total}', String(results.length))
+        .replace('{success}', String(successCount))
+        .replace('{failure}', String(failureCount));
+      window.dispatchEvent(
+        new CustomEvent('app:showToast', {
+          detail: {
+            message: summary,
+            isError: failureCount > 0,
+            isSuccess: failureCount === 0,
+            autoClose: true,
+            durationMs: failureCount > 0 ? 5_000 : undefined,
+          },
+        }),
+      );
+    })();
     return true;
   };
 

--- a/src/renderer/services/i18n.ts
+++ b/src/renderer/services/i18n.ts
@@ -1,4 +1,4 @@
-﻿import { configService } from './config';
+import { configService } from './config';
 
 // 支持的语言类型
 export type LanguageType = 'zh' | 'en';
@@ -863,6 +863,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     connectionFailed: '连接失败',
     modelConnectionTestSummary: '已测试 {total} 个模型：{success} 个连接成功，{failure} 个连接失败',
     modelConnectionTestSuccessSummary: '{success} 个模型连接成功',
+    modelConnectionTestTimeout: '连接测试超时，请检查服务是否可用',
     noModelsConfigured: '请先添加模型',
     clearApiKeyConfirmTitle: '清除 API Key',
     clearApiKeyConfirmDescription: '确定要清除当前 API Key 吗？',
@@ -4263,6 +4264,7 @@ const translations: Record<LanguageType, Record<string, string>> = {
     modelConnectionTestSummary:
       'Tested {total} models: {success} connected successfully, {failure} failed',
     modelConnectionTestSuccessSummary: '{success} models connected successfully',
+    modelConnectionTestTimeout: 'Connection test timed out. Check that the service is reachable',
     noModelsConfigured: 'Please add a model first',
     clearApiKeyConfirmTitle: 'Clear API Key',
     clearApiKeyConfirmDescription: 'Clear the current API key?',

--- a/src/renderer/services/providerModelConnection.ts
+++ b/src/renderer/services/providerModelConnection.ts
@@ -4,6 +4,7 @@ import {
   resolveCodingPlanBaseUrl,
   type ProviderConfig,
 } from '../../shared/providers';
+import { i18nService } from './i18n';
 
 export interface ProviderModelConnectionTarget {
   id: string;
@@ -25,20 +26,24 @@ export type ProviderModelConnectionTestResult =
 export interface ProviderModelConnectionTestResponse {
   ok: boolean;
   status: number;
+  statusText?: string;
   data?: unknown;
+  error?: string;
 }
 
 const CONNECTIVITY_TEST_TOKEN_BUDGET = 64;
+const CONNECTION_TEST_TIMEOUT_MS = 30_000;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
-const getResponseErrorMessage = (data: unknown, status: number): string => {
+const getResponseErrorMessage = (data: unknown, status: number, fallback?: string): string => {
   if (isRecord(data)) {
     const error = isRecord(data.error) ? data.error : undefined;
     const message = error?.message ?? data.message;
     if (typeof message === 'string' && message.trim()) return message;
   }
+  if (status === 0 && fallback?.trim()) return fallback;
   return `HTTP ${status}`;
 };
 
@@ -90,9 +95,16 @@ export function getProviderModelConnectionTestResult(
 ): ProviderModelConnectionTestResult {
   if (response.ok) return { success: true };
 
-  const message = getResponseErrorMessage(response.data, response.status);
+  const message = getResponseErrorMessage(
+    response.data,
+    response.status,
+    response.error ?? response.statusText,
+  );
   if (message.toLowerCase().includes('model output limit was reached')) {
     return { success: true };
+  }
+  if (response.status === 0 && /aborted due to timeout|timed out/i.test(message)) {
+    return { success: false, message: i18nService.t('modelConnectionTestTimeout') };
   }
   return { success: false, message };
 }
@@ -128,6 +140,7 @@ export async function testProviderModelConnection(
           max_tokens: CONNECTIVITY_TEST_TOKEN_BUDGET,
           messages: [{ role: 'user', content: 'Hi' }],
         }),
+        timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
       });
       return getProviderModelConnectionTestResult(response);
     }
@@ -168,6 +181,7 @@ export async function testProviderModelConnection(
       method: 'POST',
       headers,
       body: JSON.stringify(body),
+      timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
     });
     return getProviderModelConnectionTestResult(response);
   } catch (error) {

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -659,6 +659,7 @@ interface IElectronAPI {
       method: string;
       headers: Record<string, string>;
       body?: string;
+      timeoutMs?: number;
     }) => Promise<ApiResponse>;
     fetchModels: (input: ProviderModelDiscoveryRequest) => Promise<ProviderModelDiscoveryResult>;
     stream: (options: {

--- a/src/shared/ipc/schemas.ts
+++ b/src/shared/ipc/schemas.ts
@@ -121,6 +121,7 @@ export const ApiFetchSchema = {
     method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']),
     headers: z.record(z.string(), z.string()),
     body: z.string().optional(),
+    timeoutMs: z.number().int().positive().max(300_000).optional(),
   }),
   output: z.object({ status: z.number(), data: z.unknown() }).passthrough(),
 };


### PR DESCRIPTION
## Problem

Adding a custom provider and fetching its model list left the fetch button spinning indefinitely:

1. After `/v1/models` succeeds, `handleModelsDiscovered` awaited a **sequential real chat-completion test for every configured model** (via `testProviderModelsSequentially`), and `ProviderModelDiscoveryButton` kept its loading state until all of that resolved.
2. Those tests go through the `api:fetch` IPC channel, which used `session.defaultSession.fetch` with **no timeout and no abort signal** — one hung model (gateway internal retry, half-open connection, cold model start) meant the button never stopped.
3. The provider configuration was only persisted after all tests finished with at least one success, so leaving the page mid-run lost the discovered models.

Reproduced against a live OpenAI-compatible gateway with 14 models: every model responds, but sequentially the tests take ~80s total with no progress indication — and any single hang is unbounded.

## Fix

- `api:fetch` gains an optional `timeoutMs` (IPC schema, preload, renderer typings), applied via `AbortSignal.timeout` in the main-process handler. Existing callers are unaffected.
- Provider model connection tests now pass a 30s timeout; timeout failures surface a localized message (`modelConnectionTestTimeout`, zh + en) instead of hanging.
- `handleModelsDiscovered` runs the connection tests in the background: the discovery button stops loading as soon as the model list is merged, models appear immediately, per-model status dots show test progress, and persist/enable + summary toast still happen when the tests complete.

## Electron-specific changes

- IPC: `api:fetch` input schema adds optional `timeoutMs` (max 300s). No other IPC surface changed.

## Verification

- `oxlint`: 0 warnings; `compile:electron` (main tsc) and renderer `tsc --noEmit` pass
- Unit tests for `providerModelDiscovery` / `providerModelConnection` pass (17 tests)
- Manually verified the exact request behavior the app performs against the affected gateway (model list + per-model chat completions)
- Pre-existing `theme:check` failure on main confirmed unrelated via `git stash` comparison