### PR TITLE
fix(chat): try web-search tools optimistically when capability is unknown

### DIFF
--- a/src/renderer/services/api.ts
+++ b/src/renderer/services/api.ts
@@ -23,6 +23,7 @@ import {
 } from './localInferenceSlotRetry';
 import { probeRuntimeModelCapabilities } from './modelCapabilityProbe';
 import { StreamRequestRegistry } from './streamRequestRegistry';
+import { isToolCallUnsupportedError } from './toolCallUnsupported';
 import { WebSearchToolEventType, type WebSearchToolEventHandler } from './webSearchToolEvents';
 
 export interface ApiConfig {
@@ -127,14 +128,15 @@ class ApiService {
     modelId: string,
     config: ApiConfig,
   ): Promise<Partial<ModelCapabilities>> {
-    if (!this.supportsRuntimeCapabilityProbe(provider)) {
-      return {};
-    }
-
     const key = `${provider}\u0000${modelId}\u0000${config.baseUrl.trim()}`;
+    // Cached verdicts (including optimistic-attempt failures recorded for
+    // providers that are never probed) apply regardless of probe support.
     const cached = this.runtimeCapabilityCache.get(key);
     if (cached) {
       return cached;
+    }
+    if (!this.supportsRuntimeCapabilityProbe(provider)) {
+      return {};
     }
     const pending = this.runtimeCapabilityRequests.get(key);
     if (pending) {
@@ -663,16 +665,28 @@ class ApiService {
       config,
     );
     const supportsImages = capabilities.imageInput === ModelCapabilityStatus.Supported;
-    if (capabilities.toolCalling !== ModelCapabilityStatus.Supported) {
-      const capabilityMessage =
-        capabilities.toolCalling === ModelCapabilityStatus.Unsupported
-          ? `${i18nService.t('toolCapabilityUnsupportedFallback')}\n\n`
-          : `${i18nService.t('toolCapabilityUnknownFallback')}\n\n`;
-      // Keep the request valid for custom, aggregated, and local endpoints. The
-      // regular chat path deliberately contains no `tools` or `tool_choice`.
-      onProgress?.(capabilityMessage);
+    if (capabilities.toolCalling === ModelCapabilityStatus.Unsupported) {
+      // An explicit unsupported verdict (user setting or endpoint metadata) is
+      // honored: no tools are attempted. The regular chat path deliberately
+      // contains no `tools` or `tool_choice`.
+      onProgress?.(`${i18nService.t('toolCapabilityUnsupportedFallback')}\n\n`);
       return this.chat(message, onProgress, history, options, requestId);
     }
+    // Unknown is not a verdict: attempt the native tool loop optimistically and
+    // fall back to plain chat only when the endpoint rejects tool use.
+    const isToolCallingUnverified = capabilities.toolCalling !== ModelCapabilityStatus.Supported;
+    const fallbackToPlainChat = (error: unknown) => {
+      if (!isToolCallingUnverified || !isToolCallUnsupportedError(error)) {
+        throw error;
+      }
+      // Remember the rejection so later requests skip the doomed attempt.
+      this.runtimeCapabilityCache.set(
+        `${provider}\u0000${selectedModel.id}\u0000${config.baseUrl.trim()}`,
+        { toolCalling: ModelCapabilityStatus.Unsupported },
+      );
+      onProgress?.(`${i18nService.t('toolCapabilityUnknownFallback')}\n\n`);
+      return this.chat(message, onProgress, history, options, requestId);
+    };
     const prompt =
       'Use the web_search tool when current, factual, or external information would improve the answer. Cite result URLs when you use search.';
     const system = [
@@ -700,7 +714,7 @@ class ApiService {
         requestId,
         abortSignal,
         onToolEvent,
-      );
+      ).catch(fallbackToPlainChat);
     }
     if (apiFormat === 'gemini') {
       const contents = [...history.filter(item => item.role !== 'system'), userMessage].map(
@@ -726,7 +740,7 @@ class ApiService {
         requestId,
         abortSignal,
         onToolEvent,
-      );
+      ).catch(fallbackToPlainChat);
     }
     if (this.shouldUseOpenAIResponsesApi(provider)) {
       const input = [...history.filter(item => item.role !== 'system'), userMessage]
@@ -741,7 +755,7 @@ class ApiService {
         requestId,
         abortSignal,
         onToolEvent,
-      );
+      ).catch(fallbackToPlainChat);
     }
     const messages = [
       { role: 'system', content: system },
@@ -760,7 +774,7 @@ class ApiService {
       requestId,
       abortSignal,
       onToolEvent,
-    );
+    ).catch(fallbackToPlainChat);
   }
 
   private throwIfAborted(signal?: AbortSignal): void {

--- a/src/renderer/services/api.webSearch.test.ts
+++ b/src/renderer/services/api.webSearch.test.ts
@@ -3,7 +3,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import { ModelCapabilityStatus, ProviderName } from '../../shared/providers';
 import { store } from '../store';
 import { setAvailableModels, setDefaultSelectedModel } from '../store/slices/modelSlice';
-import { apiService } from './api';
+import { ApiError, apiService } from './api';
 import { configService } from './config';
 import { i18nService } from './i18n';
 import { WebSearchToolEventType, type WebSearchToolEvent } from './webSearchToolEvents';
@@ -20,6 +20,7 @@ test('restores the legacy API config when app bootstrap has not synced it yet', 
     name: 'Custom Bootstrap Race',
     providerKey: 'custom_0',
     supportsImage: false,
+    capabilities: { toolCalling: ModelCapabilityStatus.Unsupported },
   };
   store.dispatch(setAvailableModels([model]));
   store.dispatch(setDefaultSelectedModel(model));
@@ -36,7 +37,7 @@ test('restores the legacy API config when app bootstrap has not synced it yet', 
   });
 });
 
