### PR TITLE
feat(coding): 侧边面板增加开合过渡与独立宽度上限

### DIFF
--- a/src/renderer/components/artifacts/ArtifactPanelResizeHandle.tsx
+++ b/src/renderer/components/artifacts/ArtifactPanelResizeHandle.tsx
@@ -17,6 +17,7 @@ interface ArtifactPanelResizeHandleProps {
   disabled?: boolean;
   onReachMaxWidth?: () => void;
   maxWidthOverflowThreshold?: number;
+  onResizeStateChange?: (isResizing: boolean) => void;
 }
 
 const ArtifactPanelResizeHandle: React.FC<ArtifactPanelResizeHandleProps> = ({
@@ -29,6 +30,7 @@ const ArtifactPanelResizeHandle: React.FC<ArtifactPanelResizeHandleProps> = ({
   disabled = false,
   onReachMaxWidth,
   maxWidthOverflowThreshold = 0,
+  onResizeStateChange,
 }) => {
   const [isResizing, setIsResizing] = useState(false);
   const isResizingRef = useRef(false);
@@ -44,6 +46,10 @@ const ArtifactPanelResizeHandle: React.FC<ArtifactPanelResizeHandleProps> = ({
   useEffect(() => {
     if (!isResizing) latestWidthRef.current = currentWidth;
   }, [currentWidth, isResizing]);
+
+  useEffect(() => {
+    onResizeStateChange?.(isResizing);
+  }, [isResizing, onResizeStateChange]);
 
   const flushResizeFrame = useCallback(() => {
     frameRequestRef.current = null;
@@ -185,7 +191,7 @@ const ArtifactPanelResizeHandle: React.FC<ArtifactPanelResizeHandleProps> = ({
       aria-valuemax={Math.round(maxWidth)}
       aria-valuemin={Math.round(minWidth)}
       aria-valuenow={Math.round(currentWidth)}
-      className={`absolute inset-y-0 left-0 z-10 w-3 touch-none outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+      className={`absolute inset-y-0 left-0 z-10 w-4 -translate-x-1/2 touch-none outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
         disabled ? 'pointer-events-none cursor-default' : 'cursor-col-resize'
       }`}
       data-artifact-resize-handle=""

--- a/src/renderer/components/coding/CodingSidePanelAddMenu.tsx
+++ b/src/renderer/components/coding/CodingSidePanelAddMenu.tsx
@@ -5,18 +5,22 @@ import {
   DropdownMenuTrigger,
 } from '@shared/components/ui/dropdown-menu';
 import { Button } from '@shared/components/ui/button';
-import { FileDiff, Folder, Plus } from 'lucide-react';
+import { FileDiff, Folder, Plus, Terminal as TerminalIcon } from 'lucide-react';
 
 import { i18nService } from '../../services/i18n';
 
 interface CodingSidePanelAddMenuProps {
   onOpenReview: () => void;
   onOpenFiles: () => void;
+  onOpenInspector: () => void;
+  hasInspectorContent: boolean;
 }
 
 export const CodingSidePanelAddMenu = ({
   onOpenReview,
   onOpenFiles,
+  onOpenInspector,
+  hasInspectorContent,
 }: CodingSidePanelAddMenuProps) => (
   <DropdownMenu>
     <DropdownMenuTrigger
@@ -40,6 +44,12 @@ export const CodingSidePanelAddMenu = ({
         <Folder />
         {i18nService.t('codingAgentFiles')}
       </DropdownMenuItem>
+      {hasInspectorContent ? (
+        <DropdownMenuItem className="gap-2" onClick={onOpenInspector}>
+          <TerminalIcon />
+          {i18nService.t('codingAgentInspector')}
+        </DropdownMenuItem>
+      ) : null}
     </DropdownMenuContent>
   </DropdownMenu>
 );

--- a/src/renderer/components/coding/CodingWorkbenchView.tsx
+++ b/src/renderer/components/coding/CodingWorkbenchView.tsx
@@ -16,7 +16,16 @@ import {
   SheetTitle,
 } from '@shared/components/ui/sheet';
 import { cn } from '@shared/lib/utils';
-import { Expand, File, FileDiff, Minimize2, PanelRight, Settings2, Terminal as TerminalIcon, X } from 'lucide-react';
+import {
+  Expand,
+  File,
+  FileDiff,
+  Minimize2,
+  PanelRight,
+  Settings2,
+  Terminal as TerminalIcon,
+  X,
+} from 'lucide-react';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -75,6 +84,8 @@ import type { CodingSessionDraft, CodingSidebarSelection } from './CodingWorkspa
 import { CoworkModelPicker } from '../cowork/CoworkModelPicker';
 import { createCodingQueueService } from '../../services/codingQueue';
 import { findPendingCodingPermission } from './codingPermission';
+import { resolveCodingSidePanelMaxWidth } from './codingSidePanelSizing';
+import { useCodingSidePanelTransition } from './useCodingSidePanelTransition';
 
 const profileStatusText = (status: CodingAgentProfileStatus): string =>
   i18nService.t(CodingAgentStatusI18nKey[status]);
@@ -82,7 +93,6 @@ const profileStatusText = (status: CodingAgentProfileStatus): string =>
 const EMPTY_SNAPSHOT: CodingRoomSnapshot | null = null;
 const CODING_PANEL_MIN_WIDTH = 280;
 const CODING_PANEL_DEFAULT_WIDTH = 560;
-const CODING_PANEL_EXPAND_DRAG_OVERFLOW = 160;
 
 const ArtifactPanelFrame = lazy(() =>
   import('../artifacts').then(module => ({ default: module.ArtifactPanelFrame })),
@@ -125,6 +135,7 @@ export const CodingWorkbenchView = ({
   const [sidePanelHidden, setSidePanelHidden] = useState(false);
   const [sidePanelWidth, setSidePanelWidth] = useState(CODING_PANEL_DEFAULT_WIDTH);
   const [sidePanelExpanded, setSidePanelExpanded] = useState(false);
+  const [isSidePanelResizing, setIsSidePanelResizing] = useState(false);
   const [gitRefreshVersion, setGitRefreshVersion] = useState(0);
   const [sidePanelMaxWidth, setSidePanelMaxWidth] = useState(CODING_PANEL_DEFAULT_WIDTH);
   const [isNarrowViewport, setIsNarrowViewport] = useState(() => window.innerWidth < 1024);
@@ -147,6 +158,7 @@ export const CodingWorkbenchView = ({
   const scrollSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const eventStreamRef = useRef<HTMLDivElement | null>(null);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
+  const sidePanelFrameRef = useRef<HTMLElement | null>(null);
   const transientSidePanelWidthRef = useRef<number | null>(null);
   const sessionSetupSelectionKeyRef = useRef<string | null>(null);
   const selectionKey = `${workspaceRoot}:${selectedLaneId ?? ''}:${draftSession?.id ?? ''}`;
@@ -389,6 +401,25 @@ export const CodingWorkbenchView = ({
     !sidePanelHidden &&
     sidePanelView !== null &&
     (sidePanelView !== CodingSidePanelView.Inspector || hasInspectorContent);
+  const {
+    completeClose: completeSidePanelClose,
+    hide: hideSidePanel,
+    isClosing: isSidePanelClosing,
+    isEntering: isSidePanelEntering,
+    isPresent: isSidePanelPresent,
+    reset: resetSidePanelTransition,
+    show: showSidePanel,
+  } = useCodingSidePanelTransition({
+    isNarrowViewport,
+    onCloseComplete: () => {
+      setSidePanelExpanded(false);
+      setSidePanelHidden(true);
+    },
+  });
+  const requestHideSidePanel = useCallback(() => {
+    setSidePanelExpanded(false);
+    hideSidePanel();
+  }, [hideSidePanel]);
   const resolvedSidePanelWidth = clampArtifactPanelWidth(
     sidePanelWidth,
     CODING_PANEL_MIN_WIDTH,
@@ -410,9 +441,7 @@ export const CodingWorkbenchView = ({
         sidePanelMaxWidth,
       );
       transientSidePanelWidthRef.current = nextWidth;
-      if (workbenchRef.current) {
-        workbenchRef.current.style.gridTemplateColumns = `minmax(0, 1fr) ${nextWidth}px`;
-      }
+      setSidePanelWidth(nextWidth);
     },
     [sidePanelMaxWidth],
   );
@@ -434,7 +463,7 @@ export const CodingWorkbenchView = ({
     const root = workbenchRef.current;
     if (!root) return;
     const updateMaxWidth = () => {
-      const maxWidth = resolveArtifactPanelMaxWidth(root.clientWidth, CODING_PANEL_MIN_WIDTH);
+      const maxWidth = resolveCodingSidePanelMaxWidth(root.clientWidth, CODING_PANEL_MIN_WIDTH);
       setSidePanelMaxWidth(maxWidth);
       setSidePanelWidth(current => clampArtifactPanelWidth(current, CODING_PANEL_MIN_WIDTH, maxWidth));
     };
@@ -496,9 +525,11 @@ export const CodingWorkbenchView = ({
     setSidePanelTabs([]);
     setSidePanelHidden(false);
     setSidePanelSheetOpen(false);
-  }, [activeLane?.id]);
+    resetSidePanelTransition();
+  }, [activeLane?.id, resetSidePanelTransition]);
 
   const openSidePanelTab = useCallback((view: CodingSidePanelViewType) => {
+    showSidePanel();
     setSidePanelHidden(false);
     if (view === CodingSidePanelView.Launcher) {
       setSidePanelTabs([]);
@@ -507,27 +538,29 @@ export const CodingWorkbenchView = ({
     }
     setSidePanelTabs(current => (current.includes(view) ? current : [...current, view]));
     setSidePanelView(view);
-  }, []);
+  }, [showSidePanel]);
 
   const restoreSidePanel = useCallback(() => {
+    showSidePanel();
     setSidePanelHidden(false);
     setSidePanelView(current => current ?? CodingSidePanelView.Launcher);
-  }, []);
+  }, [showSidePanel]);
 
   const closeSidePanelTab = useCallback(
     (view: CodingSidePanelViewType) => {
       const nextTabs = sidePanelTabs.filter(tab => tab !== view);
       setSidePanelTabs(nextTabs);
       if (nextTabs.length === 0) {
-        setSidePanelView(null);
         setSidePanelSheetOpen(false);
+        setSidePanelView(CodingSidePanelView.Launcher);
+        requestHideSidePanel();
         return;
       }
       setSidePanelView(active =>
         active === view ? nextTabs.at(-1)! : active,
       );
     },
-    [sidePanelTabs],
+    [requestHideSidePanel, sidePanelTabs],
   );
 
   const prompt = draftSession
@@ -857,7 +890,6 @@ export const CodingWorkbenchView = ({
 
   return (
     <div
-      ref={workbenchRef}
       data-page-canvas
       className="flex h-full min-h-0 flex-col bg-background"
     >
@@ -891,10 +923,11 @@ export const CodingWorkbenchView = ({
         }
       />
       <div
+        ref={workbenchRef}
         className="relative grid min-h-0 min-w-0 flex-1 grid-cols-1"
         style={
-          desktopSidePanelOpen
-            ? { gridTemplateColumns: `minmax(0, 1fr) ${renderedSidePanelWidth}px` }
+          isSidePanelPresent
+            ? { gridTemplateColumns: 'minmax(0, 1fr) auto' }
             : undefined
         }
       >
@@ -1202,20 +1235,43 @@ export const CodingWorkbenchView = ({
         ) : null}
         {error && <p className="px-3 pb-2 text-xs text-destructive">{error}</p>}
       </main>
-      {desktopSidePanelOpen && (
-        <aside className={cn('relative flex min-h-0 flex-col border-l border-border-subtle max-lg:hidden', sidePanelExpanded && 'absolute inset-0 z-20 bg-background')}>
+      {isSidePanelPresent && (
+        <aside
+          ref={sidePanelFrameRef}
+          onTransitionEnd={event => {
+            if (event.target === event.currentTarget && event.propertyName === 'width') {
+              completeSidePanelClose();
+            }
+          }}
+          aria-hidden={!desktopSidePanelOpen || isSidePanelEntering || isSidePanelClosing}
+          className={cn(
+            'relative flex min-h-0 min-w-0 shrink-0 flex-col overflow-visible border-l border-border-subtle max-lg:hidden',
+            !isSidePanelResizing &&
+              'transition-[width] duration-200 ease-out motion-reduce:transition-none',
+            (isSidePanelEntering || isSidePanelClosing) && 'pointer-events-none',
+            sidePanelExpanded && 'absolute inset-0 z-20 bg-background',
+          )}
+          style={{
+            width:
+              sidePanelExpanded
+                ? '100%'
+                : desktopSidePanelOpen && !isSidePanelEntering && !isSidePanelClosing
+                ? `${renderedSidePanelWidth}px`
+                : '0px',
+          }}
+          >
           <ArtifactPanelResizeHandle
             ariaLabel={i18nService.t('codingAgentSidePanel')}
             currentWidth={resolvedSidePanelWidth}
             minWidth={CODING_PANEL_MIN_WIDTH}
             maxWidth={sidePanelMaxWidth}
-            disabled={sidePanelExpanded}
+            disabled={sidePanelExpanded || isSidePanelEntering || isSidePanelClosing}
             onResizeFrame={applySidePanelFrameWidth}
             onResizeComplete={completeSidePanelResize}
-            onReachMaxWidth={() => setSidePanelExpanded(true)}
-            maxWidthOverflowThreshold={CODING_PANEL_EXPAND_DRAG_OVERFLOW}
+            onResizeStateChange={setIsSidePanelResizing}
           />
-          <div className="flex shrink-0 items-center gap-1 border-b border-border px-3 py-2">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="flex shrink-0 items-center gap-1 border-b border-border px-1 py-2">
               {visibleSidePanelTabs.map(tab => {
                 const isReview = tab === CodingSidePanelView.Review;
                 const isInspector = tab === CodingSidePanelView.Inspector;
@@ -1262,6 +1318,8 @@ export const CodingWorkbenchView = ({
               <CodingSidePanelAddMenu
                 onOpenReview={() => openSidePanelTab(CodingSidePanelView.Review)}
                 onOpenFiles={() => openSidePanelTab(CodingSidePanelView.Files)}
+                onOpenInspector={() => openSidePanelTab(CodingSidePanelView.Inspector)}
+                hasInspectorContent={hasInspectorContent}
               />
               <div className="ml-auto flex shrink-0 items-center gap-1">
                 <Button
@@ -1282,8 +1340,7 @@ export const CodingWorkbenchView = ({
                   size="icon-sm"
                   aria-label={i18nService.t('codingAgentSidePanel')}
                   onClick={() => {
-                    setSidePanelExpanded(false);
-                    setSidePanelHidden(true);
+                    requestHideSidePanel();
                   }}
                 >
                   <PanelRight />
@@ -1314,6 +1371,7 @@ export const CodingWorkbenchView = ({
                 refreshKey={gitRefreshKey}
               />
             )}
+          </div>
           </div>
         </aside>
       )}

--- a/src/renderer/components/coding/codingSidePanelSizing.test.ts
+++ b/src/renderer/components/coding/codingSidePanelSizing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  CODING_SIDE_PANEL_MAX_CONTENT_RATIO,
+  resolveCodingSidePanelMaxWidth,
+} from './codingSidePanelSizing';
+
+describe('coding side panel sizing', () => {
+  test('allows the coding side panel slightly more than half of the workbench', () => {
+    expect(resolveCodingSidePanelMaxWidth(2000, 280)).toBe(
+      2000 * CODING_SIDE_PANEL_MAX_CONTENT_RATIO,
+    );
+  });
+
+  test('preserves the conversation reserve on narrower workbenches', () => {
+    expect(resolveCodingSidePanelMaxWidth(700, 280)).toBe(340);
+    expect(resolveCodingSidePanelMaxWidth(500, 280)).toBe(280);
+  });
+});

--- a/src/renderer/components/coding/codingSidePanelSizing.ts
+++ b/src/renderer/components/coding/codingSidePanelSizing.ts
@@ -1,0 +1,11 @@
+import { ARTIFACT_PANEL_CHAT_RESERVE } from '../artifacts/artifactPanelResize';
+
+export const CODING_SIDE_PANEL_MAX_CONTENT_RATIO = 0.6;
+
+/** Keeps a usable conversation column while allowing the coding panel a little
+ * more room than the shared artifact preview. */
+export function resolveCodingSidePanelMaxWidth(contentWidth: number, minPanelWidth: number): number {
+  const chatReserveMaximum = contentWidth - ARTIFACT_PANEL_CHAT_RESERVE;
+  const ratioMaximum = contentWidth * CODING_SIDE_PANEL_MAX_CONTENT_RATIO;
+  return Math.max(minPanelWidth, Math.min(chatReserveMaximum, ratioMaximum));
+}

--- a/src/renderer/components/coding/useCodingSidePanelTransition.test.tsx
+++ b/src/renderer/components/coding/useCodingSidePanelTransition.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { useCodingSidePanelTransition } from './useCodingSidePanelTransition';
+
+let entryFrame: FrameRequestCallback | null = null;
+let reduceMotion = false;
+
+beforeEach(() => {
+  entryFrame = null;
+  reduceMotion = false;
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    entryFrame = callback;
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query === '(prefers-reduced-motion: reduce)' && reduceMotion,
+  }));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+test('keeps the side panel mounted until its close transition completes', () => {
+  const onCloseComplete = vi.fn();
+  const view = renderHook(() =>
+    useCodingSidePanelTransition({ isNarrowViewport: false, onCloseComplete }),
+  );
+
+  act(() => view.result.current.show());
+  expect(view.result.current).toMatchObject({ isPresent: true, isEntering: true });
+
+  act(() => entryFrame?.(0));
+  expect(view.result.current.isEntering).toBe(false);
+
+  act(() => view.result.current.hide());
+  expect(view.result.current).toMatchObject({ isPresent: true, isClosing: true });
+  expect(onCloseComplete).not.toHaveBeenCalled();
+
+  act(() => view.result.current.completeClose());
+  expect(view.result.current).toMatchObject({ isPresent: false, isClosing: false });
+  expect(onCloseComplete).toHaveBeenCalledOnce();
+});
+
+test('closes immediately when reduced motion is enabled', () => {
+  reduceMotion = true;
+  const onCloseComplete = vi.fn();
+  const view = renderHook(() =>
+    useCodingSidePanelTransition({ isNarrowViewport: false, onCloseComplete }),
+  );
+
+  act(() => view.result.current.show());
+  act(() => view.result.current.hide());
+
+  expect(view.result.current).toMatchObject({ isPresent: false, isClosing: false });
+  expect(onCloseComplete).toHaveBeenCalledOnce();
+});
+
+test('finishes closing when the browser does not dispatch transitionend', () => {
+  vi.useFakeTimers();
+  const onCloseComplete = vi.fn();
+  const view = renderHook(() =>
+    useCodingSidePanelTransition({ isNarrowViewport: false, onCloseComplete }),
+  );
+
+  act(() => view.result.current.show());
+  act(() => entryFrame?.(0));
+  act(() => view.result.current.hide());
+  act(() => vi.advanceTimersByTime(240));
+
+  expect(view.result.current).toMatchObject({ isPresent: false, isClosing: false });
+  expect(onCloseComplete).toHaveBeenCalledOnce();
+});

--- a/src/renderer/components/coding/useCodingSidePanelTransition.ts
+++ b/src/renderer/components/coding/useCodingSidePanelTransition.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseCodingSidePanelTransitionOptions {
+  isNarrowViewport: boolean;
+  onCloseComplete: () => void;
+}
+
+const prefersReducedMotion = (): boolean =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// Keep this just beyond the panel's 200ms width transition. It prevents a
+// missing transitionend event from leaving the panel mounted forever.
+const CLOSE_TRANSITION_FALLBACK_MS = 240;
+
+export const useCodingSidePanelTransition = ({
+  isNarrowViewport,
+  onCloseComplete,
+}: UseCodingSidePanelTransitionOptions) => {
+  const [isPresent, setIsPresent] = useState(false);
+  const [isEntering, setIsEntering] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const entryFrameRef = useRef<number | null>(null);
+  const closeFallbackRef = useRef<number | null>(null);
+
+  const cancelEntryFrame = useCallback(() => {
+    if (entryFrameRef.current === null) return;
+    window.cancelAnimationFrame(entryFrameRef.current);
+    entryFrameRef.current = null;
+  }, []);
+
+  const cancelCloseFallback = useCallback(() => {
+    if (closeFallbackRef.current === null) return;
+    window.clearTimeout(closeFallbackRef.current);
+    closeFallbackRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    cancelEntryFrame();
+    cancelCloseFallback();
+    setIsPresent(false);
+    setIsEntering(false);
+    setIsClosing(false);
+  }, [cancelCloseFallback, cancelEntryFrame]);
+
+  useEffect(() => reset, [reset]);
+
+  useEffect(() => {
+    if (isNarrowViewport) reset();
+  }, [isNarrowViewport, reset]);
+
+  const show = useCallback(() => {
+    if (isNarrowViewport) return;
+    cancelEntryFrame();
+    setIsClosing(false);
+    if (isPresent) return;
+
+    setIsPresent(true);
+    setIsEntering(true);
+    entryFrameRef.current = window.requestAnimationFrame(() => {
+      entryFrameRef.current = null;
+      setIsEntering(false);
+    });
+  }, [cancelEntryFrame, isNarrowViewport, isPresent]);
+
+  const hide = useCallback(() => {
+    cancelEntryFrame();
+    setIsEntering(false);
+    if (!isPresent || isNarrowViewport || prefersReducedMotion()) {
+      reset();
+      onCloseComplete();
+      return;
+    }
+    setIsClosing(true);
+    cancelCloseFallback();
+    closeFallbackRef.current = window.setTimeout(() => {
+      closeFallbackRef.current = null;
+      reset();
+      onCloseComplete();
+    }, CLOSE_TRANSITION_FALLBACK_MS);
+  }, [cancelCloseFallback, cancelEntryFrame, isNarrowViewport, isPresent, onCloseComplete, reset]);
+
+  const completeClose = useCallback(() => {
+    if (!isClosing) return;
+    cancelCloseFallback();
+    reset();
+    onCloseComplete();
+  }, [cancelCloseFallback, isClosing, onCloseComplete, reset]);
+
+  return {
+    completeClose,
+    hide,
+    isClosing,
+    isEntering,
+    isPresent,
+    reset,
+    show,
+  };
+};


### PR DESCRIPTION
## Summary

为 Coding 工作台的侧边面板补上**开合过渡动画**与**独立的宽度上限**，并把拖拽缩放从直接改写 DOM 样式改为走 React 状态；同时把 Inspector 入口移到侧边面板的「添加」下拉菜单，并加宽了拖拽手柄。

## Related Issue

<!-- 无关联 issue -->

## Changes Made

### 面板开合过渡
- 新增 `useCodingSidePanelTransition`：以 `isPresent` / `isEntering` / `isClosing` 三态管理进场与退场
  - `show()` 用一帧 `requestAnimationFrame` 触发进场，避免与初始挂载同帧导致过渡被跳过
  - `hide()` 先进入退场态，由 `transitionend`（仅 `width`）收尾；另有 **240ms 兜底定时器**，防止 `transitionend` 缺失时面板永久挂载
  - `prefers-reduced-motion: reduce` 与窄视口下直接跳过动画
  - 组件卸载、切换 lane、进入窄视口时统一 reset，`rAF` 与定时器一并清理
- `CodingWorkbenchView` 网格列由固定像素改为 `auto`，改由面板自身做 200ms 宽度过渡（`motion-reduce:transition-none`）；**拖拽期间暂停过渡**以跟随指针
- 退场/进场期间设置 `aria-hidden` 与 `pointer-events-none`，避免过渡中的面板仍可交互
- 关闭最后一个标签页时不再把视图置空，而是回到 Launcher 并播放退场过渡

### 宽度上限
- 新增 `codingSidePanelSizing`：`resolveCodingSidePanelMaxWidth` 取「内容宽度 − 对话预留」与「内容宽度 × 60%」的较小值，并以最小面板宽度兜底
  - 该上限独立于共享的 artifact 预览面板，使 coding 面板可以占得更宽
- 拖拽缩放不再直接改写 `gridTemplateColumns`，改为写入 `sidePanelWidth` 状态
- 移除「拖拽超出阈值自动展开」的行为（`CODING_PANEL_EXPAND_DRAG_OVERFLOW` 与 `onReachMaxWidth` 一并删除）

### 其他
- `ArtifactPanelResizeHandle` 新增 `onResizeStateChange` 上报拖拽状态；手柄由 `w-3` 加宽到 `w-4` 并用 `-translate-x-1/2` 居中贴合分隔线
- `CodingSidePanelAddMenu` 新增 `onOpenInspector` 与 `hasInspectorContent`，Inspector 可重新从此菜单打开（仅在有内容时显示该菜单项）
- 面板头部内边距 `px-3` 调整为 `px-1`，内容区外包一层 `min-w-0` 的纵向 flex 容器以修正溢出

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] Tested locally
- [x] Added new tests
- [ ] Updated existing tests
- [ ] Manual testing performed

## Screenshots (if applicable)

<!-- 面板开合过渡与宽度上限属交互变化，静态截图难以体现；本次未附 -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Electron-Specific Changes

- [ ] Changes to main process (src/main/)
- [ ] Changes to preload script (src/main/preload.ts)
- [ ] Changes to IPC communication
- [ ] Changes to window management
- [x] None

## Additional Notes

- **本地校验**：`tsc --noEmit -p tsconfig.json` **exit 0**；新增的两个测试文件共 **5 个用例全部通过**（`codingSidePanelSizing.test.ts`、`useCodingSidePanelTransition.test.tsx`）。
- **未跑全量单测**：本机 `better-sqlite3` 是按 Electron ABI 编译的，vitest 跑在 Node 下会 `NODE_MODULE_VERSION 143` vs `137` 失败（此前几个 PR 已确认属环境问题而非代码问题，CI 中 `CI=true` 走 rebuild 分支是绿的），且本机有 Electron 开发版占用该 `.node` 文件导致 rebuild EPERM。因此 Checklist 中「单元测试本地通过」一项留空，交由 CI 判定。
- **行为变更（需留意）**：
  1. 拖拽到最大宽度**不再自动展开**面板，展开只能通过展开按钮触发
  2. 关闭侧边面板的最后一个标签页会回到 Launcher（并播放退场过渡），而不是显示空视图
- 本次改动集中在前端渲染层，未触及 main 进程、preload 与 IPC。
