### PR TITLE
fix(installer): validate cached component trees before reuse

### DIFF
--- a/scripts/installer/validate-offline-components.ps1
+++ b/scripts/installer/validate-offline-components.ps1
@@ -77,6 +77,40 @@ function Get-Components {
   return $components
 }
 
+function Measure-ComponentTree([string]$Root) {
+  # The completion record itself must stay out of the measurement: it is
+  # written after the tree is measured during expand, but present on disk
+  # during cache validation.
+  $rootFull = (Get-Item -LiteralPath $Root).FullName
+  $completeFull = Join-Path $rootFull '.complete'
+  $fileCount = 0
+  $totalBytes = [long]0
+  Get-ChildItem -LiteralPath $Root -Recurse -File -Force -ErrorAction Stop |
+    Where-Object { $_.FullName -ne $completeFull } |
+    ForEach-Object {
+      $fileCount++
+      $totalBytes += $_.Length
+    }
+  return [pscustomobject]@{ FileCount = $fileCount; TotalBytes = $totalBytes }
+}
+
+function Read-CompleteRecord([string]$Path) {
+  $raw = (Get-Content -LiteralPath $Path -Raw -ErrorAction Stop).Trim()
+  $fields = $raw -split '\|'
+  if ($fields.Count -ne 4) { return $null }
+  $fileCount = 0
+  $totalBytes = [long]0
+  if (-not [int]::TryParse($fields[2], [ref]$fileCount)) { return $null }
+  if (-not [long]::TryParse($fields[3], [ref]$totalBytes)) { return $null }
+  if ($fileCount -le 0 -or $totalBytes -le 0) { return $null }
+  return [pscustomobject]@{
+    Id = $fields[0].ToLowerInvariant()
+    ArchiveHash = $fields[1].ToLowerInvariant()
+    FileCount = $fileCount
+    TotalBytes = $totalBytes
+  }
+}
+
 function Test-ArchiveEntries([string]$ArchivePath, [string]$Prefix) {
   $normalizedPrefix = Test-SafeRelativePath $Prefix 'component prefix'
   $lines = @(& $SevenZipPath l -slt $ArchivePath)
@@ -132,10 +166,17 @@ try {
       $sentinel = Join-Path $target $component.Sentinel
       try {
         if (-not (Test-Path -LiteralPath $complete -PathType Leaf)) { continue }
-        $completeId = (Get-Content -LiteralPath $complete -Raw -ErrorAction Stop).Substring(0, 64).ToLowerInvariant()
-        if ($completeId -ne $component.Id -or -not (Test-Path -LiteralPath $sentinel -PathType Leaf)) { continue }
+        $record = Read-CompleteRecord $complete
+        if ($null -eq $record -or $record.Id -ne $component.Id) { continue }
+        if (-not (Test-Path -LiteralPath $sentinel -PathType Leaf)) { continue }
         $actualHash = (Get-FileHash -LiteralPath $sentinel -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
         if ($actualHash -ne $component.SentinelHash) { continue }
+        # A sentinel hash alone cannot detect a component tree left incomplete
+        # by an interrupted move, so the recorded entry count and byte total
+        # must match the tree on disk before the cache entry is reused.
+        $measured = Measure-ComponentTree $target
+        if ($measured.FileCount -ne $record.FileCount -or $measured.TotalBytes -ne $record.TotalBytes) { continue }
+        Remove-Item -LiteralPath "$target.installing" -Recurse -Force -ErrorAction SilentlyContinue
         New-Item -ItemType File -Path $marker -Force | Out-Null
         Write-Output "cache-hit:$($component.Key)"
       } catch {
@@ -180,9 +221,21 @@ try {
       if ($actualSentinelHash -ne $component.SentinelHash) {
         Stop-WithCode 5 "sentinel-mismatch:$($component.Key)"
       }
-      Set-Content -LiteralPath (Join-Path $installing '.complete') -Value "$($component.Id)|$($component.ArchiveHash)" -NoNewline
       Remove-Item -LiteralPath $target -Recurse -Force -ErrorAction SilentlyContinue
       Move-Item -LiteralPath $installing -Destination $target -ErrorAction Stop
+      # An interrupted move can leave the target directory incomplete, so
+      # re-verify the sentinel in place and only then publish the measured
+      # completion record that later cache validation depends on.
+      $movedSentinel = Join-Path $target $component.Sentinel
+      if (-not (Test-Path -LiteralPath $movedSentinel -PathType Leaf)) {
+        Stop-WithCode 4 "extract-failed:$($component.Key):moved-tree-incomplete"
+      }
+      $movedSentinelHash = (Get-FileHash -LiteralPath $movedSentinel -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
+      if ($movedSentinelHash -ne $component.SentinelHash) {
+        Stop-WithCode 4 "extract-failed:$($component.Key):moved-sentinel-mismatch"
+      }
+      $measured = Measure-ComponentTree $target
+      Set-Content -LiteralPath (Join-Path $target '.complete') -Value "$($component.Id)|$($component.ArchiveHash)|$($measured.FileCount)|$($measured.TotalBytes)" -NoNewline
       Write-Output "expanded:$($component.Key)"
     } catch {
       Stop-WithCode 4 "extract-failed:$($component.Key):$($_.Exception.Message)"

--- a/scripts/installer/validate-offline-components.test.ts
+++ b/scripts/installer/validate-offline-components.test.ts
@@ -1,0 +1,233 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+const scriptPath = path.join(__dirname, 'validate-offline-components.ps1');
+const targetsPath = path.join(projectRoot, 'scripts', 'nsis-offline-components.json');
+const sevenZipPath = path.join(
+  projectRoot,
+  'node_modules',
+  '7zip-bin',
+  'win',
+  'x64',
+  '7za.exe',
+);
+const temporaryDirectories: string[] = [];
+
+type ComponentTarget = { key: string; prefix: string; sentinel: string };
+
+function sha256Hex(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function runValidator(mode: 'cache' | 'expand', pluginDir: string, runtimeRoot: string) {
+  return spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      scriptPath,
+      '-Mode',
+      mode,
+      '-PluginDir',
+      pluginDir,
+      '-RuntimeRoot',
+      runtimeRoot,
+      '-ComponentTargetsPath',
+      targetsPath,
+      '-SevenZipPath',
+      sevenZipPath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+function componentId(key: string): string {
+  return sha256Hex(Buffer.from(`content-id:${key}`));
+}
+
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zhiyuan-offline-components-'));
+  temporaryDirectories.push(root);
+  const pluginDir = path.join(root, 'plugin');
+  const runtimeRoot = path.join(root, 'runtimes');
+  fs.mkdirSync(pluginDir);
+  fs.mkdirSync(runtimeRoot);
+  const targets = JSON.parse(
+    fs.readFileSync(targetsPath, 'utf8'),
+  ) as ComponentTarget[];
+
+  for (const target of targets) {
+    const id = componentId(target.key);
+    const sentinelRelative = target.sentinel.replace(/\\/g, '/');
+    const staging = path.join(root, 'staging', target.key);
+    const sentinelPath = path.join(staging, sentinelRelative);
+    fs.mkdirSync(path.dirname(sentinelPath), { recursive: true });
+    const sentinelContent = Buffer.from(`sentinel:${target.key}`);
+    fs.writeFileSync(sentinelPath, sentinelContent);
+    const extraPath = path.join(staging, target.prefix, 'extra.txt');
+    fs.mkdirSync(path.dirname(extraPath), { recursive: true });
+    fs.writeFileSync(extraPath, `extra:${target.key}`);
+
+    const archivePath = path.join(pluginDir, `component-${target.key}.7z`);
+    const archived = spawnSync(
+      sevenZipPath,
+      ['a', '-t7z', archivePath, target.prefix],
+      { cwd: staging, encoding: 'utf8' },
+    );
+    expect(archived.status, archived.stderr || archived.stdout).toBe(0);
+
+    fs.writeFileSync(path.join(pluginDir, `component-${target.key}.version`), id);
+    fs.writeFileSync(
+      path.join(pluginDir, `component-${target.key}.sha256`),
+      sha256Hex(fs.readFileSync(archivePath)),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, `component-${target.key}.sentinel-sha256`),
+      sha256Hex(sentinelContent),
+    );
+  }
+
+  return { pluginDir, runtimeRoot, targets };
+}
+
+function expandFixture(fixture: ReturnType<typeof makeFixture>) {
+  const expanded = runValidator('expand', fixture.pluginDir, fixture.runtimeRoot);
+  expect(expanded.status, expanded.stderr || expanded.stdout).toBe(0);
+  for (const target of fixture.targets) {
+    expect(expanded.stdout).toContain(`expanded:${target.key}`);
+  }
+}
+
+function targetDir(fixture: ReturnType<typeof makeFixture>, key: string): string {
+  return path.join(fixture.runtimeRoot, key, componentId(key));
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform !== 'win32')('offline component cache validator', () => {
+  test('expand publishes a measured completion record that cache mode accepts', () => {
+    const fixture = makeFixture();
+    expandFixture(fixture);
+
+    for (const target of fixture.targets) {
+      const completePath = path.join(targetDir(fixture, target.key), '.complete');
+      const record = fs.readFileSync(completePath, 'utf8').trim();
+      const fields = record.split('|');
+      expect(fields).toHaveLength(4);
+      expect(fields[0]).toBe(componentId(target.key));
+      expect(Number.parseInt(fields[2], 10)).toBeGreaterThan(0);
+      expect(Number.parseInt(fields[3], 10)).toBeGreaterThan(0);
+    }
+
+    const cached = runValidator('cache', fixture.pluginDir, fixture.runtimeRoot);
+    expect(cached.status, cached.stderr || cached.stdout).toBe(0);
+    for (const target of fixture.targets) {
+      expect(cached.stdout).toContain(`cache-hit:${target.key}`);
+      expect(
+        fs.existsSync(path.join(fixture.pluginDir, `component-${target.key}.cache-valid`)),
+      ).toBe(true);
+    }
+  });
+
+  test('cache mode rejects a component tree left incomplete by an interrupted move', () => {
+    const fixture = makeFixture();
+    expandFixture(fixture);
+
+    const victim = fixture.targets[1];
+    const victimDir = targetDir(fixture, victim.key);
+    fs.rmSync(path.join(victimDir, victim.prefix, 'extra.txt'));
+
+    const cached = runValidator('cache', fixture.pluginDir, fixture.runtimeRoot);
+    expect(cached.status).toBe(0);
+    expect(cached.stdout).not.toContain(`cache-hit:${victim.key}`);
+    expect(cached.stdout).toContain(`cache-hit:${fixture.targets[0].key}`);
+    expect(
+      fs.existsSync(path.join(fixture.pluginDir, `component-${victim.key}.cache-valid`)),
+    ).toBe(false);
+  });
+
+  test('cache mode rejects a completion record without measured entries', () => {
+    const fixture = makeFixture();
+    expandFixture(fixture);
+
+    const victim = fixture.targets[2];
+    const id = componentId(victim.key);
+    fs.writeFileSync(
+      path.join(targetDir(fixture, victim.key), '.complete'),
+      `${id}|${sha256Hex(Buffer.from('legacy'))}`,
+    );
+
+    const cached = runValidator('cache', fixture.pluginDir, fixture.runtimeRoot);
+    expect(cached.status).toBe(0);
+    expect(cached.stdout).not.toContain(`cache-hit:${victim.key}`);
+    expect(cached.stdout).toContain(`cache-hit:${fixture.targets[3].key}`);
+  });
+
+  test('cache mode removes a stale installing directory next to a valid target', () => {
+    const fixture = makeFixture();
+    expandFixture(fixture);
+
+    const key = fixture.targets[0].key;
+    const stale = `${targetDir(fixture, key)}.installing`;
+    fs.mkdirSync(path.join(stale, 'leftover'), { recursive: true });
+
+    const cached = runValidator('cache', fixture.pluginDir, fixture.runtimeRoot);
+    expect(cached.status, cached.stderr || cached.stdout).toBe(0);
+    expect(cached.stdout).toContain(`cache-hit:${key}`);
+    expect(fs.existsSync(stale)).toBe(false);
+  });
+
+  test('expand re-extracts a component whose cached target was corrupted', () => {
+    const fixture = makeFixture();
+    expandFixture(fixture);
+
+    // Mirror the installer flow: cache validation marks every component as
+    // reusable before expand runs and skips the marked ones.
+    const cached = runValidator('cache', fixture.pluginDir, fixture.runtimeRoot);
+    expect(cached.status, cached.stderr || cached.stdout).toBe(0);
+
+    const victim = fixture.targets[3];
+    const root = temporaryDirectories[temporaryDirectories.length - 1];
+    fs.rmSync(path.join(fixture.pluginDir, `component-${victim.key}.cache-valid`));
+    fs.rmSync(targetDir(fixture, victim.key), { recursive: true, force: true });
+
+    const staging = path.join(root, 'restaging');
+    const sentinelPath = path.join(staging, victim.sentinel.replace(/\\/g, '/'));
+    fs.mkdirSync(path.dirname(sentinelPath), { recursive: true });
+    fs.writeFileSync(sentinelPath, `sentinel:${victim.key}`);
+    const archivePath = path.join(fixture.pluginDir, `component-${victim.key}.7z`);
+    const archived = spawnSync(
+      sevenZipPath,
+      ['a', '-t7z', archivePath, victim.prefix],
+      { cwd: staging, encoding: 'utf8' },
+    );
+    expect(archived.status, archived.stderr || archived.stdout).toBe(0);
+    fs.writeFileSync(
+      path.join(fixture.pluginDir, `component-${victim.key}.sha256`),
+      sha256Hex(fs.readFileSync(archivePath)),
+    );
+
+    const reexpanded = runValidator('expand', fixture.pluginDir, fixture.runtimeRoot);
+    expect(reexpanded.status, reexpanded.stderr || reexpanded.stdout).toBe(0);
+    expect(reexpanded.stdout).toContain(`expanded:${victim.key}`);
+    expect(reexpanded.stdout).not.toContain(`expanded:${fixture.targets[4].key}`);
+    expect(
+      fs.existsSync(
+        path.join(targetDir(fixture, victim.key), victim.sentinel.replace(/\\/g, '/')),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The 2026.9.11-build.2 auto-update failed on Windows with NSIS exit 1 at the `离线组件展开失败` step. The failed run left the skills component in a corrupt split state: 22 of 51 skills sat in the content-addressed target directory (with a valid `.complete` marker and intact sentinel hash) while the remaining 30 were still in the leftover `.installing` directory.

The cache validator (`validate-offline-components.ps1 -Mode cache`) only checked the sentinel file hash, so a plain retry would have been a cache hit and permanently reused an incomplete skills tree.

## Fix

- **expand**: after the publishing `Move-Item`, re-verify the sentinel in place, measure the moved tree (file count + total bytes), and only then publish the `.complete` record (`id|archiveHash|fileCount|totalBytes`).
- **cache**: require the measured entry count and byte total to match the record before declaring a hit; legacy two-field records are treated as misses so existing installs self-heal with one clean re-extraction on the next update.
- cache hits also delete a stale `<target>.installing` directory left by an earlier interrupted run.

The record keeps the content id as its first 64 characters, so the existing NSIS consumer (`nsis-installer.nsh`) stays compatible.

## Validation

- New `scripts/installer/validate-offline-components.test.ts` (5 tests, Windows): expand→cache round-trip, incomplete-tree rejection, legacy-record rejection, stale `.installing` cleanup, corrupted-target re-extraction. All pass.
- Existing `validate-component-archive.test.ts` and `tests/nsis-installer.test.ts` still pass (20/20).
- `oxlint`: 0 warnings, 0 errors.

Note: `theme:check` reports stale generated CSS at HEAD on `main` (pre-existing, unrelated to this change); this PR does not touch theme files.