-test('unknown tool capability falls back to regular chat without a tool payload', async () => {
+test('unknown tool capability tries tools first and falls back when the endpoint rejects them', async () => {
   const model = {
     id: 'custom-unknown',
     name: 'Custom Unknown',
@@ -47,17 +48,93 @@ test('unknown tool capability falls back to regular chat without a tool payload'
   store.dispatch(setDefaultSelectedModel(model));
   apiService.setConfig({ apiKey: 'key', baseUrl: 'https://example.test/v1', apiFormat: 'openai' });
   const regularChat = vi.spyOn(apiService, 'chat').mockResolvedValue({ content: 'plain answer' });
-  const stream = vi.spyOn(apiService as any, 'streamOpenAIChatResponse');
+  const loop = vi
+    .spyOn(apiService as any, 'runOpenAIWebSearchLoop')
+    .mockRejectedValue(new ApiError('This model does not support tools', 400));
   const progress = vi.fn();
 
   await expect(apiService.chatWithWebSearch('latest news', progress)).resolves.toEqual({
     content: 'plain answer',
   });
 
+  expect(loop).toHaveBeenCalledOnce();
   expect(regularChat).toHaveBeenCalledOnce();
-  expect(stream).not.toHaveBeenCalled();
   expect(progress).toHaveBeenCalledWith(
     '当前模型的工具调用能力尚未确认，已改用普通对话，未执行联网搜索。\n\n',
+  );
+});
+
+test('unknown tool capability keeps the tool loop when the endpoint accepts tools', async () => {
+  const model = {
+    id: 'custom-optimistic',
+    name: 'Custom Optimistic',
+    providerKey: 'custom_0',
+    supportsImage: false,
+  };
+  store.dispatch(setAvailableModels([model]));
+  store.dispatch(setDefaultSelectedModel(model));
+  apiService.setConfig({ apiKey: 'key', baseUrl: 'https://example.test/v1', apiFormat: 'openai' });
+  const regularChat = vi.spyOn(apiService, 'chat');
+  const loop = vi
+    .spyOn(apiService as any, 'runOpenAIWebSearchLoop')
+    .mockResolvedValue({ content: 'searched answer' });
+  const progress = vi.fn();
+
+  await expect(apiService.chatWithWebSearch('latest news', progress)).resolves.toEqual({
+    content: 'searched answer',
+  });
+
+  expect(loop).toHaveBeenCalledOnce();
+  expect(regularChat).not.toHaveBeenCalled();
+  expect(progress).not.toHaveBeenCalledWith(
+    expect.stringContaining('尚未确认'),
+  );
+});
+
+test('unknown tool capability does not swallow unrelated tool-loop errors', async () => {
+  const model = {
+    id: 'custom-unknown-500',
+    name: 'Custom Unknown 500',
+    providerKey: 'custom_0',
+    supportsImage: false,
+  };
+  store.dispatch(setAvailableModels([model]));
+  store.dispatch(setDefaultSelectedModel(model));
+  apiService.setConfig({ apiKey: 'key', baseUrl: 'https://example.test/v1', apiFormat: 'openai' });
+  const regularChat = vi.spyOn(apiService, 'chat');
+  vi.spyOn(apiService as any, 'runOpenAIWebSearchLoop').mockRejectedValue(
+    new ApiError('Internal server error', 500),
+  );
+
+  await expect(apiService.chatWithWebSearch('latest news')).rejects.toThrow(
+    'Internal server error',
+  );
+  expect(regularChat).not.toHaveBeenCalled();
+});
+
+test('a rejected tool attempt is cached and not retried for the session', async () => {
+  const model = {
+    id: 'custom-cached-verdict',
+    name: 'Custom Cached Verdict',
+    providerKey: 'custom_0',
+    supportsImage: false,
+  };
+  store.dispatch(setAvailableModels([model]));
+  store.dispatch(setDefaultSelectedModel(model));
+  apiService.setConfig({ apiKey: 'key', baseUrl: 'https://example.test/v1', apiFormat: 'openai' });
+  const regularChat = vi.spyOn(apiService, 'chat').mockResolvedValue({ content: 'plain answer' });
+  const loop = vi
+    .spyOn(apiService as any, 'runOpenAIWebSearchLoop')
+    .mockRejectedValue(new ApiError('This model does not support tools', 400));
+  const progress = vi.fn();
+
+  await apiService.chatWithWebSearch('latest news', progress);
+  await apiService.chatWithWebSearch('more news', progress);
+
+  expect(loop).toHaveBeenCalledOnce();
+  expect(regularChat).toHaveBeenCalledTimes(2);
+  expect(progress).toHaveBeenLastCalledWith(
+    '当前模型不支持工具调用，已改用普通对话，未执行联网搜索。\n\n',
   );
 });
 
@@ -185,7 +262,7 @@ test('provider hints are resolved from the registry instead of a stale allowlist
   ).toBe(ProviderName.Qianfan);
 });
 
-test('a catalog model absent from the provider support table does not receive tools', async () => {
+test('a catalog model absent from the provider support table falls back after the endpoint rejects tools', async () => {
   const model = {
     id: 'ernie-4.5-8k',
     name: 'ERNIE 4.5 8K',
@@ -200,12 +277,14 @@ test('a catalog model absent from the provider support table does not receive to
     apiFormat: 'openai',
   });
   const regularChat = vi.spyOn(apiService, 'chat').mockResolvedValue({ content: 'plain answer' });
-  const toolLoop = vi.spyOn(apiService as any, 'runOpenAIWebSearchLoop');
+  const toolLoop = vi
+    .spyOn(apiService as any, 'runOpenAIWebSearchLoop')
+    .mockRejectedValue(new ApiError('tools is not supported', 400));
 
   await apiService.chatWithWebSearch('latest news');
 
+  expect(toolLoop).toHaveBeenCalledOnce();
   expect(regularChat).toHaveBeenCalledOnce();
-  expect(toolLoop).not.toHaveBeenCalled();
 });
 
 test('web-search fallback message follows the selected UI language', async () => {
@@ -220,6 +299,9 @@ test('web-search fallback message follows the selected UI language', async () =>
   store.dispatch(setDefaultSelectedModel(model));
   apiService.setConfig({ apiKey: 'key', baseUrl: 'https://example.test/v1', apiFormat: 'openai' });
   vi.spyOn(apiService, 'chat').mockResolvedValue({ content: 'plain answer' });
+  vi.spyOn(apiService as any, 'runOpenAIWebSearchLoop').mockRejectedValue(
+    new ApiError('This model does not support tools', 400),
+  );
   const progress = vi.fn();
 
   await apiService.chatWithWebSearch('latest news', progress);

--- a/src/renderer/services/toolCallUnsupported.test.ts
+++ b/src/renderer/services/toolCallUnsupported.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'vitest';
+
+import { ApiError } from './api';
+import { isToolCallUnsupportedError } from './toolCallUnsupported';
+
+test('recognizes common tool-unsupported rejections', () => {
+  const cases = [
+    new ApiError('This model does not support tools', 400),
+    new ApiError('{"error":{"message":"GLM does not support function calling"}}', 400),
+    new ApiError('Tools are not supported by this endpoint', 400),
+    new ApiError('"auto" tool choice requires --enable-auto-tool-choice', 400),
+    new ApiError('{"message":"tool_choice is not supported for this model"}', 422),
+    new ApiError('Function calling is not supported in this model', 404),
+    // Streamed errors lose the status code; the message alone must suffice.
+    new ApiError('This model does not support tool calls'),
+  ];
+  for (const error of cases) {
+    expect(isToolCallUnsupportedError(error), error.message).toBe(true);
+  }
+});
+
+test('does not misclassify unrelated failures', () => {
+  const cases: unknown[] = [
+    new ApiError('Internal server error', 500),
+    new ApiError('Invalid API key', 401),
+    new ApiError('The model `foo` does not exist', 404),
+    new ApiError('Connection reset'),
+    new Error('Unexpected stream end'),
+    'plain string',
+    null,
+    undefined,
+    // A 400 about an unrelated field is not a tool verdict.
+    new ApiError('Invalid request: max_tokens is too large', 400),
+  ];
+  for (const error of cases) {
+    expect(isToolCallUnsupportedError(error)).toBe(false);
+  }
+});

--- a/src/renderer/services/toolCallUnsupported.ts
+++ b/src/renderer/services/toolCallUnsupported.ts
@@ -1,0 +1,33 @@
+/**
+ * Classifies endpoint rejections that mean "this model/endpoint cannot accept
+ * a tools payload". Used by the optimistic web-search path: models whose
+ * tool-calling capability is Unknown are first tried with tools, and only a
+ * recognized rejection triggers the plain-chat fallback.
+ */
+
+const TOOL_UNSUPPORTED_STATUS_CODES: ReadonlySet<number> = new Set([400, 404, 422]);
+
+const TOOL_UNSUPPORTED_PATTERNS: readonly RegExp[] = [
+  /does not support (?:tools?|tool calls?|function calls?|function calling)/i,
+  /tools? (?:are|is) not supported/i,
+  /function calling is (?:not supported|unavailable)/i,
+  /tool_?choice[^"]*(?:requires|not supported|unsupported)/i,
+  /--enable-auto-tool-choice/i,
+  /tool parser[^"]*not (?:configured|available)/i,
+];
+
+/**
+ * Duck-typed on purpose: api.ts imports this module, so importing ApiError
+ * here would create a cycle. Any Error with an optional numeric statusCode
+ * (ApiError-compatible) is accepted.
+ */
+export function isToolCallUnsupportedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const statusCode = (error as Error & { statusCode?: unknown }).statusCode;
+  if (statusCode !== undefined) {
+    if (typeof statusCode !== 'number' || !TOOL_UNSUPPORTED_STATUS_CODES.has(statusCode)) {
+      return false;
+    }
+  }
+  return TOOL_UNSUPPORTED_PATTERNS.some(pattern => pattern.test(error.message));
+}


### PR DESCRIPTION
## Problem

On a **custom provider**, opening a chat with web search enabled immediately printed「当前模型的工具调用能力尚未确认，已改用普通对话，未执行联网搜索。」— without ever attempting a tool call. The capability chain makes `Unknown` almost unavoidable for custom providers:

1. Custom provider IDs are absent from `CATALOG_PROVIDER_TOOL_CAPABILITIES`, so there is no endpoint declaration to trust (the #591 fix only covers catalog providers).
2. Gateway `/v1/models` responses (one-api/new-api etc.) rarely include capability metadata, so model discovery records nothing.
3. Runtime capability probing (`supportsRuntimeCapabilityProbe`) only covers OpenRouter/Ollama/LlamaCpp — custom providers are never probed.

`chatWithWebSearch` then treated `Unknown` like `Unsupported` and degraded to plain chat. Verified against a live gateway whose model actually emits proper `tool_calls`: the app was refusing to try a capability the endpoint has.

## Fix

`Unknown` now means "unverified — try first":

- `chatWithWebSearch` attempts the native tool loop for `Unknown` models (all four dispatch paths: Anthropic / Gemini / OpenAI Responses / OpenAI-compatible).
- A new `isToolCallUnsupportedError` classifier (`src/renderer/services/toolCallUnsupported.ts`) recognizes genuine tool rejections: HTTP 400/404/422 with common message patterns from OpenAI/vLLM/SGLang/gateways ("does not support tools", "tool_choice ... requires --enable-auto-tool-choice", "tool parser ... not configured", ...), including status-less stream errors. It is duck-typed to avoid an import cycle with `api.ts`.
- Only a recognized rejection falls back to plain chat with the existing localized notice; unrelated errors (500, auth, network) still propagate.
- The rejection is recorded in the runtime capability cache, so later requests in the session skip the doomed tool attempt and report the (now proven) unsupported verdict. `getRuntimeModelCapabilities` now consults the cache before the probe-support gate so non-probed providers can carry these verdicts; the cache is still cleared on settings refresh.
- An explicit `Unsupported` verdict (user setting or endpoint metadata) still skips tools entirely — unchanged.

## Tests

- New `toolCallUnsupported.test.ts`: classifier accept/reject cases (status-code gate, JSON-wrapped gateway messages, unrelated 400s, non-Error values).
- Updated `api.webSearch.test.ts` to the new policy: unknown → loop attempted → fallback only on tool rejection; catalog model without verified tool evidence (ernie) now also tries first; added optimistic-success, unrelated-error passthrough, and per-session negative-cache cases.
- 22 tests pass; `oxlint` clean; renderer `tsc --noEmit` clean.

## Behavior note

First web-search request on an incapable unknown model costs one rejected round-trip per session before falling back; subsequent requests go straight to plain chat. Verified live that the motivating endpoint (custom gateway, GLM-5.3-Flash) answers tool calls correctly, so capable models now get web search on the first try.